### PR TITLE
Add Writer to the datastore Update interface

### DIFF
--- a/pkg/app/ops/deploymentchaincontroller/updater.go
+++ b/pkg/app/ops/deploymentchaincontroller/updater.go
@@ -101,7 +101,7 @@ func (u *updater) Run(ctx context.Context) error {
 			// Update the deployment state in deployment chain model in case
 			// the deployment state is changed.
 			if deployment.Status != deploymentRef.Status {
-				if err = u.deploymentChainStore.UpdateDeploymentChain(ctx, u.deploymentChainID,
+				if err = u.deploymentChainStore.UpdateDeploymentChain(ctx, datastore.OpsWriter, u.deploymentChainID,
 					datastore.DeploymentChainNodeDeploymentStatusUpdater(
 						deployment.DeploymentChainBlockIndex,
 						deployment.Id,
@@ -140,6 +140,7 @@ func (u *updater) Run(ctx context.Context) error {
 			// Connect missing deployment to the chain.
 			if err := u.deploymentChainStore.UpdateDeploymentChain(
 				ctx,
+				datastore.OpsWriter,
 				u.deploymentChainID,
 				datastore.DeploymentChainAddDeploymentToBlock(deployment),
 			); err != nil {

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -94,7 +94,7 @@ func (c *OrphanCommandCleaner) updateOrphanCommandsStatus(ctx context.Context) e
 	}
 
 	for _, command := range commands {
-		err := c.commandstore.UpdateCommand(ctx, command.Id, func(cmd *model.Command) error {
+		err := c.commandstore.UpdateCommand(ctx, datastore.OpsWriter, command.Id, func(cmd *model.Command) error {
 			cmd.Status = model.CommandStatus_COMMAND_TIMEOUT
 			return nil
 		})

--- a/pkg/app/server/commandstore/store.go
+++ b/pkg/app/server/commandstore/store.go
@@ -105,7 +105,7 @@ func (s *store) GetCommand(ctx context.Context, id string) (*model.Command, erro
 
 func (s *store) UpdateCommandHandled(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, unhandledAt int64) error {
 	updater := datastore.CommandHandledUpdater(status, metadata, unhandledAt)
-	if err := s.backend.UpdateCommand(ctx, id, updater); err != nil {
+	if err := s.backend.UpdateCommand(ctx, datastore.PipedWriter, id, updater); err != nil {
 		return err
 	}
 

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -318,7 +318,7 @@ func (a *API) RenameApplicationConfigFile(ctx context.Context, req *apiservice.R
 
 	for _, appID := range req.ApplicationIds {
 		var denied bool
-		err := a.applicationStore.UpdateApplication(ctx, appID, func(app *model.Application) error {
+		err := a.applicationStore.UpdateApplication(ctx, datastore.PipectlWriter, appID, func(app *model.Application) error {
 			if app.ProjectId != key.ProjectId {
 				denied = true
 				return fmt.Errorf("Requested application %s does not belong to your project", appID)
@@ -388,7 +388,7 @@ func (a *API) DisablePiped(ctx context.Context, req *apiservice.DisablePipedRequ
 	return &apiservice.DisablePipedResponse{}, nil
 }
 
-func (a *API) updatePiped(ctx context.Context, pipedID string, updater func(context.Context, string) error) error {
+func (a *API) updatePiped(ctx context.Context, pipedID string, updater func(context.Context, datastore.Writer, string) error) error {
 	key, err := requireAPIKey(ctx, model.APIKey_READ_WRITE, a.logger)
 	if err != nil {
 		return err
@@ -403,7 +403,7 @@ func (a *API) updatePiped(ctx context.Context, pipedID string, updater func(cont
 		return status.Error(codes.PermissionDenied, "Requested piped doesn't belong to your project")
 	}
 
-	if err := updater(ctx, pipedID); err != nil {
+	if err := updater(ctx, datastore.PipectlWriter, pipedID); err != nil {
 		switch err {
 		case datastore.ErrNotFound:
 			return status.Error(codes.InvalidArgument, "The piped is not found")

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -51,6 +51,21 @@ const (
 	OperatorContains
 )
 
+type Writer string
+
+const (
+	// WebWriter indicates that the writer is web.
+	WebWriter Writer = "web"
+	// PipedWriter indicates that the writer is piped.
+	PipedWriter Writer = "piped"
+	// PipectlWriter indicates that the writer is pipectl.
+	PipectlWriter Writer = "pipectl"
+	// ServerWriter indicates that the writer is server.
+	ServerWriter Writer = "server"
+	// OpsWriter indicates that the writer is ops component.
+	OpsWriter Writer = "ops"
+)
+
 var (
 	ErrNotFound        = errors.New("not found")
 	ErrInvalidArgument = errors.New("invalid argument")
@@ -62,7 +77,32 @@ var (
 )
 
 type Factory func() interface{}
-type Updater func(interface{}) error
+type UpdateFunc func(interface{}) error
+
+type Updater interface {
+	Writer() Writer
+	UpdateFunc() UpdateFunc
+}
+
+type updater struct {
+	writer     Writer
+	updateFunc UpdateFunc
+}
+
+func NewUpdater(w Writer, f UpdateFunc) Updater {
+	return &updater{
+		writer:     w,
+		updateFunc: f,
+	}
+}
+
+func (u *updater) Writer() Writer {
+	return u.writer
+}
+
+func (u *updater) UpdateFunc() UpdateFunc {
+	return u.updateFunc
+}
 
 type Collection interface {
 	Kind() string

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -101,7 +101,7 @@ var (
 
 type DeploymentChainStore interface {
 	AddDeploymentChain(ctx context.Context, d *model.DeploymentChain) error
-	UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error
+	UpdateDeploymentChain(ctx context.Context, w Writer, id string, updater func(*model.DeploymentChain) error) error
 	GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error)
 	ListDeploymentChains(ctx context.Context, opts ListOptions) ([]*model.DeploymentChain, string, error)
 }
@@ -135,16 +135,16 @@ func (s *deploymentChainStore) AddDeploymentChain(ctx context.Context, dc *model
 	return s.ds.Create(ctx, s.col, dc.Id, dc)
 }
 
-func (s *deploymentChainStore) UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error {
+func (s *deploymentChainStore) UpdateDeploymentChain(ctx context.Context, w Writer, id string, updater func(*model.DeploymentChain) error) error {
 	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
+	return s.ds.Update(ctx, s.col, id, NewUpdater(w, func(e interface{}) error {
 		dc := e.(*model.DeploymentChain)
 		if err := updater(dc); err != nil {
 			return err
 		}
 		dc.UpdatedAt = now
 		return dc.Validate()
-	})
+	}))
 }
 
 func (s *deploymentChainStore) GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error) {

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -37,7 +37,7 @@ func (e *eventCollection) Factory() Factory {
 type EventStore interface {
 	AddEvent(ctx context.Context, e model.Event) error
 	ListEvents(ctx context.Context, opts ListOptions) ([]*model.Event, string, error)
-	UpdateEventStatus(ctx context.Context, eventID string, status model.EventStatus, statusDescription string) error
+	UpdateEventStatus(ctx context.Context, w Writer, id string, status model.EventStatus, statusDescription string) error
 }
 
 type eventStore struct {
@@ -98,8 +98,8 @@ func (s *eventStore) ListEvents(ctx context.Context, opts ListOptions) ([]*model
 	return es, cursor, nil
 }
 
-func (s *eventStore) UpdateEventStatus(ctx context.Context, eventID string, status model.EventStatus, statusDescription string) error {
-	return s.ds.Update(ctx, s.col, eventID, func(e interface{}) error {
+func (s *eventStore) UpdateEventStatus(ctx context.Context, w Writer, id string, status model.EventStatus, statusDescription string) error {
+	return s.ds.Update(ctx, s.col, id, NewUpdater(w, func(e interface{}) error {
 		event := e.(*model.Event)
 		event.Status = status
 		event.StatusDescription = statusDescription
@@ -111,5 +111,5 @@ func (s *eventStore) UpdateEventStatus(ctx context.Context, eventID string, stat
 			event.Handled = true
 		}
 		return nil
-	})
+	}))
 }

--- a/pkg/datastore/firestore/firestore.go
+++ b/pkg/datastore/firestore/firestore.go
@@ -225,7 +225,7 @@ func (s *FireStore) Update(ctx context.Context, col datastore.Collection, id str
 			)
 			return err
 		}
-		if err := updater(entity); err != nil {
+		if err := updater.UpdateFunc()(entity); err != nil {
 			s.logger.Error("failed to run updater to update entity",
 				zap.String("id", id),
 				zap.String("kind", kind),

--- a/pkg/datastore/mock.go
+++ b/pkg/datastore/mock.go
@@ -10,6 +10,57 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
+// MockUpdater is a mock of Updater interface.
+type MockUpdater struct {
+	ctrl     *gomock.Controller
+	recorder *MockUpdaterMockRecorder
+}
+
+// MockUpdaterMockRecorder is the mock recorder for MockUpdater.
+type MockUpdaterMockRecorder struct {
+	mock *MockUpdater
+}
+
+// NewMockUpdater creates a new mock instance.
+func NewMockUpdater(ctrl *gomock.Controller) *MockUpdater {
+	mock := &MockUpdater{ctrl: ctrl}
+	mock.recorder = &MockUpdaterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockUpdater) EXPECT() *MockUpdaterMockRecorder {
+	return m.recorder
+}
+
+// UpdateFunc mocks base method.
+func (m *MockUpdater) UpdateFunc() UpdateFunc {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateFunc")
+	ret0, _ := ret[0].(UpdateFunc)
+	return ret0
+}
+
+// UpdateFunc indicates an expected call of UpdateFunc.
+func (mr *MockUpdaterMockRecorder) UpdateFunc() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFunc", reflect.TypeOf((*MockUpdater)(nil).UpdateFunc))
+}
+
+// Writer mocks base method.
+func (m *MockUpdater) Writer() Writer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Writer")
+	ret0, _ := ret[0].(Writer)
+	return ret0
+}
+
+// Writer indicates an expected call of Writer.
+func (mr *MockUpdaterMockRecorder) Writer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Writer", reflect.TypeOf((*MockUpdater)(nil).Writer))
+}
+
 // MockCollection is a mock of Collection interface.
 type MockCollection struct {
 	ctrl     *gomock.Controller

--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -214,7 +214,7 @@ func (m *MySQL) Update(ctx context.Context, col datastore.Collection, id string,
 		return err
 	}
 
-	if err := updater(entity); err != nil {
+	if err := updater.UpdateFunc()(entity); err != nil {
 		m.logger.Error("failed to update entity: failed to apply updater",
 			zap.String("id", id),
 			zap.String("kind", kind),

--- a/test/integration/datastore/firestore/firestore_test.go
+++ b/test/integration/datastore/firestore/firestore_test.go
@@ -264,7 +264,7 @@ func TestUpdate(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := store.Update(ctx, col, tc.id, tc.updater)
+			err := store.Update(ctx, col, tc.id, datastore.NewUpdater("", tc.updater))
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to implement the Update interface for FileDB, we need a way to specify which file should be updated/written based on the writer (web or piped or ops ...). To prepare for that, this PR introduces a new Writer type and updates the existing Updater interface to
```golang
type Updater interface {
	Writer() Writer
	UpdateFunc() UpdateFunc // this is the existing Updater interface
}
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
