### PR TITLE
Add exclude-rules to golangci-lint settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,45 @@ linters:
   enable:
     - prealloc
     - ineffassign
+    - goerr113
+    - misspell
+    - errcheck
     - gosimple
     - staticcheck
     - gosec
     - gocritic
     - unparam
     - deadcode
+    - unconvert
+    - typecheck
+    - stylecheck
+    - exportloopref
   fast: false
 linters-settings:
   goimports:
     local-prefixes: github.com/pipe-cd/pipe
+
+run:
+  timeout: 2m
+  tests: false
+  skip-dirs:
+    - "vendor$"
+    - "^bazel"
+    - pkg/app/api/cmd/samplepipedapicli
+    - pkg/app/api/cmd/samplewebapicli
+    - pkg/app/api/service/pipedservice/pipedclientfake
+
+issues:
+  exclude-rules:
+    - linters:
+      - gosec
+      text: "G204: Subprocess launched"
+    - linters:
+      - goerr113
+      text: "err113: do not define dynamic errors"
+    - linters:
+      - stylecheck
+      text: "ST1003: struct field Https"
+    - linters:
+      - stylecheck
+      text: "ST1003: struct field Id"


### PR DESCRIPTION
**What this PR does / why we need it**:
Including new linters supported at [v1.28.0](https://github.com/golangci/golangci-lint/releases/tag/v1.28.0).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
