### PR TITLE
Implement sync-by-replace option

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -45,6 +45,7 @@ const (
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
+	UserReplaceTrue           = "true"
 
 	kustomizationFileName = "kustomization.yaml"
 )

--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -58,25 +58,26 @@ var builtInApiVersions = map[string]struct{}{
 }
 
 const (
-	KindDeployment            = "Deployment"
-	KindStatefulSet           = "StatefulSet"
-	KindDaemonSet             = "DaemonSet"
-	KindReplicaSet            = "ReplicaSet"
-	KindPod                   = "Pod"
-	KindJob                   = "Job"
-	KindCronJob               = "CronJob"
-	KindConfigMap             = "ConfigMap"
-	KindSecret                = "Secret"
-	KindPersistentVolume      = "PersistentVolume"
-	KindPersistentVolumeClaim = "PersistentVolumeClaim"
-	KindService               = "Service"
-	KindIngress               = "Ingress"
-	KindServiceAccount        = "ServiceAccount"
-	KindRole                  = "Role"
-	KindRoleBinding           = "RoleBinding"
-	KindClusterRole           = "ClusterRole"
-	KindClusterRoleBinding    = "ClusterRoleBinding"
-	KindNameSpace             = "NameSpace"
+	KindDeployment               = "Deployment"
+	KindStatefulSet              = "StatefulSet"
+	KindDaemonSet                = "DaemonSet"
+	KindReplicaSet               = "ReplicaSet"
+	KindPod                      = "Pod"
+	KindJob                      = "Job"
+	KindCronJob                  = "CronJob"
+	KindConfigMap                = "ConfigMap"
+	KindSecret                   = "Secret"
+	KindPersistentVolume         = "PersistentVolume"
+	KindPersistentVolumeClaim    = "PersistentVolumeClaim"
+	KindService                  = "Service"
+	KindIngress                  = "Ingress"
+	KindServiceAccount           = "ServiceAccount"
+	KindRole                     = "Role"
+	KindRoleBinding              = "RoleBinding"
+	KindClusterRole              = "ClusterRole"
+	KindClusterRoleBinding       = "ClusterRoleBinding"
+	KindNameSpace                = "NameSpace"
+	KindCustomResourceDefinition = "CustomResourceDefinition"
 
 	DefaultNamespace = "default"
 )
@@ -179,6 +180,18 @@ func (k ResourceKey) IsSecret() bool {
 	if !IsKubernetesBuiltInResource(k.APIVersion) {
 		return false
 	}
+	return true
+}
+
+func (k ResourceKey) IsCRD() bool {
+	if k.Kind != KindCustomResourceDefinition {
+		return false
+	}
+
+	if !IsKubernetesBuiltInResource(k.APIVersion) {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -212,11 +212,25 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 		lp.Infof("Start applying %d manifests to %q namespace", len(manifests), namespace)
 	}
 	for _, m := range manifests {
-		if err := applier.ApplyManifest(ctx, m); err != nil {
-			lp.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableLogString(), err)
-			return err
+		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
+		if annotation == provider.UserReplaceTrue {
+			err := applier.ReplaceManifest(ctx, m)
+			if errors.Is(err, provider.ErrNotFound) {
+				lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
+				err = applier.CreateManifest(ctx, m)
+			}
+			if err != nil {
+				lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				return err
+			}
+			lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
+		} else {
+			if err := applier.ApplyManifest(ctx, m); err != nil {
+				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				return err
+			}
+			lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
 		}
-		lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement `pipecd.dev/sync-by-replace: "true"` option. This enable use of `kubectl replace/create` instead of `kubectl apply`. 
With this change, CRD is not supported  for simplicity.

**Which issue(s) this PR fixes**:

Fixes #3173

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add `pipecd.dev/sync-by-replace: "true"` option that enables use of `kubectl replace/create` instead of `kubectl apply`. 
```
