### PR TITLE
Add ServiceManifest method for handling CloudRun's services

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "client_test.go",
         "diff_test.go",
         "servicemanifest_test.go",
     ],

--- a/pkg/app/piped/cloudprovider/cloudrun/client.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client.go
@@ -185,3 +185,12 @@ func manifestToRunService(sm ServiceManifest) (*run.Service, error) {
 	}
 	return &s, nil
 }
+
+func (s *Service) ServiceManifest() (ServiceManifest, error) {
+	r := (*run.Service)(s)
+	data, err := r.MarshalJSON()
+	if err != nil {
+		return ServiceManifest{}, err
+	}
+	return ParseServiceManifest(data)
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/client_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client_test.go
@@ -17,6 +17,7 @@ package cloudrun
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ func TestMakeCloudRunParent(t *testing.T) {
 	const projectID = "projectID"
 	got := makeCloudRunParent(projectID)
 	want := "namespaces/projectID"
-	require.Equal(t, want, got)
+	assert.Equal(t, want, got)
 }
 
 func TestMakeCloudRunServiceName(t *testing.T) {
@@ -34,7 +35,7 @@ func TestMakeCloudRunServiceName(t *testing.T) {
 	)
 	got := makeCloudRunServiceName(projectID, serviceID)
 	want := "namespaces/projectID/services/serviceID"
-	require.Equal(t, want, got)
+	assert.Equal(t, want, got)
 }
 
 func TestMakeCloudRunRevisionName(t *testing.T) {
@@ -44,7 +45,7 @@ func TestMakeCloudRunRevisionName(t *testing.T) {
 	)
 	got := makeCloudRunRevisionName(projectID, revisionID)
 	want := "namespaces/projectID/revisions/revisionID"
-	require.Equal(t, want, got)
+	assert.Equal(t, want, got)
 }
 
 func TestManifestToRunService(t *testing.T) {
@@ -54,7 +55,7 @@ func TestManifestToRunService(t *testing.T) {
 
 	got, err := manifestToRunService(sm)
 	require.NoError(t, err)
-	require.NotEmpty(t, got)
+	assert.NotEmpty(t, got)
 }
 
 func TestService(t *testing.T) {
@@ -67,5 +68,5 @@ func TestService(t *testing.T) {
 	s := (*Service)(svc)
 	got, err := s.ServiceManifest()
 	require.NoError(t, err)
-	require.Equal(t, sm, got)
+	assert.Equal(t, sm, got)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/client_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeCloudRunParent(t *testing.T) {
+	const projectID = "projectID"
+	got := makeCloudRunParent(projectID)
+	want := "namespaces/projectID"
+	require.Equal(t, want, got)
+}
+
+func TestMakeCloudRunServiceName(t *testing.T) {
+	const (
+		projectID = "projectID"
+		serviceID = "serviceID"
+	)
+	got := makeCloudRunServiceName(projectID, serviceID)
+	want := "namespaces/projectID/services/serviceID"
+	require.Equal(t, want, got)
+}
+
+func TestMakeCloudRunRevisionName(t *testing.T) {
+	const (
+		projectID  = "projectID"
+		revisionID = "revisionID"
+	)
+	got := makeCloudRunRevisionName(projectID, revisionID)
+	want := "namespaces/projectID/revisions/revisionID"
+	require.Equal(t, want, got)
+}
+
+func TestManifestToRunService(t *testing.T) {
+	sm, err := ParseServiceManifest([]byte(manifest))
+	require.NoError(t, err)
+	require.NotEmpty(t, sm)
+
+	got, err := manifestToRunService(sm)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+}
+
+func TestService(t *testing.T) {
+	sm, err := ParseServiceManifest([]byte(manifest))
+	require.NoError(t, err)
+
+	svc, err := manifestToRunService(sm)
+	require.NoError(t, err)
+
+	s := (*Service)(svc)
+	got, err := s.ServiceManifest()
+	require.NoError(t, err)
+	require.Equal(t, sm, got)
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/client_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The PipeCD Authors.
+// Copyright 2022 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement ServiceManifest method for replacing client service with serviceManifest.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
