### PR TITLE
Fix wrong license note in dockers/static

### DIFF
--- a/dockers/static/main.go
+++ b/dockers/static/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Kapetanios Authors.
+// Copyright 2020 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
