### PR TITLE
Add labels getter method for ServiceManifest

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
@@ -64,6 +64,10 @@ func (m ServiceManifest) YamlBytes() ([]byte, error) {
 	return yaml.Marshal(m.u)
 }
 
+func (m ServiceManifest) Labels() map[string]string {
+	return m.u.GetLabels()
+}
+
 func (m ServiceManifest) AddLabels(labels map[string]string) {
 	if len(labels) == 0 {
 		return

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
@@ -34,14 +34,14 @@ metadata:
 spec:
   template:
     metadata:
-      name: helloworld-v050-0b13751
+      name: helloworld-v010-1234567
       annotations:
         autoscaling.knative.dev/maxScale: '1'
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
       containers:
-      - image: gcr.io/pipecd/helloworld:v0.5.0
+      - image: gcr.io/pipecd/helloworld:v0.1.0
         args:
         - server
         ports:
@@ -52,7 +52,7 @@ spec:
             cpu: 1000m
             memory: 128Mi
   traffic:
-  - revisionName: helloworld-v050-0b13751
+  - revisionName: helloworld-v010-1234567
     percent: 100
 `
 
@@ -62,17 +62,17 @@ func TestServiceManifest(t *testing.T) {
 	require.NotEmpty(t, sm)
 
 	// SetRevision
-	err = sm.SetRevision("helloworld-v050-0b13751")
+	err = sm.SetRevision("helloworld-v010-1234567")
 	require.NoError(t, err)
 
 	// UpdateTraffic
 	traffics := []RevisionTraffic{
 		{
-			RevisionName: "helloworld-v050-0b13751",
+			RevisionName: "helloworld-v010-1234567",
 			Percent:      50,
 		},
 		{
-			RevisionName: "helloworld-v050-cb01dce",
+			RevisionName: "helloworld-v011-2345678",
 			Percent:      50,
 		},
 	}
@@ -101,8 +101,8 @@ func TestLoadServiceManifest(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, sm)
 
-	// Failed
-	sm, err = loadServiceManifest("testdata/not_found")
+	// Failure
+	_, err = loadServiceManifest("testdata/not_found")
 	require.Error(t, err)
 }
 
@@ -113,7 +113,7 @@ func TestParseServiceManifest(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "helloworld", sm.Name)
 
-	// Failed
+	// Failure
 	data = []byte("error")
 	_, err = ParseServiceManifest(data)
 	require.Error(t, err)
@@ -124,9 +124,9 @@ func TestDecideRevisionName(t *testing.T) {
 	sm, err := ParseServiceManifest(data)
 	require.NoError(t, err)
 
-	name, err := DecideRevisionName(sm, "bbdc2ed674ce4fd987")
+	name, err := DecideRevisionName(sm, "12345678912345678")
 	require.NoError(t, err)
-	require.Equal(t, "helloworld-v050-bbdc2ed", name)
+	require.Equal(t, "helloworld-v010-1234567", name)
 }
 
 func TestFindImageTag(t *testing.T) {
@@ -152,14 +152,14 @@ metadata:
 spec:
   template:
     metadata:
-      name: helloworld-v050-0b13751
+      name: helloworld-v010-1234567
       annotations:
         autoscaling.knative.dev/maxScale: '1'
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
       containers:
-      - image: gcr.io/pipecd/helloworld:v0.5.0
+      - image: gcr.io/pipecd/helloworld:v0.1.0
         args:
         - server
         ports:
@@ -170,10 +170,10 @@ spec:
             cpu: 1000m
             memory: 128Mi
   traffic:
-  - revisionName: helloworld-v050-0b13751
+  - revisionName: helloworld-v010-1234567
     percent: 100
 `,
-			want:    "v0.5.0",
+			want:    "v0.1.0",
 			wantErr: false,
 		},
 		{
@@ -186,7 +186,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: helloworld-v050-0b13751
+      name: helloworld-v010-1234567
       annotations:
         autoscaling.knative.dev/maxScale: '1'
     spec:
@@ -212,7 +212,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: helloworld-v050-0b13751
+      name: helloworld-v010-1234567
       annotations:
         autoscaling.knative.dev/maxScale: '1'
     spec:
@@ -229,7 +229,7 @@ spec:
             cpu: 1000m
             memory: 128Mi
   traffic:
-  - revisionName: helloworld-v050-0b13751
+  - revisionName: helloworld-v010-1234567
     percent: 100
 `,
 			want:    "",

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
@@ -13,3 +13,242 @@
 // limitations under the License.
 
 package cloudrun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const manifest = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+    pipecd-dev-managed-by: piped
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+      - image: gcr.io/pipecd/helloworld:v0.5.0
+        args:
+        - server
+        ports:
+        - name: http1
+          containerPort: 9085
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+  traffic:
+  - revisionName: helloworld-v050-0b13751
+    percent: 100
+`
+
+func TestServiceManifest(t *testing.T) {
+	sm, err := ParseServiceManifest([]byte(manifest))
+	require.NoError(t, err)
+	require.NotEmpty(t, sm)
+
+	// SetRevision
+	err = sm.SetRevision("helloworld-v050-0b13751")
+	require.NoError(t, err)
+
+	// UpdateTraffic
+	traffics := []RevisionTraffic{
+		{
+			RevisionName: "helloworld-v050-0b13751",
+			Percent:      50,
+		},
+		{
+			RevisionName: "helloworld-v050-cb01dce",
+			Percent:      50,
+		},
+	}
+	err = sm.UpdateTraffic(traffics)
+	require.NoError(t, err)
+
+	// YamlBytes
+	data, err := sm.YamlBytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// AddLabels
+	labels := map[string]string{
+		LabelPiped:       "hoge",
+		LabelApplication: "foo",
+	}
+	sm.AddLabels(labels)
+
+	// Labels
+	require.Len(t, sm.Labels(), 4)
+}
+
+func TestLoadServiceManifest(t *testing.T) {
+	// Success
+	sm, err := loadServiceManifest("testdata/new_manifest.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, sm)
+
+	// Failed
+	sm, err = loadServiceManifest("testdata/not_found")
+	require.Error(t, err)
+}
+
+func TestParseServiceManifest(t *testing.T) {
+	// Success
+	data := []byte(manifest)
+	sm, err := ParseServiceManifest(data)
+	require.NoError(t, err)
+	require.Equal(t, "helloworld", sm.Name)
+
+	// Failed
+	data = []byte("error")
+	_, err = ParseServiceManifest(data)
+	require.Error(t, err)
+}
+
+func TestDecideRevisionName(t *testing.T) {
+	data := []byte(manifest)
+	sm, err := ParseServiceManifest(data)
+	require.NoError(t, err)
+
+	name, err := DecideRevisionName(sm, "bbdc2ed674ce4fd987")
+	require.NoError(t, err)
+	require.Equal(t, "helloworld-v050-bbdc2ed", name)
+}
+
+func TestFindImageTag(t *testing.T) {
+	testcases := []struct {
+		name     string
+		manifest string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name: "ok",
+			manifest: `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+    pipecd-dev-managed-by: piped
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+      - image: gcr.io/pipecd/helloworld:v0.5.0
+        args:
+        - server
+        ports:
+        - name: http1
+          containerPort: 9085
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+  traffic:
+  - revisionName: helloworld-v050-0b13751
+    percent: 100
+`,
+			want:    "v0.5.0",
+			wantErr: false,
+		},
+		{
+			name: "err: containers missing",
+			manifest: `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+`,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "err: image missing",
+			manifest: `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+    pipecd-dev-managed-by: piped
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      name: helloworld-v050-0b13751
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+      - args:
+        - server
+        ports:
+        - name: http1
+          containerPort: 9085
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+  traffic:
+  - revisionName: helloworld-v050-0b13751
+    percent: 100
+`,
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(tc.manifest)
+			sm, err := ParseServiceManifest(data)
+			require.NoError(t, err)
+
+			got, err := FindImageTag(sm)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Implement a Labels() Getter to retrieve the appID.
- Add service manifes test

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
