### PR TITLE
Don't check error type

### DIFF
--- a/pkg/app/api/stagelogstore/filestore.go
+++ b/pkg/app/api/stagelogstore/filestore.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/pipe-cd/pipe/pkg/filestore"
@@ -38,7 +37,7 @@ func (f *stageLogFileStore) Get(ctx context.Context, deploymentID, stageID strin
 	path := stageLogPath(deploymentID, stageID, retriedCount)
 	lf := logFragment{}
 	reader, err := f.filestore.NewReader(ctx, path)
-	if err != nil && !errors.Is(err, filestore.ErrNotFound) {
+	if err != nil {
 		return lf, err
 	}
 	blocks := make([]*model.LogBlock, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:
The check should be done by the caller of `stageLogFileStore.Get`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
