### PR TITLE
Add kubectl create/replace

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
@@ -140,8 +140,7 @@ func (c *Kubectl) Replace(ctx context.Context, namespace string, manifest Manife
 		return errorReplaceNotFound
 	}
 
-	return fmt.Errorf("failed to replace: %s (%v)", string(out), err)
-
+	return fmt.Errorf("failed to replace: %s (%w)", string(out), err)
 }
 
 func (c *Kubectl) Delete(ctx context.Context, namespace string, r ResourceKey) (err error) {

--- a/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
@@ -102,7 +102,7 @@ func (c *Kubectl) Create(ctx context.Context, namespace string, manifest Manifes
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to create: %s (%v)", string(out), err)
+		return fmt.Errorf("failed to create: %s (%w)", string(out), err)
 	}
 	return nil
 }

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -249,8 +249,16 @@ func (p *provider) ReplaceManifest(ctx context.Context, manifest Manifest) error
 	if p.initErr != nil {
 		return p.initErr
 	}
+	err := p.kubectl.Replace(ctx, p.getNamespaceToRun(manifest.Key), manifest)
+	if err == nil {
+		return nil
+	}
 
-	return p.kubectl.Replace(ctx, p.getNamespaceToRun(manifest.Key), manifest)
+	if errors.Is(err, errorReplaceNotFound) {
+		return ErrNotFound
+	}
+
+	return err
 }
 
 // Delete deletes the given resource from Kubernetes cluster.

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -244,6 +244,7 @@ func (p *provider) CreateManifest(ctx context.Context, manifest Manifest) error 
 	return p.kubectl.Create(ctx, p.getNamespaceToRun(manifest.Key), manifest)
 }
 
+// ReplaceManifest uses kubectl to replace the given manifests.
 func (p *provider) ReplaceManifest(ctx context.Context, manifest Manifest) error {
 	p.initOnce.Do(func() { p.init(ctx) })
 	if p.initErr != nil {

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -234,7 +234,7 @@ func (p *provider) ApplyManifest(ctx context.Context, manifest Manifest) error {
 	return p.kubectl.Apply(ctx, p.getNamespaceToRun(manifest.Key), manifest)
 }
 
-// CreateManifest does applying the given manifest.
+// CreateManifest uses kubectl to create the given manifests.
 func (p *provider) CreateManifest(ctx context.Context, manifest Manifest) error {
 	p.initOnce.Do(func() { p.init(ctx) })
 	if p.initErr != nil {

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -71,6 +71,10 @@ type Applier interface {
 	Apply(ctx context.Context) error
 	// ApplyManifest does applying the given manifest.
 	ApplyManifest(ctx context.Context, manifest Manifest) error
+	// CreateManifest does creating resource from given manifest.
+	CreateManifest(ctx context.Context, manifest Manifest) error
+	// ReplaceManifest does replacing resource from given manifest.
+	ReplaceManifest(ctx context.Context, manifest Manifest) error
 	// Delete deletes the given resource from Kubernetes cluster.
 	Delete(ctx context.Context, key ResourceKey) error
 }
@@ -228,6 +232,25 @@ func (p *provider) ApplyManifest(ctx context.Context, manifest Manifest) error {
 	}
 
 	return p.kubectl.Apply(ctx, p.getNamespaceToRun(manifest.Key), manifest)
+}
+
+// CreateManifest does applying the given manifest.
+func (p *provider) CreateManifest(ctx context.Context, manifest Manifest) error {
+	p.initOnce.Do(func() { p.init(ctx) })
+	if p.initErr != nil {
+		return p.initErr
+	}
+
+	return p.kubectl.Create(ctx, p.getNamespaceToRun(manifest.Key), manifest)
+}
+
+func (p *provider) ReplaceManifest(ctx context.Context, manifest Manifest) error {
+	p.initOnce.Do(func() { p.init(ctx) })
+	if p.initErr != nil {
+		return p.initErr
+	}
+
+	return p.kubectl.Replace(ctx, p.getNamespaceToRun(manifest.Key), manifest)
 }
 
 // Delete deletes the given resource from Kubernetes cluster.

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetesmetrics/metrics.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetesmetrics/metrics.go
@@ -34,8 +34,10 @@ const (
 type ToolCommand string
 
 const (
-	LabelApplyCommand  ToolCommand = "apply"
-	LabelDeleteCommand ToolCommand = "delete"
+	LabelApplyCommand   ToolCommand = "apply"
+	LabelCreateCommand  ToolCommand = "create"
+	LabelReplaceCommand ToolCommand = "replace"
+	LabelDeleteCommand  ToolCommand = "delete"
 )
 
 type CommandOutput string


### PR DESCRIPTION
**What this PR does / why we need it**:
Add kubectl create/replace operation. Create is needed if there is no resource and cannot replace.
rel: #3173 

I plan to use replace first, and if it fails due to resource not found error, then create resource. So only handle replace error. 
The reason why use replace command always first is we cannot know whether specified resource already exists before `kubectl replace`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
