### PR TITLE
Update ListUnhandledCommands rpc to return an empty list instead of Unimplemented error

### DIFF
--- a/pkg/app/api/api/piped_api.go
+++ b/pkg/app/api/api/piped_api.go
@@ -401,7 +401,8 @@ func (a *PipedAPI) ReportStageStatusChanged(ctx context.Context, req *pipedservi
 // On other side, the web will periodically check the command status and feedback the result to user.
 // In the future, we may need a solution to remove all old-handled commands from datastore for space.
 func (a *PipedAPI) ListUnhandledCommands(ctx context.Context, req *pipedservice.ListUnhandledCommandsRequest) (*pipedservice.ListUnhandledCommandsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	return &pipedservice.ListUnhandledCommandsResponse{}, nil
+	// nil, status.Error(codes.Unimplemented, "")
 }
 
 // ReportCommandHandled is called by piped to mark a specific command as handled.


### PR DESCRIPTION
Currently, piped is calling that RPC periodically and showing many of annoying Unimplemented error stacktraces.
This PR temporarily changes it to return an empty list of commands.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
