### PR TITLE
Ensure to make previous events OUTDATED whenever registering an event

### DIFF
--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -911,7 +911,6 @@ func (a *PipedAPI) ReportEventStatuses(ctx context.Context, req *pipedservice.Re
 		return nil, err
 	}
 	for _, e := range req.Events {
-		// TODO: For success status, change all previous events with the same event key to OUTDATED
 		if err := a.eventStore.UpdateEventStatus(ctx, e.Id, e.Status, e.StatusDescription); err != nil {
 			switch err {
 			case datastore.ErrNotFound:


### PR DESCRIPTION
**What this PR does / why we need it**:
Whenever you register an event, it will make previous events `OUTDATED`.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipecd/issues/3109

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
