### PR TITLE
Fix the query used to list application in ops to reuse an existing index

### DIFF
--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -58,6 +58,10 @@ func (c *Filler) Run(ctx context.Context) error {
 					Field:     "CreatedAt",
 					Direction: datastore.Asc,
 				},
+				{
+					Field:     "Id",
+					Direction: datastore.Asc,
+				},
 			},
 			Cursor: cursor,
 			Limit:  limit,


### PR DESCRIPTION
**What this PR does / why we need it**:

The current code requires adding a new index on "delete" and "created_at", but we are already having an index on "delete", "id", "created_at" so I fixed the query to reuse the existing one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
