### PR TITLE
Avoid stacked toast of the same reason

### DIFF
--- a/pkg/app/web/src/middlewares/thunk-error-handler.ts
+++ b/pkg/app/web/src/middlewares/thunk-error-handler.ts
@@ -12,7 +12,7 @@ export const thunkErrorHandler: Middleware = ({
   let res;
   try {
     res = await next(action);
-  } catch (err) {
+  } catch (err: any) {
     if (process.env.NODE_ENV === "development") {
       console.error(err);
     }
@@ -26,7 +26,7 @@ export const thunkErrorHandler: Middleware = ({
 
   if (isPlainAction(action)) {
     if (action.type.includes("rejected")) {
-      dispatch(addToast({ message: action.error.message, severity: "error" }));
+      dispatch(addToast({ message: action.error.message, severity: "error", issuer: action.type }));
     }
   }
 

--- a/pkg/app/web/src/modules/toasts/index.test.ts
+++ b/pkg/app/web/src/modules/toasts/index.test.ts
@@ -57,4 +57,30 @@ describe("toastsSlice reducer", () => {
       ids: [],
     });
   });
+
+  it(`should not add the same toast which cause by the same reason with the latest toast`, () => {
+    expect(
+      toastsSlice.reducer(
+        {
+          entities: {
+            "1": { id: "1", message: "toast message", severity: "error", issuer: "api/rejected" },
+          },
+          ids: ["1"],
+        },
+        {
+          type: addToast.type,
+          payload: {
+            message: "toast message",
+            severity: "error",
+            issuer: "api/rejected",
+          },
+        }
+      )
+    ).toEqual({
+      entities: {
+        "1": { id: "1", message: "toast message", severity: "error", issuer: "api/rejected" },
+      },
+      ids: ["1"],
+    })
+  });
 });

--- a/pkg/app/web/src/modules/toasts/index.ts
+++ b/pkg/app/web/src/modules/toasts/index.ts
@@ -10,6 +10,7 @@ export interface IToast {
   id: string;
   message: string;
   severity?: ToastSeverity;
+  issuer?: string;
   to?: string;
 }
 
@@ -26,13 +27,23 @@ export const toastsSlice = createSlice({
       action: PayloadAction<{
         message: string;
         severity?: ToastSeverity;
+        issuer?: string;
         to?: string;
       }>
     ) {
+      const toasts = selectAll(state);
+      const lastToast = toasts[toasts.length - 1];
+      if (
+        lastToast?.issuer === action.payload.issuer &&
+        lastToast?.message === action.payload.message
+      ) {
+        return;
+      }
       toastsAdapter.addOne(state, {
         id: `${Date.now()}`,
         message: action.payload.message,
         severity: action.payload.severity,
+        issuer: action.payload.issuer,
         to: action.payload.to,
       });
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Before

https://user-images.githubusercontent.com/32532742/138092609-4a40aac1-b4c3-4e03-b167-a8bfb8c4127c.mp4

After

https://user-images.githubusercontent.com/32532742/138092652-2d2ce35f-bdbd-4207-b1d6-ba7d580c562b.mp4

Due to the change in this PR, toast caused by the same reason (same issuer) and has the same message with the latest toast in the toast list will not be added to the toast list, that avoids annoying stacked toasts in case of errors occurred intervally.

**Which issue(s) this PR fixes**:

Fixes #2411 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```