### PR TITLE
Fix service manifest file path

### DIFF
--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -257,7 +257,12 @@ func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo
 			}
 		}
 
-		manifest, err = provider.LoadServiceManifest(appDir, app.GitPath.ConfigFilename)
+		var manifestFile string
+		if cfg.CloudRunApplicationSpec != nil {
+			manifestFile = cfg.CloudRunApplicationSpec.Input.ServiceManifestFile
+		}
+
+		manifest, err = provider.LoadServiceManifest(appDir, manifestFile)
 		if err != nil {
 			return provider.ServiceManifest{}, fmt.Errorf("failed to load new service manifest: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for wrong CloudRun's service manifest path.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
