### PR TITLE
Fix to fetch additional deploys/events anytime

### DIFF
--- a/pkg/app/web/src/modules/deployments/index.test.ts
+++ b/pkg/app/web/src/modules/deployments/index.test.ts
@@ -220,7 +220,7 @@ describe("deploymentsSlice reducer", () => {
         entities: { [dummyDeployment.id]: dummyDeployment },
         status: "succeeded",
         cursor: "next cursor",
-        minUpdatedAt: dummyDeployment.updatedAt - 2592000,
+        minUpdatedAt: -2592000,
       });
     });
   });

--- a/pkg/app/web/src/modules/deployments/index.ts
+++ b/pkg/app/web/src/modules/deployments/index.ts
@@ -238,9 +238,7 @@ export const deploymentsSlice = createSlice({
         const deployments = action.payload.deployments;
         if (deployments.length < FETCH_MORE_ITEMS_PER_PAGE) {
           state.hasMore = false;
-          state.minUpdatedAt =
-            deployments[deployments.length - 1].updatedAt -
-            TIME_RANGE_LIMIT_IN_SECONDS;
+          state.minUpdatedAt = state.minUpdatedAt - TIME_RANGE_LIMIT_IN_SECONDS;
         } else {
           state.hasMore = true;
         }

--- a/pkg/app/web/src/modules/events/index.ts
+++ b/pkg/app/web/src/modules/events/index.ts
@@ -141,9 +141,7 @@ export const eventsSlice = createSlice({
         const events = action.payload.events;
         if (events.length < FETCH_MORE_ITEMS_PER_PAGE) {
           state.hasMore = false;
-          // TODO: Enable to fetch more Events even if the last response is none
-          state.minUpdatedAt =
-            events[events.length - 1].updatedAt - TIME_RANGE_LIMIT_IN_SECONDS;
+          state.minUpdatedAt = state.minUpdatedAt - TIME_RANGE_LIMIT_IN_SECONDS;
         } else {
           state.hasMore = true;
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
The more button will be available even if the last response is none.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/3104

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
