### PR TITLE
Ensure to be completed with failure

### DIFF
--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -491,6 +491,7 @@ func (s *scheduler) ensurePreparing(ctx context.Context, lp logpersister.StageLo
 		if err != nil {
 			err = fmt.Errorf("Failed to load deployment configuration (%v)", err)
 			lp.AppendError(err.Error())
+			return
 		}
 		s.deploymentConfig = cfg
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Keeping performing the stage despite failed to load deployment config. That occurs panic every time.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
