### PR TITLE
Enable to set event status

### DIFF
--- a/pkg/app/piped/eventwatcher/BUILD.bazel
+++ b/pkg/app/piped/eventwatcher/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/app/server/service/pipedservice:go_default_library",
+        "//pkg/backoff:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -191,7 +191,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 				)
 				continue
 			}
-			if err := w.updateValues(ctx, repo, cfg.Events, commitMsg); err != nil {
+			if err := w.updateValues(ctx, repo, repoCfg.RepoID, cfg.Events, commitMsg); err != nil {
 				w.logger.Error("failed to update the values",
 					zap.String("repo-id", repoCfg.RepoID),
 					zap.Error(err),
@@ -215,7 +215,7 @@ func (w *watcher) cloneRepo(ctx context.Context, repoCfg config.PipedRepository)
 }
 
 // updateValues inspects all Event-definition and pushes the changes to git repo if there is.
-func (w *watcher) updateValues(ctx context.Context, repo git.Repo, events []config.EventWatcherEvent, commitMsg string) error {
+func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string, events []config.EventWatcherEvent, commitMsg string) error {
 	// Copy the repo to another directory to modify local file to avoid reverting previous changes.
 	tmpDir, err := os.MkdirTemp(w.workingDir, "repo")
 	if err != nil {
@@ -248,7 +248,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, events []conf
 		eventResults = append(eventResults, &pipedservice.ReportEventStatusesRequest_Event{
 			Id:                latestEvent.Id,
 			Status:            model.EventStatus_EVENT_SUCCESS,
-			StatusDescription: fmt.Sprintf("Successfully updated %d files", len(e.Replacements)),
+			StatusDescription: fmt.Sprintf("Successfully updated %d files in the %q repository", len(e.Replacements), repoID),
 		})
 	}
 

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -233,7 +233,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, events []conf
 		if !ok {
 			continue
 		}
-		if latestEvent.Handled {
+		if latestEvent.IsHandled() {
 			continue
 		}
 		if err := w.commitFiles(ctx, latestEvent.Data, e, tmpRepo, commitMsg); err != nil {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -248,7 +248,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, events []conf
 		eventResults = append(eventResults, &pipedservice.ReportEventStatusesRequest_Event{
 			Id:                latestEvent.Id,
 			Status:            model.EventStatus_EVENT_SUCCESS,
-			StatusDescription: fmt.Sprintf("Successfully handled by %q piped", w.config.PipedID),
+			StatusDescription: fmt.Sprintf("Successfully updated %d files", len(e.Replacements)),
 		})
 	}
 

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -400,12 +400,14 @@ func (a *API) RegisterEvent(ctx context.Context, req *apiservice.RegisterEventRe
 	id := uuid.New().String()
 
 	err = a.eventStore.AddEvent(ctx, model.Event{
-		Id:        id,
-		Name:      req.Name,
-		Data:      req.Data,
-		Labels:    req.Labels,
-		EventKey:  model.MakeEventKey(req.Name, req.Labels),
-		ProjectId: key.ProjectId,
+		Id:                id,
+		Name:              req.Name,
+		Data:              req.Data,
+		Labels:            req.Labels,
+		EventKey:          model.MakeEventKey(req.Name, req.Labels),
+		ProjectId:         key.ProjectId,
+		Status:            model.EventStatus_EVENT_NOT_HANDLED,
+		StatusDescription: fmt.Sprintf("It is going to be replaced by %s", req.Data),
 	})
 	if errors.Is(err, datastore.ErrAlreadyExists) {
 		return nil, status.Error(codes.AlreadyExists, "The event already exists")

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -881,14 +881,15 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 	}, nil
 }
 
+// Deprecated. This is only for the old Piped agents.
 func (a *PipedAPI) ReportEventsHandled(ctx context.Context, req *pipedservice.ReportEventsHandledRequest) (*pipedservice.ReportEventsHandledResponse, error) {
-	_, _, _, err := rpcauth.ExtractPipedToken(ctx)
+	_, pipedID, _, err := rpcauth.ExtractPipedToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, id := range req.EventIds {
-		if err := a.eventStore.MarkEventHandled(ctx, id); err != nil {
+		if err := a.eventStore.UpdateEventStatus(ctx, id, model.EventStatus_EVENT_SUCCESS, fmt.Sprintf("successfully handled by %q piped", pipedID)); err != nil {
 			switch err {
 			case datastore.ErrNotFound:
 				return nil, status.Errorf(codes.NotFound, "event %q is not found", id)
@@ -902,6 +903,29 @@ func (a *PipedAPI) ReportEventsHandled(ctx context.Context, req *pipedservice.Re
 		}
 	}
 	return &pipedservice.ReportEventsHandledResponse{}, nil
+}
+
+func (a *PipedAPI) ReportEventStatuses(ctx context.Context, req *pipedservice.ReportEventStatusesRequest) (*pipedservice.ReportEventStatusesResponse, error) {
+	_, _, _, err := rpcauth.ExtractPipedToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range req.Events {
+		// TODO: For success status, change all previous events with the same event key to OUTDATED
+		if err := a.eventStore.UpdateEventStatus(ctx, e.Id, e.Status, e.StatusDescription); err != nil {
+			switch err {
+			case datastore.ErrNotFound:
+				return nil, status.Errorf(codes.NotFound, "event %q is not found", e.Id)
+			default:
+				a.logger.Error("failed to update event status",
+					zap.String("event-id", e.Id),
+					zap.Error(err),
+				)
+				return nil, status.Errorf(codes.Internal, "failed to update event status %q", e.Id)
+			}
+		}
+	}
+	return &pipedservice.ReportEventStatusesResponse{}, nil
 }
 
 func (a *PipedAPI) GetLatestAnalysisResult(ctx context.Context, req *pipedservice.GetLatestAnalysisResultRequest) (*pipedservice.GetLatestAnalysisResultResponse, error) {

--- a/pkg/app/server/service/pipedservice/service.proto
+++ b/pkg/app/server/service/pipedservice/service.proto
@@ -146,7 +146,10 @@ service PipedService {
     // ListEvents returns a list of Events inside the given range.
     rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {}
     // ReportEventHandled marks the given all events as handled.
+    // Deprecated. This is only for the old Piped agents.
     rpc ReportEventsHandled(ReportEventsHandledRequest) returns (ReportEventsHandledResponse) {}
+    // ReportEventStatuses reports a status list of events.
+    rpc ReportEventStatuses(ReportEventStatusesRequest) returns (ReportEventStatusesResponse) {}
 
     // GetLatestAnalysisResult returns the most successful analysis result.
     rpc GetLatestAnalysisResult(GetLatestAnalysisResultRequest) returns (GetLatestAnalysisResultResponse) {}
@@ -447,6 +450,18 @@ message ReportEventsHandledRequest {
 }
 
 message ReportEventsHandledResponse {
+}
+
+message ReportEventStatusesRequest {
+    message Event {
+        string id = 1 [(validate.rules).string.min_len = 1];
+        model.EventStatus status = 2 [(validate.rules).enum.defined_only = true];
+        string status_description = 3 [(validate.rules).string.min_len = 1];
+    }
+    repeated Event events = 1;
+}
+
+message ReportEventStatusesResponse {
 }
 
 message GetLatestAnalysisResultRequest {

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -88,9 +88,10 @@ func (s *eventStore) UpdateEventStatus(ctx context.Context, eventID string, stat
 		event := e.(*model.Event)
 		event.Status = status
 		event.StatusDescription = statusDescription
-		if status == model.EventStatus_EVENT_SUCCESS || status == model.EventStatus_EVENT_FAILURE {
-			event.Handled = true
+		if event.IsHandled() {
 			event.HandledAt = s.nowFunc().Unix()
+			// For older Piped agents, this is required.
+			event.Handled = true
 		}
 		return nil
 	})

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -24,6 +24,10 @@ import (
 
 var hashFunc = sha256.New
 
+func (e *Event) IsHandled() bool {
+	return e.Status == EventStatus_EVENT_SUCCESS || e.Status == EventStatus_EVENT_FAILURE
+}
+
 // MakeEventKey builds a fixed-length identifier based on the given name
 // and labels. It returns the exact same string as long as both are the same.
 func MakeEventKey(name string, labels map[string]string) string {

--- a/pkg/model/event.proto
+++ b/pkg/model/event.proto
@@ -19,6 +19,13 @@ option go_package = "github.com/pipe-cd/pipecd/pkg/model";
 
 import "validate/validate.proto";
 
+enum EventStatus {
+    EVENT_NOT_HANDLED = 0;
+    EVENT_SUCCESS = 1;
+    EVENT_FAILURE = 2;
+    EVENT_OUTDATED = 3;
+}
+
 message Event {
     // The generated unique identifier.
     string id = 1 [(validate.rules).string.min_len = 1];
@@ -35,6 +42,9 @@ message Event {
     string event_key = 6 [(validate.rules).string.min_len = 1];
     // True if it have been handled.
     bool handled = 7;
+    // The handle status of event.
+    EventStatus status = 8 [(validate.rules).enum.defined_only = true];
+    string status_description = 9;
 
     // Unix time when the event was handled.
     int64 handled_at = 13;

--- a/pkg/model/event.proto
+++ b/pkg/model/event.proto
@@ -41,7 +41,7 @@ message Event {
     // A fixed-length identifier consists of its own name and labels.
     string event_key = 6 [(validate.rules).string.min_len = 1];
     // True if it have been handled.
-    bool handled = 7;
+    bool handled = 7 [deprecated = true];
     // The handle status of event.
     EventStatus status = 8 [(validate.rules).enum.defined_only = true];
     string status_description = 9;


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to visualize events, Piped needs to update event statuses based on the result. That's what this does.
Primarily this does:
- add a new rpc `ReportEventStatuses` to PipedAPI
- ensure Piped to update event statuses with the above rpc


**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/2611

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
EventWatcher no longer tries to process failing events indefinitely
```
