### PR TITLE
Add Diff function for CloudRun drift detector

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "cache.go",
         "client.go",
         "cloudrun.go",
+        "diff.go",
         "servicemanifest.go",
     ],
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/cloudprovider/cloudrun",
@@ -13,6 +14,7 @@ go_library(
     deps = [
         "//pkg/cache:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
@@ -27,6 +29,14 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["servicemanifest_test.go"],
+    srcs = [
+        "diff_test.go",
+        "servicemanifest_test.go",
+    ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    deps = [
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/app/piped/cloudprovider/cloudrun/diff.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/diff.go
@@ -1,0 +1,129 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pipe-cd/pipecd/pkg/diff"
+)
+
+const (
+	diffCommand = "diff"
+)
+
+type DiffResult struct {
+	Diff *diff.Result
+	Old  ServiceManifest
+	New  ServiceManifest
+}
+
+func Diff(old, new ServiceManifest, opts ...diff.Option) (*DiffResult, error) {
+	d, err := diff.DiffUnstructureds(*old.u, *new.u, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if !d.HasDiff() {
+		return &DiffResult{}, nil
+	}
+	ret := &DiffResult{
+		Old:  old,
+		New:  new,
+		Diff: d,
+	}
+	return ret, nil
+}
+
+type DiffRenderOptions struct {
+	// If true, use "diff" command to render.
+	UseDiffCommand bool
+}
+
+func (d *DiffResult) Render(opt DiffRenderOptions) string {
+	var b strings.Builder
+	opts := []diff.RenderOption{
+		diff.WithLeftPadding(1),
+	}
+	renderer := diff.NewRenderer(opts...)
+	if !opt.UseDiffCommand {
+		b.WriteString(renderer.Render(d.Diff.Nodes()))
+	} else {
+		d, err := diffByCommand(diffCommand, d.Old, d.New)
+		if err != nil {
+			b.WriteString(fmt.Sprintf("An error occurred while rendering diff (%v)", err))
+		} else {
+			b.Write(d)
+		}
+	}
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func diffByCommand(command string, old, new ServiceManifest) ([]byte, error) {
+	oldBytes, err := old.YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	newBytes, err := new.YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	oldFile, err := os.CreateTemp("", "old")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(oldFile.Name())
+	if _, err := oldFile.Write(oldBytes); err != nil {
+		return nil, err
+	}
+
+	newFile, err := os.CreateTemp("", "new")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(newFile.Name())
+	if _, err := newFile.Write(newBytes); err != nil {
+		return nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(command, "-u", "-N", oldFile.Name(), newFile.Name())
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if stdout.Len() > 0 {
+		// diff exits with a non-zero status when the files don't match.
+		// Ignore that failure as long as we get output.
+		err = nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to run diff, err = %w, %s", err, stderr.String())
+	}
+
+	// Remote two-line header from output.
+	data := bytes.TrimSpace(stdout.Bytes())
+	rows := bytes.SplitN(data, []byte("\n"), 3)
+	if len(rows) == 3 {
+		return rows[2], nil
+	}
+	return data, nil
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/diff.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/diff.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The PipeCD Authors.
+// Copyright 2022 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ type DiffResult struct {
 	Diff *diff.Result
 	Old  ServiceManifest
 	New  ServiceManifest
+}
+
+func (d *DiffResult) NoChange() bool {
+	return len(d.Diff.Nodes()) == 0
 }
 
 func Diff(old, new ServiceManifest, opts ...diff.Option) (*DiffResult, error) {
@@ -119,7 +123,7 @@ func diffByCommand(command string, old, new ServiceManifest) ([]byte, error) {
 		return nil, fmt.Errorf("failed to run diff, err = %w, %s", err, stderr.String())
 	}
 
-	// Remote two-line header from output.
+	// Remove two-line header from output.
 	data := bytes.TrimSpace(stdout.Bytes())
 	rows := bytes.SplitN(data, []byte("\n"), 3)
 	if len(rows) == 3 {

--- a/pkg/app/piped/cloudprovider/cloudrun/diff_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/diff_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The PipeCD Authors.
+// Copyright 2022 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,23 @@ func TestDiff(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func TestDiff_Render(t *testing.T) {
+func TestDiffResult_NoChange(t *testing.T) {
+	old, err := loadServiceManifest("testdata/old_manifest.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, old)
+
+	new, err := loadServiceManifest("testdata/new_manifest.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, new)
+
+	result, err := Diff(old, new)
+	require.NoError(t, err)
+
+	got := result.NoChange()
+	require.False(t, got)
+}
+
+func TestDiffResult_Render(t *testing.T) {
 	old, err := loadServiceManifest("testdata/old_manifest.yaml")
 	require.NoError(t, err)
 

--- a/pkg/app/piped/cloudprovider/cloudrun/diff_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/diff_test.go
@@ -1,0 +1,143 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiff(t *testing.T) {
+	old, err := loadServiceManifest("testdata/old_manifest.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, old)
+
+	new, err := loadServiceManifest("testdata/new_manifest.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, new)
+
+	// Have diff.
+	got, err := Diff(old, new)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	// Don't have diff.
+	got, err = Diff(old, old)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestDiff_Render(t *testing.T) {
+	old, err := loadServiceManifest("testdata/old_manifest.yaml")
+	require.NoError(t, err)
+
+	new, err := loadServiceManifest("testdata/new_manifest.yaml")
+	require.NoError(t, err)
+
+	result, err := Diff(old, new)
+	require.NoError(t, err)
+
+	// Not use diff command
+	opt := DiffRenderOptions{}
+	got := result.Render(opt)
+	want := `  spec:
+    template:
+      spec:
+        containers:
+          -
+            #spec.template.spec.containers.0.image
+-           image: gcr.io/pipecd/helloworld:v0.6.0
++           image: gcr.io/pipecd/helloworld:v0.5.0
+
+
+`
+	require.Equal(t, want, got)
+
+	// Use diff command
+	opt = DiffRenderOptions{UseDiffCommand: true}
+	got = result.Render(opt)
+	want = `@@ -18,7 +18,7 @@
+       containers:
+       - args:
+         - server
+-        image: gcr.io/pipecd/helloworld:v0.6.0
++        image: gcr.io/pipecd/helloworld:v0.5.0
+         ports:
+         - containerPort: 9085
+           name: http1
+`
+	require.Equal(t, want, got)
+}
+
+func TestDiffByCommand(t *testing.T) {
+	testcases := []struct {
+		name        string
+		command     string
+		oldManifest string
+		newManifest string
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name:        "no command",
+			command:     "non-existent-diff",
+			oldManifest: "testdata/old_manifest.yaml",
+			newManifest: "testdata/old_manifest.yaml",
+			expected:    "",
+			expectedErr: true,
+		},
+		{
+			name:        "no diff",
+			command:     diffCommand,
+			oldManifest: "testdata/old_manifest.yaml",
+			newManifest: "testdata/old_manifest.yaml",
+			expected:    "",
+		},
+		{
+			name:        "has diff",
+			command:     diffCommand,
+			oldManifest: "testdata/old_manifest.yaml",
+			newManifest: "testdata/new_manifest.yaml",
+			expected: `@@ -18,7 +18,7 @@
+       containers:
+       - args:
+         - server
+-        image: gcr.io/pipecd/helloworld:v0.6.0
++        image: gcr.io/pipecd/helloworld:v0.5.0
+         ports:
+         - containerPort: 9085
+           name: http1`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			old, err := loadServiceManifest(tc.oldManifest)
+			require.NoError(t, err)
+
+			new, err := loadServiceManifest(tc.newManifest)
+			require.NoError(t, err)
+
+			got, err := diffByCommand(tc.command, old, new)
+			if tc.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expected, string(got))
+		})
+	}
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/testdata/new_manifest.yaml
+++ b/pkg/app/piped/cloudprovider/cloudrun/testdata/new_manifest.yaml
@@ -1,0 +1,32 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+      - image: gcr.io/pipecd/helloworld:v0.5.0
+        args:
+        - server
+        ports:
+        - name: http1
+          containerPort: 9085
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+  traffic:
+  - revisionName: helloworld-v050-0b13751
+    percent: 100

--- a/pkg/app/piped/cloudprovider/cloudrun/testdata/old_manifest.yaml
+++ b/pkg/app/piped/cloudprovider/cloudrun/testdata/old_manifest.yaml
@@ -1,0 +1,32 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+      - image: gcr.io/pipecd/helloworld:v0.6.0
+        args:
+        - server
+        ports:
+        - name: http1
+          containerPort: 9085
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+  traffic:
+  - revisionName: helloworld-v050-0b13751
+    percent: 100

--- a/pkg/app/piped/cloudprovider/kubernetes/diff.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff.go
@@ -194,7 +194,7 @@ func diffByCommand(command string, old, new Manifest) ([]byte, error) {
 		return nil, fmt.Errorf("failed to run diff, err = %w, %s", err, stderr.String())
 	}
 
-	// Remote two-line header from output.
+	// Remove two-line header from output.
 	data := bytes.TrimSpace(stdout.Bytes())
 	rows := bytes.SplitN(data, []byte("\n"), 3)
 	if len(rows) == 3 {

--- a/pkg/app/piped/cloudprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/manifest.go
@@ -226,7 +226,7 @@ func ParseManifests(data string) ([]Manifest, error) {
 	)
 
 	for _, part := range parts {
-		//	Ignore all the cases where no content between separator.
+		// Ignore all the cases where no content between separator.
 		part = strings.TrimSpace(part)
 		if len(part) == 0 {
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This function is used to extract the diff between headManifest and liveManifest by CloudRun detector.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
