### PR TITLE
Fix to pass ctx to NewStore in livestatestore

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -308,7 +308,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	var liveStateGetter livestatestore.Getter
 	// Start running application live state store.
 	{
-		s := livestatestore.NewStore(cfg, applicationLister, p.gracePeriod, input.Logger)
+		s := livestatestore.NewStore(ctx, cfg, applicationLister, p.gracePeriod, input.Logger)
 		group.Go(func() error {
 			return s.Run(ctx)
 		})

--- a/pkg/app/piped/livestatestore/cloudrun/store.go
+++ b/pkg/app/piped/livestatestore/cloudrun/store.go
@@ -34,7 +34,7 @@ type Store struct {
 type Getter interface {
 }
 
-func NewStore(cfg *config.CloudProviderCloudRunConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
+func NewStore(_ context.Context, cfg *config.CloudProviderCloudRunConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("cloudrun").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -90,7 +90,7 @@ type store struct {
 	logger      *zap.Logger
 }
 
-func NewStore(cfg *config.PipedSpec, appLister applicationLister, gracePeriod time.Duration, logger *zap.Logger) Store {
+func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationLister, gracePeriod time.Duration, logger *zap.Logger) Store {
 	logger = logger.Named("livestatestore")
 
 	s := &store{
@@ -113,7 +113,7 @@ func NewStore(cfg *config.PipedSpec, appLister applicationLister, gracePeriod ti
 			s.terraformStores[cp.Name] = store
 
 		case model.CloudProviderCloudRun:
-			store := cloudrun.NewStore(cp.CloudRunConfig, cp.Name, appLister, logger)
+			store := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, appLister, logger)
 			s.cloudrunStores[cp.Name] = store
 
 		case model.CloudProviderLambda:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to pass `ctx` in order to initialize client when call NewStore.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
