### PR TITLE
Empower WebAPI to list events

### DIFF
--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -271,7 +271,7 @@ func (s *server) run(ctx context.Context, input cli.Input) error {
 			return err
 		}
 
-		service := grpcapi.NewWebAPI(ctx, ds, fs, sls, alss, cmds, is, statCache, rd, cfg.ProjectMap(), encryptDecrypter, input.Logger)
+		service := grpcapi.NewWebAPI(ctx, ds, sls, alss, cmds, is, statCache, rd, cfg.ProjectMap(), encryptDecrypter, input.Logger)
 		opts := []rpc.Option{
 			rpc.WithPort(s.webAPIPort),
 			rpc.WithGracePeriod(s.gracePeriod),

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -801,7 +801,7 @@ func (a *PipedAPI) GetLatestEvent(ctx context.Context, req *pipedservice.GetLate
 			},
 		},
 	}
-	events, err := a.eventStore.ListEvents(ctx, opts)
+	events, _, err := a.eventStore.ListEvents(ctx, opts)
 	if err != nil {
 		a.logger.Error("failed to list events", zap.Error(err))
 		return nil, status.Error(codes.Internal, "failed to list event")
@@ -871,7 +871,7 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 		}
 	}
 
-	events, err := a.eventStore.ListEvents(ctx, opts)
+	events, _, err := a.eventStore.ListEvents(ctx, opts)
 	if err != nil {
 		a.logger.Error("failed to list events", zap.Error(err))
 		return nil, status.Error(codes.Internal, "failed to list events")

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -59,6 +59,7 @@ type WebAPI struct {
 	pipedStore                datastore.PipedStore
 	projectStore              datastore.ProjectStore
 	apiKeyStore               datastore.APIKeyStore
+	eventStore                datastore.EventStore
 	stageLogStore             stagelogstore.Store
 	applicationLiveStateStore applicationlivestatestore.Store
 	commandStore              commandstore.Store
@@ -81,7 +82,6 @@ type WebAPI struct {
 func NewWebAPI(
 	ctx context.Context,
 	ds datastore.DataStore,
-	fs filestore.Store,
 	sls stagelogstore.Store,
 	alss applicationlivestatestore.Store,
 	cmds commandstore.Store,
@@ -100,6 +100,7 @@ func NewWebAPI(
 		pipedStore:                datastore.NewPipedStore(ds),
 		projectStore:              datastore.NewProjectStore(ds),
 		apiKeyStore:               datastore.NewAPIKeyStore(ds),
+		eventStore:                datastore.NewEventStore(ds),
 		stageLogStore:             sls,
 		applicationLiveStateStore: alss,
 		commandStore:              cmds,
@@ -1837,5 +1838,116 @@ func (a *WebAPI) GetDeploymentChain(ctx context.Context, req *webservice.GetDepl
 }
 
 func (a *WebAPI) ListEvents(ctx context.Context, req *webservice.ListEventsRequest) (*webservice.ListEventsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Not implemented")
+	claims, err := rpcauth.ExtractClaims(ctx)
+	if err != nil {
+		a.logger.Error("failed to authenticate the current user", zap.Error(err))
+		return nil, err
+	}
+
+	orders := []datastore.Order{
+		{
+			Field:     "UpdatedAt",
+			Direction: datastore.Desc,
+		},
+		{
+			Field:     "Id",
+			Direction: datastore.Asc,
+		},
+	}
+	filters := []datastore.ListFilter{
+		{
+			Field:    "ProjectId",
+			Operator: datastore.OperatorEqual,
+			Value:    claims.Role.ProjectId,
+		},
+		{
+			Field:    "UpdatedAt",
+			Operator: datastore.OperatorGreaterThanOrEqual,
+			Value:    req.PageMinUpdatedAt,
+		},
+	}
+	if o := req.Options; o != nil {
+		if o.Name != "" {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Name",
+				Operator: datastore.OperatorEqual,
+				Value:    o.Name,
+			})
+		}
+		// Allowing multiple so that it can do In Query later.
+		// Currently only the first value is used.
+		if len(o.Statuses) > 0 {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Status",
+				Operator: datastore.OperatorEqual,
+				Value:    o.Statuses[0],
+			})
+		}
+	}
+
+	pageSize := int(req.PageSize)
+	options := datastore.ListOptions{
+		Filters: filters,
+		Orders:  orders,
+		Limit:   pageSize,
+		Cursor:  req.Cursor,
+	}
+	events, cursor, err := a.eventStore.ListEvents(ctx, options)
+	if err != nil {
+		a.logger.Error("failed to get events", zap.Error(err))
+		return nil, status.Error(codes.Internal, "Failed to get events")
+	}
+	labels := req.Options.Labels
+	if len(labels) == 0 || len(events) == 0 {
+		return &webservice.ListEventsResponse{
+			Events: events,
+			Cursor: cursor,
+		}, nil
+	}
+
+	// Start filtering them by labels.
+	//
+	// NOTE: Filtering by labels is done by the application-side because we need to create composite indexes for every combination in the filter.
+	// We don't want to depend on any other search engine, that's why it filters here.
+	filtered := make([]*model.Event, 0, len(events))
+	for _, e := range events {
+		if e.ContainLabels(labels) {
+			filtered = append(filtered, e)
+		}
+	}
+	// Stop running additional queries for more data, and return filtered events immediately with
+	// current cursor if the size before filtering is already less than the page size.
+	if len(events) < pageSize {
+		return &webservice.ListEventsResponse{
+			Events: filtered,
+			Cursor: cursor,
+		}, nil
+	}
+	// Repeat the query until the number of filtered events reaches the page size,
+	// or until it finishes scanning to page_min_updated_at.
+	for len(filtered) < pageSize {
+		options.Cursor = cursor
+		events, cursor, err = a.eventStore.ListEvents(ctx, options)
+		if err != nil {
+			a.logger.Error("failed to get events", zap.Error(err))
+			return nil, status.Error(codes.Internal, "Failed to get events")
+		}
+		if len(events) == 0 {
+			break
+		}
+		for _, e := range events {
+			if e.ContainLabels(labels) {
+				filtered = append(filtered, e)
+			}
+		}
+		// We've already specified UpdatedAt >= req.PageMinUpdatedAt, so we need to check just equality.
+		if events[len(events)-1].UpdatedAt == req.PageMinUpdatedAt {
+			break
+		}
+	}
+	// TODO: Think about possibility that the response of ListEvents exceeds the page size
+	return &webservice.ListEventsResponse{
+		Events: filtered,
+		Cursor: cursor,
+	}, nil
 }

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -28,6 +28,24 @@ func (e *Event) IsHandled() bool {
 	return e.Status == EventStatus_EVENT_SUCCESS || e.Status == EventStatus_EVENT_FAILURE
 }
 
+// ContainLabels checks if it has all the given labels.
+func (d *Event) ContainLabels(labels map[string]string) bool {
+	if len(d.Labels) < len(labels) {
+		return false
+	}
+
+	for k, v := range labels {
+		value, ok := d.Labels[k]
+		if !ok {
+			return false
+		}
+		if value != v {
+			return false
+		}
+	}
+	return true
+}
+
 // MakeEventKey builds a fixed-length identifier based on the given name
 // and labels. It returns the exact same string as long as both are the same.
 func MakeEventKey(name string, labels map[string]string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR primarily adds a new rpc named `ListEvents` which is about the same as `ListDeployment` in that:
- does paging with the cursor
- prevent it from scanning all entities by setting min_updated_at
- Filtering entities by labels by the application side

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipecd/issues/2611

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
