### PR TITLE
Fix unable to create objects without env_id value in case of using MySQL as datastore

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -7,6 +7,7 @@ CREATE INDEX application_disabled_updated_at_desc ON Application (Disabled, Upda
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
 ALTER TABLE Application ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL NOT NULL;
+ALTER TABLE Application MODIFY EnvId VARCHAR(36) GENERATED ALWAYS AS (IFNULL(data->>"$.env_id", "")) VIRTUAL NOT NULL;
 CREATE INDEX application_env_id_updated_at_desc ON Application (EnvId, UpdatedAt DESC);
 
 -- index on `Name` ASC and `UpdatedAt` DESC
@@ -62,6 +63,7 @@ CREATE INDEX deployment_project_id_updated_at_desc ON Deployment (ProjectId, Upd
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
 ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL NOT NULL;
+ALTER TABLE Deployment MODIFY EnvId VARCHAR(36) GENERATED ALWAYS AS (IFNULL(data->>"$.env_id", "")) VIRTUAL NOT NULL;
 CREATE INDEX deployment_env_id_updated_at_desc ON Deployment (EnvId, UpdatedAt DESC);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC


### PR DESCRIPTION
**What this PR does / why we need it**:

Add default value for `data->>"$.env_id"` since the field `env_id` is optional.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
