### PR TITLE
Run go mod download only when go.mod changed

### DIFF
--- a/dockers/actions-plan-preview/Dockerfile
+++ b/dockers/actions-plan-preview/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.17.3-alpine3.15 as builder
-COPY . /app
-RUN cd /app && go build -o /plan-preview .
+WORKDIR /app
+COPY go.mod go.sum  ./
+RUN go mod download
+COPY . ./
+RUN go build -o /plan-preview .
 
 FROM gcr.io/pipecd/pipectl:v0.22.0
 COPY --from=builder /plan-preview /


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, `go mod download` is executed every time the source code is changed.
This change will cause the `go mod download` to be executed only when the `go.mod, go.sum` is modified.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
