### PR TITLE
Add ability to notify all events to users when an event field is empty

### DIFF
--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -443,7 +443,7 @@ type DeploymentNotification struct {
 func (n *DeploymentNotification) FindSlackAccounts(event model.NotificationEventType) []string {
 	var as []string
 	for _, v := range n.Mentions {
-		if v.Event == "" {		
+		if v.Event == "" {
 			as = append(as, v.Slack...)
 		}
 		if e := "EVENT_" + v.Event; e == event.String() {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to mention the specified Slack accounts for all events when the event name was not given
```
