### PR TITLE
Update golangci-lint settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,14 @@
 linters:
   disable-all: true
   enable:
-    - dogsled
-    - gofmt
-    - goimports
-    - gomodguard
-    - goprintffuncname
-    - ineffassign
-    - misspell
-    - nakedret
-    - nestif
     - prealloc
-      #- lll
-      #- gomnd
-      #- godox
-      #- scopelint
-      #- whitespace
-      #- wsl
-      #- dupl
-      #- funlen
-      #- gocognit
-      #- gocyclo
-
+    - ineffassign
+    - gosimple
+    - staticcheck
+    - gosec
+    - gocritic
+    - unparam
+    - deadcode
   fast: false
 linters-settings:
   goimports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Linters that require to preload Go packages are now available on Piped project.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
