### PR TITLE
Support mentioning users in the TRIGGERED event for other than k8s

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -181,19 +181,21 @@ func (t *Trigger) getMentionedAccounts(d *model.Deployment) ([]string, error) {
 		return nil, err
 	}
 
-	if cfg.KubernetesDeploymentSpec != nil {
-		if cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification == nil {
-			// There is no event to mention users.
-			return nil, nil
-		}
+	spec, ok := cfg.GetGenericDeployment()
+	if !ok {
+		return nil, fmt.Errorf("unsupported application kind: %s", cfg.Kind)
+	}
 
-		for _, v := range cfg.KubernetesDeploymentSpec.GenericDeploymentSpec.DeploymentNotification.Mentions {
-			if e := "EVENT_" + v.Event; e == model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED.String() {
-				return v.Slack, nil
-			}
+	if spec.DeploymentNotification == nil {
+		// There is no event to mention users.
+		return nil, nil
+	}
+
+	for _, v := range spec.DeploymentNotification.Mentions {
+		if e := "EVENT_" + v.Event; e == model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED.String() {
+			return v.Slack, nil
 		}
 	}
-	// TODO: Support mention users for other application kinds than K8s.
 
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2607

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
