### PR TITLE
Empower WebAPI to filter applications by tags

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -859,8 +859,20 @@ func (a *WebAPI) ListApplications(ctx context.Context, req *webservice.ListAppli
 		return nil, status.Error(codes.Internal, "Failed to get applications")
 	}
 
+	if len(req.Options.Tags) == 0 {
+		return &webservice.ListApplicationsResponse{
+			Applications: apps,
+		}, nil
+	}
+
+	filtered := make([]*model.Application, 0, len(apps))
+	for _, a := range apps {
+		if a.ContainTags(req.Options.Tags) {
+			filtered = append(filtered, a)
+		}
+	}
 	return &webservice.ListApplicationsResponse{
-		Applications: apps,
+		Applications: filtered,
 	}, nil
 }
 

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -49,3 +49,20 @@ func (s ApplicationSyncState) HasChanged(next ApplicationSyncState) bool {
 func MakeApplicationURL(baseURL, applicationID string) string {
 	return fmt.Sprintf("%s/applications/%s", strings.TrimSuffix(baseURL, "/"), applicationID)
 }
+
+// ContainTags checks if it has all the given tags.
+func (d *Application) ContainTags(tags []string) bool {
+	if len(d.Tags) < len(tags) {
+		return false
+	}
+	tagMap := make(map[string]struct{}, len(d.Tags))
+	for i := range d.Tags {
+		tagMap[d.Tags[i]] = struct{}{}
+	}
+	for _, tag := range tags {
+		if _, ok := tagMap[tag]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/model/application_test.go
+++ b/pkg/model/application_test.go
@@ -47,3 +47,37 @@ func TestMakeApplicationURL(t *testing.T) {
 		})
 	}
 }
+
+func TestApplication_ContainTags(t *testing.T) {
+	testcases := []struct {
+		name string
+		app  *Application
+		tags []string
+		want bool
+	}{
+		{
+			name: "all given tags aren't contained",
+			app:  &Application{Tags: []string{"foo"}},
+			tags: []string{"foo", "bar"},
+			want: false,
+		},
+		{
+			name: "a tag is contained",
+			app:  &Application{Tags: []string{"foo", "bar"}},
+			tags: []string{"foo"},
+			want: true,
+		},
+		{
+			name: "all tags are contained",
+			app:  &Application{Tags: []string{"foo", "bar", "baz"}},
+			tags: []string{"baz", "foo", "bar"},
+			want: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.app.ContainTags(tc.tags)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows WebAPI to filter to return only deployments that have all the needed tags.
Unlike deployments, it currently doesn't support any kind of paging, so it's enough to just filter once.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
