### PR TITLE
Add project info to notification events' messages

### DIFF
--- a/pkg/app/piped/notifier/notifier.go
+++ b/pkg/app/piped/notifier/notifier.go
@@ -102,9 +102,10 @@ func (n *Notifier) Run(ctx context.Context) error {
 	n.Notify(model.NotificationEvent{
 		Type: model.NotificationEventType_EVENT_PIPED_STARTED,
 		Metadata: &model.NotificationEventPipedStarted{
-			Id:      n.config.PipedID,
-			Name:    n.config.Name,
-			Version: version.Get().Version,
+			Id:        n.config.PipedID,
+			Name:      n.config.Name,
+			Version:   version.Get().Version,
+			ProjectId: n.config.ProjectID,
 		},
 	})
 
@@ -118,9 +119,10 @@ func (n *Notifier) Run(ctx context.Context) error {
 	n.Notify(model.NotificationEvent{
 		Type: model.NotificationEventType_EVENT_PIPED_STOPPED,
 		Metadata: &model.NotificationEventPipedStopped{
-			Id:      n.config.PipedID,
-			Name:    n.config.Name,
-			Version: version.Get().Version,
+			Id:        n.config.PipedID,
+			Name:      n.config.Name,
+			Version:   version.Get().Version,
+			ProjectId: n.config.ProjectID,
 		},
 	})
 

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -117,10 +117,12 @@ message NotificationEventPipedStarted {
     string id = 1 [(validate.rules).string.min_len = 1];
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
+    string project_id = 4 [(validate.rules).string.min_len = 1];
 }
 
 message NotificationEventPipedStopped {
     string id = 1 [(validate.rules).string.min_len = 1];
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
+    string project_id = 4 [(validate.rules).string.min_len = 1];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of working on multiple projects (just as us on the PipeCD development environment), this project information would help. Also, we can use it as a query value for the link to the PipeCD console with `?project=` key to ensure redirection to the right project for the notified events.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add Project information to notification events' messages
```
