### PR TITLE
Fix index in mysql piped table

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -96,7 +96,7 @@ CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name,
 --
 
 -- index on `ProjectId` ASC and `EnvIds` ASC
-ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
+ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (NULLIF(data ->> "$.env_ids", '[]')) VIRTUAL;
 CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));
 
 --


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, env is not set when registering Piped.
However, the piped table has an index that assumes that env is set.
This index causes the following query to return unexpected results.

```
mysql> SELECT * FROM Piped\G;
*************************** 1. row ***************************
       Id: 0x45F51AEC2D144304A1E35C64CA716451
     Data: {"id": "2d144304-1aec-45f5-a1e3-5c64ca716451", "desc": "test3", "keys": [{"hash": "$2a$10$rMijzSXcVaEK7ms9WC19DOPfldgaIdEeb9vKWVe7aq5y4NVgIa4qm", "creator": "hello-pipecd", "created_at": 1643263730}], "name": "test3", "_extra": "test3", "created_at": 1643263730, "project_id": "quickstart", "updated_at": 1643263730}
ProjectId: quickstart
 Disabled: 0
    Extra: test3
CreatedAt: 1643263730
UpdatedAt: 1643263730
   EnvIds: []

ERROR:
No query specified

mysql> SELECT * FROM Piped WHERE ProjectId = "quickstart";
Empty set (0.01 sec)
```

This is caused by an index like the following
```
ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (NULLIF(data ->> "$.env_ids", '[]')) VIRTUAL;
CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));
```

This sql creates an EnvIds column from the env_ids in the Data column and creates a composite index of the ProjectId and EnvIds columns.
However, the current control plane does not set env_ids, so the EnvIds column is inserted as an empty array in json.
The Multi-Valued Indexes in mysql do not add a record to the index in such a case.
Therefore, if the data is scanned using this index, it will not be included in the results.

> If a multi-valued key part has an empty array, no entries are added to the index, and the data record is not accessible by an index scan.
https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued

To fix this, insert NULL instead of an empty array of json.
The Multi-Valued Indexes in mysql will add 1 record to the index if it is null.

> If multi-valued key part generation returns a NULL value, a single entry containing NULL is added to the multi-valued index. If the key part is defined as If the key part is defined as NOT NULL, an error is reported.
If the key part is defined as NOT NULL, an error is reported.
https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued

**Which issue(s) this PR fixes**:

Fixes #3149

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
