### PR TITLE
Copy owner id told by event to parent id

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/state.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/state.go
@@ -43,8 +43,9 @@ func MakeKubernetesResourceState(uid string, key ResourceKey, obj *unstructured.
 	sort.Strings(ownerIDs)
 
 	state := model.KubernetesResourceState{
-		Id:         uid,
-		OwnerIds:   ownerIDs,
+		Id:       uid,
+		OwnerIds: ownerIDs,
+		// TODO: Think about adding more parents by using label selectors
 		ParentIds:  ownerIDs,
 		Name:       key.Name,
 		ApiVersion: key.APIVersion,

--- a/pkg/app/piped/livestatestore/kubernetes/store.go
+++ b/pkg/app/piped/livestatestore/kubernetes/store.go
@@ -252,8 +252,6 @@ func (s *store) getAppLiveState(appID string) (AppState, bool) {
 	)
 	for i := range nodes {
 		state := nodes[i].state
-		state.ParentIds = state.OwnerIds
-		// TODO: Think about adding more parents by using label selectors.
 		resources = append(resources, &state)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The reason why the relationships between resources aren't updated correctly could be thought because parents id was empty.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/279

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
