### PR TITLE
Fix formatting errors

### DIFF
--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -228,7 +228,7 @@ func (b *builder) buildApp(ctx context.Context, worker int, command string, app 
 	if deploy, err := b.getMostRecentlySuccessfulDeployment(ctx, app.Id); err == nil {
 		preCommit = deploy.Trigger.Commit.Hash
 	} else if status.Code(err) != codes.NotFound {
-		r.Error = fmt.Sprintf("failed while finding the last successful deployment (%w)", err)
+		r.Error = fmt.Sprintf("failed while finding the last successful deployment (%v)", err)
 		return r
 	}
 

--- a/pkg/app/piped/sourcedecrypter/decrypter.go
+++ b/pkg/app/piped/sourcedecrypter/decrypter.go
@@ -33,7 +33,7 @@ func DecryptSecrets(appDir string, enc config.SecretEncryption, dcr secretDecryp
 		return nil
 	}
 	if len(enc.EncryptedSecrets) == 0 {
-		return fmt.Errorf("no encrypted secret was specified to decrypt (%w)", enc.DecryptionTargets)
+		return fmt.Errorf("no encrypted secret was specified to decrypt (%q)", enc.DecryptionTargets)
 	}
 
 	secrets := make(map[string]string, len(enc.EncryptedSecrets))


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspends these two errors:
```console
pkg/app/piped/planpreview/builder.go:231:13: Sprintf call has error-wrapping directive %w, which is only supported by Errorf

pkg/app/piped/sourcedecrypter/decrypter.go:36:10: Errorf format %w has arg enc.DecryptionTargets of wrong type []string
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
