### PR TITLE
Ensure that old deploy source could be loaded normally even when the config name was changed

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/admin:go_default_library",
+        "//pkg/app/ops/configfilenamefiller:go_default_library",
         "//pkg/app/ops/deploymentchaincontroller:go_default_library",
         "//pkg/app/ops/firestoreindexensurer:go_default_library",
         "//pkg/app/ops/handler:go_default_library",

--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pipe-cd/pipecd/pkg/admin"
+	"github.com/pipe-cd/pipecd/pkg/app/ops/configfilenamefiller"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/deploymentchaincontroller"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/firestoreindexensurer"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/handler"
@@ -158,6 +159,15 @@ func (s *ops) run(ctx context.Context, input cli.Input) error {
 		cleaner := orphancommandcleaner.NewOrphanCommandCleaner(ds, input.Logger)
 		group.Go(func() error {
 			return cleaner.Run(ctx)
+		})
+	}
+
+	// TODO: Remove this configfilenamefiller once the migration task completed.
+	// Start running configfilenamefiller.
+	{
+		filler := configfilenamefiller.NewFiller(ds, input.Logger)
+		group.Go(func() error {
+			return filler.Run(ctx)
 		})
 	}
 

--- a/pkg/app/ops/configfilenamefiller/BUILD.bazel
+++ b/pkg/app/ops/configfilenamefiller/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["configfilenamefiller.go"],
+    importpath = "github.com/pipe-cd/pipecd/pkg/app/ops/configfilenamefiller",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/datastore:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -73,7 +73,7 @@ func (c *Filler) Run(ctx context.Context) error {
 			return err
 		}
 
