### PR TITLE
Fix signal stop

### DIFF
--- a/dockers/chart-releaser/DOCKER_BUILD
+++ b/dockers/chart-releaser/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.2.0
+version: 1.2.1
 registry: gcr.io/pipecd/chart-releaser

--- a/dockers/chart-releaser/DOCKER_BUILD
+++ b/dockers/chart-releaser/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.2.1
+version: 1.3.0
 registry: gcr.io/pipecd/chart-releaser

--- a/dockers/chart-releaser/Dockerfile
+++ b/dockers/chart-releaser/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine3.10 AS builder
+FROM golang:1.17.6-alpine3.15 AS builder
 COPY main.go /pipecd/main.go
 ADD install-helm.sh /installer/install-helm.sh
 RUN apk --no-cache add curl bash
@@ -8,7 +8,7 @@ RUN cd /pipecd && \
     go mod tidy && \
     go build -o chart-releaser main.go
 
-FROM alpine:3.10
+FROM alpine:3.15
 COPY --from=builder /pipecd/chart-releaser ./
 COPY --from=builder /helm /usr/local/bin
 RUN apk --no-cache add ca-certificates && \

--- a/dockers/chart-releaser/Dockerfile
+++ b/dockers/chart-releaser/Dockerfile
@@ -5,6 +5,7 @@ RUN apk --no-cache add curl bash
 RUN /installer/install-helm.sh
 RUN cd /pipecd && \
     go mod init pipecd.dev/chart-releaser && \
+    go mod tidy && \
     go build -o chart-releaser main.go
 
 FROM alpine:3.10

--- a/dockers/chart-releaser/main.go
+++ b/dockers/chart-releaser/main.go
@@ -68,17 +68,9 @@ func main() {
 }
 
 func run() error {
-	pctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	ctx, stop := signal.NotifyContext(pctx, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
-	defer stop()
-
-	go func() {
-		log.Println("Waiting for signals...")
-		<-ctx.Done()
-		log.Println("Received signal, exiting...")
-		stop()
-	}()
+	ctx, _ = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 
 	// Initialize gcs client.
 	var options []option.ClientOption
@@ -95,6 +87,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("unable to create a temporary working directory: %v", err)
 	}
+	defer os.RemoveAll(workingDir)
 	log.Printf("Successfully created a temporary working directory: %s", workingDir)
 
 	// Download current index.yaml file from storage.

--- a/dockers/chart-releaser/main.go
+++ b/dockers/chart-releaser/main.go
@@ -62,6 +62,12 @@ func init() {
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Thie function is called `log.Fatalf`, if err is catched. `log.Fatalf` calls `os.Exit(n)` and `os.Exit` is defined `deferred functions are not run.`
FYI https://pkg.go.dev/os#Exit

As tha above reason, if `log.Fatalf` is called, `defer signal.Stop(ch)` will not run.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
