### PR TITLE
Linebreak for recently deployed version info in applications list

### DIFF
--- a/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -30,6 +30,10 @@ const useStyles = makeStyles((theme) => ({
   disabled: {
     background: theme.palette.grey[200],
   },
+  version: {
+    maxWidth: 300,
+    wordBreak: "break-word",
+  },
 }));
 
 const EmptyDeploymentData: FC = () => (
@@ -120,7 +124,7 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
           <TableCell>{env?.name}</TableCell>
           {recentlyDeployment ? (
             <>
-              <TableCell>
+              <TableCell className={clsx(classes.version)}>
                 {recentlyDeployment.version.includes(',') ? (
                   recentlyDeployment.version.split(',').map((v) => (
                     <>


### PR DESCRIPTION
**What this PR does / why we need it**:

Before

<img width="1792" alt="Screen Shot 2021-10-23 at 15 44 10" src="https://user-images.githubusercontent.com/32532742/138545977-a2b7253f-5e69-4c3b-8b97-3ce43d84543b.png">

After

<img width="1792" alt="Screen Shot 2021-10-23 at 15 43 12" src="https://user-images.githubusercontent.com/32532742/138545980-b7e1e771-20a9-4634-8616-7814aa8588fa.png">

with long version string

<img width="1792" alt="Screen Shot 2021-10-23 at 16 02 13" src="https://user-images.githubusercontent.com/32532742/138546348-3a9f26f5-8669-4b59-8d8e-9f6b869f7204.png">

**Which issue(s) this PR fixes**:

Fixes #2668

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
