### PR TITLE
Revise datastore interface

### DIFF
--- a/pkg/datastore/BUILD.bazel
+++ b/pkg/datastore/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "apikey.go",
         "applicationstore.go",
+        "collectionstore.go",
         "commandstore.go",
         "datastore.go",
         "deploymentchainstore.go",

--- a/pkg/datastore/collectionstore.go
+++ b/pkg/datastore/collectionstore.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import "context"
+
+type collectionStore struct {
+	col Collection
+	ds  DataStore
+}
+
+func (c *collectionStore) Find(ctx context.Context, opts ListOptions) (Iterator, error) {
+	return c.ds.Find(ctx, c.col.Kind(), opts)
+}
+
+func (c *collectionStore) Get(ctx context.Context, id string, entity interface{}) error {
+	return c.ds.Get(ctx, c.col.Kind(), id, entity)
+}
+
+func (c *collectionStore) Create(ctx context.Context, id string, entity interface{}) error {
+	return c.ds.Create(ctx, c.col.Kind(), id, entity)
+}
+
+func (c *collectionStore) Put(ctx context.Context, id string, entity interface{}) error {
+	return c.ds.Put(ctx, c.col.Kind(), id, entity)
+}
+
+func (c *collectionStore) Update(ctx context.Context, id string, updater Updater) error {
+	return c.ds.Update(ctx, c.col.Kind(), id, c.col.Factory(), updater)
+}

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -64,6 +64,28 @@ var (
 type Factory func() interface{}
 type Updater func(interface{}) error
 
+type Collection interface {
+	Kind() string
+	Factory() Factory
+}
+
+type CollectionStore interface {
+	// Find finds the documents matched given criteria.
+	Find(ctx context.Context, opts ListOptions) (Iterator, error)
+	// Get gets one document specified with ID, and unmarshal it to typed struct.
+	// If the document can not be found in datastore, ErrNotFound will be returned.
+	Get(ctx context.Context, id string, entity interface{}) error
+	// Create saves a new entity to the datastore.
+	// If an entity with the same ID is already existing, ErrAlreadyExists will be returned.
+	Create(ctx context.Context, id string, entity interface{}) error
+	// Put saves the entity into the datastore with a given id and kind.
+	// Put does not check the existence of the entity with same ID.
+	Put(ctx context.Context, id string, entity interface{}) error
+	// Update updates an existing entity in the datastore.
+	// If updating entity was not found in the datastore, ErrNotFound will be returned.
+	Update(ctx context.Context, id string, updater Updater) error
+}
+
 type DataStore interface {
 	// Find finds the documents matched given criteria.
 	Find(ctx context.Context, kind string, opts ListOptions) (Iterator, error)
@@ -104,8 +126,4 @@ type ListOptions struct {
 	Filters []ListFilter
 	Orders  []Order
 	Cursor  string
-}
-
-type backend struct {
-	ds DataStore
 }

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -22,10 +22,17 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-const DeploymentModelKind = "Deployment"
+type deploymentCollection struct {
+}
 
-var deploymentFactory = func() interface{} {
-	return &model.Deployment{}
+func (d *deploymentCollection) Kind() string {
+	return "Deployment"
+}
+
+func (d *deploymentCollection) Factory() Factory {
+	return func() interface{} {
+		return &model.Deployment{}
+	}
 }
 
 var (
@@ -98,14 +105,15 @@ type DeploymentStore interface {
 }
 
 type deploymentStore struct {
-	backend
+	backend CollectionStore
 	nowFunc func() time.Time
 }
 
 func NewDeploymentStore(ds DataStore) DeploymentStore {
 	return &deploymentStore{
-		backend: backend{
-			ds: ds,
+		backend: &collectionStore{
+			col: &deploymentCollection{},
+			ds:  ds,
 		},
 		nowFunc: time.Now,
 	}
@@ -122,12 +130,12 @@ func (s *deploymentStore) AddDeployment(ctx context.Context, d *model.Deployment
 	if err := d.Validate(); err != nil {
 		return err
 	}
-	return s.ds.Create(ctx, DeploymentModelKind, d.Id, d)
+	return s.backend.Create(ctx, d.Id, d)
 }
 
 func (s *deploymentStore) UpdateDeployment(ctx context.Context, id string, updater func(*model.Deployment) error) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, DeploymentModelKind, id, deploymentFactory, func(e interface{}) error {
+	return s.backend.Update(ctx, id, func(e interface{}) error {
 		d := e.(*model.Deployment)
 		if err := updater(d); err != nil {
 			return err
@@ -139,7 +147,7 @@ func (s *deploymentStore) UpdateDeployment(ctx context.Context, id string, updat
 
 func (s *deploymentStore) PutDeploymentMetadata(ctx context.Context, id string, metadata map[string]string) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, DeploymentModelKind, id, deploymentFactory, func(e interface{}) error {
+	return s.backend.Update(ctx, id, func(e interface{}) error {
 		d := e.(*model.Deployment)
 		d.Metadata = mergeMetadata(d.Metadata, metadata)
 		d.UpdatedAt = now
@@ -149,7 +157,7 @@ func (s *deploymentStore) PutDeploymentMetadata(ctx context.Context, id string, 
 
 func (s *deploymentStore) PutDeploymentStageMetadata(ctx context.Context, deploymentID, stageID string, metadata map[string]string) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, DeploymentModelKind, deploymentID, deploymentFactory, func(e interface{}) error {
+	return s.backend.Update(ctx, deploymentID, func(e interface{}) error {
 		d := e.(*model.Deployment)
 		for _, stage := range d.Stages {
 			if stage.Id == stageID {
@@ -174,7 +182,7 @@ func mergeMetadata(ori map[string]string, new map[string]string) map[string]stri
 }
 
 func (s *deploymentStore) ListDeployments(ctx context.Context, opts ListOptions) ([]*model.Deployment, string, error) {
-	it, err := s.ds.Find(ctx, DeploymentModelKind, opts)
+	it, err := s.backend.Find(ctx, opts)
 	if err != nil {
 		return nil, "", err
 	}
@@ -204,7 +212,7 @@ func (s *deploymentStore) ListDeployments(ctx context.Context, opts ListOptions)
 
 func (s *deploymentStore) GetDeployment(ctx context.Context, id string) (*model.Deployment, error) {
 	var entity model.Deployment
-	if err := s.ds.Get(ctx, DeploymentModelKind, id, &entity); err != nil {
+	if err := s.backend.Get(ctx, id, &entity); err != nil {
 		return nil, err
 	}
 	return &entity, nil

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -21,12 +21,20 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-const PipedModelKind = "Piped"
+type pipedCollection struct {
+}
 
-var (
-	pipedFactory = func() interface{} {
+func (p *pipedCollection) Kind() string {
+	return "Piped"
+}
+
+func (p *pipedCollection) Factory() Factory {
+	return func() interface{} {
 		return &model.Piped{}
 	}
+}
+
+var (
 	PipedMetadataUpdater = func(
 		cloudProviders []*model.Piped_CloudProvider,
 		repos []*model.ApplicationGitRepository,
@@ -62,14 +70,15 @@ type PipedStore interface {
 }
 
 type pipedStore struct {
-	backend
+	backend CollectionStore
 	nowFunc func() time.Time
 }
 
 func NewPipedStore(ds DataStore) PipedStore {
 	return &pipedStore{
-		backend: backend{
-			ds: ds,
+		backend: &collectionStore{
+			col: &pipedCollection{},
+			ds:  ds,
 		},
 		nowFunc: time.Now,
 	}
@@ -86,19 +95,19 @@ func (s *pipedStore) AddPiped(ctx context.Context, piped *model.Piped) error {
 	if err := piped.Validate(); err != nil {
 		return err
 	}
-	return s.ds.Create(ctx, PipedModelKind, piped.Id, piped)
+	return s.backend.Create(ctx, piped.Id, piped)
 }
 
 func (s *pipedStore) GetPiped(ctx context.Context, id string) (*model.Piped, error) {
 	var entity model.Piped
-	if err := s.ds.Get(ctx, PipedModelKind, id, &entity); err != nil {
+	if err := s.backend.Get(ctx, id, &entity); err != nil {
 		return nil, err
 	}
 	return &entity, nil
 }
 
 func (s *pipedStore) ListPipeds(ctx context.Context, opts ListOptions) ([]*model.Piped, error) {
-	it, err := s.ds.Find(ctx, PipedModelKind, opts)
+	it, err := s.backend.Find(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +128,7 @@ func (s *pipedStore) ListPipeds(ctx context.Context, opts ListOptions) ([]*model
 
 func (s *pipedStore) UpdatePiped(ctx context.Context, id string, updater func(piped *model.Piped) error) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, PipedModelKind, id, pipedFactory, func(e interface{}) error {
+	return s.backend.Update(ctx, id, func(e interface{}) error {
 		p := e.(*model.Piped)
 		if err := updater(p); err != nil {
 			return err

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -21,10 +21,17 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-const ProjectModelKind = "Project"
+type projectCollection struct {
+}
 
-var projectFactory = func() interface{} {
-	return &model.Project{}
+func (p *projectCollection) Kind() string {
+	return "Project"
+}
+
+func (p *projectCollection) Factory() Factory {
+	return func() interface{} {
+		return &model.Project{}
+	}
 }
 
 type ProjectStore interface {
@@ -40,14 +47,15 @@ type ProjectStore interface {
 }
 
 type projectStore struct {
-	backend
+	backend CollectionStore
 	nowFunc func() time.Time
 }
 
 func NewProjectStore(ds DataStore) ProjectStore {
 	return &projectStore{
-		backend: backend{
-			ds: ds,
+		backend: &collectionStore{
+			col: &projectCollection{},
+			ds:  ds,
 		},
 		nowFunc: time.Now,
 	}
@@ -64,12 +72,12 @@ func (s *projectStore) AddProject(ctx context.Context, proj *model.Project) erro
 	if err := proj.Validate(); err != nil {
 		return err
 	}
-	return s.ds.Create(ctx, ProjectModelKind, proj.Id, proj)
+	return s.backend.Create(ctx, proj.Id, proj)
 }
 
 func (s *projectStore) UpdateProject(ctx context.Context, id string, updater func(project *model.Project) error) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, ProjectModelKind, id, projectFactory, func(e interface{}) error {
+	return s.backend.Update(ctx, id, func(e interface{}) error {
 		p := e.(*model.Project)
 		if err := updater(p); err != nil {
 			return err
@@ -126,14 +134,14 @@ func (s *projectStore) UpdateProjectRBACConfig(ctx context.Context, id string, r
 
 func (s *projectStore) GetProject(ctx context.Context, id string) (*model.Project, error) {
 	var entity model.Project
-	if err := s.ds.Get(ctx, ProjectModelKind, id, &entity); err != nil {
+	if err := s.backend.Get(ctx, id, &entity); err != nil {
 		return nil, err
 	}
 	return &entity, nil
 }
 
 func (s *projectStore) ListProjects(ctx context.Context, opts ListOptions) ([]model.Project, error) {
-	it, err := s.ds.Find(ctx, ProjectModelKind, opts)
+	it, err := s.backend.Find(ctx, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Just as we do on https://github.com/pipe-cd/pipecd/pull/3113, but instead of making `Collection` interface directly as a parameter for Datastore interface, create a CollectionStore interface which is a wrapper of Datastore object with specified/configurable Store object
https://github.com/pipe-cd/pipecd/pull/3111/files#diff-c2a2bcb11861b2665e176007622d47ad3892256241238e9cac8f39e6fe200a67

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
