### PR TITLE
Enable using current username as default value for static admin edit form

### DIFF
--- a/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
+++ b/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
@@ -73,7 +73,6 @@ const StaticAdminDialog: FC<{
             id="username"
             name="username"
             value={formik.values.username}
-            defaultValue={formik.values.username}
             variant="outlined"
             margin="dense"
             label="Username"
@@ -210,12 +209,14 @@ export const StaticAdminForm: FC = memo(function StaticAdminForm() {
           </div>
         )}
       </div>
-      <StaticAdminDialog
-        open={isEdit}
-        currentUsername={currentUsername || ""}
-        onClose={handleClose}
-        onSubmit={handleSubmit}
-      />
+      {currentUsername && (
+        <StaticAdminDialog
+          open={isEdit}
+          currentUsername={currentUsername}
+          onClose={handleClose}
+          onSubmit={handleSubmit}
+        />
+      )}
     </>
   );
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Before

https://user-images.githubusercontent.com/32532742/138025488-76b7ba46-a792-4e25-9b30-293fa7433bbb.mp4

After

https://user-images.githubusercontent.com/32532742/138025508-a0d064b5-b1c4-4210-88dc-f916518376bd.mp4

Besides, this change suspends the error `ForwardRef(InputBase) contains an input of type text with both value and defaultValue props.` printed out in browser console by delay rendering StaticAdminForm until the current username fetched from storage is available instead of force use the defaultValue attribute of the TextForm component.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
