### PR TITLE
Show the offset from UTC at the stage log

### DIFF
--- a/pkg/app/web/src/components/log-line.tsx
+++ b/pkg/app/web/src/components/log-line.tsx
@@ -48,7 +48,7 @@ interface Props {
   createdAt: number;
 }
 
-const TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss Z";
 
 export const LogLine: FC<Props> = ({
   body,


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/87775353-ebff1580-c860-11ea-8db8-45565efa4644.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
