### PR TITLE
Update containerd config to fix ImagePullBackOff error

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -56,6 +56,8 @@ containerdConfigPatches:
     config_path = "${REG_CONFIG_DIR}"
 EOF
 
+# Connect the registry to the cluster network
+# (the network may already be connected)
 docker network connect "kind" "${REG_NAME}" || true
 
 # Create containerd config files in cluster
@@ -76,9 +78,6 @@ server = \"https://localhost:${REG_PORT}\"
 EOF
 systemctl restart containerd
 "
-
-# Connect the registry to the cluster network
-# (the network may already be connected)
 
 # Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, `make kind-up` uses `plugins."io.containerd.grpc.v1.cri".registry.mirrors` to configure local image registry. However, this is [deprecated](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-image-registry) and causes ImagePullBackOff error.
To fix this, update registry configs to use `plugins."io.containerd.grpc.v1.cri".registry`, set `config_path`, and add `hosts.toml` file. ([registry configuration docs](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration))

**Which issue(s) this PR fixes**:

Fixes #3152

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
