### PR TITLE
Add driftdetector for CloudRun

### DIFF
--- a/pkg/app/piped/driftdetector/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/driftdetector/cloudrun/BUILD.bazel
@@ -5,4 +5,15 @@ go_library(
     srcs = ["detector.go"],
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/cloudrun",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/app/piped/cloudprovider/cloudrun:go_default_library",
+        "//pkg/app/piped/livestatestore/cloudrun:go_default_library",
+        "//pkg/app/piped/sourcedecrypter:go_default_library",
+        "//pkg/cache:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/diff:go_default_library",
+        "//pkg/git:go_default_library",
+        "//pkg/model:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
 )

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -248,7 +248,7 @@ func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo
 		if d.secretDecrypter != nil && gds.Encryption != nil {
 			appDir, err = d.getDecryptingDirPath(app, repo)
 			if err != nil {
-				return provider.ServiceManifest{}, err
+				return provider.ServiceManifest{}, fmt.Errorf("failed to get decrypting directory path: %w", err)
 			}
 
 			if err := sourcedecrypter.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -13,3 +13,316 @@
 // limitations under the License.
 
 package cloudrun
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/cloudprovider/cloudrun"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/livestatestore/cloudrun"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/sourcedecrypter"
+	"github.com/pipe-cd/pipecd/pkg/cache"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/diff"
+	"github.com/pipe-cd/pipecd/pkg/git"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type applicationLister interface {
+	ListByCloudProvider(name string) []*model.Application
+}
+
+type gitClient interface {
+	Clone(ctx context.Context, repoID, remote, branch, destination string) (git.Repo, error)
+}
+
+type secretDecrypter interface {
+	Decrypt(string) (string, error)
+}
+
+type reporter interface {
+	ReportApplicationSyncState(ctx context.Context, appID string, state model.ApplicationSyncState) error
+}
+
+type detector struct {
+	provider          config.PipedCloudProvider
+	appLister         applicationLister
+	gitClient         gitClient
+	stateGetter       cloudrun.Getter
+	reporter          reporter
+	appManifestsCache cache.Cache
+	interval          time.Duration
+	config            *config.PipedSpec
+	secretDecrypter   secretDecrypter
+	logger            *zap.Logger
+
+	gitRepos map[string]git.Repo
+}
+
+func NewDetector(
+	cp config.PipedCloudProvider,
+	appLister applicationLister,
+	gitClient gitClient,
+	stateGetter cloudrun.Getter,
+	reporter reporter,
+	appManifestsCache cache.Cache,
+	cfg *config.PipedSpec,
+	sd secretDecrypter,
+	logger *zap.Logger,
+) *detector {
+
+	logger = logger.Named("cloudrun-detector").With(
+		zap.String("cloud-provider", cp.Name),
+	)
+	return &detector{
+		provider:          cp,
+		appLister:         appLister,
+		gitClient:         gitClient,
+		stateGetter:       stateGetter,
+		reporter:          reporter,
+		appManifestsCache: appManifestsCache,
+		interval:          time.Minute,
+		config:            cfg,
+		secretDecrypter:   sd,
+		gitRepos:          make(map[string]git.Repo),
+		logger:            logger,
+	}
+}
+
+func (d *detector) Run(ctx context.Context) error {
+	d.logger.Info("start running drift detector for cloudrun applications")
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.Info("drift detector for cloudrun applications has been stopped")
+			return nil
+
+		case <-ticker.C:
+			d.check(ctx)
+		}
+	}
+}
+
+func (d *detector) ProviderName() string {
+	return d.provider.Name
+}
+
+func (d *detector) check(ctx context.Context) error {
+	appsByRepo := d.listGroupedApplication()
+
+	for repoID, apps := range appsByRepo {
+		gitRepo, ok := d.gitRepos[repoID]
+		if !ok {
+			// Clone repository for the first time.
+			gr, err := d.cloneGitRepository(ctx, repoID)
+			if err != nil {
+				d.logger.Error("failed to clone git repository",
+					zap.String("repo-id", repoID),
+					zap.Error(err),
+				)
+				continue
+			}
+			gitRepo = gr
+			d.gitRepos[repoID] = gitRepo
+		}
+
+		// Fetch the latest commit to compare the states.
+		branch := gitRepo.GetClonedBranch()
+		if err := gitRepo.Pull(ctx, branch); err != nil {
+			d.logger.Error("failed to pull repository branch",
+				zap.String("repo-id", repoID),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Get the head commit of the repository.
+		headCommit, err := gitRepo.GetLatestCommit(ctx)
+		if err != nil {
+			d.logger.Error("failed to get head commit hash",
+				zap.String("repo-id", repoID),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Start checking all applications in this repository.
+		for _, app := range apps {
+			if err := d.checkApplication(ctx, app, gitRepo, headCommit); err != nil {
+				d.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
+			}
+		}
+	}
+	return nil
+}
+
+func (d *detector) cloneGitRepository(ctx context.Context, repoID string) (git.Repo, error) {
+	repoCfg, ok := d.config.GetRepository(repoID)
+	if !ok {
+		return nil, fmt.Errorf("repository %s was not found in piped configuration", repoID)
+	}
+	return d.gitClient.Clone(ctx, repoID, repoCfg.Remote, repoCfg.Branch, "")
+}
+
+// listGroupedApplication retrieves all applications those should be handled by this director
+// and then groups them by repoID.
+func (d *detector) listGroupedApplication() map[string][]*model.Application {
+	var (
+		apps = d.appLister.ListByCloudProvider(d.provider.Name)
+		m    = make(map[string][]*model.Application)
+	)
+	for _, app := range apps {
+		repoID := app.GitPath.Repo.Id
+		if _, ok := m[repoID]; !ok {
+			m[repoID] = []*model.Application{app}
+		} else {
+			m[repoID] = append(m[repoID], app)
+		}
+	}
+	return m
+}
+
+func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit) error {
+	headManifest, err := d.loadHeadServiceManifest(app, repo, headCommit)
+	if err != nil {
+		return err
+	}
+	d.logger.Info(fmt.Sprintf("application %s has a service manifest at commit %s", app.Id, headCommit.Hash))
+
+	liveManifest, ok := d.stateGetter.GetServiceManifest(app.Id)
+	if !ok {
+		return fmt.Errorf("failed to get live service manifest")
+	}
+	d.logger.Info(fmt.Sprintf("application %s has a live service manifest", app.Id))
+
+	result, err := provider.Diff(
+		headManifest,
+		liveManifest,
+		diff.WithEquateEmpty(),
+		diff.WithIgnoreAddingMapKeys(),
+		diff.WithCompareNumberAndNumericString(),
+	)
+	if err != nil {
+		return err
+	}
+
+	state := makeSyncState(result, headCommit.Hash)
+
+	return d.reporter.ReportApplicationSyncState(ctx, app.Id, state)
+}
+
+func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.ServiceManifest, error) {
+	var (
+		manifestCache = provider.ServiceManifestCache{
+			AppID:  app.Id,
+			Cache:  d.appManifestsCache,
+			Logger: d.logger,
+		}
+		repoDir = repo.GetPath()
+		appDir  = filepath.Join(repoDir, app.GitPath.Path)
+	)
+
+	manifest, ok := manifestCache.Get(headCommit.Hash)
+	if !ok {
+		// When the manifests were not in the cache we have to load them.
+		cfg, err := d.loadApplicationConfiguration(repoDir, app)
+		if err != nil {
+			return provider.ServiceManifest{}, fmt.Errorf("failed to load application configuration: %w", err)
+		}
+
+		gds, ok := cfg.GetGenericApplication()
+		if !ok {
+			return provider.ServiceManifest{}, fmt.Errorf("unsupport application kind %s", cfg.Kind)
+		}
+
+		if d.secretDecrypter != nil && gds.Encryption != nil {
+			appDir, err = d.getDecryptingDirPath(app, repo)
+			if err != nil {
+				return provider.ServiceManifest{}, err
+			}
+
+			if err := sourcedecrypter.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {
+				return provider.ServiceManifest{}, fmt.Errorf("failed to decrypt secrets (%w)", err)
+			}
+		}
+
+		manifest, err = provider.LoadServiceManifest(appDir, app.GitPath.ConfigFilename)
+		if err != nil {
+			return provider.ServiceManifest{}, fmt.Errorf("failed to load new service manifest: %w", err)
+		}
+		manifestCache.Put(headCommit.Hash, manifest)
+	}
+	return manifest, nil
+}
+
+// We have to copy repository into another directory because
+// decrypting the sealed secrets might change the git repository.
+func (d *detector) getDecryptingDirPath(app *model.Application, repo git.Repo) (string, error) {
+	dir, err := os.MkdirTemp("", "detector-git-decrypt")
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare a temporary directory for git repository (%w)", err)
+	}
+	defer os.RemoveAll(dir)
+
+	repo, err = repo.Copy(filepath.Join(dir, "repo"))
+	if err != nil {
+		return "", fmt.Errorf("failed to copy the cloned git repository (%w)", err)
+	}
+	repoDir := repo.GetPath()
+	return filepath.Join(repoDir, app.GitPath.Path), nil
+}
+
+func (d *detector) loadApplicationConfiguration(repoPath string, app *model.Application) (*config.Config, error) {
+	path := filepath.Join(repoPath, app.GitPath.GetApplicationConfigFilePath())
+	cfg, err := config.LoadFromYAML(path)
+	if err != nil {
+		return nil, err
+	}
+	if appKind, ok := config.ToApplicationKind(cfg.Kind); !ok || appKind != app.Kind {
+		return nil, fmt.Errorf("application in application configuration file is not match, got: %s, expected: %s", appKind, app.Kind)
+	}
+	return cfg, nil
+}
+
+func makeSyncState(r *provider.DiffResult, commit string) model.ApplicationSyncState {
+	if r.NoChange() {
+		return model.ApplicationSyncState{
+			Status:    model.ApplicationSyncStatus_SYNCED,
+			Timestamp: time.Now().Unix(),
+		}
+	}
+
+	shortReason := fmt.Sprintf("The service manifest doesn't be synced")
+	if len(commit) >= 7 {
+		commit = commit[:7]
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual live state:\n\n", commit))
+	b.WriteString("--- Expected\n+++ Actual\n\n")
+
+	details := r.Render(provider.DiffRenderOptions{
+		// Currently, we do not use the diff command to render the result
+		// because CloudRun adds a large number of default values to the
+		// running manifest that causes a wrong diff text.
+		UseDiffCommand: false,
+	})
+	b.WriteString(details)
+
+	return model.ApplicationSyncState{
+		Status:      model.ApplicationSyncStatus_OUT_OF_SYNC,
+		ShortReason: shortReason,
+		Reason:      b.String(),
+		Timestamp:   time.Now().Unix(),
+	}
+}

--- a/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/app/piped/cloudprovider/cloudrun:go_default_library",
         "//pkg/config:go_default_library",
-        "//pkg/model:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement driftdetector for CloudRun.
Even if this PR is merged, it'll not affect the release because the call is not executed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
