### PR TITLE
Use piped context to list applications

### DIFF
--- a/pkg/app/api/api/piped_api.go
+++ b/pkg/app/api/api/piped_api.go
@@ -99,8 +99,22 @@ func (a *PipedAPI) ReportPipedMeta(ctx context.Context, req *pipedservice.Report
 // Disabled applications should not be included in the response.
 // Piped uses this RPC to fetch and sync the application configuration into its local database.
 func (a *PipedAPI) ListApplications(ctx context.Context, req *pipedservice.ListApplicationsRequest) (*pipedservice.ListApplicationsResponse, error) {
+	projectID, pipedID, _, err := rpcauth.ExtractPipedToken(ctx)
+	if err != nil {
+		return nil, err
+	}
 	opts := datastore.ListOptions{
 		Filters: []datastore.ListFilter{
+			{
+				Field:    "ProjectId",
+				Operator: "==",
+				Value:    projectID,
+			},
+			{
+				Field:    "PipedId",
+				Operator: "==",
+				Value:    pipedID,
+			},
 			{
 				Field:    "Disabled",
 				Operator: "==",

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -197,7 +197,7 @@ func (t *Trigger) checkApplication(ctx context.Context, app *model.Application, 
 	}
 
 	// Check whether the most recently applied one is the head commit or not.
-	// If not, nothing to do for this time.
+	// If so, nothing to do for this time.
 	if headCommit.Hash == preCommitHash {
 		logger.Info(fmt.Sprintf("no update to sync for application: %s, hash: %s", app.Id, headCommit.Hash))
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
It currently retrieves all applications because of nothing filters.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
