### PR TITLE
Remove alpha badge of remote-config and remote-update from stable docs and docs-v0.24.x

### DIFF
--- a/docs/content/en/docs-v0.24.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.24.x/feature-status/_index.md
@@ -99,8 +99,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch metrics | Incubating |
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch log | Incubating |
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by HTTP request (smoke test...) | Incubating |
-| [Remote upgrade](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Alpha |
-| [Remote config](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Alpha |
+| [Remote upgrade](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Beta |
+| [Remote config](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Beta |
 
 ### ControlPlane's Core
 

--- a/docs/content/en/docs-v0.24.x/operator-manual/piped/remote-upgrade-remote-config.md
+++ b/docs/content/en/docs-v0.24.x/operator-manual/piped/remote-upgrade-remote-config.md
@@ -8,8 +8,6 @@ description: >
 
 ## Remote upgrade
 
-> NOTE: This feature is currently under Alpha status.
-
 The remote upgrade is the ability to restart the currently running Piped with another version from the web console.
 This reduces the effort involved in updating Piped to newer versions.
 All Pipeds that are running by the provided Piped container image can be enabled to use this feature.
@@ -27,8 +25,6 @@ Select a list of Pipeds to upgrade from Settings page
 </p>
 
 ## Remote config
-
-> NOTE: This feature is currently under Alpha status.
 
 Although the remote-upgrade allows you remotely restart your Pipeds to run any new version you want, if your Piped is loading its config locally where Piped is running, you still need to manually restart Piped after adding any change on that config data. Remote-config is for you to remove that kind of manual operation.
 

--- a/docs/content/en/docs/feature-status/_index.md
+++ b/docs/content/en/docs/feature-status/_index.md
@@ -99,8 +99,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch metrics | Incubating |
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch log | Incubating |
 | [ADA](/docs/user-guide/automated-deployment-analysis/) by HTTP request (smoke test...) | Incubating |
-| [Remote upgrade](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Alpha |
-| [Remote config](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Alpha |
+| [Remote upgrade](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Beta |
+| [Remote config](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Beta |
 
 ### ControlPlane's Core
 

--- a/docs/content/en/docs/operator-manual/piped/remote-upgrade-remote-config.md
+++ b/docs/content/en/docs/operator-manual/piped/remote-upgrade-remote-config.md
@@ -8,8 +8,6 @@ description: >
 
 ## Remote upgrade
 
-> NOTE: This feature is currently under Alpha status.
-
 The remote upgrade is the ability to restart the currently running Piped with another version from the web console.
 This reduces the effort involved in updating Piped to newer versions.
 All Pipeds that are running by the provided Piped container image can be enabled to use this feature.
@@ -27,8 +25,6 @@ Select a list of Pipeds to upgrade from Settings page
 </p>
 
 ## Remote config
-
-> NOTE: This feature is currently under Alpha status.
 
 Although the remote-upgrade allows you remotely restart your Pipeds to run any new version you want, if your Piped is loading its config locally where Piped is running, you still need to manually restart Piped after adding any change on that config data. Remote-config is for you to remove that kind of manual operation.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The status change of those features has already been announced in the latest release but the docs are still not being updated.

https://github.com/pipe-cd/pipecd/releases/tag/v0.24.5


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
