### PR TITLE
Make it possible to customize variant label

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -36,6 +36,10 @@ spec:
 | timeout | duration | The maximum length of time to execute deployment before giving up. Default is 6h. | No |
 | notification | [DeploymentNotification](#deploymentnotification) | Additional configuration used while sending notification to external services. | No |
 | postSync | [PostSync](#postsync) | Additional configuration used as extra actions once the deployment is triggered. | No |
+| variantLabelKey | string | The label will be configured to variant manifests used to distinguish them. Default is pipecd.dev/variant. | No |
+| variantLabelPrimary | string | The value for PRIMARY variant. Default is primary. | No |
+| variantLabelBaseline | string | The value for BASELINE variant. Default is baseline. | No |
+| variantLabelCanary | string | The value for CANARY variant. Default is canary. | No |
 
 ## Terraform application
 

--- a/pkg/app/piped/executor/kubernetes/canary_test.go
+++ b/pkg/app/piped/executor/kubernetes/canary_test.go
@@ -37,6 +37,12 @@ func TestEnsureCanaryRollout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	appCfg := &config.KubernetesApplicationSpec{
+		VariantLabelKey:      "pipecd.dev/variant",
+		VariantLabelPrimary:  "primary",
+		VariantLabelBaseline: "baseline",
+		VariantLabelCanary:   "canary",
+	}
 	testcases := []struct {
 		name     string
 		executor *deployExecutor
@@ -56,6 +62,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 					LogPersister: &fakeLogPersister{},
 					Logger:       zap.NewNop(),
 				},
+				appCfg: appCfg,
 			},
 		},
 		{
@@ -85,6 +92,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 					p.EXPECT().LoadManifests(gomock.Any()).Return(nil, fmt.Errorf("error"))
 					return p
 				}(),
+				appCfg: appCfg,
 			},
 		},
 		{
@@ -115,6 +123,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 					p.EXPECT().LoadManifests(gomock.Any()).Return([]provider.Manifest{}, nil)
 					return p
 				}(),
+				appCfg: appCfg,
 			},
 		},
 		{

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -33,10 +33,6 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/yamlprocessor"
 )
 
