### PR TITLE
Enable share query url to non login user

### DIFF
--- a/pkg/app/web/src/routes.tsx
+++ b/pkg/app/web/src/routes.tsx
@@ -118,7 +118,7 @@ export const Routes: FC = () => {
           <Route
             path={PAGE_PATH_TOP}
             component={(props: RouteComponentProps) => {
-              localStorage.setItem(REDIRECT_PATH_KEY, props.location.pathname);
+              localStorage.setItem(REDIRECT_PATH_KEY, `${props.location.pathname}${props.location.search}`);
               return <Redirect to={`${PAGE_PATH_LOGIN}${props.location.search}`} />
             }}
           />


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, only the URL path is kept to redirect users after logged in, this change to ensure the query path is kept as well so that users will be redirected to the right shared URL after they logged in.

**Which issue(s) this PR fixes**:

Follow PR #2662 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
