### PR TITLE
Drop piped table env_ids index

### DIFF
--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -246,6 +246,7 @@ func ensureSQLDatabase(ctx context.Context, cfg *config.ControlPlaneSpec, logger
 		}
 	}()
 
+	logger.Info("start running SQL schema and indexes ensurer")
 	if err = mysqlEnsurer.Run(ctx); err != nil {
 		logger.Error("failed to ensure SQL schema and indexes", zap.Error(err))
 		return err

--- a/pkg/datastore/mysql/ensurer/client.go
+++ b/pkg/datastore/mysql/ensurer/client.go
@@ -32,8 +32,9 @@ var (
 )
 
 const (
-	mysqlErrorCodeDuplicateColumnName = 1060
-	mysqlErrorCodeDuplicateKeyName    = 1061
+	mysqlErrorCodeDuplicateColumnName  = 1060
+	mysqlErrorCodeDuplicateKeyName     = 1061
+	mysqlErrorCodeColumnOrKeyNotExists = 1091
 )
 
 type mysqlEnsurer struct {
@@ -63,7 +64,9 @@ func (m *mysqlEnsurer) EnsureIndexes(ctx context.Context) error {
 	for _, stmt := range makeCreateIndexStatements(mysqlDatabaseIndexes) {
 		_, err := m.client.ExecContext(ctx, stmt)
 		// Ignore in case error duplicate key name or column name occurred.
-		if mysqlErr, ok := err.(*driver.MySQLError); ok && (mysqlErr.Number == mysqlErrorCodeDuplicateKeyName || mysqlErr.Number == mysqlErrorCodeDuplicateColumnName) {
+		if mysqlErr, ok := err.(*driver.MySQLError); ok && (mysqlErr.Number == mysqlErrorCodeDuplicateKeyName ||
+			mysqlErr.Number == mysqlErrorCodeDuplicateColumnName ||
+			mysqlErr.Number == mysqlErrorCodeColumnOrKeyNotExists) {
 			continue
 		}
 		if err != nil {

--- a/pkg/datastore/mysql/ensurer/client.go
+++ b/pkg/datastore/mysql/ensurer/client.go
@@ -63,7 +63,9 @@ func NewMySQLEnsurer(url, database, usernameFile, passwordFile string, logger *z
 func (m *mysqlEnsurer) EnsureIndexes(ctx context.Context) error {
 	for _, stmt := range makeCreateIndexStatements(mysqlDatabaseIndexes) {
 		_, err := m.client.ExecContext(ctx, stmt)
-		// Ignore in case error duplicate key name or column name occurred.
+		// Ignore in case error inc case:
+		// - Duplicate key name or column name occurred.
+		// - Try to remove not exists column or key.
 		if mysqlErr, ok := err.(*driver.MySQLError); ok && (mysqlErr.Number == mysqlErrorCodeDuplicateKeyName ||
 			mysqlErr.Number == mysqlErrorCodeDuplicateColumnName ||
 			mysqlErr.Number == mysqlErrorCodeColumnOrKeyNotExists) {

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -124,6 +124,10 @@ CREATE INDEX piped_project_id_asc ON Piped (ProjectId);
 -- index on `ProjectId` ASC and `EnvIds` ASC
 ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
 CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));
+-- Remove the `piped_project_id_env_ids_asc` index due to issue around empty array value on column
+-- which be a part of mulitple columns index.
+-- ref: https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued
+DROP INDEX piped_project_id_env_ids_asc ON Piped;
 
 --
 -- DeploymentChain table indexes

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -123,7 +123,6 @@ CREATE INDEX piped_project_id_asc ON Piped (ProjectId);
 
 -- index on `ProjectId` ASC and `EnvIds` ASC
 ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
-CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));
 -- Remove the `piped_project_id_env_ids_asc` index due to issue around empty array value on column
 -- which be a part of mulitple columns index.
 -- ref: https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-multi-valued


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the unneeded index `piped_project_id_env_ids_asc` on Piped table. The queries on MySQL datastore work with/without index but we chose to make that index since this `EnvIds` field is a virtual generated column, which its value will be generated every time we query for it, which makes the operation a bit slower.
Since the `Environment` concept is deprecated and will be removed in the near future, I think it's fine to just remove this index to get rid of environment-related unstable queries issues. Besides, the number of piped(s) which be controlled by a control-plane is not too many, query without index is acceptable at this meantime.

Tested on my local, some places we needed to use this index previously

![Screen Shot 2022-02-06 at 14 20 25](https://user-images.githubusercontent.com/32532742/152668706-9527fa4e-9be3-4122-b0f9-fcc76d8c8c9f.png)

![Screen Shot 2022-02-06 at 14 21 17](https://user-images.githubusercontent.com/32532742/152668722-7e75103d-8a21-4a4f-b259-3fce139213ad.png)

**Which issue(s) this PR fixes**:

Fixes #3191

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
