### PR TITLE
Guarantee manifests' order to be stable

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -176,15 +176,26 @@ func (k ResourceKey) IsSecret() bool {
 func (k ResourceKey) IsLess(a ResourceKey) bool {
 	if k.APIVersion < a.APIVersion {
 		return true
+	} else if k.APIVersion > a.APIVersion {
+		return false
 	}
+
 	if k.Kind < a.Kind {
 		return true
+	} else if k.Kind > a.Kind {
+		return false
 	}
+
 	if k.Namespace < a.Namespace {
 		return true
+	} else if k.Namespace > a.Namespace {
+		return false
 	}
+
 	if k.Name < a.Name {
 		return true
+	} else if k.Name > a.Name {
+		return false
 	}
 	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It has been compared between different order slices. This PR makes the sort stable.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/331

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