-		c.logger.Info(fmt.Sprintf("found %d applications to fill", len()))
+		c.logger.Info(fmt.Sprintf("found %d applications to fill", len(apps)))
 		for _, app := range apps {
 			c.logger.Info(fmt.Sprintf("will fill config filename for application %s", app.Id))
 

--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -43,7 +43,6 @@ func (c *Filler) Run(ctx context.Context) error {
 	var limit, count = 50, 0
 	var sleepInternal = 100 * time.Millisecond
 	var cursor string
-	var minCreatedAt int64
 
 	for {
 		apps, next, err := c.applicationStore.ListApplications(ctx, datastore.ListOptions{
@@ -52,11 +51,6 @@ func (c *Filler) Run(ctx context.Context) error {
 					Field:    "Deleted",
 					Operator: datastore.OperatorEqual,
 					Value:    false,
-				},
-				{
-					Field:    "CreatedAt",
-					Operator: datastore.OperatorGreaterThanOrEqual,
-					Value:    minCreatedAt,
 				},
 			},
 			Orders: []datastore.Order{

--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configfilenamefiller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+)
+
+type Filler struct {
+	applicationStore datastore.ApplicationStore
+	logger           *zap.Logger
+}
+
+func NewFiller(ds datastore.DataStore, logger *zap.Logger) *Filler {
+	return &Filler{
+		applicationStore: datastore.NewApplicationStore(ds),
+		logger:           logger.Named("fill-config-filename"),
+	}
+}
+
+func (c *Filler) Run(ctx context.Context) error {
+	c.logger.Info("start running Filler")
+	defer c.logger.Info("Filler has been stopped")
+
+	var limit, count = 50, 0
+	var sleepInternal = 100 * time.Millisecond
+	var cursor string
+	var minCreatedAt int64
+
+	for {
+		apps, next, err := c.applicationStore.ListApplications(ctx, datastore.ListOptions{
+			Filters: []datastore.ListFilter{
+				{
+					Field:    "Deleted",
+					Operator: datastore.OperatorEqual,
+					Value:    false,
+				},
+				{
+					Field:    "CreatedAt",
+					Operator: datastore.OperatorGreaterThanOrEqual,
+					Value:    minCreatedAt,
+				},
+			},
+			Orders: []datastore.Order{
+				{
+					Field:     "CreatedAt",
+					Direction: datastore.Asc,
+				},
+			},
+			Cursor: cursor,
+			Limit:  limit,
+		})
+		if err != nil {
+			c.logger.Error("failed to list applications", zap.Error(err))
+			return err
+		}
+
+		c.logger.Info(fmt.Sprintf("found %d applications to fill", len()))
+		for _, app := range apps {
+			c.logger.Info(fmt.Sprintf("will fill config filename for application %s", app.Id))
+
+			if err := c.applicationStore.FillConfigFilenameToDeploymentReference(ctx, app.Id); err != nil {
+				c.logger.Error(fmt.Sprintf("failed to fill config filename for application %s", app.Id), zap.Error(err))
+				return err
+			}
+
+			count++
+			c.logger.Info(fmt.Sprintf("filled config filename for application %s", app.Id))
+			time.Sleep(sleepInternal)
+		}
+
+		if next == "" {
+			c.logger.Info(fmt.Sprintf("successfully filled config filename to all %d applications", count))
+			return nil
+		}
+		cursor = next
+	}
+}

--- a/pkg/app/piped/eventwatcher/BUILD.bazel
+++ b/pkg/app/piped/eventwatcher/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/server/service/pipedservice:go_default_library",
         "//pkg/backoff:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/regexpool:go_default_library",
         "//pkg/yamlprocessor:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/piped/eventwatcher/BUILD.bazel
+++ b/pkg/app/piped/eventwatcher/BUILD.bazel
@@ -6,14 +6,12 @@ go_library(
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/app/server/service/pipedservice:go_default_library",
         "//pkg/backoff:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/regexpool:go_default_library",
         "//pkg/yamlprocessor:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -436,7 +436,14 @@ func (a *PipedAPI) ReportDeploymentPlanned(ctx context.Context, req *pipedservic
 		return nil, err
 	}
 
-	updater := datastore.DeploymentToPlannedUpdater(req.Summary, req.StatusReason, req.RunningCommitHash, req.Version, req.Stages)
+	updater := datastore.DeploymentToPlannedUpdater(
+		req.Summary,
+		req.StatusReason,
+		req.RunningCommitHash,
+		req.RunningConfigFilename,
+		req.Version,
+		req.Stages,
+	)
 	err = a.deploymentStore.UpdateDeployment(ctx, req.DeploymentId, updater)
 	if err != nil {
 		switch err {

--- a/pkg/app/server/service/pipedservice/service.proto
+++ b/pkg/app/server/service/pipedservice/service.proto
@@ -284,6 +284,8 @@ message ReportDeploymentPlannedRequest {
     string status_reason = 3;
     // Hash value of the most recently successfully deployed commit.
     string running_commit_hash = 4;
+    // The config file name used by the last successful deployment.
+    string running_config_filename = 9;
     // The application version this deployment is trying to deploy.
     string version = 5;
     // The planned stages.

--- a/pkg/app/web/src/__fixtures__/dummy-application.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-application.ts
@@ -47,6 +47,7 @@ export const dummyApplication: Application.AsObject = {
     startedAt: startedAt.unix(),
     version: "v1",
     trigger: dummyTrigger,
+    configFilename: "",
   },
   mostRecentlyTriggeredDeployment: {
     deploymentId: "deployment-1",
@@ -55,6 +56,7 @@ export const dummyApplication: Application.AsObject = {
     startedAt: startedAt.unix(),
     version: "v1",
     trigger: dummyTrigger,
+    configFilename: "",
   },
   syncState: dummyApplicationSyncState,
   updatedAt: updatedAt.unix(),

--- a/pkg/app/web/src/__fixtures__/dummy-deployment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-deployment.ts
@@ -17,6 +17,7 @@ export const dummyDeployment: Deployment.AsObject = {
   applicationName: dummyApplication.name,
   applicationId: dummyApplication.id,
   runningCommitHash: randomUUID().slice(0, 8),
+  runningConfigFilename: ".pipe.yaml",
   stagesList: dummyPipeline,
   status: DeploymentStatus.DEPLOYMENT_SUCCESS,
   statusReason: "good",

--- a/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
@@ -44,6 +44,7 @@ const fakeDeployment: Deployment.AsObject = {
     strategySummary: "",
   },
   runningCommitHash: "3808585b46f1e90196d7ffe8dd04c807a251febc",
+  runningConfigFilename: ".pipe.yaml",
   summary: "This deployment is debug",
   status: 2,
   statusReason: "",

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -36,12 +36,13 @@ func (d *deploymentCollection) Factory() Factory {
 }
 
 var (
-	DeploymentToPlannedUpdater = func(summary, statusReason, runningCommitHash, version string, stages []*model.PipelineStage) func(*model.Deployment) error {
+	DeploymentToPlannedUpdater = func(summary, statusReason, runningCommitHash, runningConfigFilename, version string, stages []*model.PipelineStage) func(*model.Deployment) error {
 		return func(d *model.Deployment) error {
 			d.Status = model.DeploymentStatus_DEPLOYMENT_PLANNED
 			d.Summary = summary
 			d.StatusReason = statusReason
 			d.RunningCommitHash = runningCommitHash
+			d.RunningConfigFilename = runningConfigFilename
 			d.Version = version
 			d.Stages = stages
 			return nil

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -30,11 +30,12 @@ import (
 
 func TestDeploymentToPlannedUpdater(t *testing.T) {
 	var (
-		expectedDesc              = "updated-summary"
-		expectedStatusDesc        = "update-status-desc"
-		expectedRunningCommitHash = "update-running-commit-hash"
-		expectedVersion           = "update-version"
-		expectedStages            = []*model.PipelineStage{
+		expectedDesc                  = "updated-summary"
+		expectedStatusDesc            = "update-status-desc"
+		expectedRunningCommitHash     = "update-running-commit-hash"
+		expectedRunningConfigFilename = "update-running-config-filename"
+		expectedVersion               = "update-version"
+		expectedStages                = []*model.PipelineStage{
 			{
 				Id:    "stage-id1",
 				Name:  "stage1",
@@ -60,6 +61,7 @@ func TestDeploymentToPlannedUpdater(t *testing.T) {
 			expectedDesc,
 			expectedStatusDesc,
 			expectedRunningCommitHash,
+			expectedRunningConfigFilename,
 			expectedVersion,
 			expectedStages,
 		)
@@ -71,6 +73,7 @@ func TestDeploymentToPlannedUpdater(t *testing.T) {
 	assert.Equal(t, expectedDesc, d.Summary)
 	assert.Equal(t, expectedStatusDesc, d.StatusReason)
 	assert.Equal(t, expectedRunningCommitHash, d.RunningCommitHash)
+	assert.Equal(t, expectedRunningConfigFilename, d.RunningConfigFilename)
 	assert.Equal(t, expectedVersion, d.Version)
 	assert.Equal(t, expectedStages, d.Stages)
 }

--- a/pkg/model/application.proto
+++ b/pkg/model/application.proto
@@ -90,6 +90,7 @@ message ApplicationDeploymentReference {
     DeploymentTrigger trigger = 2 [(validate.rules).message.required = true];
     string summary = 3;
     string version = 4;
+    string config_filename = 5;
 
     int64 started_at = 14 [(validate.rules).int64.gt = 0];
     int64 completed_at = 15 [(validate.rules).int64.gte = 0];

--- a/pkg/model/deployment.proto
+++ b/pkg/model/deployment.proto
@@ -72,13 +72,15 @@ message Deployment {
     map<string, string> labels = 10;
 
     DeploymentTrigger trigger = 20 [(validate.rules).message.required = true];
-    // Hash value of the most recently successfully deployed commit.
-    string running_commit_hash = 21;
     // Simple description about what this deployment does.
     // e.g. Scale from 10 to 100 replicas.
     // e.g. Update image from v1.5.0 to v1.6.0.
     string summary = 22;
     string version = 23;
+
+    // Hash value of the most recently successfully deployed commit.
+    string running_commit_hash = 21;
+    string running_config_filename = 60;
 
     DeploymentStatus status = 30 [(validate.rules).enum.defined_only = true];
     // The human-readable description why the deployment is at current status.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does:
- Add `ConfigFilename` field to mark the name of the config file that was used in the last successful deployment
- Update Piped to use that value while loading the running source
- Add an `Ops` tasks to fill the missing values of that field for the existing application

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Ensure that the Pipeline sync works normally even when the config file name was changed
```