-const (
-	variantLabel = "pipecd.dev/variant" // Variant name: primary, stage, baseline
-)
-
 type deployExecutor struct {
 	executor.Input
 
@@ -195,7 +191,7 @@ func loadManifests(ctx context.Context, appID, commit string, manifestsCache cac
 	return manifests, nil
 }
 
-func addBuiltinAnnontations(manifests []provider.Manifest, variant, hash, pipedID, appID string) {
+func addBuiltinAnnontations(manifests []provider.Manifest, variantLabel, variant, hash, pipedID, appID string) {
 	for i := range manifests {
 		manifests[i].AddAnnotations(map[string]string{
 			provider.LabelManagedBy:          provider.ManagedByPiped,
@@ -326,7 +322,7 @@ func duplicateManifest(m provider.Manifest, nameSuffix string) provider.Manifest
 	return m.Duplicate(name)
 }
 
-func generateVariantServiceManifests(services []provider.Manifest, variant, nameSuffix string) ([]provider.Manifest, error) {
+func generateVariantServiceManifests(services []provider.Manifest, variantLabel, variant, nameSuffix string) ([]provider.Manifest, error) {
 	manifests := make([]provider.Manifest, 0, len(services))
 	updateService := func(s *corev1.Service) {
 		s.Name = makeSuffixedName(s.Name, nameSuffix)
@@ -359,7 +355,7 @@ func generateVariantServiceManifests(services []provider.Manifest, variant, name
 	return manifests, nil
 }
 
-func generateVariantWorkloadManifests(workloads, configmaps, secrets []provider.Manifest, variant, nameSuffix string, replicasCalculator func(*int32) int32) ([]provider.Manifest, error) {
+func generateVariantWorkloadManifests(workloads, configmaps, secrets []provider.Manifest, variantLabel, variant, nameSuffix string, replicasCalculator func(*int32) int32) ([]provider.Manifest, error) {
 	manifests := make([]provider.Manifest, 0, len(workloads))
 
 	cmNames := make(map[string]struct{}, len(configmaps))
@@ -461,7 +457,7 @@ func generateVariantWorkloadManifests(workloads, configmaps, secrets []provider.
 	return manifests, nil
 }
 
-func checkVariantSelectorInWorkload(m provider.Manifest, variant string) error {
+func checkVariantSelectorInWorkload(m provider.Manifest, variantLabel, variant string) error {
 	var (
 		matchLabelsFields = []string{"spec", "selector", "matchLabels"}
 		labelsFields      = []string{"spec", "template", "metadata", "labels"}
@@ -494,7 +490,7 @@ func checkVariantSelectorInWorkload(m provider.Manifest, variant string) error {
 	return nil
 }
 
-func ensureVariantSelectorInWorkload(m provider.Manifest, variant string) error {
+func ensureVariantSelectorInWorkload(m provider.Manifest, variantLabel, variant string) error {
 	variantMap := map[string]string{
 		variantLabel: variant,
 	}

--- a/pkg/app/piped/executor/kubernetes/primary_test.go
+++ b/pkg/app/piped/executor/kubernetes/primary_test.go
@@ -37,6 +37,12 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	appCfg := &config.KubernetesApplicationSpec{
+		VariantLabelKey:      "pipecd.dev/variant",
+		VariantLabelPrimary:  "primary",
+		VariantLabelBaseline: "baseline",
+		VariantLabelCanary:   "canary",
+	}
 	testcases := []struct {
 		name     string
 		executor *deployExecutor
@@ -56,6 +62,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					LogPersister: &fakeLogPersister{},
 					Logger:       zap.NewNop(),
 				},
+				appCfg: appCfg,
 			},
 		},
 		{
@@ -85,6 +92,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					p.EXPECT().LoadManifests(gomock.Any()).Return(nil, fmt.Errorf("error"))
 					return p
 				}(),
+				appCfg: appCfg,
 			},
 		},
 		{

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -98,10 +98,12 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
+	variantLabel := appCfg.VariantLabelKey
+	primaryVariant := appCfg.VariantLabelPrimary
 	if appCfg.QuickSync.AddVariantLabelToSelector {
 		workloads := findWorkloadManifests(manifests, appCfg.Workloads)
 		for _, m := range workloads {
-			if err := ensureVariantSelectorInWorkload(m, primaryVariant); err != nil {
+			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
 				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableLogString(), err)
 				return model.StageStatus_STAGE_FAILURE
 			}
@@ -111,6 +113,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 	// Add builtin annotations for tracking application live state.
 	addBuiltinAnnontations(
 		manifests,
+		variantLabel,
 		primaryVariant,
 		e.Deployment.RunningCommitHash,
 		e.PipedConfig.PipedID,

--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -45,10 +45,12 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
+	variantLabel := e.appCfg.VariantLabelKey
+	primaryVariant := e.appCfg.VariantLabelPrimary
 	if e.appCfg.QuickSync.AddVariantLabelToSelector {
 		workloads := findWorkloadManifests(manifests, e.appCfg.Workloads)
 		for _, m := range workloads {
-			if err := ensureVariantSelectorInWorkload(m, primaryVariant); err != nil {
+			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
 				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableLogString(), err)
 				return model.StageStatus_STAGE_FAILURE
 			}
@@ -58,6 +60,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	// Add builtin annotations for tracking application live state.
 	addBuiltinAnnontations(
 		manifests,
+		variantLabel,
 		primaryVariant,
 		e.commit,
 		e.PipedConfig.PipedID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to reference Kubernetes application config in order to customize variant label.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Make it possible to customize the variant label of Kubernetes application
```
