### PR TITLE
Fix typo environment name in docs

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/installation/installing-on-fargate.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/installation/installing-on-fargate.md
@@ -101,7 +101,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/launcher launcher --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/launcher launcher --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {
@@ -136,7 +136,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/piped piped --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/piped piped --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {

--- a/docs/content/en/docs-v0.21.x/operator-manual/piped/installation/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.21.x/operator-manual/piped/installation/installing-on-fargate.md
@@ -101,7 +101,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/launcher launcher --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/launcher launcher --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {
@@ -136,7 +136,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/piped piped --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/piped piped --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {

--- a/docs/content/en/docs/operator-manual/piped/installation/installing-on-fargate.md
+++ b/docs/content/en/docs/operator-manual/piped/installation/installing-on-fargate.md
@@ -101,7 +101,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/launcher launcher --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/launcher launcher --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {
@@ -136,7 +136,7 @@ description: >
         "-c"
       ],
       "command": [
-        "/bin/sh -c \"/piped piped --config-data=$(echo $configData)\""
+        "/bin/sh -c \"/piped piped --config-data=$(echo $CONFIG_DATA)\""
       ],
       "secrets": [
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
