### PR TITLE
Remove UpdateApplication interface from application store

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -298,7 +298,6 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 
 	apps, cursor, err := a.applicationStore.List(ctx, opts)
 	if err != nil {
-		a.logger.Error("failed to list applications", zap.Error(err))
 		return nil, gRPCEntityOperationError(err, "failed to list applications")
 	}
 

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -296,9 +296,10 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 		Cursor:  req.Cursor,
 	}
 
-	apps, cursor, err := listApplications(ctx, a.applicationStore, opts, a.logger)
+	apps, cursor, err := a.applicationStore.List(ctx, opts)
 	if err != nil {
-		return nil, err
+		a.logger.Error("failed to list applications", zap.Error(err))
+		return nil, gRPCEntityOperationError(err, "failed to list applications")
 	}
 
 	return &apiservice.ListApplicationsResponse{
@@ -314,21 +315,15 @@ func (a *API) RenameApplicationConfigFile(ctx context.Context, req *apiservice.R
 	}
 
 	for _, appID := range req.ApplicationIds {
-		var denied bool
-		err := a.applicationStore.UpdateApplication(ctx, appID, func(app *model.Application) error {
-			if app.ProjectId != key.ProjectId {
-				denied = true
-				return fmt.Errorf("Requested application %s does not belong to your project", appID)
-			}
-			app.GitPath.ConfigFilename = req.NewFilename
-			return nil
-		})
+		app, err := a.applicationStore.Get(ctx, appID)
 		if err != nil {
-			if denied {
-				return nil, status.Error(codes.PermissionDenied, err.Error())
-			}
-			a.logger.Error("failed to update application", zap.Error(err))
-			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to update application %s", appID))
+			return nil, gRPCEntityOperationError(err, fmt.Sprintf("failed to get application %s", appID))
+		}
+		if app.ProjectId != key.ProjectId {
+			return nil, status.Error(codes.PermissionDenied, fmt.Sprintf("requested application %s does not belong to your project", appID))
+		}
+		if err = a.applicationStore.UpdateConfigFilename(ctx, appID, req.NewFilename); err != nil {
+			return nil, gRPCEntityOperationError(err, fmt.Sprintf("failed to update application %s config file name", appID))
 		}
 	}
 

--- a/pkg/app/server/grpcapi/grpcapi.go
+++ b/pkg/app/server/grpcapi/grpcapi.go
@@ -66,16 +66,6 @@ func getApplication(ctx context.Context, store datastore.ApplicationStore, id st
 	return app, nil
 }
 
-func listApplications(ctx context.Context, store datastore.ApplicationStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Application, string, error) {
-	apps, cursor, err := store.List(ctx, opts)
-	if err != nil {
-		logger.Error("failed to list applications", zap.Error(err))
-		return nil, "", status.Error(codes.Internal, "Failed to list applications")
-	}
-
-	return apps, cursor, nil
-}
-
 func getDeployment(ctx context.Context, store datastore.DeploymentStore, id string, logger *zap.Logger) (*model.Deployment, error) {
 	deployment, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -227,7 +227,7 @@ func (a *PipedAPI) ReportApplicationSyncState(ctx context.Context, req *pipedser
 		return nil, err
 	}
 
-	if err := a.applicationStore.UpdateApplicationSyncState(ctx, req.ApplicationId, req.State); err != nil {
+	if err := a.applicationStore.UpdateSyncState(ctx, req.ApplicationId, req.State); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("update sync state of application %s", req.ApplicationId))
 	}
 
@@ -244,11 +244,7 @@ func (a *PipedAPI) ReportApplicationDeployingStatus(ctx context.Context, req *pi
 		return nil, err
 	}
 
-	err = a.applicationStore.UpdateApplication(ctx, req.ApplicationId, func(app *model.Application) error {
-		app.Deploying = req.Deploying
-		return nil
-	})
-	if err != nil {
+	if err = a.applicationStore.UpdateDeployingStatus(ctx, req.ApplicationId, req.Deploying); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("update deploying status of application %s", req.ApplicationId))
 	}
 
@@ -266,7 +262,7 @@ func (a *PipedAPI) ReportApplicationMostRecentDeployment(ctx context.Context, re
 		return nil, err
 	}
 
