### PR TITLE
Disable commitMessage plugin

### DIFF
--- a/.kapetanios/plugin.yaml
+++ b/.kapetanios/plugin.yaml
@@ -63,9 +63,9 @@ spec:
 
   # A plugin to validate PR's commit messages against the specified format.
   # See more: https://kapetanios.dev/docs/plugins/commitmessage
-  commitMessage:
-    enabled: true
-    formatRegex: '^[A-Z\[]'
+  # commitMessage:
+  #   enabled: true
+  #   formatRegex: '^[A-Z\[]'
 
   # A plugin provides command to generate the changelog from latest release.
   # See more: https://kapetanios.dev/docs/plugins/changelog


### PR DESCRIPTION
Because we are using the `merger` with `Squash` mode so the merge commit message will be the PR title.
That is good enough and we don't need to check the PR's commit message.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
