### PR TITLE
Change timeout for AddApplicationDrawer test to 50000ms

### DIFF
--- a/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
+++ b/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
@@ -8,7 +8,7 @@ import { dummyPiped } from "~/__fixtures__/dummy-piped";
 import { createStore, render, screen, waitFor } from "~~/test-utils";
 import { AddApplicationDrawer } from ".";
 
-jest.setTimeout(20_000);
+jest.setTimeout(50_000);
 
 beforeAll(() => {
   server.listen();


### PR DESCRIPTION
**What this PR does / why we need it**:
In most failure cases is caused by the test for `AddApplicationDrawer`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
