### PR TITLE
Change events filter to suggest possible event names

### DIFF
--- a/pkg/app/web/src/components/events-page/event-filter/index.tsx
+++ b/pkg/app/web/src/components/events-page/event-filter/index.tsx
@@ -53,9 +53,18 @@ export const EventFilter: FC<EventFilterProps> = memo(function EventFilter({
   const events = useAppSelector<Event.AsObject[]>((state) =>
     selectAllEvents(state.events)
   );
+
+  const [allNames, setAllNames] = useState(new Array<string>());
+  useEffect(() => {
+    const names = new Set<string>();
+    events.map((app) => {
+      names.add(app.name);
+    });
+    setAllNames(Array.from(names));
+  }, [events]);
+
   const [allLabels, setAllLabels] = useState(new Array<string>());
   const [selectedLabels, setSelectedLabels] = useState(new Array<string>());
-
   useEffect(() => {
     const labels = new Set<string>();
     events
@@ -72,23 +81,35 @@ export const EventFilter: FC<EventFilterProps> = memo(function EventFilter({
     <FilterView
       onClear={() => {
         onClear();
+        setSelectedLabels([]);
       }}
     >
-      {/* TODO: Suggest possible event names on the event filter */}
       <FormControl className={classes.formItem} variant="outlined">
-        <TextField
+        <Autocomplete
+          autoHighlight
           id="filter-event-name"
-          value={options.name ?? ""}
-          label="Name"
-          className={classes.select}
-          variant="outlined"
-          onChange={(e) => {
+          noOptionsText="No selectable name"
+          options={allNames}
+          value={options.name}
+          onInputChange={(_, value) => {
+            setAllNames([value]);
+          }}
+          onChange={(_, newValue) => {
+            setAllNames([]);
             handleUpdateFilterValue({
-              name:
-                e.target.value === ALL_VALUE ? undefined : `${e.target.value}`,
+              name: newValue !== null ? newValue : "",
             });
           }}
-        ></TextField>
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              variant="outlined"
+              label="Name"
+              margin="dense"
+              fullWidth
+            />
+          )}
+        />
       </FormControl>
 
       <FormControl className={classes.formItem} variant="outlined">

--- a/pkg/app/web/src/components/events-page/event-filter/index.tsx
+++ b/pkg/app/web/src/components/events-page/event-filter/index.tsx
@@ -57,8 +57,8 @@ export const EventFilter: FC<EventFilterProps> = memo(function EventFilter({
   const [allNames, setAllNames] = useState(new Array<string>());
   useEffect(() => {
     const names = new Set<string>();
-    events.map((app) => {
-      names.add(app.name);
+    events.map((event) => {
+      names.add(event.name);
     });
     setAllNames(Array.from(names));
   }, [events]);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR applies the Autocomplete components that suggest Event names that can be known from the pre-fetched latest 50 events.

It needs to allow to be filled with a name that isn't in the options because the web client doesn't know the name of every event in the past.

![Kapture 2022-01-21 at 16 11 46](https://user-images.githubusercontent.com/19730728/150482664-e69e7c47-d580-4801-8868-687b7cfedd76.gif)

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/3080

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
