### PR TITLE
remove unnecessary dependencies catched by go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,7 @@ require (
 	cloud.google.com/go/storage v1.6.0
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/golang/mock v1.4.3
-	github.com/golang/protobuf v1.4.0
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-github/v29 v29.0.3


### PR DESCRIPTION
**What this PR does / why we need it**:

Run `make dep` on my local removed unnecessary dependencies. I checked all opening PRs but it looks like those others aren't going remove these dependencies.

I'm not yet familiar with Bazel tools, just playing around with commands from the Makefile, please correct me if I'm wrong 😅 

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
