### PR TITLE
Add livestatestore for CloudRun

### DIFF
--- a/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
@@ -2,10 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["store.go"],
+    srcs = [
+        "cloudrun.go",
+        "store.go",
+    ],
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/livestatestore/cloudrun",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/piped/cloudprovider/cloudrun:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/model:go_default_library",
         "@org_uber_go_zap//:go_default_library",

--- a/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
+++ b/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
@@ -68,9 +68,11 @@ func (s *Store) Run(ctx context.Context) error {
 			return nil
 
 		case <-tick.C:
-			if err := s.store.run(ctx); err == nil {
-				s.logger.Info("successfully synced all cloudrun services")
+			if err := s.store.run(ctx); err != nil {
+				s.logger.Error("failed to sync cloudrun services", zap.Error(err))
+				continue
 			}
+			s.logger.Info("successfully synced all cloudrun services")
 		}
 	}
 }

--- a/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
+++ b/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudrun
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/cloudprovider/cloudrun"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type applicationLister interface {
+	List() []*model.Application
+}
+
+type Store struct {
+	store    *store
+	logger   *zap.Logger
+	interval time.Duration
+}
+
+type Getter interface {
+	GetAppLiveServiceManifest(appID string) provider.ServiceManifest
+}
+
+func NewStore(cfg *config.CloudProviderCloudRunConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
+	logger = logger.Named("cloudrun").
+		With(zap.String("cloud-provider", cloudProvider))
+
+	return &Store{
+		store: &store{
+			apps:   make(map[string]provider.ServiceManifest),
+			logger: logger.Named("store"),
+		},
+		interval: 15 * time.Second,
+		logger:   logger,
+	}
+}
+
+func (s *Store) Run(ctx context.Context) error {
+	s.logger.Info("start running cloudrun app state store")
+
+	tick := time.NewTicker(s.interval)
+	defer tick.Stop()
+
+L:
+	for {
+		select {
+		case <-ctx.Done():
+			break L
+
+		case <-tick.C:
+			if err := s.store.run(ctx); err != nil {
+				continue
+			}
+			s.logger.Info("successfully synced all cloudrun services")
+		}
+	}
+
+	s.logger.Info("cloudrun app state store has been stopped")
+	return nil
+}
+
+func (s *Store) GetAppLiveServiceManifest(appID string) provider.ServiceManifest {
+	return s.store.GetAppLiveServiceManifest(appID)
+}

--- a/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
+++ b/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
@@ -31,7 +31,7 @@ type Store struct {
 }
 
 type Getter interface {
-	GetServiceManifest(appID string) provider.ServiceManifest
+	GetServiceManifest(appID string) (provider.ServiceManifest, bool)
 }
 
 func NewStore(ctx context.Context, cfg *config.CloudProviderCloudRunConfig, cloudProvider string, logger *zap.Logger) (*Store, error) {
@@ -77,6 +77,6 @@ func (s *Store) Run(ctx context.Context) error {
 	}
 }
 
-func (s *Store) GetServiceManifest(appID string) provider.ServiceManifest {
+func (s *Store) GetServiceManifest(appID string) (provider.ServiceManifest, bool) {
 	return s.store.GetServiceManifest(appID)
 }

--- a/pkg/app/piped/livestatestore/cloudrun/store.go
+++ b/pkg/app/piped/livestatestore/cloudrun/store.go
@@ -16,6 +16,7 @@ package cloudrun
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 
 	"go.uber.org/zap"
@@ -43,8 +44,7 @@ func (s *store) run(ctx context.Context) error {
 		// https://cloud.google.com/run/quotas#api
 		v, next, err := s.client.List(ctx, ops)
 		if err != nil {
-			s.logger.Error("failed to list cloudrun services: %v", zap.Error(err))
-			return err
+			return fmt.Errorf("failed to list cloudrun services: %w", err)
 		}
 		svc = append(svc, v...)
 		if next == "" {
@@ -64,7 +64,7 @@ func (s *store) setApps(svc []*provider.Service) {
 	for i := range svc {
 		sm, err := svc[i].ServiceManifest()
 		if err != nil {
-			s.logger.Error("failed to load cloudrun service into service manifest: %v", zap.Error(err))
+			s.logger.Error("failed to load cloudrun service into service manifest", zap.Error(err))
 			continue
 		}
 		appID := sm.Labels()[provider.LabelApplication]
@@ -89,7 +89,7 @@ func (s *store) GetServiceManifest(appID string) provider.ServiceManifest {
 	}
 	sm, ok := apps[appID]
 	if !ok {
-		s.logger.Info("this app was not found: %s", zap.String("app-id", appID))
+		s.logger.Info("this app was not found", zap.String("app-id", appID))
 		return provider.ServiceManifest{}
 	}
 

--- a/pkg/app/piped/livestatestore/cloudrun/store.go
+++ b/pkg/app/piped/livestatestore/cloudrun/store.go
@@ -81,17 +81,17 @@ func (s *store) loadApps() map[string]provider.ServiceManifest {
 	return apps.(map[string]provider.ServiceManifest)
 }
 
-func (s *store) GetServiceManifest(appID string) provider.ServiceManifest {
+func (s *store) GetServiceManifest(appID string) (provider.ServiceManifest, bool) {
 	apps := s.loadApps()
 	if apps == nil {
-		s.logger.Error("failed to load apps")
-		return provider.ServiceManifest{}
-	}
-	sm, ok := apps[appID]
-	if !ok {
-		s.logger.Info("this app was not found", zap.String("app-id", appID))
-		return provider.ServiceManifest{}
+		s.logger.Error("failed to load cloudrun apps")
+		return provider.ServiceManifest{}, false
 	}
 
-	return sm
+	sm, ok := apps[appID]
+	if !ok {
+		return provider.ServiceManifest{}, false
+	}
+
+	return sm, true
 }

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -63,6 +63,7 @@ type terraformStore interface {
 
 type cloudRunStore interface {
 	Run(ctx context.Context) error
+	cloudrun.Getter
 }
 
 type lambdaStore interface {

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -116,7 +116,7 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 		case model.CloudProviderCloudRun:
 			store, err := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, logger)
 			if err != nil {
-				logger.Error("failed to create a new cloudrun's livestatestore: %v", zap.Error(err))
+				logger.Error("failed to create a new cloudrun's livestatestore", zap.Error(err))
 				continue
 			}
 			s.cloudrunStores[cp.Name] = store

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -114,7 +114,11 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 			s.terraformStores[cp.Name] = store
 
 		case model.CloudProviderCloudRun:
-			store := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, appLister, logger)
+			store, err := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, logger)
+			if err != nil {
+				logger.Error("failed to create a new cloudrun's livestatestore: %v", zap.Error(err))
+				continue
+			}
 			s.cloudrunStores[cp.Name] = store
 
 		case model.CloudProviderLambda:


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement livestatestore's Run function.
The CloudRun service managed by piped is polled once every 15s and saved in the in-memory cache.
Here, Look-ahead cache is adopted and basically there are always caches.
In the init implementation, The lag of up to 15s in Configuration drift detection is allowed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
