### PR TITLE
Add an admin HTTP server to launcher

### DIFF
--- a/pkg/app/launcher/cmd/launcher/BUILD.bazel
+++ b/pkg/app/launcher/cmd/launcher/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pipe-cd/pipe/pkg/app/launcher/cmd/launcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/admin:go_default_library",
         "//pkg/app/api/service/pipedservice:go_default_library",
         "//pkg/cli:go_default_library",
         "//pkg/config:go_default_library",
@@ -20,6 +21,7 @@ go_library(
         "@com_google_cloud_go//secretmanager/apiv1:go_default_library",
         "@go_googleapis//google/cloud/secretmanager/v1:secretmanager_go_proto",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to run Launcher as a CloudRun service, it is required to have at least one HTTP server to serve incoming requests.
I tried to use the `admin` server of its Piped for that requirement but CloudRun is killing the Launcher container immediately because launching Piped and its server takes time. Since CloudRun is not providing any way to delay that readiness probe currently, so this PR adds another `admin` HTTP server into Launcher.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
