### PR TITLE
Use cached app id when resource deleted

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -193,7 +193,7 @@ func (p *provider) LoadManifests(ctx context.Context) (manifests []Manifest, err
 		manifests, err = ParseManifests(data)
 
 	case TemplatingMethodNone:
-		manifests, err = LoadPlainYAMLMannifests(ctx, p.appDir, p.input.Manifests)
+		manifests, err = LoadPlainYAMLManifests(ctx, p.appDir, p.input.Manifests)
 
 	default:
 		err = fmt.Errorf("unsupport templating method %v", p.templatingMethod)

--- a/pkg/app/piped/cloudprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/manifest.go
@@ -107,7 +107,7 @@ func ParseFromStructuredObject(s interface{}) (Manifest, error) {
 	}, nil
 }
 
-func LoadPlainYAMLMannifests(ctx context.Context, dir string, names []string) ([]Manifest, error) {
+func LoadPlainYAMLManifests(ctx context.Context, dir string, names []string) ([]Manifest, error) {
 	// If no name was specified we have to walk the app directory to collect the manifest list.
 	if len(names) == 0 {
 		err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {

--- a/pkg/app/piped/executor/kubernetes/canary.go
+++ b/pkg/app/piped/executor/kubernetes/canary.go
@@ -183,7 +183,7 @@ func (e *Executor) generateCanaryManifests(namespace string, manifests []provide
 		canaryManifests = append(canaryManifests, m)
 	}
 
-	// Generate new workload manifests for VANARY variant.
+	// Generate new workload manifests for CANARY variant.
 	// The generated ones will mount to the new ConfigMaps and Secrets.
 	replicasCalculator := func(cur *int32) int32 {
 		if cur == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to utilize application id cached in `store.resources` when deleting resources whose all owners are deleted before them.

This PR does:
1. Ensure to use an appID cached in `store.resources` when resources updated
2. and then use that when resources deleted as well

Let me explain `1.` in detail.
The application id of a Depended node that doesn't contain appID in its annotations is cached in `store.resources`. Therefore, https://github.com/pipe-cd/pipe/issues/302 can be fixed by using `appResource.appID`.

However, when the owner is deleted, the Depended node is updated and appID is overwritten with empty characters:

```
09:42:31	received delete event for apps/v1:ReplicaSet:default:canary-canary-54c9846d97	{“cloud-provider”: “kubernetes-default”}
09:42:31	received update event for v1:Pod:default:canary-canary-54c9846d97-dpzj7	{“cloud-provider”: “kubernetes-default”}
```
We can prevent them from overwriting by using appID cached in `store.resources`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/302

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
