### PR TITLE
Add MySQL index for new event watcher

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -96,23 +96,23 @@ CREATE INDEX event_project_id_updated_at_desc ON Event (ProjectId, UpdatedAt DES
 
 -- index on `EventKey` ASC, `Name` ASC, `ProjectId` ASC and `CreatedAt` DESC
 ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL NOT NULL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
-CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
+CREATE INDEX event_event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, CreatedAt DESC
 ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
-CREATE INDEX project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
+CREATE INDEX event_project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
 ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
-CREATE INDEX project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
+CREATE INDEX event_project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `UpdatedAt` DESC
 ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
-CREATE INDEX name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
+CREATE INDEX event_name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
 ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
-CREATE INDEX name_project_id_status_updated_at_desc ON Event (Name, ProjectId, Status, UpdatedAt DESC);
+CREATE INDEX event_name_project_id_status_updated_at_desc ON Event (Name, ProjectId, Status, UpdatedAt DESC);
 
 --
 -- Piped table indexes

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -98,13 +98,17 @@ CREATE INDEX event_project_id_updated_at_desc ON Event (ProjectId, UpdatedAt DES
 ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL NOT NULL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
 CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
 
+-- index on `ProjectId` ASC, `Status` ASC, CreatedAt DESC
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
+CREATE INDEX project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
+
 -- index on `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
 ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
-CREATE INDEX project_id_status_updated_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
+CREATE INDEX project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `UpdatedAt` DESC
 ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
-CREATE INDEX event_key_name_project_id_created_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
+CREATE INDEX name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
 ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an index used for https://github.com/pipe-cd/pipecd/pull/3124 and fixes a couple of wrong index names that haven't released yet.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
