### PR TITLE
Ensure to make NOT_HANDLED events that a new event created to OUTDATED

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -356,6 +356,27 @@
         "arrayConfig": ""
       },
       {
+        "fieldPath": "CreatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Event",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
         "fieldPath": "Status",
         "order": "ASCENDING",
         "arrayConfig": ""

--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -356,6 +356,11 @@
         "arrayConfig": ""
       },
       {
+        "fieldPath": "Status",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
         "fieldPath": "CreatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -380,6 +380,27 @@ func TestParseIndexes(t *testing.T) {
 					ArrayConfig: "",
 				},
 				{
+					FieldPath:   "CreatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
+			CollectionGroup: "Event",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
 					FieldPath:   "Status",
 					Order:       "ASCENDING",
 					ArrayConfig: "",

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -380,6 +380,11 @@ func TestParseIndexes(t *testing.T) {
 					ArrayConfig: "",
 				},
 				{
+					FieldPath:   "Status",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
 					FieldPath:   "CreatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",

--- a/pkg/app/piped/apistore/eventstore/BUILD.bazel
+++ b/pkg/app/piped/apistore/eventstore/BUILD.bazel
@@ -9,8 +9,6 @@ go_library(
         "//pkg/app/server/service/pipedservice:go_default_library",
         "//pkg/model:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//codes:go_default_library",
-        "@org_golang_google_grpc//status:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -121,6 +121,7 @@ func (s *store) sync(ctx context.Context) error {
 		return fmt.Errorf("failed to list events: %w", err)
 	}
 	if len(resp.Events) == 0 {
+		s.notHandledEvents.Store(make(map[string][]*model.Event))
 		return nil
 	}
 

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -137,16 +137,16 @@ func (s *store) ListNotHandled(name string, labels map[string]string, minCreated
 
 	events := notHandledEvents.(map[string][]*model.Event)[key]
 	out := make([]*model.Event, 0, len(events))
-	for _, e := range events {
+	for i, e := range events {
 		if e.CreatedAt < minCreatedAt {
+			break
+		}
+		if i >= limit {
 			break
 		}
 		out = append(out, e)
 	}
-	if len(out) < limit {
-		return out
-	}
-	return out[:limit]
+	return out
 }
 
 func (s *store) Lister() Lister {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -291,11 +291,13 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	}
 
 	// Start running event store.
-	eventStore := eventstore.NewStore(apiClient, p.gracePeriod, input.Logger)
+	var eventLister eventstore.Lister
 	{
+		store := eventstore.NewStore(apiClient, p.gracePeriod, input.Logger)
 		group.Go(func() error {
-			return eventStore.Run(ctx)
+			return store.Run(ctx)
 		})
+		eventLister = store.Lister()
 	}
 
 	analysisResultStore := analysisresultstore.NewStore(apiClient, input.Logger)
@@ -402,7 +404,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	{
 		w := eventwatcher.NewWatcher(
 			cfg,
-			eventStore,
+			eventLister,
 			gitClient,
 			apiClient,
 			input.Logger,

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -404,6 +404,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			cfg,
 			eventStore,
 			gitClient,
+			apiClient,
 			input.Logger,
 		)
 		group.Go(func() error {

--- a/pkg/app/piped/eventwatcher/BUILD.bazel
+++ b/pkg/app/piped/eventwatcher/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/server/service/pipedservice:go_default_library",
         "//pkg/backoff:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/regexpool:go_default_library",
         "//pkg/yamlprocessor:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -733,6 +733,24 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 			Value:    req.To,
 		})
 	}
+	if req.Status != pipedservice.ListEventsRequest_ALL {
+		var status model.EventStatus
+		switch req.Status {
+		case pipedservice.ListEventsRequest_NOT_HANDLED:
+			status = model.EventStatus_EVENT_NOT_HANDLED
+		case pipedservice.ListEventsRequest_SUCCESS:
+			status = model.EventStatus_EVENT_SUCCESS
+		case pipedservice.ListEventsRequest_FAILURE:
+			status = model.EventStatus_EVENT_FAILURE
+		case pipedservice.ListEventsRequest_OUTDATED:
+			status = model.EventStatus_EVENT_OUTDATED
+		}
+		opts.Filters = append(opts.Filters, datastore.ListFilter{
+			Field:    "Status",
+			Operator: datastore.OperatorEqual,
+			Value:    status,
+		})
+	}
 	switch req.Order {
 	case pipedservice.ListOrder_ASC:
 		opts.Orders = []datastore.Order{

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -744,6 +744,8 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 			status = model.EventStatus_EVENT_FAILURE
 		case pipedservice.ListEventsRequest_OUTDATED:
 			status = model.EventStatus_EVENT_OUTDATED
+		default:
+			return nil, fmt.Errorf("unknown status %v given", req.Status)
 		}
 		opts.Filters = append(opts.Filters, datastore.ListFilter{
 			Field:    "Status",

--- a/pkg/app/server/service/pipedservice/service.proto
+++ b/pkg/app/server/service/pipedservice/service.proto
@@ -438,9 +438,17 @@ message GetLatestEventResponse {
 
 
 message ListEventsRequest {
+    enum Status {
+        ALL = 0;
+        NOT_HANDLED = 1;
+        SUCCESS = 2;
+        FAILURE = 3;
+        OUTDATED = 4;
+    }
     int64 from = 1;
     int64 to = 2;
     ListOrder order = 3 [(validate.rules).enum.defined_only = true];
+    Status status = 4 [(validate.rules).enum.defined_only = true];
 }
 
 message ListEventsResponse {


### PR DESCRIPTION
**What this PR does / why we need it**:
With it, up to 10 events that are not handled and new events are created will be `OUTDATED`.

![image](https://user-images.githubusercontent.com/19730728/151133312-8970d48c-7d53-4e73-9403-17193e372fa9.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/3109

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
