### PR TITLE
Make sure to show status description even if that is too long

### DIFF
--- a/pkg/app/web/src/components/events-page/event-item/index.tsx
+++ b/pkg/app/web/src/components/events-page/event-item/index.tsx
@@ -4,7 +4,6 @@ import { FC, memo } from "react";
 import { EVENT_STATE_TEXT } from "~/constants/event-status-text";
 import { useAppSelector } from "~/hooks/redux";
 import { Event, selectById as selectEventById } from "~/modules/events";
-import { ellipsis } from "~/styles/text";
 import { EventStatusIcon } from "~/components/event-status-icon";
 
 const useStyles = makeStyles((theme) => ({
@@ -26,7 +25,6 @@ const useStyles = makeStyles((theme) => ({
     width: "100px",
   },
   description: {
-    ...ellipsis,
     color: theme.palette.text.hint,
   },
   labelChip: {
@@ -64,10 +62,11 @@ export const EventItem: FC<EventItemProps> = memo(function EventItem({ id }) {
       </Box>
       <Box
         display="flex"
+        height={72}
         flexDirection="column"
         flex={1}
         pl={2}
-        overflow="hidden"
+        overflow="scroll"
       >
         <Box display="flex" alignItems="baseline">
           <Typography variant="h6" component="span">
@@ -89,7 +88,6 @@ export const EventItem: FC<EventItemProps> = memo(function EventItem({ id }) {
           </Typography>
         </Box>
         <Typography variant="body1" className={classes.description}>
-          {/* TODO: Show status description even if that is too long */}
           {event.statusDescription || NO_DESCRIPTION}
         </Typography>
       </Box>


### PR DESCRIPTION
**What this PR does / why we need it**:

Before

![image](https://user-images.githubusercontent.com/19730728/151930624-90b68be4-29a0-4bbd-a4c9-bad6532b8cd1.png)

After

![Kapture 2022-02-01 at 16 48 43](https://user-images.githubusercontent.com/19730728/151930725-1fb602c4-c9a2-4d67-b9e9-ef194f72772e.gif)

I'm aware that it's not the best, but it settles the worst case where we can't see the entire description.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/3081

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