-	err = a.applicationStore.UpdateApplicationMostRecentDeployment(ctx, req.ApplicationId, req.Status, req.Deployment)
+	err = a.applicationStore.UpdateMostRecentDeployment(ctx, req.ApplicationId, req.Status, req.Deployment)
 	if err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("update deployment reference of application %s", req.ApplicationId))
 	}
@@ -887,13 +883,7 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 		}
 	}
 	for _, appInfo := range req.Applications {
-		updater := func(app *model.Application) error {
-			app.Name = appInfo.Name
-			app.Labels = appInfo.Labels
-			app.Description = appInfo.Description
-			return nil
-		}
-		if err := a.applicationStore.UpdateApplication(ctx, appInfo.Id, updater); err != nil {
+		if err := a.applicationStore.UpdateBasicInfo(ctx, appInfo.Id, appInfo.Name, appInfo.Description, appInfo.Labels); err != nil {
 			return nil, gRPCEntityOperationError(err, fmt.Sprintf("update config of application %s", appInfo.Id))
 		}
 	}

--- a/pkg/app/server/service/webservice/service.proto
+++ b/pkg/app/server/service/webservice/service.proto
@@ -58,7 +58,6 @@ service WebService {
     // Application
     rpc AddApplication(AddApplicationRequest) returns (AddApplicationResponse) {}
     rpc UpdateApplication(UpdateApplicationRequest) returns (UpdateApplicationResponse) {}
-    rpc UpdateApplicationDescription(UpdateApplicationDescriptionRequest) returns (UpdateApplicationDescriptionResponse) {}
     rpc EnableApplication(EnableApplicationRequest) returns (EnableApplicationResponse) {}
     rpc DisableApplication(DisableApplicationRequest) returns (DisableApplicationResponse) {}
     rpc DeleteApplication(DeleteApplicationRequest) returns (DeleteApplicationResponse) {}
@@ -246,14 +245,6 @@ message UpdateApplicationRequest {
 }
 
 message UpdateApplicationResponse {
-}
-
-message UpdateApplicationDescriptionRequest {
-    string application_id = 1 [(validate.rules).string.min_len = 1];
-    string description = 2;
-}
-
-message UpdateApplicationDescriptionResponse {
 }
 
 message EnableApplicationRequest {

--- a/pkg/app/web/src/mocks/services/application.ts
+++ b/pkg/app/web/src/mocks/services/application.ts
@@ -7,7 +7,6 @@ import {
   GetApplicationResponse,
   ListApplicationsResponse,
   SyncApplicationResponse,
-  UpdateApplicationDescriptionResponse,
   UpdateApplicationResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 import { ApplicationKind } from "~/modules/applications";
@@ -54,12 +53,6 @@ export const applicationHandlers = [
   createHandler<DeleteApplicationResponse>("/DeleteApplication", () => {
     return new DeleteApplicationResponse();
   }),
-  createHandler<UpdateApplicationDescriptionResponse>(
-    "/UpdateApplicationDescription",
-    () => {
-      return new UpdateApplicationDescriptionResponse();
-    }
-  ),
   updateApplicationHandler,
   createHandler<AddApplicationResponse>("/AddApplication", () => {
     const response = new AddApplicationResponse();

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -39,7 +39,7 @@ type APIKeyStore interface {
 	Add(ctx context.Context, k *model.APIKey) error
 	Get(ctx context.Context, id string) (*model.APIKey, error)
 	List(ctx context.Context, opts ListOptions) ([]*model.APIKey, error)
-	DisableAPIKey(ctx context.Context, id, projectID string) error
+	Disable(ctx context.Context, id, projectID string) error
 }
 
 type apiKeyStore struct {
@@ -99,7 +99,7 @@ func (s *apiKeyStore) List(ctx context.Context, opts ListOptions) ([]*model.APIK
 	return ks, nil
 }
 
-func (s *apiKeyStore) DisableAPIKey(ctx context.Context, id, projectID string) error {
+func (s *apiKeyStore) Disable(ctx context.Context, id, projectID string) error {
 	now := s.nowFunc().Unix()
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		k := e.(*model.APIKey)

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -152,7 +152,7 @@ func (s *applicationStore) Disable(ctx context.Context, id string) error {
 	})
 }
 
-func (s *applicationStore) updateApplication(ctx context.Context, id string, updater func(*model.Application) error) error {
+func (s *applicationStore) update(ctx context.Context, id string, updater func(*model.Application) error) error {
 	now := s.nowFunc().Unix()
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		a := e.(*model.Application)
@@ -168,14 +168,14 @@ func (s *applicationStore) updateApplication(ctx context.Context, id string, upd
 }
 
 func (s *applicationStore) UpdateSyncState(ctx context.Context, id string, syncState *model.ApplicationSyncState) error {
-	return s.updateApplication(ctx, id, func(a *model.Application) error {
+	return s.update(ctx, id, func(a *model.Application) error {
 		a.SyncState = syncState
 		return nil
 	})
 }
 
 func (s *applicationStore) UpdateMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, deployment *model.ApplicationDeploymentReference) error {
-	return s.updateApplication(ctx, id, func(a *model.Application) error {
+	return s.update(ctx, id, func(a *model.Application) error {
 		switch status {
 		case model.DeploymentStatus_DEPLOYMENT_SUCCESS:
 			a.MostRecentlySuccessfulDeployment = deployment
@@ -187,21 +187,21 @@ func (s *applicationStore) UpdateMostRecentDeployment(ctx context.Context, id st
 }
 
 func (s *applicationStore) UpdateConfigFilename(ctx context.Context, id, configFilename string) error {
-	return s.updateApplication(ctx, id, func(app *model.Application) error {
+	return s.update(ctx, id, func(app *model.Application) error {
 		app.GitPath.ConfigFilename = configFilename
 		return nil
 	})
 }
 
 func (s *applicationStore) UpdateDeployingStatus(ctx context.Context, id string, deploying bool) error {
-	return s.updateApplication(ctx, id, func(app *model.Application) error {
+	return s.update(ctx, id, func(app *model.Application) error {
 		app.Deploying = deploying
 		return nil
 	})
 }
 
 func (s *applicationStore) UpdateBasicInfo(ctx context.Context, id, name, description string, labels map[string]string) error {
-	return s.updateApplication(ctx, id, func(app *model.Application) error {
+	return s.update(ctx, id, func(app *model.Application) error {
 		app.Name = name
 		app.Description = description
 		app.Labels = labels
@@ -210,7 +210,7 @@ func (s *applicationStore) UpdateBasicInfo(ctx context.Context, id, name, descri
 }
 
 func (s *applicationStore) UpdateConfiguration(ctx context.Context, id, pipedID, cloudProvider, configFilename string) error {
-	return s.updateApplication(ctx, id, func(app *model.Application) error {
+	return s.update(ctx, id, func(app *model.Application) error {
 		app.PipedId = pipedID
 		app.CloudProvider = cloudProvider
 		app.GitPath.ConfigFilename = configFilename

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -40,11 +40,14 @@ type ApplicationStore interface {
 	Get(ctx context.Context, id string) (*model.Application, error)
 	List(ctx context.Context, opts ListOptions) ([]*model.Application, string, error)
 	Delete(ctx context.Context, id string) error
-	EnableApplication(ctx context.Context, id string) error
-	DisableApplication(ctx context.Context, id string) error
-	UpdateApplication(ctx context.Context, id string, updater func(*model.Application) error) error
-	UpdateApplicationSyncState(ctx context.Context, id string, syncState *model.ApplicationSyncState) error
-	UpdateApplicationMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, deployment *model.ApplicationDeploymentReference) error
+	Enable(ctx context.Context, id string) error
+	Disable(ctx context.Context, id string) error
+	UpdateSyncState(ctx context.Context, id string, syncState *model.ApplicationSyncState) error
+	UpdateMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, deployment *model.ApplicationDeploymentReference) error
+	UpdateConfigFilename(ctx context.Context, id, configFilename string) error
+	UpdateDeployingStatus(ctx context.Context, id string, deploying bool) error
+	UpdateBasicInfo(ctx context.Context, id, name, description string, labels map[string]string) error
+	UpdateConfiguration(ctx context.Context, id, pipedID, cloudProvider, configFilename string) error
 }
 
 type applicationStore struct {
@@ -125,7 +128,7 @@ func (s *applicationStore) Delete(ctx context.Context, id string) error {
 	})
 }
 
-func (s *applicationStore) EnableApplication(ctx context.Context, id string) error {
+func (s *applicationStore) Enable(ctx context.Context, id string) error {
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
@@ -137,7 +140,7 @@ func (s *applicationStore) EnableApplication(ctx context.Context, id string) err
 	})
 }
 
-func (s *applicationStore) DisableApplication(ctx context.Context, id string) error {
+func (s *applicationStore) Disable(ctx context.Context, id string) error {
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
@@ -149,7 +152,7 @@ func (s *applicationStore) DisableApplication(ctx context.Context, id string) er
 	})
 }
 
-func (s *applicationStore) UpdateApplication(ctx context.Context, id string, updater func(*model.Application) error) error {
+func (s *applicationStore) updateApplication(ctx context.Context, id string, updater func(*model.Application) error) error {
 	now := s.nowFunc().Unix()
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		a := e.(*model.Application)
@@ -164,21 +167,53 @@ func (s *applicationStore) UpdateApplication(ctx context.Context, id string, upd
 	})
 }
 
-func (s *applicationStore) UpdateApplicationSyncState(ctx context.Context, id string, syncState *model.ApplicationSyncState) error {
-	return s.UpdateApplication(ctx, id, func(a *model.Application) error {
+func (s *applicationStore) UpdateSyncState(ctx context.Context, id string, syncState *model.ApplicationSyncState) error {
+	return s.updateApplication(ctx, id, func(a *model.Application) error {
 		a.SyncState = syncState
 		return nil
 	})
 }
 
-func (s *applicationStore) UpdateApplicationMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, deployment *model.ApplicationDeploymentReference) error {
-	return s.UpdateApplication(ctx, id, func(a *model.Application) error {
+func (s *applicationStore) UpdateMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, deployment *model.ApplicationDeploymentReference) error {
+	return s.updateApplication(ctx, id, func(a *model.Application) error {
 		switch status {
 		case model.DeploymentStatus_DEPLOYMENT_SUCCESS:
 			a.MostRecentlySuccessfulDeployment = deployment
 		case model.DeploymentStatus_DEPLOYMENT_PENDING:
 			a.MostRecentlyTriggeredDeployment = deployment
 		}
+		return nil
+	})
+}
+
+func (s *applicationStore) UpdateConfigFilename(ctx context.Context, id, configFilename string) error {
+	return s.updateApplication(ctx, id, func(app *model.Application) error {
+		app.GitPath.ConfigFilename = configFilename
+		return nil
+	})
+}
+
+func (s *applicationStore) UpdateDeployingStatus(ctx context.Context, id string, deploying bool) error {
+	return s.updateApplication(ctx, id, func(app *model.Application) error {
+		app.Deploying = deploying
+		return nil
+	})
+}
+
+func (s *applicationStore) UpdateBasicInfo(ctx context.Context, id, name, description string, labels map[string]string) error {
+	return s.updateApplication(ctx, id, func(app *model.Application) error {
+		app.Name = name
+		app.Description = description
+		app.Labels = labels
+		return nil
+	})
+}
+
+func (s *applicationStore) UpdateConfiguration(ctx context.Context, id, pipedID, cloudProvider, configFilename string) error {
+	return s.updateApplication(ctx, id, func(app *model.Application) error {
+		app.PipedId = pipedID
+		app.CloudProvider = cloudProvider
+		app.GitPath.ConfigFilename = configFilename
 		return nil
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, I removed
- the general use `UpdateApplication` function from ApplicationStore interface.
- the `UpdateApplicationDescription` rpc from web service proto (since we remove that feature on the web console)

For the next step, I want to make separated XXXStore interfaces that be used on the API layer to avoid huge interface issues (the current huge ApplicationStore interface exists because I created a bunch of new functions which are the replacement for UpdateApplication + updater pattern).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
