### PR TITLE
Make prepare-version-docs command run multiple times

### DIFF
--- a/hack/prepare-version-docs.sh
+++ b/hack/prepare-version-docs.sh
@@ -25,7 +25,7 @@ echo "Prepare version docs"
 
 CONTENT_DIR=docs/content/en
 
-# Update $CONTENT_DIR/docs
+# Update stable docs at $CONTENT_DIR/docs
 rm -rf $CONTENT_DIR/docs
 cp -rf $CONTENT_DIR/docs-dev $CONTENT_DIR/docs
 cat <<EOT > $CONTENT_DIR/docs/_index.md
@@ -39,6 +39,8 @@ menu:
 ---
 EOT
 
+# Remove $CONTENT_DIR/docs-$1 if existed
+rm -rf $CONTENT_DIR/docs-$1
 # Create new $CONTENT_DIR/docs-$1
 cp -rf $CONTENT_DIR/docs-dev $CONTENT_DIR/docs-$1
 cp -rf docs/themes/docsy/layouts/docs/ docs/layouts/docs-$1
@@ -50,15 +52,21 @@ type: docs
 ---
 EOT
 
-# Update docs/config.toml
-tail -r docs/config.toml | tail -n +5 | tail -r >> docs/config.toml.tmp
-cat <<EOT >> docs/config.toml.tmp
+# Update docs/config.toml in case this version docs is not yet existed
+if grep -Fq "$1" docs/config.toml
+then
+  echo "Docs for version $1 existed, updating..."
+else
+  echo "Docs for version $1 has not existed, adding..."
+  tail -r docs/config.toml | tail -n +5 | tail -r >> docs/config.toml.tmp
+  cat <<EOT >> docs/config.toml.tmp
 
 [[params.versions]]
   version = "$1"
   url = "/docs-$1/"
 EOT
-tail -4 docs/config.toml >> docs/config.toml.tmp
-mv docs/config.toml.tmp docs/config.toml
+  tail -4 docs/config.toml >> docs/config.toml.tmp
+  mv docs/config.toml.tmp docs/config.toml
+fi
 
 echo "Version docs has been prepared successfully at $CONTENT_DIR/docs-$1/"


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, once we use the command `make prepare-version-docs`, it generates `/docs-$1` directory and in case we want to update the docs for that version $1, we have to do it manually both to `/docs-dev` and `/docs-$1` to keep it's consistent. By this change, the flow will be
- Update `/docs-dev`
- Run `make prepare-version-docs version=$1` to dump version docs and mark it as stable version docs (sync with `/docs`)
- In case we want to update `/docs-$1` or in case new features are added in minor version (keep latest version docs same as $1), just update the `/docs-dev` and re-run `make  prepare-version-docs version=$1` command, it will ensure all changes on dev be synced with the `/docs` and `/docs-$1`

Note:
- if the docs you create are for features that have not yet been released, only update the `/docs-dev` and don't run this `make prepare-version-docs` command.
- the existed `make sync-stable-docs` can sync content between `/docs` and `/docs-$1` but we have no way to know what should be kept or removed applied to the `/docs-dev`, so that command should only be used to confirm the synced status between `/docs` and `/docs-$1`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
