### PR TITLE
Rename signing-key to encryption-key

### DIFF
--- a/docs/content/en/docs/operator-manual/control-plane/installation.md
+++ b/docs/content/en/docs/operator-manual/control-plane/installation.md
@@ -23,12 +23,12 @@ So before installing PipeCD, let's add the above Helm chart repository to your H
 helm repo add pipecd https://charts.pipecd.dev
 ```
 
-### 2. Preparing a signing key
+### 2. Preparing an encryption key
 
-PipeCD requires a key for signing JWT token while authenticating. You can use the following command to generate a signing key.
+PipeCD requires a key for encrypting sensitive data or signing JWT token while authenticating. You can use the following command to generate an encryption key.
 
 ``` console
-openssl rand 64 -out token-signing-key
+openssl rand 64 -out encryption-key
 ```
 
 ### 3. Preparing control-plane configuration file and installing
@@ -66,7 +66,7 @@ After all, install the control-plane as bellow:
 helm install pipecd pipecd/pipecd --version=VERSION --namespace=NAMESPACE \
   --set api.args.insecureCookie=true \
   --set-file config.data=path-to-control-plane-configuration-file \
-  --set-file secret.signingKey.data=path-to-signing-key-file \
+  --set-file secret.encryptionKey.data=path-to-encryption-key-file \
   --set-file secret.firestoreServiceAccount.data=path-to-service-account-file \
   --set-file secret.gcsServiceAccount.data=path-to-service-account-file
 ```
@@ -105,7 +105,7 @@ After all, install the control-plane as bellow:
 helm install pipecd pipecd/pipecd --version=VERSION --namespace=NAMESPACE \
   --set api.args.insecureCookie=true \
   --set-file config.data=path-to-control-plane-configuration-file \
-  --set-file secret.signingKey.data=path-to-signing-key-file \
+  --set-file secret.encryptionKey.data=path-to-encryption-key-file \
   --set-file secret.minioAccessKey.data=path-to-minio-access-key-file
   --set-file secret.minioSecretKey.data=path-to-minio-secret-key-file
 ```

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           - --config-file=/etc/pipecd-config/{{ .Values.config.fileName }}
           - --use-fake-response={{ .Values.api.args.useFakeResponse }}
           - --enable-grpc-reflection={{ .Values.api.args.enableGRPCReflection }}
-          - --token-signing-key-file={{ .Values.secret.mountPath }}/{{ .Values.secret.signingKey.fileName }}
+          - --encryption-key-file={{ .Values.secret.mountPath }}/{{ .Values.secret.encryptionKey.fileName }}
           ports:
             - name: piped-api
               containerPort: 9080

--- a/manifests/pipecd/templates/secret.yaml
+++ b/manifests/pipecd/templates/secret.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "pipecd.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if .Values.secret.signingKey.data }}
-  {{ .Values.secret.signingKey.fileName }}: {{ .Values.secret.signingKey.data | b64enc | quote }}
+{{- if .Values.secret.encryptionKey.data }}
+  {{ .Values.secret.encryptionKey.fileName }}: {{ .Values.secret.encryptionKey.data | b64enc | quote }}
 {{- end }}
 {{- if .Values.secret.firestoreServiceAccount.data }}
   {{ .Values.secret.firestoreServiceAccount.fileName }}: {{ .Values.secret.firestoreServiceAccount.data | b64enc | quote }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -63,8 +63,8 @@ secret:
   # The name of the Secret should be mounted to container.
   name: "pipecd-secrets"
   mountPath: /etc/pipecd-secret
-  signingKey:
-    fileName: "signing-key"
+  encryptionKey:
+    fileName: "encryption-key"
     data: ""
   firestoreServiceAccount:
     fileName: "firestore-service-account"

--- a/quickstart/control-plane-values.yaml
+++ b/quickstart/control-plane-values.yaml
@@ -25,8 +25,8 @@ config:
             passwordHash: "$2a$10$ye96mUqUqTnjUqgwQJbJzel/LJibRhUnmzyypACkvrTSnQpVFZ7qK" # bcrypt value of "hello-pipecd"
 
 secret:
-  signingKey:
-    data: quickstart
+  encryptionKey:
+    data: encryption-key-just-used-for-quickstart
   minioAccessKey:
     data: quickstart-access-key
   minioSecretKey:


### PR DESCRIPTION
**What this PR does / why we need it**:

Because from now the key is used for both encrypting the sensitive data
and signing the JWT token

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
