### PR TITLE
Do not remove curl from piped-base image

### DIFF
--- a/dockers/piped-base/DOCKER_BUILD
+++ b/dockers/piped-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.0.2
+version: 0.0.3
 registry: gcr.io/pipecd/piped-base

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -24,5 +24,4 @@ RUN \
     /installer/install-kustomize.sh && \
     # Delete installer directory.
     rm -rf /installer && \
-    apk del curl && \
     rm -f /var/cache/apk/*


### PR DESCRIPTION
**What this PR does / why we need it**:

`curl` is required for installing tools such as `kubectl`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
