### PR TITLE
Add MakeManagedByPipedLabel function for filtering CloudRun services with label selector

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     size = "small",
     srcs = [
         "client_test.go",
+        "cloudrun_test.go",
         "diff_test.go",
         "servicemanifest_test.go",
     ],

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -113,6 +113,6 @@ func (r *registry) Client(ctx context.Context, name string, cfg *config.CloudPro
 	return client, nil
 }
 
-func NewManagedByPipedLabel() string {
+func MakeManagedByPipedLabel() string {
 	return fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByPiped)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -17,6 +17,7 @@ package cloudrun
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -110,4 +111,8 @@ func (r *registry) Client(ctx context.Context, name string, cfg *config.CloudPro
 	r.mu.Unlock()
 
 	return client, nil
+}
+
+func NewManagedByPipedLabel() string {
+	return fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByPiped)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadServiceManifest(t *testing.T) {
+	const (
+		appDir      = "testdata"
+		serviceFile = "new_manifest.yaml"
+	)
+	// Success
+	got, err := LoadServiceManifest(appDir, serviceFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	// Failure
+	_, err = LoadServiceManifest(appDir, "")
+	require.Error(t, err)
+}
+
+func TestNewManagedByPipedLabel(t *testing.T) {
+	want := "pipecd-dev-managed-by=piped"
+	got := NewManagedByPipedLabel()
+	require.Equal(t, want, got)
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
@@ -17,6 +17,7 @@ package cloudrun
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,15 +29,15 @@ func TestLoadServiceManifest(t *testing.T) {
 	// Success
 	got, err := LoadServiceManifest(appDir, serviceFile)
 	require.NoError(t, err)
-	require.NotEmpty(t, got)
+	assert.NotEmpty(t, got)
 
 	// Failure
 	_, err = LoadServiceManifest(appDir, "")
-	require.Error(t, err)
+	assert.Error(t, err)
 }
 
-func TestNewManagedByPipedLabel(t *testing.T) {
+func TestMakeManagedByPipedLabel(t *testing.T) {
 	want := "pipecd-dev-managed-by=piped"
-	got := NewManagedByPipedLabel()
-	require.Equal(t, want, got)
+	got := MakeManagedByPipedLabel()
+	assert.Equal(t, want, got)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
@@ -95,17 +95,6 @@ func TestServiceManifest(t *testing.T) {
 	require.Len(t, sm.Labels(), 4)
 }
 
-func TestLoadServiceManifest(t *testing.T) {
-	// Success
-	sm, err := loadServiceManifest("testdata/new_manifest.yaml")
-	require.NoError(t, err)
-	require.NotEmpty(t, sm)
-
-	// Failure
-	_, err = loadServiceManifest("testdata/not_found")
-	require.Error(t, err)
-}
-
 func TestParseServiceManifest(t *testing.T) {
 	// Success
 	data := []byte(manifest)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add MakeManagedByPipedLabel function for filtering CloudRun services with label selector.
see details: https://pkg.go.dev/google.golang.org/api/run/v1#NamespacesServicesListCall.LabelSelector

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
