### PR TITLE
Fix wrong regex in monitoring config

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -196,7 +196,7 @@ data:
         metric_relabel_configs:
           - source_labels: [grpc_service]
             target_label: pipecd_grpc_service
-            regex: pipe.api.service.(.+)service.(.+)
+            regex: grpc.service.(.+)service.(.+)
             replacement: $1
 
       - job_name: pipecd-ops


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we have already migrated into a new path scheme.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
