### PR TITLE
Fix event watcher not to handle already handled events

### DIFF
--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -190,12 +190,18 @@ func (s *store) UpdateStatuses(ctx context.Context, latestEvents []model.Event) 
 	for _, e := range latestEvents {
 		s.mu.Lock()
 		cached, ok := s.latestEvents[e.EventKey]
-		if ok && cached.Id != e.Id {
+		if !ok {
+			s.latestEvents[e.EventKey] = &e
+			s.mu.Unlock()
+			continue
+		}
+		if cached.Id != e.Id {
 			// There is already an event newer than the given one.
 			s.mu.Unlock()
 			continue
 		}
-		s.latestEvents[e.EventKey] = &e
+		s.latestEvents[e.EventKey].Status = e.Status
+		s.latestEvents[e.EventKey].StatusDescription = e.StatusDescription
 		s.mu.Unlock()
 	}
 	return nil

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -188,14 +188,13 @@ func (s *store) UpdateStatuses(ctx context.Context, latestEvents []model.Event) 
 
 	// Update cached events.
 	for _, e := range latestEvents {
-		s.mu.RLock()
+		s.mu.Lock()
 		cached, ok := s.latestEvents[e.EventKey]
-		s.mu.RUnlock()
 		if ok && cached.Id != e.Id {
 			// There is already an event newer than the given one.
+			s.mu.Unlock()
 			continue
 		}
-		s.mu.Lock()
 		s.latestEvents[e.EventKey] = &e
 		s.mu.Unlock()
 	}

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -32,7 +32,7 @@ import (
 // Getter helps get an event. All objects returned here must be treated as read-only.
 type Getter interface {
 	// GetLatest returns the latest event that meets the given conditions.
-	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type Store interface {
@@ -142,10 +142,10 @@ func (s *store) Getter() Getter {
 	return s
 }
 
-func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool) {
+func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool) {
 	key := model.MakeEventKey(name, labels)
 
-	if !forceRefresh {
+	if !notUsingCache {
 		s.mu.RLock()
 		event, ok = s.latestEvents[key]
 		s.mu.RUnlock()

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -35,7 +35,7 @@ type Store interface {
 	// GetLatest returns the latest event that meets the given conditions.
 	// All objects returned here must be treated as read-only.
 	GetLatest(ctx context.Context, name string, labels map[string]string) (*model.Event, bool)
-	// GetLatest updates the status of the latest events.
+	// UpdateStatuses updates the status of the latest events.
 	// The second arg supposed to be the latest event. If it's not the latest, it will be ignored.
 	UpdateStatuses(ctx context.Context, latestEvents []model.Event) error
 }

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -32,7 +32,7 @@ import (
 // Getter helps get an event. All objects returned here must be treated as read-only.
 type Getter interface {
 	// GetLatest returns the latest event that meets the given conditions.
-	GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type Store interface {
@@ -142,10 +142,10 @@ func (s *store) Getter() Getter {
 	return s
 }
 
-func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool) {
+func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool) {
 	key := model.MakeEventKey(name, labels)
 
-	if !notUsingCache {
+	if !forceRefresh {
 		s.mu.RLock()
 		event, ok = s.latestEvents[key]
 		s.mu.RUnlock()

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -32,7 +32,7 @@ import (
 // Getter helps get an event. All objects returned here must be treated as read-only.
 type Getter interface {
 	// GetLatest returns the latest event that meets the given conditions.
-	GetLatest(ctx context.Context, name string, labels map[string]string) (*model.Event, bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type Store interface {
@@ -142,13 +142,16 @@ func (s *store) Getter() Getter {
 	return s
 }
 
-func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string) (*model.Event, bool) {
+func (s *store) GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool) {
 	key := model.MakeEventKey(name, labels)
-	s.mu.RLock()
-	event, ok := s.latestEvents[key]
-	s.mu.RUnlock()
-	if ok {
-		return event, true
+
+	if !forceRefresh {
+		s.mu.RLock()
+		event, ok = s.latestEvents[key]
+		s.mu.RUnlock()
+		if ok {
+			return event, true, true
+		}
 	}
 
 	// If not found in the cache, fetch from the control-plane.
@@ -161,19 +164,15 @@ func (s *store) GetLatest(ctx context.Context, name string, labels map[string]st
 			zap.String("event-name", name),
 			zap.Any("labels", labels),
 		)
-		return nil, false
+		return nil, false, false
 	}
 	if err != nil {
 		s.logger.Error("failed to get the latest event", zap.Error(err))
-		return nil, false
+		return nil, false, false
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	cached, ok := s.latestEvents[key]
-	if ok && cached.CreatedAt > event.CreatedAt {
-		return resp.Event, true
-	}
 	s.latestEvents[key] = resp.Event
-	return resp.Event, true
+	s.mu.Unlock()
+	return resp.Event, false, true
 }

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -291,13 +291,11 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	}
 
 	// Start running event store.
-	var eventGetter eventstore.Getter
+	eventStore := eventstore.NewStore(apiClient, p.gracePeriod, input.Logger)
 	{
-		store := eventstore.NewStore(apiClient, p.gracePeriod, input.Logger)
 		group.Go(func() error {
-			return store.Run(ctx)
+			return eventStore.Run(ctx)
 		})
-		eventGetter = store.Getter()
 	}
 
 	analysisResultStore := analysisresultstore.NewStore(apiClient, input.Logger)
@@ -399,9 +397,8 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	{
 		w := eventwatcher.NewWatcher(
 			cfg,
-			eventGetter,
+			eventStore,
 			gitClient,
-			apiClient,
 			input.Logger,
 		)
 		group.Go(func() error {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -54,7 +54,7 @@ type Watcher interface {
 }
 
 type eventGetter interface {
-	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type gitClient interface {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -54,7 +54,7 @@ type Watcher interface {
 }
 
 type eventGetter interface {
-	GetLatest(ctx context.Context, name string, labels map[string]string, notUsingCache bool) (event *model.Event, cacheUsed bool, ok bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type gitClient interface {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -54,7 +54,7 @@ type Watcher interface {
 }
 
 type eventGetter interface {
-	GetLatest(ctx context.Context, name string, labels map[string]string) (*model.Event, bool)
+	GetLatest(ctx context.Context, name string, labels map[string]string, forceRefresh bool) (event *model.Event, cacheUsed bool, ok bool)
 }
 
 type gitClient interface {
@@ -229,13 +229,24 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 
 	eventResults := make([]*pipedservice.ReportEventStatusesRequest_Event, 0, len(events))
 	for _, e := range events {
-		latestEvent, ok := w.eventGetter.GetLatest(ctx, e.Name, e.Labels)
+		latestEvent, cacheUsed, ok := w.eventGetter.GetLatest(ctx, e.Name, e.Labels, false)
 		if !ok {
 			continue
 		}
 		if latestEvent.IsHandled() {
 			continue
 		}
+		if cacheUsed {
+			// Refresh cache because the status of cached Events is likely to be out of date.
+			latestEvent, _, ok = w.eventGetter.GetLatest(ctx, e.Name, e.Labels, true)
+			if !ok {
+				continue
+			}
+		}
+		if latestEvent.IsHandled() {
+			continue
+		}
+
 		if err := w.commitFiles(ctx, latestEvent.Data, e, tmpRepo, commitMsg); err != nil {
 			w.logger.Error("failed to commit outdated files", zap.Error(err))
 			eventResults = append(eventResults, &pipedservice.ReportEventStatusesRequest_Event{


### PR DESCRIPTION
**What this PR does / why we need it**:
Even though the status of Event was updated, the status of the latest event cached by Piped had not changed. Hence we've been facing an issue that Piped tries to handle handled Events unless we restarted Piped.

This PR addresses it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
