### PR TITLE
Add piped config-data flag

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -76,6 +76,7 @@ import (
 
 type piped struct {
 	configFile      string
+	configData      string
 	configGCPSecret string
 
 	insecure                             bool
@@ -105,6 +106,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&p.configFile, "config-file", p.configFile, "The path to the configuration file.")
+	cmd.Flags().StringVar(&p.configData, "config-data", p.configData, "The configuration data in YAML/JSON format.")
 	cmd.Flags().StringVar(&p.configGCPSecret, "config-gcp-secret", p.configGCPSecret, "The resource ID of secret that contains Piped config and be stored in GCP SecretManager.")
 
 	cmd.Flags().BoolVar(&p.insecure, "insecure", p.insecure, "Whether disabling transport security while connecting to control-plane.")
@@ -491,6 +493,14 @@ func (p *piped) loadConfig(ctx context.Context) (*config.PipedSpec, error) {
 
 	if p.configFile != "" {
 		cfg, err := config.LoadFromYAML(p.configFile)
+		if err != nil {
+			return nil, err
+		}
+		return extract(cfg)
+	}
+
+	if p.configData != "" {
+		cfg, err := config.DecodeYAML([]byte(p.configData))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sample command would look like
```console
$ piped piped --metrics \
--tools-dir=/tmp/piped-bin \
--config-data="`cat .dev/piped-config.yaml`"
```
or
```console
$ piped piped --metrics \
--tools-dir=/tmp/piped-bin \
--config-data='{"apiVersion": "pipecd.dev/v1beta1", "kind": "Piped",...}'
```
or
```console
$ piped piped --metrics \
--tools-dir=/tmp/piped-bin \
--config-data="`echo $CONFIG_DATA`"
```

**Which issue(s) this PR fixes**:

Fixes #2392 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable Piped to load configuration via command line argument using --config-data flag
```
