### PR TITLE
Disable host key checking while cloning source in Launcher

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -149,7 +149,7 @@ func (l *launcher) run(ctx context.Context, t cli.Telemetry) error {
 			git.WithLogger(t.Logger),
 		}
 		if l.gitSSHKeyFile != "" {
-			options = append(options, git.WithGitEnv(`GIT_SSH_COMMAND="ssh -i `+l.gitSSHKeyFile+` -F /dev/null"`))
+			options = append(options, git.WithGitEnv(`GIT_SSH_COMMAND="ssh -i `+l.gitSSHKeyFile+` -o StrictHostKeyChecking=no -F /dev/null"`))
 		}
 		gc, err := git.NewClient(options...)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This disables the prompt from the first cloning.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
