### PR TITLE
Fix a bug that causes piped crashes while rolling back

### DIFF
--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -502,17 +502,15 @@ func (s *scheduler) ensurePreparing(ctx context.Context, lp logpersister.StageLo
 	// Load deployment configuration for this application.
 	cfg, err := loadDeploymentConfiguration(gitRepo.GetPath(), s.deployment)
 	if err != nil {
-		err = fmt.Errorf("failed to load deployment configuration (%w)", err)
 		lp.Errorf("Failed to load deployment configuration (%v)", err)
-		return err
+		return fmt.Errorf("failed to load deployment configuration (%w)", err)
 	}
 	s.deploymentConfig = cfg
 
 	pp, ok := cfg.GetPipelineable()
 	if !ok {
-		err = fmt.Errorf("unsupport non pipelineable application %s", cfg.Kind)
 		lp.Errorf("Unsupport non pipelineable application %s", cfg.Kind)
-		return err
+		return fmt.Errorf("unsupport non pipelineable application %s", cfg.Kind)
 	}
 	s.pipelineable = pp
 	lp.Success("Successfully loaded deployment configuration")


### PR DESCRIPTION
**What this PR does / why we need it**:

Scenario:
- A deployment is triggered
- The first stage (e.g. `K8S_SYNC`) is cancelled from web UI while `ensurePreparing` is running
- So `prepareOnce` is marked as executed but `s.deploymentConfig = cfg` is still not configured
- The rollback stage starts running
- Because the `prepareOnce` was marked as executed so `s.deploymentConfig` is still nil
- That causes a panic when accessing `s.deploymentConfig` in rollback execution

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

/cc @nakabonne 