### PR TITLE
Make piped only allows config-data in base64 format

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -106,7 +106,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&p.configFile, "config-file", p.configFile, "The path to the configuration file.")
-	// TODO: Remove config-data and config-gcp-secret once launcher component released.
 	cmd.Flags().StringVar(&p.configData, "config-data", p.configData, "The base64 encoded string of the configuration data.")
 	cmd.Flags().StringVar(&p.configGCPSecret, "config-gcp-secret", p.configGCPSecret, "The resource ID of secret that contains Piped config and be stored in GCP SecretManager.")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Passing raw JSON/YAML config data for piped as its input directly could cause a lot of misoperation, so this PR changes to accept base64 encoded data instead.

**Which issue(s) this PR fixes**:

Fixes #2565
Follow PR #2686 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Configuration passed as piped `--config-data` flag's value must be in base64 format
```
