### PR TITLE
Fix bug always use the same livestate store in case of multiple cloudproviders of the same kind are set

### DIFF
--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -134,32 +134,37 @@ func (s *store) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
 	for i := range s.kubernetesStores {
+		cpName := i
 		group.Go(func() error {
-			return s.kubernetesStores[i].Run(ctx)
+			return s.kubernetesStores[cpName].Run(ctx)
 		})
 	}
 
 	for i := range s.terraformStores {
+		cpName := i
 		group.Go(func() error {
-			return s.terraformStores[i].Run(ctx)
+			return s.terraformStores[cpName].Run(ctx)
 		})
 	}
 
 	for i := range s.cloudrunStores {
+		cpName := i
 		group.Go(func() error {
-			return s.cloudrunStores[i].Run(ctx)
+			return s.cloudrunStores[cpName].Run(ctx)
 		})
 	}
 
 	for i := range s.lambdaStores {
+		cpName := i
 		group.Go(func() error {
-			return s.lambdaStores[i].Run(ctx)
+			return s.lambdaStores[cpName].Run(ctx)
 		})
 	}
 
 	for i := range s.ecsStores {
+		cpName := i
 		group.Go(func() error {
-			return s.ecsStores[i].Run(ctx)
+			return s.ecsStores[cpName].Run(ctx)
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, in case of multiple cloud-providers of the same kind are set in Piped configuration, only one store is used to handle the livestate's works. Even we have a map that contains multiple livestate stores pointed by the cloud-provider's name, we always pass the same key to get the last livestate store from the map.

Thanks @nghialv 😌
Ref: https://golang.org/doc/faq#closures_and_goroutines

**Which issue(s) this PR fixes**:

Fixes #2622

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bug always use the same livestate store in case of multiple cloud-providers of the same kind are set
```
