### PR TITLE
Refine Event list UI

### DIFF
--- a/pkg/app/web/src/components/events-page/event-item/index.tsx
+++ b/pkg/app/web/src/components/events-page/event-item/index.tsx
@@ -12,7 +12,6 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     display: "flex",
     alignItems: "center",
-    height: 72,
     backgroundColor: theme.palette.background.paper,
   },
   info: {
@@ -60,14 +59,7 @@ export const EventItem: FC<EventItemProps> = memo(function EventItem({ id }) {
           {EVENT_STATE_TEXT[event.status]}
         </Typography>
       </Box>
-      <Box
-        display="flex"
-        height={72}
-        flexDirection="column"
-        flex={1}
-        pl={2}
-        overflow="scroll"
-      >
+      <Box display="flex" flexDirection="column" flex={1} pl={2}>
         <Box display="flex" alignItems="baseline">
           <Typography variant="h6" component="span">
             {event.name}


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the event log be shown without a scroller
Before

<img width="1439" alt="Screen Shot 2022-02-05 at 17 22 49" src="https://user-images.githubusercontent.com/32532742/152634396-bb45d9f4-52bc-4af6-8f00-1735adcd6cea.png">

After

<img width="1440" alt="Screen Shot 2022-02-05 at 17 23 17" src="https://user-images.githubusercontent.com/32532742/152634401-cec48c22-cd49-476f-a1d3-fd9fd8d239fc.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
