### PR TITLE
Fix a bug that causes driftdetector generates a wrong message

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -172,6 +172,36 @@ func (k ResourceKey) IsLess(a ResourceKey) bool {
 	return false
 }
 
+// IsLessWithIgnoringNamespace reports whether the key should sort before the given key,
+// but this ignores the comparation of the namesapce.
+func (k ResourceKey) IsLessWithIgnoringNamespace(a ResourceKey) bool {
+	if k.APIVersion < a.APIVersion {
+		return true
+	}
+	if k.Kind < a.Kind {
+		return true
+	}
+	if k.Name < a.Name {
+		return true
+	}
+	return false
+}
+
+// IsEqualWithIgnoringNamespace checks whether the key is equal to the given key,
+// but this ignores the comparation of the namesapce.
+func (k ResourceKey) IsEqualWithIgnoringNamespace(a ResourceKey) bool {
+	if k.APIVersion != a.APIVersion {
+		return false
+	}
+	if k.Kind != a.Kind {
+		return false
+	}
+	if k.Name != a.Name {
+		return false
+	}
+	return true
+}
+
 func MakeResourceKey(obj *unstructured.Unstructured) ResourceKey {
 	k := ResourceKey{
 		APIVersion: obj.GetAPIVersion(),


### PR DESCRIPTION
**What this PR does / why we need it**:

ResourceKey has a namespace field. For live objects, that field is not empty but most of the git objects they are emtpy.
This causes comparing the resource key between live object and git object will be not correct.
So we add another comparation function with ignoring the namespace to use.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
