### PR TITLE
Fix display wrong value for version selector box

### DIFF
--- a/docs/assets/js/navbar-version-selector.js
+++ b/docs/assets/js/navbar-version-selector.js
@@ -4,11 +4,11 @@
     var Selector = {
         init: function () {
             $(document).ready(function () {
-                const paths = window.location.pathname.split("/").filter(p => p.startsWith('docs'))
+                const paths = window.location.pathname.split("/").filter(p => p.startsWith('docs-'))
                 if (paths.length === 0) {
                     return
                 }
-                const version = paths[0].replace('docs', '').replace("-", '');
+                const version = paths[0].replace('docs-', '');
                 if (version) {
                     $('.navbar-version-menu')[0].text = version;
                 };


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix version selector value 

<img width="1200" alt="Screen Shot 2021-10-14 at 2 00 17" src="https://user-images.githubusercontent.com/32532742/137181066-b89345a0-5116-45b6-b392-334879bb4df1.png">

**Which issue(s) this PR fixes**:

Follow #2628 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
