### PR TITLE
Add a new pipectl command to rename multiple application configuration files

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -255,8 +255,8 @@ You can encrypt it the same way you do [from the web](/docs/user-guide/secret-ma
       --env-name={ENV_NAME} \ # Optional.
       --before=.pipe.yaml \
       --after=app.pipecd.yaml \
-      --update-at-local=true \ # Whether to rename files in Git locally.
-      --update-at-control-plane=false # Whether to update application information on control plane to use the new name.
+      --update-on-local=true \ # Whether to rename files in Git locally.
+      --update-on-control-plane=false # Whether to update application information on control plane to use the new name.
   ```
 
 ### Migrating deployment configuration files to application configuration files

--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -244,6 +244,21 @@ You can encrypt it the same way you do [from the web](/docs/user-guide/secret-ma
       --input-file={PATH_TO_SECRET_FILE}
   ```
 
+### Rename multiple application configuration files
+
+  ``` console
+  pipectl app-config rename \
+      --address={CONTROL_PLANE_API_ADDRESS} \
+      --api-key={API_KEY} \
+      --repo-root-path={ABSOLUTE_PATH_TO_ROOT_OF_REPOSITORY} \
+      --repo-id={REPO_ID} \
+      --env-name={ENV_NAME} \ # Optional.
+      --before=.pipe.yaml \
+      --after=app.pipecd.yaml \
+      --update-at-local=true \ # Whether to rename files in Git locally.
+      --update-at-control-plane=false # Whether to update application information on control plane to use the new name.
+  ```
+
 ### Migrating deployment configuration files to application configuration files
 
   ``` console

--- a/pkg/app/pipectl/cmd/appconfig/BUILD.bazel
+++ b/pkg/app/pipectl/cmd/appconfig/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "appconfig.go",
         "migratefromdeployconfig.go",
+        "rename.go",
     ],
     importpath = "github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/appconfig",
     visibility = ["//visibility:public"],
@@ -12,6 +13,7 @@ go_library(
         "//pkg/app/pipectl/client:go_default_library",
         "//pkg/app/server/service/apiservice:go_default_library",
         "//pkg/cli:go_default_library",
+        "//pkg/model:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/pkg/app/pipectl/cmd/appconfig/appconfig.go
+++ b/pkg/app/pipectl/cmd/appconfig/appconfig.go
@@ -34,7 +34,8 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newListCommand(c),
+		newMigrateCommand(c),
+		newRenameCommand(c),
 	)
 
 	c.clientOptions.RegisterPersistentFlags(cmd)

--- a/pkg/app/pipectl/cmd/appconfig/migratefromdeployconfig.go
+++ b/pkg/app/pipectl/cmd/appconfig/migratefromdeployconfig.go
@@ -39,7 +39,7 @@ type migrateFromDeployConfig struct {
 	stdout       io.Writer
 }
 
-func newListCommand(root *command) *cobra.Command {
+func newMigrateCommand(root *command) *cobra.Command {
 	m := &migrateFromDeployConfig{
 		root:   root,
 		stdout: os.Stdout,

--- a/pkg/app/pipectl/cmd/appconfig/rename.go
+++ b/pkg/app/pipectl/cmd/appconfig/rename.go
@@ -37,7 +37,7 @@ type rename struct {
 	envName              string
 	before               string
 	after                string
-	updateAtLocal        bool
+	updateOnLocal        bool
 	updateOnControlPlane bool
 	stdout               io.Writer
 }
@@ -58,7 +58,7 @@ func newRenameCommand(root *command) *cobra.Command {
 	cmd.Flags().StringVar(&c.envName, "env-name", c.envName, "The environment name.")
 	cmd.Flags().StringVar(&c.before, "before", c.before, "The current name of configuration file.")
 	cmd.Flags().StringVar(&c.after, "after", c.after, "The new name of configuration file.")
-	cmd.Flags().BoolVar(&c.updateAtLocal, "update-at-local", c.updateAtLocal, "Whether to rename files in Git locally.")
+	cmd.Flags().BoolVar(&c.updateOnLocal, "update-on-local", c.updateOnLocal, "Whether to rename files in Git locally.")
 	cmd.Flags().BoolVar(&c.updateOnControlPlane, "update-on-control-plane", c.updateOnControlPlane, "Whether to update application information on control plane to use the new name.")
 
 	cmd.MarkFlagRequired("repo-root-path")
@@ -70,8 +70,8 @@ func newRenameCommand(root *command) *cobra.Command {
 }
 
 func (c *rename) run(ctx context.Context, _ cli.Input) error {
-	if !c.updateAtLocal && !c.updateOnControlPlane {
-		fmt.Fprintln(c.stdout, "Nothing to do since both --update-at-local and --update-on-control-plane were set to false.")
+	if !c.updateOnLocal && !c.updateOnControlPlane {
+		fmt.Fprintln(c.stdout, "Nothing to do since both --update-on-local and --update-on-control-plane were set to false.")
 		return nil
 	}
 
@@ -117,7 +117,7 @@ func (c *rename) run(ctx context.Context, _ cli.Input) error {
 		return nil
 	}
 
-	if c.updateAtLocal {
+	if c.updateOnLocal {
 		for i, app := range targets {
 			// Ensure the existence of the current configuration file.
 			var (

--- a/pkg/app/pipectl/cmd/appconfig/rename.go
+++ b/pkg/app/pipectl/cmd/appconfig/rename.go
@@ -83,8 +83,10 @@ func (c *rename) run(ctx context.Context, _ cli.Input) error {
 
 	fmt.Fprintln(c.stdout, "Start finding applications to rename their configuration files...")
 
-	var cursor string
-	var targets = make([]*model.Application, 0, 0)
+	var (
+		cursor  string
+		targets []*model.Application
+	)
 
 	for {
 		req := &apiservice.ListApplicationsRequest{

--- a/pkg/app/pipectl/cmd/appconfig/rename.go
+++ b/pkg/app/pipectl/cmd/appconfig/rename.go
@@ -71,7 +71,7 @@ func newRenameCommand(root *command) *cobra.Command {
 
 func (c *rename) run(ctx context.Context, _ cli.Input) error {
 	if !c.updateAtLocal && !c.updateOnControlPlane {
-		fmt.Fprintln(c.stdout, "Nothing to do since both --update-at-local and --update-on-control-plane were not set.")
+		fmt.Fprintln(c.stdout, "Nothing to do since both --update-at-local and --update-on-control-plane were set to false.")
 		return nil
 	}
 

--- a/pkg/app/pipectl/cmd/appconfig/rename.go
+++ b/pkg/app/pipectl/cmd/appconfig/rename.go
@@ -133,7 +133,7 @@ func (c *rename) run(ctx context.Context, _ cli.Input) error {
 			)
 			_, err := os.Stat(newPath)
 			if err == nil {
-				return fmt.Errorf("Unable to use the new name %q since it will override %s", c.after, newPath)
+				return fmt.Errorf("unable to use the new name %q since it will override %s", c.after, newPath)
 			}
 			if !errors.Is(err, os.ErrNotExist) {
 				return err

--- a/pkg/app/pipectl/cmd/appconfig/rename.go
+++ b/pkg/app/pipectl/cmd/appconfig/rename.go
@@ -1,0 +1,170 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
+	"github.com/pipe-cd/pipecd/pkg/cli"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type rename struct {
+	root *command
+
+	repoRootPath         string
+	repoID               string
+	envName              string
+	before               string
+	after                string
+	updateAtLocal        bool
+	updateOnControlPlane bool
+	stdout               io.Writer
+}
+
+func newRenameCommand(root *command) *cobra.Command {
+	c := &rename{
+		root:   root,
+		stdout: os.Stdout,
+	}
+	cmd := &cobra.Command{
+		Use:   "rename",
+		Short: "Finds all applications that has the given configuration file name to change.",
+		RunE:  cli.WithContext(c.run),
+	}
+
+	cmd.Flags().StringVar(&c.repoRootPath, "repo-root-path", c.repoRootPath, "The absolute path to the root directory of the Git repository.")
+	cmd.Flags().StringVar(&c.repoID, "repo-id", c.repoID, "The repository ID that is being registered in Piped config.")
+	cmd.Flags().StringVar(&c.envName, "env-name", c.envName, "The environment name.")
+	cmd.Flags().StringVar(&c.before, "before", c.before, "The current name of configuration file.")
+	cmd.Flags().StringVar(&c.after, "after", c.after, "The new name of configuration file.")
+	cmd.Flags().BoolVar(&c.updateAtLocal, "update-at-local", c.updateAtLocal, "Whether to rename files in Git locally.")
+	cmd.Flags().BoolVar(&c.updateOnControlPlane, "update-on-control-plane", c.updateOnControlPlane, "Whether to update application information on control plane to use the new name.")
+
+	cmd.MarkFlagRequired("repo-root-path")
+	cmd.MarkFlagRequired("repo-id")
+	cmd.MarkFlagRequired("before")
+	cmd.MarkFlagRequired("after")
+
+	return cmd
+}
+
+func (c *rename) run(ctx context.Context, _ cli.Input) error {
+	if !c.updateAtLocal && !c.updateOnControlPlane {
+		fmt.Fprintln(c.stdout, "Nothing to do since both --update-at-local and --update-on-control-plane were not set.")
+		return nil
+	}
+
+	cli, err := c.root.clientOptions.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize client: %w", err)
+	}
+	defer cli.Close()
+
+	fmt.Fprintln(c.stdout, "Start finding applications to rename their configuration files...")
+
+	var cursor string
+	var targets = make([]*model.Application, 0, 0)
+
+	for {
+		req := &apiservice.ListApplicationsRequest{
+			EnvName: c.envName,
+			Cursor:  cursor,
+		}
+		resp, err := cli.ListApplications(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to list application: %w", err)
+		}
+		for _, app := range resp.Applications {
+			if app.GitPath.Repo.Id != c.repoID {
+				continue
+			}
+			if app.GitPath.GetApplicationConfigFilename() != c.before {
+				continue
+			}
+			targets = append(targets, app)
+		}
+		if resp.Cursor == "" {
+			break
+		}
+		cursor = resp.Cursor
+	}
+
+	fmt.Fprintf(c.stdout, "Found %d applications to update\n", len(targets))
+	if len(targets) == 0 {
+		return nil
+	}
+
+	if c.updateAtLocal {
+		for i, app := range targets {
+			// Ensure the existence of the current configuration file.
+			var (
+				oldRelPath = app.GitPath.GetApplicationConfigFilePath()
+				oldPath    = filepath.Join(c.repoRootPath, oldRelPath)
+			)
+			if _, err := os.Stat(oldPath); err != nil {
+				return err
+			}
+
+			// Ensure that the new name is not conflicting with any existing files.
+			var (
+				newRelPath = filepath.Join(app.GitPath.Path, c.after)
+				newPath    = filepath.Join(c.repoRootPath, newRelPath)
+			)
+			_, err := os.Stat(newPath)
+			if err == nil {
+				return fmt.Errorf("Unable to use the new name %q since it will override %s", c.after, newPath)
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+
+			// Rename file locally.
+			if err := os.Rename(oldPath, newPath); err != nil {
+				return err
+			}
+			fmt.Fprintf(c.stdout, "%d. renamed %s to %s\n", i+1, oldRelPath, newRelPath)
+		}
+		fmt.Fprintf(c.stdout, "Successfully renamed %d applications locally\n", len(targets))
+	}
+
+	if c.updateOnControlPlane {
+		limit := 20
+		for i := 0; i < len(targets); i += limit {
+			req := &apiservice.RenameApplicationConfigFileRequest{
+				ApplicationIds: make([]string, 0, limit),
+				NewFilename:    c.after,
+			}
+			for j := i; j < len(targets) && j < i+limit; j++ {
+				req.ApplicationIds = append(req.ApplicationIds, targets[j].Id)
+			}
+			_, err := cli.RenameApplicationConfigFile(ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to update the configuration file name on the control plane: %w", err)
+			}
+		}
+		fmt.Fprintf(c.stdout, "Successfully renamed %d applications on the control plane\n", len(targets))
+	}
+
+	return nil
+}

--- a/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/livestatestore/cloudrun/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/app/piped/cloudprovider/cloudrun:go_default_library",
         "//pkg/config:go_default_library",
-        "//pkg/model:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -28,13 +28,17 @@ const (
 
 // GetApplicationConfigFilePath returns the path to application configuration file.
 func (p ApplicationGitPath) GetApplicationConfigFilePath() string {
+	return filepath.Join(p.Path, p.GetApplicationConfigFilename())
+}
+
+func (p ApplicationGitPath) GetApplicationConfigFilename() string {
 	// The config file name used to allow to be empty until the default name got changed.
 	// So empty means the old default name.
 	filename := oldDefaultApplicationConfigFilename
 	if n := p.ConfigFilename; n != "" {
 		filename = n
 	}
-	return filepath.Join(p.Path, filename)
+	return filename
 }
 
 // HasChanged checks whether the content of sync state has been changed.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a new pipectl command to rename multiple application configuration files
```
