### PR TITLE
Fix unable to fetch list Piped in case of using MySQL as datastore

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -111,6 +111,9 @@ CREATE INDEX name_project_id_status_updated_at_desc ON Event (Name, ProjectId, S
 -- Piped table indexes
 --
 
+-- index on `ProjectId` ASC
+CREATE INDEX piped_project_id_asc ON Piped (ProjectId);
+
 -- index on `ProjectId` ASC and `EnvIds` ASC
 ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
 CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we're going to remove the `environment` concept from PipeCD project, the field `EnvIds` is now nullable and will be replaced with an empty array value (`[]`) due to our current MySQL index ensure. 

Since we list all available piped based on ProjectId value and we only have one index `piped_project_id_env_ids_asc` currently on Piped table, that index will be used.

> If a multi-valued key part has an empty array, no entries are added to the index, and the data record is not accessible by an index scan.

ref: https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued

This PR adds another index on ProjectId so that MySQL will use this index instead of the multiple column index. The multiple column index will be removed once we completely remove the `environment` concept from PipeCD.

Thanks @amaany3 for investigation (PR #3151)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
