### PR TITLE
Fix missing DeploymentChain encode type for MySQL storage

### DIFF
--- a/pkg/datastore/mysql/model_wrapper.go
+++ b/pkg/datastore/mysql/model_wrapper.go
@@ -92,6 +92,14 @@ func wrapModel(entity interface{}) (interface{}, error) {
 			Event: *e,
 			Extra: e.Name,
 		}, nil
+	case *model.DeploymentChain:
+		if e == nil {
+			return nil, fmt.Errorf("nil entity given")
+		}
+		return &deploymentChain{
+			DeploymentChain: *e,
+			Extra:           e.Id,
+		}, nil
 	default:
 		return nil, fmt.Errorf("%T is not supported", e)
 	}
@@ -151,4 +159,9 @@ type apiKey struct {
 type event struct {
 	model.Event `json:",inline"`
 	Extra       string `json:"_extra"`
+}
+
+type deploymentChain struct {
+	model.DeploymentChain `json:",inline"`
+	Extra                 string `json:"_extra"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
