### PR TITLE
Fix the insecure parameter in piped's manifest

### DIFF
--- a/manifests/piped/templates/_helpers.tpl
+++ b/manifests/piped/templates/_helpers.tpl
@@ -142,12 +142,13 @@ A set of args for Launcher.
 {{- end }}
 - --metrics={{ .Values.args.metrics }}
 - --enable-default-kubernetes-cloud-provider={{ .Values.args.enableDefaultKubernetesCloudProvider }}
-- --insecure={{ .Values.args.insecure }}
 - --log-encoding={{ .Values.args.logEncoding }}
 - --add-login-user-to-passwd={{ .Values.args.addLoginUserToPasswd }}
-{{- end }}
 {{- if .Values.quickstart.enabled }}
 - --insecure=true
+{{- else }}
+- --insecure={{ .Values.args.insecure }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -158,7 +159,11 @@ A set of args for Piped.
 - --config-file=/etc/piped-config/{{ .Values.config.fileName }}
 - --metrics={{ .Values.args.metrics }}
 - --enable-default-kubernetes-cloud-provider={{ .Values.args.enableDefaultKubernetesCloudProvider }}
-- --insecure={{ .Values.args.insecure }}
 - --log-encoding={{ .Values.args.logEncoding }}
 - --add-login-user-to-passwd={{ .Values.args.addLoginUserToPasswd }}
+{{- if .Values.quickstart.enabled }}
+- --insecure=true
+{{- else }}
+- --insecure={{ .Values.args.insecure }}
+{{- end }}
 {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -4,6 +4,7 @@ image:
 args:
   metrics: true
   enableDefaultKubernetesCloudProvider: true
+  insecure: false
   # One of "humanize", "json", or "console" is available.
   logEncoding: humanize
   # Specifies whether it adds logged-in user to /etc/passwd at runtime.


### PR DESCRIPTION
**What this PR does / why we need it**:
Restored args.insecure, which was removed by the fix in this [commit](https://github.com/pipe-cd/pipecd/commit/e83656bb9f6f3f7b4e762d405d74334581dd3321#diff-8fdfcfc509b32270e8e85cec9084512ccb34a8c87c8a8f48e35d6e3096f5495c).
Also fixed to set insecure=true for quickstart.

**Which issue(s) this PR fixes**:

Fixes #3071

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
