### PR TITLE
Revert ingress to use "ImplementationSpecific" as pathType since "Prefix" is not being supported by old controllers

### DIFF
--- a/manifests/pipecd/templates/ingress.yaml
+++ b/manifests/pipecd/templates/ingress.yaml
@@ -22,29 +22,29 @@ spec:
   rules:
   - http:
       paths:
-      - path: /grpc.service.pipedservice.PipedService/
-        pathType: Prefix
+      - path: /grpc.service.pipedservice.PipedService/*
+        pathType: ImplementationSpecific
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}
             port:
               number: {{ .Values.service.port }}
-      - path: /pipe.api.service.pipedservice.PipedService/
-        pathType: Prefix
+      - path: /pipe.api.service.pipedservice.PipedService/*
+        pathType: ImplementationSpecific
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}
             port:
               number: {{ .Values.service.port }}
-      - path: /grpc.service.apiservice.APIService/
-        pathType: Prefix
+      - path: /grpc.service.apiservice.APIService/*
+        pathType: ImplementationSpecific
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}
             port:
               number: {{ .Values.service.port }}
-      - path: /pipe.api.service.apiservice.APIService/
-        pathType: Prefix
+      - path: /pipe.api.service.apiservice.APIService/*
+        pathType: ImplementationSpecific
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:

> For GKE clusters running versions earlier than 1.21.3-gke.1600, the only supported value for the pathType field is ImplementationSpecific. For clusters running version 1.21.3-gke.1600 or later, Prefix and Exact values are also supported for pathType.

**Which issue(s) this PR fixes**:

Fixes #3090 
Fixes #3091

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
