### PR TITLE
Add RELEASE env to whitelist for hugo security policy

### DIFF
--- a/.kapetanios/postsubmit.yaml
+++ b/.kapetanios/postsubmit.yaml
@@ -80,7 +80,7 @@ spec:
     steps:
     - name: build
       description: Build static files
-      runner: gcr.io/pipecd/hugo:1.1.0
+      runner: gcr.io/pipecd/hugo:1.2.0
       commands:
         - cd docs
         - npm install autoprefixer

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,3 +18,5 @@ public/
 resources/
 node_modules/
 
+# Hugo
+.hugo_build.lock

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -50,6 +50,10 @@ anchor = "smart"
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
 id = "UA-178762762-1"
 
+[security]
+[security.funcs]
+getenv = ['^HUGO_', 'RELEASE']
+
 # Language configuration
 
 [languages]

--- a/docs/content/en/docs-dev/contribution-guidelines/development.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/development.md
@@ -33,7 +33,7 @@ For more information, you might want to read the [installation notes of `bazelis
 - `make buildifier`: formats bazel BUILD and .bzl files with a standard convention.
 - `make clean`: cleans all bazel cache.
 - `make expose-generated-go`: exposes generated Go files (`.pb.go`, `.mock.go`...) to editors and IDEs.
-- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.88.1` or later to be installed).
+- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.92.1` or later to be installed).
 
 **NOTE**: The first time of running a bazel command will take some minutes because bazel needs to download all required dependencies. From the second time it will be very fast.
 

--- a/docs/content/en/docs-v0.25.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.25.x/contribution-guidelines/development.md
@@ -33,7 +33,7 @@ For more information, you might want to read the [installation notes of `bazelis
 - `make buildifier`: formats bazel BUILD and .bzl files with a standard convention.
 - `make clean`: cleans all bazel cache.
 - `make expose-generated-go`: exposes generated Go files (`.pb.go`, `.mock.go`...) to editors and IDEs.
-- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.88.1` or later to be installed).
+- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.92.1` or later to be installed).
 
 **NOTE**: The first time of running a bazel command will take some minutes because bazel needs to download all required dependencies. From the second time it will be very fast.
 

--- a/docs/content/en/docs/contribution-guidelines/development.md
+++ b/docs/content/en/docs/contribution-guidelines/development.md
@@ -33,7 +33,7 @@ For more information, you might want to read the [installation notes of `bazelis
 - `make buildifier`: formats bazel BUILD and .bzl files with a standard convention.
 - `make clean`: cleans all bazel cache.
 - `make expose-generated-go`: exposes generated Go files (`.pb.go`, `.mock.go`...) to editors and IDEs.
-- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.88.1` or later to be installed).
+- `make site`: runs PipeCD site (https://pipecd.dev) locally (requires [hugo](https://github.com/gohugoio/hugo) with `_extended` version `0.92.1` or later to be installed).
 
 **NOTE**: The first time of running a bazel command will take some minutes because bazel needs to download all required dependencies. From the second time it will be very fast.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We're able to configure [security policy](https://gohugo.io/about/security-model/#security-policy) since v0.91.0.
By default, We cannot build docs because RELEASE env is not whitelisted in policy `security.funcs.getenv` with later v0.91.0 hence I add RELEASE env to whitelist.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
