### PR TITLE
Ensure the existence of variant label in service manifest when application is routing by Pod

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/manifest.go
@@ -82,6 +82,15 @@ func (m Manifest) GetAnnotations() map[string]string {
 	return m.u.GetAnnotations()
 }
 
+func (m Manifest) GetNestedStringMap(fields ...string) (map[string]string, error) {
+	sm, _, err := unstructured.NestedStringMap(m.u.Object, fields...)
+	if err != nil {
+		return nil, err
+	}
+
+	return sm, nil
+}
+
 // AddStringMapValues adds or overrides the given key-values into the string map
 // that can be found at the specified fields.
 func (m Manifest) AddStringMapValues(values map[string]string, fields ...string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
