### PR TITLE
Avoid panic while trigger deployment for kind that not k8s

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -181,15 +181,19 @@ func (t *Trigger) getMentionedAccounts(d *model.Deployment) ([]string, error) {
 		return nil, err
 	}
 
-	if cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification == nil {
-		// There is no event to mention users.
-		return nil, nil
-	}
+	if cfg.KubernetesDeploymentSpec != nil {
+		if cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification == nil {
+			// There is no event to mention users.
+			return nil, nil
+		}
 
-	for _, v := range cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification.Mentions {
-		if e := "EVENT_" + v.Event; e == model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED.String() {
-			return v.Slack, nil
+		for _, v := range cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification.Mentions {
+			if e := "EVENT_" + v.Event; e == model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED.String() {
+				return v.Slack, nil
+			}
 		}
 	}
+	// TODO: Support mention users for other application kinds than K8s.
+
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Follow PR #2581 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
