### PR TITLE
Add builtin labels for CloudRun

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -41,6 +41,12 @@ type (
 	Revision run.Revision
 )
 
+const (
+	LabelManagedBy = "pipecd-dev-managed-by" // Always be piped.
+	LabelPiped     = "pipecd-dev-piped"      // The id of piped handling this application.
+	ManagedByPiped = "piped"
+)
+
 type Client interface {
 	Create(ctx context.Context, sm ServiceManifest) (*Service, error)
 	Update(ctx context.Context, sm ServiceManifest) (*Service, error)

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -42,9 +42,11 @@ type (
 )
 
 const (
-	LabelManagedBy = "pipecd-dev-managed-by" // Always be piped.
-	LabelPiped     = "pipecd-dev-piped"      // The id of piped handling this application.
-	ManagedByPiped = "piped"
+	LabelManagedBy   = "pipecd-dev-managed-by"  // Always be piped.
+	LabelPiped       = "pipecd-dev-piped"       // The id of piped handling this application.
+	LabelApplication = "pipecd-dev-application" // The application this resource belongs to.
+	LabelCommitHash  = "pipecd-dev-commit-hash" // Hash value of the deployed commit.
+	ManagedByPiped   = "piped"
 )
 
 type Client interface {

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
@@ -70,12 +70,12 @@ func (m ServiceManifest) AddLabels(labels map[string]string) {
 	}
 
 	lbls := m.u.GetLabels()
-	if lbls != nil {
-		for k, v := range labels {
-			lbls[k] = v
-		}
-	} else {
-		lbls = labels
+	if lbls == nil {
+		m.u.SetLabels(labels)
+		return
+	}
+	for k, v := range labels {
+		lbls[k] = v
 	}
 	m.u.SetLabels(lbls)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
@@ -64,6 +64,22 @@ func (m ServiceManifest) YamlBytes() ([]byte, error) {
 	return yaml.Marshal(m.u)
 }
 
+func (m ServiceManifest) AddLabels(labels map[string]string) {
+	if len(labels) == 0 {
+		return
+	}
+
+	lbls := m.u.GetLabels()
+	if lbls != nil {
+		for k, v := range labels {
+			lbls[k] = v
+		}
+	} else {
+		lbls = labels
+	}
+	m.u.SetLabels(lbls)
+}
+
 func loadServiceManifest(path string) (ServiceManifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -148,10 +148,12 @@ func revisionExists(ctx context.Context, client provider.Client, revisionName st
 	return false, err
 }
 
-func addBuiltinLabels(sm provider.ServiceManifest, pipedID string) {
+func addBuiltinLabels(sm provider.ServiceManifest, hash, pipedID, appID string) {
 	labels := map[string]string{
-		provider.LabelManagedBy: provider.ManagedByPiped,
-		provider.LabelPiped:     pipedID,
+		provider.LabelManagedBy:   provider.ManagedByPiped,
+		provider.LabelPiped:       pipedID,
+		provider.LabelApplication: appID,
+		provider.LabelCommitHash:  hash,
 	}
 	sm.AddLabels(labels)
 }

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -147,3 +147,11 @@ func revisionExists(ctx context.Context, client provider.Client, revisionName st
 	lp.Errorf("Failed while checking the existence of revision %s (%v)", revisionName, err)
 	return false, err
 }
+
+func addBuiltinLabels(sm provider.ServiceManifest, pipedID string) {
+	labels := map[string]string{
+		provider.LabelManagedBy: provider.ManagedByPiped,
+		provider.LabelPiped:     pipedID,
+	}
+	sm.AddLabels(labels)
+}

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -104,6 +104,9 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	// Add builtin labels for tracking application live state
+	addBuiltinLabels(sm, e.PipedConfig.PipedID)
+
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -105,7 +105,8 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	}
 
 	// Add builtin labels for tracking application live state
-	addBuiltinLabels(sm, e.PipedConfig.PipedID)
+	commit := e.Deployment.CommitHash()
+	addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId)
 
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/piped/executor/cloudrun/rollback.go
+++ b/pkg/app/piped/executor/cloudrun/rollback.go
@@ -97,6 +97,9 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	// Add builtin labels for tracking application live state
+	addBuiltinLabels(sm, e.PipedConfig.PipedID)
+
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/cloudrun/rollback.go
+++ b/pkg/app/piped/executor/cloudrun/rollback.go
@@ -98,7 +98,8 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 	}
 
 	// Add builtin labels for tracking application live state
-	addBuiltinLabels(sm, e.PipedConfig.PipedID)
+	commit := e.Deployment.CommitHash()
+	addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId)
 
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE


### PR DESCRIPTION
**What this PR does / why we need it**:
Add builtin labels for tracking application live state.
I've only added minimum num of labels yet, but please tell me if there are any labels that I should add.

see details for label rules:
https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
