### PR TITLE
Add HealthStatus method to check health of service and revision

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/cloudrun/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/cache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/diff:go_default_library",
+        "//pkg/model:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
@@ -40,9 +41,8 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
+        "//pkg/model:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@io_k8s_sigs_yaml//:go_default_library",
-        "@org_golang_google_api//run/v1:go_default_library",
     ],
 )

--- a/pkg/app/piped/cloudprovider/cloudrun/client.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	"google.golang.org/api/run/v1"
-	"sigs.k8s.io/yaml"
 )
 
 type client struct {
@@ -63,7 +62,7 @@ func newClient(ctx context.Context, projectID, region, credentialsFile string, l
 }
 
 func (c *client) Create(ctx context.Context, sm ServiceManifest) (*Service, error) {
-	svcCfg, err := manifestToRunService(sm)
+	svcCfg, err := sm.RunService()
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +85,7 @@ func (c *client) Create(ctx context.Context, sm ServiceManifest) (*Service, erro
 }
 
 func (c *client) Update(ctx context.Context, sm ServiceManifest) (*Service, error) {
-	svcCfg, err := manifestToRunService(sm)
+	svcCfg, err := sm.RunService()
 	if err != nil {
 		return nil, err
 	}
@@ -171,30 +170,4 @@ func makeCloudRunServiceName(projectID, serviceID string) string {
 
 func makeCloudRunRevisionName(projectID, revisionID string) string {
 	return fmt.Sprintf("namespaces/%s/revisions/%s", projectID, revisionID)
-}
-
-func manifestToRunService(sm ServiceManifest) (*run.Service, error) {
-	data, err := sm.YamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	var s run.Service
-	if err := yaml.Unmarshal(data, &s); err != nil {
-		return nil, err
-	}
-	return &s, nil
-}
-
-func manifestToRunRevision(rm RevisionManifest) (*run.Revision, error) {
-	data, err := rm.YamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	var r run.Revision
-	if err := yaml.Unmarshal(data, &r); err != nil {
-		return nil, err
-	}
-	return &r, nil
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/client.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client.go
@@ -185,3 +185,16 @@ func manifestToRunService(sm ServiceManifest) (*run.Service, error) {
 	}
 	return &s, nil
 }
+
+func manifestToRunRevision(rm RevisionManifest) (*run.Revision, error) {
+	data, err := rm.YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	var r run.Revision
+	if err := yaml.Unmarshal(data, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/client_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client_test.go
@@ -57,3 +57,13 @@ func TestManifestToRunService(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, got)
 }
+
+func TestManifestToRunRevision(t *testing.T) {
+	rm, err := ParseRevisionManifest([]byte(revisionManifest))
+	require.NoError(t, err)
+	require.NotEmpty(t, rm)
+
+	got, err := manifestToRunRevision(rm)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/client_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/client_test.go
@@ -53,7 +53,7 @@ func TestManifestToRunService(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, sm)
 
-	got, err := manifestToRunService(sm)
+	got, err := sm.RunService()
 	require.NoError(t, err)
 	assert.NotEmpty(t, got)
 }
@@ -63,7 +63,7 @@ func TestManifestToRunRevision(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, rm)
 
-	got, err := manifestToRunRevision(rm)
+	got, err := rm.RunRevision()
 	require.NoError(t, err)
 	assert.NotEmpty(t, got)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -154,16 +154,14 @@ func (s *Service) HealthStatus() (model.CloudRunResourceState_HealthStatus, stri
 		errMessage = "Unexpected error while calculating: %s"
 	)
 	if status == nil {
-		msg := fmt.Sprintf(errMessage, "unable to find status")
-		return model.CloudRunResourceState_UNKNOWN, msg
+		return model.CloudRunResourceState_UNKNOWN, fmt.Sprintf(errMessage, "unable to find status")
 	}
 
 	conds := status.Conditions
 	for _, c := range conds {
 		isHealthy, err := strconv.ParseBool(c.Status)
 		if err != nil {
-			msg := fmt.Sprintf(errMessage, "unable to parse status: %s", c.Status)
-			return model.CloudRunResourceState_UNKNOWN, msg
+			return model.CloudRunResourceState_UNKNOWN, fmt.Sprintf(errMessage, "unable to parse status: %s", c.Status)
 		}
 		if !isHealthy {
 			return model.CloudRunResourceState_OTHER, c.Message
@@ -187,16 +185,14 @@ func (r *Revision) HealthStatus() (model.CloudRunResourceState_HealthStatus, str
 		errMessage = "Unexpected error while calculating: %s"
 	)
 	if status == nil {
-		msg := fmt.Sprintf(errMessage, "unable to find status")
-		return model.CloudRunResourceState_UNKNOWN, msg
+		return model.CloudRunResourceState_UNKNOWN, fmt.Sprintf(errMessage, "unable to find status")
 	}
 
 	conds := status.Conditions
 	for _, c := range conds {
 		isHealthy, err := strconv.ParseBool(c.Status)
 		if err != nil {
-			msg := fmt.Sprintf(errMessage, "unable to parse status: %s", c.Status)
-			return model.CloudRunResourceState_UNKNOWN, msg
+			return model.CloudRunResourceState_UNKNOWN, fmt.Sprintf(errMessage, "unable to parse status: %s", c.Status)
 		}
 		if !isHealthy {
 			return model.CloudRunResourceState_OTHER, c.Message

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
@@ -48,7 +48,7 @@ func TestService(t *testing.T) {
 	sm, err := ParseServiceManifest([]byte(serviceManifest))
 	require.NoError(t, err)
 
-	svc, err := manifestToRunService(sm)
+	svc, err := sm.RunService()
 	require.NoError(t, err)
 
 	// ServiceManifest
@@ -291,7 +291,7 @@ status:
 			sm, err := ParseServiceManifest(data)
 			require.NoError(t, err)
 
-			svc, err := manifestToRunService(sm)
+			svc, err := sm.RunService()
 			require.NoError(t, err)
 
 			s := (*Service)(svc)
@@ -306,7 +306,7 @@ func TestRevision(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, rm)
 
-	rev, err := manifestToRunRevision(rm)
+	rev, err := rm.RunRevision()
 	require.NoError(t, err)
 
 	r := (*Revision)(rev)
@@ -578,7 +578,7 @@ status:
 			rm, err := ParseRevisionManifest(data)
 			require.NoError(t, err)
 
-			rev, err := manifestToRunRevision(rm)
+			rev, err := rm.RunRevision()
 			require.NoError(t, err)
 
 			r := (*Revision)(rev)

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
@@ -17,11 +17,10 @@ package cloudrun
 import (
 	"testing"
 
-	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/api/run/v1"
-	"sigs.k8s.io/yaml"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 func TestLoadServiceManifest(t *testing.T) {
@@ -307,15 +306,10 @@ func TestRevision(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, rm)
 
-	data, err := yaml.Marshal(rm.u)
-	require.NoError(t, err)
-	require.NotEmpty(t, data)
-
-	var rev run.Revision
-	err = yaml.Unmarshal(data, &rev)
+	rev, err := manifestToRunRevision(rm)
 	require.NoError(t, err)
 
-	r := (*Revision)(&rev)
+	r := (*Revision)(rev)
 	got, err := r.RevisionManifest()
 	require.NoError(t, err)
 	assert.Equal(t, rm, got)
@@ -584,14 +578,10 @@ status:
 			rm, err := ParseRevisionManifest(data)
 			require.NoError(t, err)
 
-			v, err := yaml.Marshal(rm.u)
+			rev, err := manifestToRunRevision(rm)
 			require.NoError(t, err)
 
-			var rev run.Revision
-			err = yaml.Unmarshal(v, &rev)
-			require.NoError(t, err)
-
-			r := (*Revision)(&rev)
+			r := (*Revision)(rev)
 			got, _ := r.HealthStatus()
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest.go
@@ -35,3 +35,7 @@ func ParseRevisionManifest(data []byte) (RevisionManifest, error) {
 		u:    &obj,
 	}, nil
 }
+
+func (r RevisionManifest) YamlBytes() ([]byte, error) {
+	return yaml.Marshal(r.u)
+}

--- a/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest.go
@@ -15,6 +15,7 @@
 package cloudrun
 
 import (
+	"google.golang.org/api/run/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
@@ -38,4 +39,17 @@ func ParseRevisionManifest(data []byte) (RevisionManifest, error) {
 
 func (r RevisionManifest) YamlBytes() ([]byte, error) {
 	return yaml.Marshal(r.u)
+}
+
+func (r RevisionManifest) RunRevision() (*run.Revision, error) {
+	data, err := r.YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	var rev run.Revision
+	if err := yaml.Unmarshal(data, &rev); err != nil {
+		return nil, err
+	}
+	return &rev, nil
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/revisionmanifest_test.go
@@ -17,6 +17,7 @@ package cloudrun
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +89,9 @@ func TestRevisionManifest(t *testing.T) {
 	rm, err := ParseRevisionManifest([]byte(revisionManifest))
 	require.NoError(t, err)
 	require.NotEmpty(t, rm)
+
+	// YamlBytes
+	data, err := rm.YamlBytes()
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
 }

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"google.golang.org/api/run/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
@@ -90,6 +91,19 @@ func (m ServiceManifest) AddLabels(labels map[string]string) {
 		lbls[k] = v
 	}
 	m.u.SetLabels(lbls)
+}
+
+func (m ServiceManifest) RunService() (*run.Service, error) {
+	data, err := m.YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	var s run.Service
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
 }
 
 func loadServiceManifest(path string) (ServiceManifest, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add HealthStatus method to check health of service and revision of CloudRun.
I will explain each health condition below.

```
- If there are only True Status in condition section, model.CloudRunResourceState_HEALTHY is returned.
- If there is at least one Unknown or False Status in condition section, the one defined earlier is returned.
  For example, model.CloudRunResourceState_OTHER is returned if the first status in condition section is false.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
