### PR TITLE
Fix unable to add new standalone deployment in case of using MySQL as datastore

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -78,6 +78,7 @@ CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
 -- index on `DeploymentChainId` ASC and `UpdatedAt` DESC
 ALTER TABLE Deployment ADD COLUMN DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.deployment_chain_id") VIRTUAL NOT NULL;
+ALTER TABLE Deployment MODIFY DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (IFNULL(data->>"$.deployment_chain_id", "")) VIRTUAL NOT NULL;
 CREATE INDEX deployment_chain_id_updated_at_desc ON Deployment (DeploymentChainId, UpdatedAt DESC);
 
 --


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of creating a standalone deployment object, the `data->>"$.deployment_chain_id"` value will be null (object generated by proto has omitted empty configuration); thus this `NOT NULL` column should have a default value in case there is no value for deployment object.

**Which issue(s) this PR fixes**:

Follows PR #2990

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
