### PR TITLE
Ensure to pass application's tags to deployment when triggering

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -172,6 +172,7 @@ func buildDeployment(
 		},
 		GitPath:       app.GitPath,
 		CloudProvider: app.CloudProvider,
+		Tags:          app.Tags,
 		Status:        model.DeploymentStatus_DEPLOYMENT_PENDING,
 		StatusReason:  "The deployment is waiting to be planned",
 		Metadata:      metadata,


### PR DESCRIPTION
**What this PR does / why we need it**:
For filtering deployments by tags.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
