### PR TITLE
Log the number of scanned and filled applications while filling config filename in ops

### DIFF
--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -67,11 +67,11 @@ func (c *Filler) Run(ctx context.Context) error {
 			Limit:  limit,
 		})
 		if err != nil {
-			c.logger.Error("failed to list applications", zap.Error(err))
+			c.logger.Error("failed to list apps", zap.Error(err))
 			return err
 		}
 
-		c.logger.Info(fmt.Sprintf("found %d applications to fill", len(apps)))
+		c.logger.Info(fmt.Sprintf("found %d apps to fill", len(apps)))
 		for _, app := range apps {
 			scans++
 			if app.MostRecentlySuccessfulDeployment == nil || app.MostRecentlySuccessfulDeployment.ConfigFilename != "" {
@@ -91,7 +91,7 @@ func (c *Filler) Run(ctx context.Context) error {
 		}
 
 		if next == "" {
-			c.logger.Info(fmt.Sprintf("successfully scanned %d apps and filled config filename for %d applications", scans, fills))
+			c.logger.Info(fmt.Sprintf("successfully scanned %d apps and filled config filename for %d apps", scans, fills))
 			return nil
 		}
 		cursor = next

--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -40,7 +40,7 @@ func (c *Filler) Run(ctx context.Context) error {
 	c.logger.Info("start running Filler")
 	defer c.logger.Info("Filler has been stopped")
 
-	var limit, count = 50, 0
+	var limit, scans, fills = 50, 0, 0
 	var sleepInternal = 100 * time.Millisecond
 	var cursor string
 
@@ -73,6 +73,7 @@ func (c *Filler) Run(ctx context.Context) error {
 
 		c.logger.Info(fmt.Sprintf("found %d applications to fill", len(apps)))
 		for _, app := range apps {
+			scans++
 			if app.MostRecentlySuccessfulDeployment == nil || app.MostRecentlySuccessfulDeployment.ConfigFilename != "" {
 				c.logger.Info(fmt.Sprintf("there is no need to fill config filename for application %s", app.Id))
 				continue
@@ -84,13 +85,13 @@ func (c *Filler) Run(ctx context.Context) error {
 				return err
 			}
 
-			count++
+			fills++
 			c.logger.Info(fmt.Sprintf("filled config filename for application %s", app.Id))
 			time.Sleep(sleepInternal)
 		}
 
 		if next == "" {
-			c.logger.Info(fmt.Sprintf("successfully filled config filename to all %d applications", count))
+			c.logger.Info(fmt.Sprintf("successfully scanned %d apps and filled config filename for %d applications", scans, fills))
 			return nil
 		}
 		cursor = next


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
