### PR TITLE
Append dummy path to file creation URL

### DIFF
--- a/pkg/git/url.go
+++ b/pkg/git/url.go
@@ -108,6 +108,10 @@ func MakeFileCreationURL(repoURL, dir, branch, filename, value string) (string, 
 		u.Path = fmt.Sprintf("%s/%s/%s/%s", repoPath, "new", branch, dir)
 		params := &url.Values{}
 		if filename != "" {
+			// NOTE: We're getting an issue with specifying a filename: https://github.com/isaacs/github/issues/1527
+			//   In short, the last path part of the URL is ignored.
+			//   For now, appending dummy path as a workaround.
+			u.Path += "/dummy"
 			params.Add("filename", filename)
 		}
 		if value != "" {

--- a/pkg/git/url_test.go
+++ b/pkg/git/url_test.go
@@ -181,8 +181,23 @@ func TestMakeFileCreationURL(t *testing.T) {
 			dir:      "path/to",
 			branch:   "abc",
 			filename: "foo.txt",
-			want:     "https://github.com/org/repo/new/abc/path/to?filename=foo.txt",
+			want:     "https://github.com/org/repo/new/abc/path/to/dummy?filename=foo.txt",
 			wantErr:  false,
+		},
+		{
+			name:    "given value",
+			repoURL: "git@github.com:org/repo.git",
+			dir:     "path/to",
+			branch:  "abc",
+			value: `# Comment
+foo:
+  bar:
+    baz:
+      - a
+      - b
+`,
+			want:    "https://github.com/org/repo/new/abc/path/to?value=%23+Comment%0Afoo%3A%0A++bar%3A%0A++++baz%3A%0A++++++-+a%0A++++++-+b%0A",
+			wantErr: false,
 		},
 		{
 			name:     "given filename and value",
@@ -197,7 +212,7 @@ foo:
       - a
       - b
 `,
-			want:    "https://github.com/org/repo/new/abc/path/to?filename=foo.txt&value=%23+Comment%0Afoo%3A%0A++bar%3A%0A++++baz%3A%0A++++++-+a%0A++++++-+b%0A",
+			want:    "https://github.com/org/repo/new/abc/path/to/dummy?filename=foo.txt&value=%23+Comment%0Afoo%3A%0A++bar%3A%0A++++baz%3A%0A++++++-+a%0A++++++-+b%0A",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
We're getting an issue with specifying a filename: https://github.com/isaacs/github/issues/1527
In short, the last path part of the URL is ignored when specifying a filename. For now, appending dummy path as a workaround.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
