### PR TITLE
Refactor stores interface

### DIFF
--- a/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
+++ b/pkg/app/ops/configfilenamefiller/configfilenamefiller.go
@@ -45,7 +45,7 @@ func (c *Filler) Run(ctx context.Context) error {
 	var cursor string
 
 	for {
-		apps, next, err := c.applicationStore.ListApplications(ctx, datastore.ListOptions{
+		apps, next, err := c.applicationStore.List(ctx, datastore.ListOptions{
 			Filters: []datastore.ListFilter{
 				{
 					Field:    "Deleted",

--- a/pkg/app/ops/deploymentchaincontroller/controller.go
+++ b/pkg/app/ops/deploymentchaincontroller/controller.go
@@ -168,6 +168,6 @@ func listNotCompletedDeploymentChain(ctx context.Context, dcs datastore.Deployme
 		},
 	}
 
-	chains, _, err := dcs.ListDeploymentChains(ctx, opts)
+	chains, _, err := dcs.List(ctx, opts)
 	return chains, err
 }

--- a/pkg/app/ops/deploymentchaincontroller/updater.go
+++ b/pkg/app/ops/deploymentchaincontroller/updater.go
@@ -89,7 +89,7 @@ func (u *updater) Run(ctx context.Context) error {
 			if model.IsCompletedDeployment(deploymentRef.Status) {
 				continue
 			}
-			deployment, err := u.deploymentStore.GetDeployment(ctx, deploymentRef.DeploymentId)
+			deployment, err := u.deploymentStore.Get(ctx, deploymentRef.DeploymentId)
 			if err != nil {
 				u.logger.Error("failed while update deployment chain: can not get deployment",
 					zap.String("deploymentChainId", u.deploymentChainID),
@@ -180,7 +180,7 @@ func (u *updater) listAllMissingDeployments(ctx context.Context) ([]*model.Deplo
 			},
 		},
 	}
-	deployments, _, err := u.deploymentStore.ListDeployments(ctx, options)
+	deployments, _, err := u.deploymentStore.List(ctx, options)
 	if err != nil {
 		u.logger.Error("failed to fetch all deployments in chain",
 			zap.String("deploymentChainId", u.deploymentChainID),

--- a/pkg/app/ops/handler/handler.go
+++ b/pkg/app/ops/handler/handler.go
@@ -39,8 +39,8 @@ var (
 )
 
 type projectStore interface {
-	AddProject(ctx context.Context, proj *model.Project) error
-	ListProjects(ctx context.Context, opts datastore.ListOptions) ([]model.Project, error)
+	Add(ctx context.Context, proj *model.Project) error
+	List(ctx context.Context, opts datastore.ListOptions) ([]model.Project, error)
 }
 
 type Handler struct {
@@ -129,7 +129,7 @@ func (h *Handler) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	projects, err := h.projectStore.ListProjects(ctx, datastore.ListOptions{})
+	projects, err := h.projectStore.List(ctx, datastore.ListOptions{})
 	if err != nil {
 		h.logger.Error("failed to retrieve the list of projects", zap.Error(err))
 		http.Error(w, "Unable to retrieve projects", http.StatusInternalServerError)
@@ -210,7 +210,7 @@ func (h *Handler) handleAddProject(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := h.projectStore.AddProject(ctx, project); err != nil {
+	if err := h.projectStore.Add(ctx, project); err != nil {
 		h.logger.Error("failed to add a new project",
 			zap.String("id", id),
 			zap.Error(err),
@@ -241,7 +241,7 @@ func (h *Handler) handleApplicationCounts(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	projects, err := h.projectStore.ListProjects(ctx, datastore.ListOptions{})
+	projects, err := h.projectStore.List(ctx, datastore.ListOptions{})
 	if err != nil {
 		h.logger.Error("failed to retrieve the list of projects", zap.Error(err))
 		http.Error(w, "Unable to retrieve projects", http.StatusInternalServerError)

--- a/pkg/app/ops/insightcollector/applications.go
+++ b/pkg/app/ops/insightcollector/applications.go
@@ -59,7 +59,7 @@ func (c *Collector) listApplications(ctx context.Context, to time.Time) ([]*mode
 	var applications []*model.Application
 
 	for {
-		apps, next, err := c.applicationStore.ListApplications(ctx, datastore.ListOptions{
+		apps, next, err := c.applicationStore.List(ctx, datastore.ListOptions{
 			Filters: []datastore.ListFilter{
 				{
 					Field:    "Deleted",

--- a/pkg/app/ops/insightcollector/deployments.go
+++ b/pkg/app/ops/insightcollector/deployments.go
@@ -81,7 +81,7 @@ func (c *Collector) findDeploymentsCreatedInRange(ctx context.Context, from, to 
 	var deployments []*model.Deployment
 	maxCreatedAt := to
 	for {
-		d, _, err := c.deploymentStore.ListDeployments(ctx, datastore.ListOptions{
+		d, _, err := c.deploymentStore.List(ctx, datastore.ListOptions{
 			Limit: limit,
 			Filters: append(filters, datastore.ListFilter{
 				Field:    "CreatedAt",
@@ -121,7 +121,7 @@ func (c *Collector) findDeploymentsCompletedInRange(ctx context.Context, from, t
 	var deployments []*model.Deployment
 	maxCompletedAt := to
 	for {
-		d, _, err := c.deploymentStore.ListDeployments(ctx, datastore.ListOptions{
+		d, _, err := c.deploymentStore.List(ctx, datastore.ListOptions{
 			Limit: limit,
 			Filters: append(filters, datastore.ListFilter{
 				Field:    "CompletedAt",

--- a/pkg/app/ops/insightcollector/deployments_test.go
+++ b/pkg/app/ops/insightcollector/deployments_test.go
@@ -477,7 +477,7 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 				to:   time.Date(2020, 1, 4, 0, 0, 0, 0, time.UTC).Unix(),
 			},
 			prepareMockDataStoreFn: func(m *datastoretest.MockDeploymentStore) {
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -511,7 +511,7 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 						CreatedAt: time.Date(2020, 1, 3, 10, 0, 0, 0, time.UTC).Unix(),
 					},
 				}, "", nil)
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -545,7 +545,7 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 						CreatedAt: time.Date(2020, 1, 3, 5, 0, 0, 0, time.UTC).Unix(),
 					},
 				}, "", nil)
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -602,7 +602,7 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 				to:   time.Date(2020, 1, 4, 0, 0, 0, 0, time.UTC).Unix(),
 			},
 			prepareMockDataStoreFn: func(m *datastoretest.MockDeploymentStore) {
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -673,7 +673,7 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 				to:   time.Date(2020, 1, 4, 0, 0, 0, 0, time.UTC).Unix(),
 			},
 			prepareMockDataStoreFn: func(m *datastoretest.MockDeploymentStore) {
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -707,7 +707,7 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 						CompletedAt: time.Date(2020, 1, 3, 10, 0, 0, 0, time.UTC).Unix(),
 					},
 				}, "", nil)
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -741,7 +741,7 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 						CompletedAt: time.Date(2020, 1, 3, 5, 0, 0, 0, time.UTC).Unix(),
 					},
 				}, "", nil)
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{
@@ -798,7 +798,7 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 				to:   time.Date(2020, 1, 4, 0, 0, 0, 0, time.UTC).Unix(),
 			},
 			prepareMockDataStoreFn: func(m *datastoretest.MockDeploymentStore) {
-				m.EXPECT().ListDeployments(gomock.Any(), datastore.ListOptions{
+				m.EXPECT().List(gomock.Any(), datastore.ListOptions{
 					Limit: 50,
 					Filters: []datastore.ListFilter{
 						{

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -82,7 +82,7 @@ func (c *OrphanCommandCleaner) updateOrphanCommandsStatus(ctx context.Context) e
 			},
 		},
 	}
-	commands, err := c.commandstore.ListCommands(ctx, opts)
+	commands, err := c.commandstore.List(ctx, opts)
 	if err != nil {
 		c.logger.Error("failed to list not-handled commands", zap.Error(err))
 		return err

--- a/pkg/app/server/apikeyverifier/verifier.go
+++ b/pkg/app/server/apikeyverifier/verifier.go
@@ -27,7 +27,7 @@ import (
 )
 
 type apiKeyGetter interface {
-	GetAPIKey(ctx context.Context, id string) (*model.APIKey, error)
+	Get(ctx context.Context, id string) (*model.APIKey, error)
 }
 
 type Verifier struct {
@@ -62,7 +62,7 @@ func (v *Verifier) Verify(ctx context.Context, key string) (*model.APIKey, error
 
 	// If the cache data was not found,
 	// we have to retrieve from datastore and save it to the cache.
-	apiKey, err = v.apiKeyStore.GetAPIKey(ctx, keyID)
+	apiKey, err = v.apiKeyStore.Get(ctx, keyID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find API key %s from datastore, %w", keyID, err)
 	}

--- a/pkg/app/server/apikeyverifier/verifier_test.go
+++ b/pkg/app/server/apikeyverifier/verifier_test.go
@@ -32,7 +32,7 @@ type fakeAPIKeyGetter struct {
 	apiKeys map[string]*model.APIKey
 }
 
-func (g *fakeAPIKeyGetter) GetAPIKey(_ context.Context, id string) (*model.APIKey, error) {
+func (g *fakeAPIKeyGetter) Get(_ context.Context, id string) (*model.APIKey, error) {
 	g.calls++
 	p, ok := g.apiKeys[id]
 	if ok {

--- a/pkg/app/server/commandstore/store.go
+++ b/pkg/app/server/commandstore/store.go
@@ -63,7 +63,7 @@ func (s *store) ListUnhandledCommands(ctx context.Context, pipedID string) ([]*m
 			},
 		},
 	}
-	commands, err := s.backend.ListCommands(ctx, opts)
+	commands, err := s.backend.List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *store) ListUnhandledCommands(ctx context.Context, pipedID string) ([]*m
 }
 
 func (s *store) AddCommand(ctx context.Context, command *model.Command) error {
-	if err := s.backend.AddCommand(ctx, command); err != nil {
+	if err := s.backend.Add(ctx, command); err != nil {
 		s.logger.Error("failed to put command to datastore", zap.Error(err))
 		return err
 	}
@@ -91,7 +91,7 @@ func (s *store) GetCommand(ctx context.Context, id string) (*model.Command, erro
 		return cacheResp, nil
 	}
 
-	dsResp, err := s.backend.GetCommand(ctx, id)
+	dsResp, err := s.backend.Get(ctx, id)
 	if err != nil {
 		s.logger.Error("failed to get command from datastore", zap.Error(err))
 		return nil, err
@@ -109,7 +109,7 @@ func (s *store) UpdateCommandHandled(ctx context.Context, id string, status mode
 		return err
 	}
 
-	cmd, err := s.backend.GetCommand(ctx, id)
+	cmd, err := s.backend.Get(ctx, id)
 	if err != nil {
 		s.logger.Error("failed to get command from datastore", zap.Error(err))
 	}

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -118,7 +118,7 @@ func (a *API) AddApplication(ctx context.Context, req *apiservice.AddApplication
 		CloudProvider: req.CloudProvider,
 		Description:   req.Description,
 	}
-	if err := a.applicationStore.AddApplication(ctx, &app); err != nil {
+	if err := a.applicationStore.Add(ctx, &app); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add application %s", app.Id))
 	}
 
@@ -420,7 +420,7 @@ func (a *API) RegisterEvent(ctx context.Context, req *apiservice.RegisterEventRe
 		Status:            model.EventStatus_EVENT_NOT_HANDLED,
 		StatusDescription: fmt.Sprintf("It is going to be replaced by %s", req.Data),
 	}
-	if err = a.eventStore.AddEvent(ctx, event); err != nil {
+	if err = a.eventStore.Add(ctx, event); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add event %s", id))
 	}
 
@@ -435,7 +435,7 @@ func (a *API) RequestPlanPreview(ctx context.Context, req *apiservice.RequestPla
 
 	// TODO: We may need to cache the list of pipeds to reduce load on database.
 	// Adding the cache after understanding the real situation from our metrics data.
-	pipeds, err := a.pipedStore.ListPipeds(ctx, datastore.ListOptions{
+	pipeds, err := a.pipedStore.List(ctx, datastore.ListOptions{
 		Filters: []datastore.ListFilter{
 			{
 				Field:    "ProjectId",

--- a/pkg/app/server/grpcapi/grpcapi.go
+++ b/pkg/app/server/grpcapi/grpcapi.go
@@ -40,7 +40,7 @@ type commandOutputPutter interface {
 }
 
 func getPiped(ctx context.Context, store datastore.PipedStore, id string, logger *zap.Logger) (*model.Piped, error) {
-	piped, err := store.GetPiped(ctx, id)
+	piped, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Piped is not found")
 	}
@@ -53,7 +53,7 @@ func getPiped(ctx context.Context, store datastore.PipedStore, id string, logger
 }
 
 func getApplication(ctx context.Context, store datastore.ApplicationStore, id string, logger *zap.Logger) (*model.Application, error) {
-	app, err := store.GetApplication(ctx, id)
+	app, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Application is not found")
 	}
@@ -66,7 +66,7 @@ func getApplication(ctx context.Context, store datastore.ApplicationStore, id st
 }
 
 func listApplications(ctx context.Context, store datastore.ApplicationStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Application, string, error) {
-	apps, cursor, err := store.ListApplications(ctx, opts)
+	apps, cursor, err := store.List(ctx, opts)
 	if err != nil {
 		logger.Error("failed to list applications", zap.Error(err))
 		return nil, "", status.Error(codes.Internal, "Failed to list applications")
@@ -76,7 +76,7 @@ func listApplications(ctx context.Context, store datastore.ApplicationStore, opt
 }
 
 func getDeployment(ctx context.Context, store datastore.DeploymentStore, id string, logger *zap.Logger) (*model.Deployment, error) {
-	deployment, err := store.GetDeployment(ctx, id)
+	deployment, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Deployment is not found")
 	}
@@ -137,7 +137,7 @@ func makeGitPath(repoID, path, cfgFilename string, piped *model.Piped, logger *z
 }
 
 func listEnvironments(ctx context.Context, store datastore.EnvironmentStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Environment, error) {
-	envs, err := store.ListEnvironments(ctx, opts)
+	envs, err := store.List(ctx, opts)
 	if err != nil {
 		logger.Error("failed to list environments", zap.Error(err))
 		return nil, status.Error(codes.Internal, "Failed to list environments")
@@ -147,7 +147,7 @@ func listEnvironments(ctx context.Context, store datastore.EnvironmentStore, opt
 }
 
 func getEnvironment(ctx context.Context, store datastore.EnvironmentStore, id string, logger *zap.Logger) (*model.Environment, error) {
-	env, err := store.GetEnvironment(ctx, id)
+	env, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Environment is not found")
 	}

--- a/pkg/app/server/grpcapi/piped_api_test.go
+++ b/pkg/app/server/grpcapi/piped_api_test.go
@@ -83,7 +83,7 @@ func TestValidateAppBelongsToPiped(t *testing.T) {
 			applicationStore: func() datastore.ApplicationStore {
 				s := datastoretest.NewMockApplicationStore(ctrl)
 				s.EXPECT().
-					GetApplication(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
+					Get(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -103,7 +103,7 @@ func TestValidateAppBelongsToPiped(t *testing.T) {
 			applicationStore: func() datastore.ApplicationStore {
 				s := datastoretest.NewMockApplicationStore(ctrl)
 				s.EXPECT().
-					GetApplication(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
+					Get(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
 				return s
 			}(),
 			wantErr: true,
@@ -175,7 +175,7 @@ func TestValidateDeploymentBelongsToPiped(t *testing.T) {
 			deploymentStore: func() datastore.DeploymentStore {
 				s := datastoretest.NewMockDeploymentStore(ctrl)
 				s.EXPECT().
-					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
+					Get(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -195,7 +195,7 @@ func TestValidateDeploymentBelongsToPiped(t *testing.T) {
 			deploymentStore: func() datastore.DeploymentStore {
 				s := datastoretest.NewMockDeploymentStore(ctrl)
 				s.EXPECT().
-					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
+					Get(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
 				return s
 			}(),
 			wantErr: true,
@@ -267,7 +267,7 @@ func TestValidateEnvBelongsToProject(t *testing.T) {
 			environmentStore: func() datastore.EnvironmentStore {
 				s := datastoretest.NewMockEnvironmentStore(ctrl)
 				s.EXPECT().
-					GetEnvironment(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -287,7 +287,7 @@ func TestValidateEnvBelongsToProject(t *testing.T) {
 			environmentStore: func() datastore.EnvironmentStore {
 				s := datastoretest.NewMockEnvironmentStore(ctrl)
 				s.EXPECT().
-					GetEnvironment(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: true,

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -144,7 +144,7 @@ func (a *WebAPI) ListEnvironments(ctx context.Context, req *webservice.ListEnvir
 			},
 		},
 	}
-	envs, err := a.environmentStore.ListEnvironments(ctx, opts)
+	envs, err := a.environmentStore.List(ctx, opts)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, "list environments")
 	}
@@ -181,7 +181,7 @@ func (a *WebAPI) DeleteEnvironment(ctx context.Context, req *webservice.DeleteEn
 		return nil, err
 	}
 	// Check if no Piped has permission to the given environment.
-	pipeds, err := a.pipedStore.ListPipeds(ctx, datastore.ListOptions{
+	pipeds, err := a.pipedStore.List(ctx, datastore.ListOptions{
 		Filters: []datastore.ListFilter{
 			{
 				Field:    "ProjectId",
@@ -220,7 +220,7 @@ func (a *WebAPI) DeleteEnvironment(ctx context.Context, req *webservice.DeleteEn
 	}
 
 	// Delete all applications that belongs to the given env.
-	apps, _, err := a.applicationStore.ListApplications(ctx, datastore.ListOptions{
+	apps, _, err := a.applicationStore.List(ctx, datastore.ListOptions{
 		Filters: []datastore.ListFilter{
 			{
 				Field:    "ProjectId",
@@ -245,12 +245,12 @@ func (a *WebAPI) DeleteEnvironment(ctx context.Context, req *webservice.DeleteEn
 		if app.ProjectId != claims.Role.ProjectId {
 			continue
 		}
-		if err := a.applicationStore.DeleteApplication(ctx, app.Id); err != nil {
+		if err := a.applicationStore.Delete(ctx, app.Id); err != nil {
 			return nil, gRPCEntityOperationError(err, fmt.Sprintf("delete application %s", app.Id))
 		}
 	}
 
-	if err := a.environmentStore.DeleteEnvironment(ctx, req.EnvironmentId); err != nil {
+	if err := a.environmentStore.Delete(ctx, req.EnvironmentId); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("delete environment %s", req.EnvironmentId))
 	}
 
@@ -329,7 +329,7 @@ func (a *WebAPI) RegisterPiped(ctx context.Context, req *webservice.RegisterPipe
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("Failed to create key: %v", err))
 	}
 
-	if err = a.pipedStore.AddPiped(ctx, &piped); err != nil {
+	if err = a.pipedStore.Add(ctx, &piped); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add piped %s", piped.Id))
 	}
 
@@ -454,7 +454,7 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 		}
 	}
 
-	pipeds, err := a.pipedStore.ListPipeds(ctx, opts)
+	pipeds, err := a.pipedStore.List(ctx, opts)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, "list pipeds")
 	}
@@ -647,7 +647,7 @@ func (a *WebAPI) AddApplication(ctx context.Context, req *webservice.AddApplicat
 		Description:   req.Description,
 		Labels:        req.Labels,
 	}
-	if err = a.applicationStore.AddApplication(ctx, &app); err != nil {
+	if err = a.applicationStore.Add(ctx, &app); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add application %s", app.Id))
 	}
 
@@ -736,7 +736,7 @@ func (a *WebAPI) DeleteApplication(ctx context.Context, req *webservice.DeleteAp
 		return nil, err
 	}
 
-	if err := a.applicationStore.DeleteApplication(ctx, req.ApplicationId); err != nil {
+	if err := a.applicationStore.Delete(ctx, req.ApplicationId); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("delete application %s", req.ApplicationId))
 	}
 
@@ -831,7 +831,7 @@ func (a *WebAPI) ListApplications(ctx context.Context, req *webservice.ListAppli
 		}
 	}
 
-	apps, _, err := a.applicationStore.ListApplications(ctx, datastore.ListOptions{
+	apps, _, err := a.applicationStore.List(ctx, datastore.ListOptions{
 		Filters: filters,
 		Orders:  orders,
 	})
@@ -1045,7 +1045,7 @@ func (a *WebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploy
 		Limit:   pageSize,
 		Cursor:  req.Cursor,
 	}
-	deployments, cursor, err := a.deploymentStore.ListDeployments(ctx, options)
+	deployments, cursor, err := a.deploymentStore.List(ctx, options)
 	if err != nil {
 		a.logger.Error("failed to get deployments", zap.Error(err))
 		return nil, status.Error(codes.Internal, "Failed to get deployments")
@@ -1080,7 +1080,7 @@ func (a *WebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploy
 	// or until it finishes scanning to page_min_updated_at.
 	for len(filtered) < pageSize {
 		options.Cursor = cursor
-		deployments, cursor, err = a.deploymentStore.ListDeployments(ctx, options)
+		deployments, cursor, err = a.deploymentStore.List(ctx, options)
 		if err != nil {
 			a.logger.Error("failed to get deployments", zap.Error(err))
 			return nil, status.Error(codes.Internal, "Failed to get deployments")
@@ -1349,7 +1349,7 @@ func (a *WebAPI) getProject(ctx context.Context, projectID string) (*model.Proje
 		}, nil
 	}
 
-	project, err := a.projectStore.GetProject(ctx, projectID)
+	project, err := a.projectStore.Get(ctx, projectID)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("get project %s", projectID))
 	}
@@ -1517,7 +1517,7 @@ func (a *WebAPI) GenerateAPIKey(ctx context.Context, req *webservice.GenerateAPI
 		Creator:   claims.Subject,
 	}
 
-	if err = a.apiKeyStore.AddAPIKey(ctx, &apiKey); err != nil {
+	if err = a.apiKeyStore.Add(ctx, &apiKey); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add API key %s", apiKey.Id))
 	}
 
@@ -1567,7 +1567,7 @@ func (a *WebAPI) ListAPIKeys(ctx context.Context, req *webservice.ListAPIKeysReq
 		}
 	}
 
-	apiKeys, err := a.apiKeyStore.ListAPIKeys(ctx, opts)
+	apiKeys, err := a.apiKeyStore.List(ctx, opts)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, "list API keys")
 	}
@@ -1699,7 +1699,7 @@ func (a *WebAPI) ListDeploymentChains(ctx context.Context, req *webservice.ListD
 		Cursor:  req.Cursor,
 	}
 
-	deploymentChains, cursor, err := a.deploymentChainStore.ListDeploymentChains(ctx, options)
+	deploymentChains, cursor, err := a.deploymentChainStore.List(ctx, options)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, "list deployment chains")
 	}
@@ -1717,7 +1717,7 @@ func (a *WebAPI) GetDeploymentChain(ctx context.Context, req *webservice.GetDepl
 		return nil, err
 	}
 
-	dc, err := a.deploymentChainStore.GetDeploymentChain(ctx, req.DeploymentChainId)
+	dc, err := a.deploymentChainStore.Get(ctx, req.DeploymentChainId)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("get deployment chain %s", req.DeploymentChainId))
 	}
@@ -1786,7 +1786,7 @@ func (a *WebAPI) ListEvents(ctx context.Context, req *webservice.ListEventsReque
 		Limit:   pageSize,
 		Cursor:  req.Cursor,
 	}
-	events, cursor, err := a.eventStore.ListEvents(ctx, options)
+	events, cursor, err := a.eventStore.List(ctx, options)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, "list events")
 	}
@@ -1821,7 +1821,7 @@ func (a *WebAPI) ListEvents(ctx context.Context, req *webservice.ListEventsReque
 	// or until it finishes scanning to page_min_updated_at.
 	for len(filtered) < pageSize {
 		options.Cursor = cursor
-		events, cursor, err = a.eventStore.ListEvents(ctx, options)
+		events, cursor, err = a.eventStore.List(ctx, options)
 		if err != nil {
 			a.logger.Error("failed to get events", zap.Error(err))
 			return nil, status.Error(codes.Internal, "Failed to get events")

--- a/pkg/app/server/grpcapi/web_api_test.go
+++ b/pkg/app/server/grpcapi/web_api_test.go
@@ -83,7 +83,7 @@ func TestValidateAppBelongsToProject(t *testing.T) {
 			applicationStore: func() datastore.ApplicationStore {
 				s := datastoretest.NewMockApplicationStore(ctrl)
 				s.EXPECT().
-					GetApplication(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -103,7 +103,7 @@ func TestValidateAppBelongsToProject(t *testing.T) {
 			applicationStore: func() datastore.ApplicationStore {
 				s := datastoretest.NewMockApplicationStore(ctrl)
 				s.EXPECT().
-					GetApplication(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: true,
@@ -175,7 +175,7 @@ func TestValidateDeploymentBelongsToProject(t *testing.T) {
 			deploymentStore: func() datastore.DeploymentStore {
 				s := datastoretest.NewMockDeploymentStore(ctrl)
 				s.EXPECT().
-					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -195,7 +195,7 @@ func TestValidateDeploymentBelongsToProject(t *testing.T) {
 			deploymentStore: func() datastore.DeploymentStore {
 				s := datastoretest.NewMockDeploymentStore(ctrl)
 				s.EXPECT().
-					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: true,
@@ -267,7 +267,7 @@ func TestValidatePipedBelongsToProject(t *testing.T) {
 			pipedStore: func() datastore.PipedStore {
 				s := datastoretest.NewMockPipedStore(ctrl)
 				s.EXPECT().
-					GetPiped(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: false,
@@ -287,7 +287,7 @@ func TestValidatePipedBelongsToProject(t *testing.T) {
 			pipedStore: func() datastore.PipedStore {
 				s := datastoretest.NewMockPipedStore(ctrl)
 				s.EXPECT().
-					GetPiped(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
+					Get(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
 				return s
 			}(),
 			wantErr: true,

--- a/pkg/app/server/httpapi/auth_handler.go
+++ b/pkg/app/server/httpapi/auth_handler.go
@@ -55,7 +55,7 @@ const (
 )
 
 type projectGetter interface {
-	GetProject(ctx context.Context, id string) (*model.Project, error)
+	Get(ctx context.Context, id string) (*model.Project, error)
 }
 
 type decrypter interface {

--- a/pkg/app/server/httpapi/callback.go
+++ b/pkg/app/server/httpapi/callback.go
@@ -53,7 +53,7 @@ func (h *authHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	proj, err := h.projectGetter.GetProject(ctx, projectID)
+	proj, err := h.projectGetter.Get(ctx, projectID)
 	if err != nil {
 		h.handleError(w, r, fmt.Sprintf("Unable to find project %s", projectID), err)
 		return

--- a/pkg/app/server/httpapi/login.go
+++ b/pkg/app/server/httpapi/login.go
@@ -46,7 +46,7 @@ func (h *authHandler) handleSSOLogin(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	proj, err := h.projectGetter.GetProject(ctx, projectID)
+	proj, err := h.projectGetter.Get(ctx, projectID)
 	if err != nil {
 		h.handleError(w, r, fmt.Sprintf("Unable to find project %s", projectID), err)
 		return
@@ -114,7 +114,7 @@ func (h *authHandler) handleStaticAdminLogin(w http.ResponseWriter, r *http.Requ
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		proj, err := h.projectGetter.GetProject(ctx, projectID)
+		proj, err := h.projectGetter.Get(ctx, projectID)
 		if err != nil {
 			h.handleError(w, r, fmt.Sprintf("Unable to find project: %s", projectID), err)
 			return

--- a/pkg/app/server/pipedverifier/verifier.go
+++ b/pkg/app/server/pipedverifier/verifier.go
@@ -28,11 +28,11 @@ import (
 )
 
 type projectGetter interface {
-	GetProject(ctx context.Context, id string) (*model.Project, error)
+	Get(ctx context.Context, id string) (*model.Project, error)
 }
 
 type pipedGetter interface {
-	GetPiped(ctx context.Context, id string) (*model.Piped, error)
+	Get(ctx context.Context, id string) (*model.Piped, error)
 }
 
 type Verifier struct {
@@ -90,7 +90,7 @@ func (v *Verifier) Verify(ctx context.Context, projectID, pipedID, pipedKey stri
 
 	// If the cache data was not found or stale,
 	// we have to retrieve from datastore and save it to the cache.
-	piped, err = v.pipedStore.GetPiped(ctx, pipedID)
+	piped, err = v.pipedStore.Get(ctx, pipedID)
 	if err != nil {
 		return fmt.Errorf("unable to find piped %s from datastore, %w", pipedID, err)
 	}
@@ -125,7 +125,7 @@ func (v *Verifier) verifyProject(ctx context.Context, projectID, pipedID string)
 		return nil
 	}
 
-	if _, err := v.projectStore.GetProject(ctx, projectID); err != nil {
+	if _, err := v.projectStore.Get(ctx, projectID); err != nil {
 		return fmt.Errorf("project %s for piped %s was not found", projectID, pipedID)
 	}
 

--- a/pkg/app/server/pipedverifier/verifier_test.go
+++ b/pkg/app/server/pipedverifier/verifier_test.go
@@ -34,7 +34,7 @@ type fakeProjectGetter struct {
 	projects map[string]*model.Project
 }
 
-func (g *fakeProjectGetter) GetProject(_ context.Context, id string) (*model.Project, error) {
+func (g *fakeProjectGetter) Get(_ context.Context, id string) (*model.Project, error) {
 	g.calls++
 	p, ok := g.projects[id]
 	if ok {
@@ -49,7 +49,7 @@ type fakePipedGetter struct {
 	pipeds map[string]*model.Piped
 }
 
-func (g *fakePipedGetter) GetPiped(_ context.Context, id string) (*model.Piped, error) {
+func (g *fakePipedGetter) Get(_ context.Context, id string) (*model.Piped, error) {
 	g.calls++
 	p, ok := g.pipeds[id]
 	if ok {

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -36,9 +36,9 @@ func (a *apiKeyCollection) Factory() Factory {
 }
 
 type APIKeyStore interface {
-	AddAPIKey(ctx context.Context, k *model.APIKey) error
-	GetAPIKey(ctx context.Context, id string) (*model.APIKey, error)
-	ListAPIKeys(ctx context.Context, opts ListOptions) ([]*model.APIKey, error)
+	Add(ctx context.Context, k *model.APIKey) error
+	Get(ctx context.Context, id string) (*model.APIKey, error)
+	List(ctx context.Context, opts ListOptions) ([]*model.APIKey, error)
 	DisableAPIKey(ctx context.Context, id, projectID string) error
 }
 
@@ -57,7 +57,7 @@ func NewAPIKeyStore(ds DataStore) APIKeyStore {
 	}
 }
 
-func (s *apiKeyStore) AddAPIKey(ctx context.Context, k *model.APIKey) error {
+func (s *apiKeyStore) Add(ctx context.Context, k *model.APIKey) error {
 	now := s.nowFunc().Unix()
 	if k.CreatedAt == 0 {
 		k.CreatedAt = now
@@ -71,7 +71,7 @@ func (s *apiKeyStore) AddAPIKey(ctx context.Context, k *model.APIKey) error {
 	return s.ds.Create(ctx, s.col, k.Id, k)
 }
 
-func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*model.APIKey, error) {
+func (s *apiKeyStore) Get(ctx context.Context, id string) (*model.APIKey, error) {
 	var entity model.APIKey
 	if err := s.ds.Get(ctx, s.col, id, &entity); err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*model.APIKey, 
 	return &entity, nil
 }
 
-func (s *apiKeyStore) ListAPIKeys(ctx context.Context, opts ListOptions) ([]*model.APIKey, error) {
+func (s *apiKeyStore) List(ctx context.Context, opts ListOptions) ([]*model.APIKey, error) {
 	it, err := s.ds.Find(ctx, s.col, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/datastore/apikey_test.go
+++ b/pkg/datastore/apikey_test.go
@@ -65,7 +65,7 @@ func TestAddAPIKey(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewAPIKeyStore(tc.dsFactory(tc.apiKey))
-			err := s.AddAPIKey(context.Background(), tc.apiKey)
+			err := s.Add(context.Background(), tc.apiKey)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -120,7 +120,7 @@ func TestListAPIKeys(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewAPIKeyStore(tc.ds)
-			_, err := s.ListAPIKeys(context.Background(), tc.opts)
+			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err)
 		})
 	}

--- a/pkg/datastore/applicationstore_test.go
+++ b/pkg/datastore/applicationstore_test.go
@@ -71,7 +71,7 @@ func TestAddApplication(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewApplicationStore(tc.dsFactory(tc.application))
-			err := s.AddApplication(context.Background(), tc.application)
+			err := s.Add(context.Background(), tc.application)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -116,7 +116,7 @@ func TestGetApplication(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewApplicationStore(tc.ds)
-			_, err := s.GetApplication(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -171,7 +171,7 @@ func TestListApplications(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewApplicationStore(tc.ds)
-			_, _, err := s.ListApplications(context.Background(), tc.opts)
+			_, _, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -46,9 +46,9 @@ var (
 )
 
 type CommandStore interface {
-	AddCommand(ctx context.Context, cmd *model.Command) error
-	GetCommand(ctx context.Context, id string) (*model.Command, error)
-	ListCommands(ctx context.Context, opts ListOptions) ([]*model.Command, error)
+	Add(ctx context.Context, cmd *model.Command) error
+	Get(ctx context.Context, id string) (*model.Command, error)
+	List(ctx context.Context, opts ListOptions) ([]*model.Command, error)
 	UpdateCommand(ctx context.Context, id string, updater func(piped *model.Command) error) error
 }
 
@@ -67,7 +67,7 @@ func NewCommandStore(ds DataStore) CommandStore {
 	}
 }
 
-func (s *commandStore) AddCommand(ctx context.Context, cmd *model.Command) error {
+func (s *commandStore) Add(ctx context.Context, cmd *model.Command) error {
 	now := s.nowFunc().Unix()
 	if cmd.CreatedAt == 0 {
 		cmd.CreatedAt = now
@@ -81,19 +81,15 @@ func (s *commandStore) AddCommand(ctx context.Context, cmd *model.Command) error
 	return s.ds.Create(ctx, s.col, cmd.Id, cmd)
 }
 
-func (s *commandStore) UpdateCommand(ctx context.Context, id string, updater func(piped *model.Command) error) error {
-	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
-		p := e.(*model.Command)
-		if err := updater(p); err != nil {
-			return err
-		}
-		p.UpdatedAt = now
-		return p.Validate()
-	})
+func (s *commandStore) Get(ctx context.Context, id string) (*model.Command, error) {
+	var entity model.Command
+	if err := s.ds.Get(ctx, s.col, id, &entity); err != nil {
+		return nil, err
+	}
+	return &entity, nil
 }
 
-func (s *commandStore) ListCommands(ctx context.Context, opts ListOptions) ([]*model.Command, error) {
+func (s *commandStore) List(ctx context.Context, opts ListOptions) ([]*model.Command, error) {
 	it, err := s.ds.Find(ctx, s.col, opts)
 	if err != nil {
 		return nil, err
@@ -113,10 +109,14 @@ func (s *commandStore) ListCommands(ctx context.Context, opts ListOptions) ([]*m
 	return cmds, nil
 }
 
-func (s *commandStore) GetCommand(ctx context.Context, id string) (*model.Command, error) {
-	var entity model.Command
-	if err := s.ds.Get(ctx, s.col, id, &entity); err != nil {
-		return nil, err
-	}
-	return &entity, nil
+func (s *commandStore) UpdateCommand(ctx context.Context, id string, updater func(piped *model.Command) error) error {
+	now := s.nowFunc().Unix()
+	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
+		p := e.(*model.Command)
+		if err := updater(p); err != nil {
+			return err
+		}
+		p.UpdatedAt = now
+		return p.Validate()
+	})
 }

--- a/pkg/datastore/commandstore_test.go
+++ b/pkg/datastore/commandstore_test.go
@@ -62,7 +62,7 @@ func TestAddCommand(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewCommandStore(tc.dsFactory(tc.command))
-			err := s.AddCommand(context.Background(), tc.command)
+			err := s.Add(context.Background(), tc.command)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -107,7 +107,7 @@ func TestGetCommand(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewCommandStore(tc.ds)
-			_, err := s.GetCommand(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -162,7 +162,7 @@ func TestListCommands(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewCommandStore(tc.ds)
-			_, err := s.ListCommands(context.Background(), tc.opts)
+			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -100,9 +100,9 @@ var (
 )
 
 type DeploymentChainStore interface {
-	AddDeploymentChain(ctx context.Context, d *model.DeploymentChain) error
-	GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error)
-	ListDeploymentChains(ctx context.Context, opts ListOptions) ([]*model.DeploymentChain, string, error)
+	Add(ctx context.Context, d *model.DeploymentChain) error
+	Get(ctx context.Context, id string) (*model.DeploymentChain, error)
+	List(ctx context.Context, opts ListOptions) ([]*model.DeploymentChain, string, error)
 	UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error
 }
 
@@ -121,7 +121,7 @@ func NewDeploymentChainStore(ds DataStore) DeploymentChainStore {
 	}
 }
 
-func (s *deploymentChainStore) AddDeploymentChain(ctx context.Context, dc *model.DeploymentChain) error {
+func (s *deploymentChainStore) Add(ctx context.Context, dc *model.DeploymentChain) error {
 	now := s.nowFunc().Unix()
 	if dc.CreatedAt == 0 {
 		dc.CreatedAt = now
@@ -135,19 +135,7 @@ func (s *deploymentChainStore) AddDeploymentChain(ctx context.Context, dc *model
 	return s.ds.Create(ctx, s.col, dc.Id, dc)
 }
 
-func (s *deploymentChainStore) UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error {
-	now := s.nowFunc().Unix()
-	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
-		dc := e.(*model.DeploymentChain)
-		if err := updater(dc); err != nil {
-			return err
-		}
-		dc.UpdatedAt = now
-		return dc.Validate()
-	})
-}
-
-func (s *deploymentChainStore) GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error) {
+func (s *deploymentChainStore) Get(ctx context.Context, id string) (*model.DeploymentChain, error) {
 	var entity model.DeploymentChain
 	if err := s.ds.Get(ctx, s.col, id, &entity); err != nil {
 		return nil, err
@@ -155,7 +143,7 @@ func (s *deploymentChainStore) GetDeploymentChain(ctx context.Context, id string
 	return &entity, nil
 }
 
-func (s *deploymentChainStore) ListDeploymentChains(ctx context.Context, opts ListOptions) ([]*model.DeploymentChain, string, error) {
+func (s *deploymentChainStore) List(ctx context.Context, opts ListOptions) ([]*model.DeploymentChain, string, error) {
 	it, err := s.ds.Find(ctx, s.col, opts)
 	if err != nil {
 		return nil, "", err
@@ -182,4 +170,16 @@ func (s *deploymentChainStore) ListDeploymentChains(ctx context.Context, opts Li
 		return nil, "", err
 	}
 	return dcs, cursor, nil
+}
+
+func (s *deploymentChainStore) UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error {
+	now := s.nowFunc().Unix()
+	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
+		dc := e.(*model.DeploymentChain)
+		if err := updater(dc); err != nil {
+			return err
+		}
+		dc.UpdatedAt = now
+		return dc.Validate()
+	})
 }

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -357,7 +357,7 @@ func TestAddDeployment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewDeploymentStore(tc.dsFactory(tc.deployment))
-			err := s.AddDeployment(context.Background(), tc.deployment)
+			err := s.Add(context.Background(), tc.deployment)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -402,7 +402,7 @@ func TestGetDeployment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewDeploymentStore(tc.ds)
-			_, err := s.GetDeployment(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -457,7 +457,7 @@ func TestListDeployments(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewDeploymentStore(tc.ds)
-			_, _, err := s.ListDeployments(context.Background(), tc.opts)
+			_, _, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/environmentstore_test.go
+++ b/pkg/datastore/environmentstore_test.go
@@ -25,50 +25,6 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-func TestAddEnvironment(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	testcases := []struct {
-		name        string
-		environment *model.Environment
-		dsFactory   func(*model.Environment) DataStore
-		wantErr     bool
-	}{
-		{
-			name:        "Invalid environment",
-			environment: &model.Environment{},
-			dsFactory:   func(d *model.Environment) DataStore { return nil },
-			wantErr:     true,
-		},
-		{
-			name: "Valid environment",
-			environment: &model.Environment{
-				Id:        "id",
-				Name:      "name",
-				ProjectId: "project-id",
-
-				CreatedAt: 1,
-				UpdatedAt: 1,
-			},
-			dsFactory: func(d *model.Environment) DataStore {
-				ds := NewMockDataStore(ctrl)
-				ds.EXPECT().Create(gomock.Any(), gomock.Any(), d.Id, d)
-				return ds
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			s := NewEnvironmentStore(tc.dsFactory(tc.environment))
-			err := s.AddEnvironment(context.Background(), tc.environment)
-			assert.Equal(t, tc.wantErr, err != nil)
-		})
-	}
-}
-
 func TestGetEnvironment(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -108,7 +64,7 @@ func TestGetEnvironment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewEnvironmentStore(tc.ds)
-			_, err := s.GetEnvironment(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -163,7 +119,7 @@ func TestListEnvironment(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewEnvironmentStore(tc.ds)
-			_, err := s.ListEnvironments(context.Background(), tc.opts)
+			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -35,8 +35,8 @@ func (e *eventCollection) Factory() Factory {
 }
 
 type EventStore interface {
-	AddEvent(ctx context.Context, e model.Event) error
-	ListEvents(ctx context.Context, opts ListOptions) ([]*model.Event, string, error)
+	Add(ctx context.Context, e model.Event) error
+	List(ctx context.Context, opts ListOptions) ([]*model.Event, string, error)
 	UpdateEventStatus(ctx context.Context, eventID string, status model.EventStatus, statusDescription string) error
 }
 
@@ -55,7 +55,7 @@ func NewEventStore(ds DataStore) EventStore {
 	}
 }
 
-func (s *eventStore) AddEvent(ctx context.Context, e model.Event) error {
+func (s *eventStore) Add(ctx context.Context, e model.Event) error {
 	now := s.nowFunc().Unix()
 	if e.CreatedAt == 0 {
 		e.CreatedAt = now
@@ -69,7 +69,7 @@ func (s *eventStore) AddEvent(ctx context.Context, e model.Event) error {
 	return s.ds.Create(ctx, s.col, e.Id, &e)
 }
 
-func (s *eventStore) ListEvents(ctx context.Context, opts ListOptions) ([]*model.Event, string, error) {
+func (s *eventStore) List(ctx context.Context, opts ListOptions) ([]*model.Event, string, error) {
 	it, err := s.ds.Find(ctx, s.col, opts)
 	if err != nil {
 		return nil, "", err

--- a/pkg/datastore/eventstore_test.go
+++ b/pkg/datastore/eventstore_test.go
@@ -69,7 +69,7 @@ func TestAddEvent(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewEventStore(tc.ds)
-			err := s.AddEvent(context.Background(), tc.event)
+			err := s.Add(context.Background(), tc.event)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -59,9 +59,9 @@ var (
 )
 
 type PipedStore interface {
-	AddPiped(ctx context.Context, piped *model.Piped) error
-	GetPiped(ctx context.Context, id string) (*model.Piped, error)
-	ListPipeds(ctx context.Context, opts ListOptions) ([]*model.Piped, error)
+	Add(ctx context.Context, piped *model.Piped) error
+	Get(ctx context.Context, id string) (*model.Piped, error)
+	List(ctx context.Context, opts ListOptions) ([]*model.Piped, error)
 	UpdatePiped(ctx context.Context, id string, updater func(piped *model.Piped) error) error
 	EnablePiped(ctx context.Context, id string) error
 	DisablePiped(ctx context.Context, id string) error
@@ -84,7 +84,7 @@ func NewPipedStore(ds DataStore) PipedStore {
 	}
 }
 
-func (s *pipedStore) AddPiped(ctx context.Context, piped *model.Piped) error {
+func (s *pipedStore) Add(ctx context.Context, piped *model.Piped) error {
 	now := s.nowFunc().Unix()
 	if piped.CreatedAt == 0 {
 		piped.CreatedAt = now
@@ -98,7 +98,7 @@ func (s *pipedStore) AddPiped(ctx context.Context, piped *model.Piped) error {
 	return s.ds.Create(ctx, s.col, piped.Id, piped)
 }
 
-func (s *pipedStore) GetPiped(ctx context.Context, id string) (*model.Piped, error) {
+func (s *pipedStore) Get(ctx context.Context, id string) (*model.Piped, error) {
 	var entity model.Piped
 	if err := s.ds.Get(ctx, s.col, id, &entity); err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (s *pipedStore) GetPiped(ctx context.Context, id string) (*model.Piped, err
 	return &entity, nil
 }
 
-func (s *pipedStore) ListPipeds(ctx context.Context, opts ListOptions) ([]*model.Piped, error) {
+func (s *pipedStore) List(ctx context.Context, opts ListOptions) ([]*model.Piped, error) {
 	it, err := s.ds.Find(ctx, s.col, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/datastore/pipedstore_test.go
+++ b/pkg/datastore/pipedstore_test.go
@@ -64,7 +64,7 @@ func TestAddPiped(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewPipedStore(tc.dsFactory(tc.piped))
-			err := s.AddPiped(context.Background(), tc.piped)
+			err := s.Add(context.Background(), tc.piped)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -109,7 +109,7 @@ func TestGetPiped(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewPipedStore(tc.ds)
-			_, err := s.GetPiped(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -164,7 +164,7 @@ func TestListPipeds(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewPipedStore(tc.ds)
-			_, err := s.ListPipeds(context.Background(), tc.opts)
+			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/datastore/projectstore_test.go
+++ b/pkg/datastore/projectstore_test.go
@@ -64,7 +64,7 @@ func TestAddProject(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewProjectStore(tc.dsFactory(tc.project))
-			err := s.AddProject(context.Background(), tc.project)
+			err := s.Add(context.Background(), tc.project)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -109,7 +109,7 @@ func TestGetProject(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewProjectStore(tc.ds)
-			_, err := s.GetProject(context.Background(), tc.id)
+			_, err := s.Get(context.Background(), tc.id)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -164,7 +164,7 @@ func TestListProjects(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewProjectStore(tc.ds)
-			_, err := s.ListProjects(context.Background(), tc.opts)
+			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}

--- a/pkg/insight/insightmetrics/metrics.go
+++ b/pkg/insight/insightmetrics/metrics.go
@@ -78,7 +78,7 @@ func (i *insightMetricsCollector) collectApplicationCount() (map[string]map[stri
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	projects, err := i.projectStore.ListProjects(ctx, datastore.ListOptions{})
+	projects, err := i.projectStore.List(ctx, datastore.ListOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, I updated the stores interface to rename all stores' functions like
- `AddXXX` to `Add`
- `GetXXX` to `Get`
- `ListXXXs` to `List`

So that the caller side will be
```golang
xxxStore.Add(ctx, entity)
xxxStore.Get(ctx, id)
xxxStore.List(ctx, ops)
```
Also just found out that `AddEnvironment` function in `EnvironmentStore` is no longer being used, so remove it as well.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
