### PR TITLE
Decoupling API with models store interface

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -35,13 +35,43 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
 
+type apiApplicationStore interface {
+	Add(ctx context.Context, app *model.Application) error
+	Get(ctx context.Context, id string) (*model.Application, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
+	UpdateConfigFilename(ctx context.Context, id, filename string) error
+}
+
+type apiEnvironmentStore interface {
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Environment, error)
+}
+
+type apiDeploymentStore interface {
+	Get(ctx context.Context, id string) (*model.Deployment, error)
+}
+
+type apiPipedStore interface {
+	Get(ctx context.Context, id string) (*model.Piped, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Piped, error)
+	EnablePiped(ctx context.Context, id string) error
+	DisablePiped(ctx context.Context, id string) error
+}
+
+type apiEventStore interface {
+	Add(ctx context.Context, event model.Event) error
+}
+
+type commandOutputGetter interface {
+	Get(ctx context.Context, commandID string) ([]byte, error)
+}
+
 // API implements the behaviors for the gRPC definitions of API.
 type API struct {
-	applicationStore    datastore.ApplicationStore
-	environmentStore    datastore.EnvironmentStore
-	deploymentStore     datastore.DeploymentStore
-	pipedStore          datastore.PipedStore
-	eventStore          datastore.EventStore
+	applicationStore    apiApplicationStore
+	environmentStore    apiEnvironmentStore
+	deploymentStore     apiDeploymentStore
+	pipedStore          apiPipedStore
+	eventStore          apiEventStore
 	commandStore        commandstore.Store
 	commandOutputGetter commandOutputGetter
 
@@ -244,9 +274,10 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 			},
 			Limit: limit,
 		}
-		envs, err := listEnvironments(ctx, a.environmentStore, envListOpts, a.logger)
+		envs, err := a.environmentStore.List(ctx, envListOpts)
 		if err != nil {
-			return nil, err
+			a.logger.Error("failed to list environments", zap.Error(err))
+			return nil, status.Error(codes.Internal, "Failed to list environments")
 		}
 
 		switch len(envs) {

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -276,8 +276,7 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 		}
 		envs, err := a.environmentStore.List(ctx, envListOpts)
 		if err != nil {
-			a.logger.Error("failed to list environments", zap.Error(err))
-			return nil, status.Error(codes.Internal, "Failed to list environments")
+			return nil, gRPCEntityOperationError(err, "list environment")
 		}
 
 		switch len(envs) {

--- a/pkg/app/server/grpcapi/grpcapi.go
+++ b/pkg/app/server/grpcapi/grpcapi.go
@@ -32,15 +32,23 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-type commandOutputGetter interface {
-	Get(ctx context.Context, commandID string) ([]byte, error)
+type applicationGetter interface {
+	Get(ctx context.Context, id string) (*model.Application, error)
 }
 
-type commandOutputPutter interface {
-	Put(ctx context.Context, commandID string, data []byte) error
+type deploymentGetter interface {
+	Get(ctx context.Context, id string) (*model.Deployment, error)
 }
 
-func getPiped(ctx context.Context, store datastore.PipedStore, id string, logger *zap.Logger) (*model.Piped, error) {
+type pipedGetter interface {
+	Get(ctx context.Context, id string) (*model.Piped, error)
+}
+
+type environmentGetter interface {
+	Get(ctx context.Context, id string) (*model.Environment, error)
+}
+
+func getPiped(ctx context.Context, store pipedGetter, id string, logger *zap.Logger) (*model.Piped, error) {
 	piped, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Piped is not found")
@@ -53,7 +61,7 @@ func getPiped(ctx context.Context, store datastore.PipedStore, id string, logger
 	return piped, nil
 }
 
-func getApplication(ctx context.Context, store datastore.ApplicationStore, id string, logger *zap.Logger) (*model.Application, error) {
+func getApplication(ctx context.Context, store applicationGetter, id string, logger *zap.Logger) (*model.Application, error) {
 	app, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Application is not found")
@@ -66,7 +74,7 @@ func getApplication(ctx context.Context, store datastore.ApplicationStore, id st
 	return app, nil
 }
 
-func getDeployment(ctx context.Context, store datastore.DeploymentStore, id string, logger *zap.Logger) (*model.Deployment, error) {
+func getDeployment(ctx context.Context, store deploymentGetter, id string, logger *zap.Logger) (*model.Deployment, error) {
 	deployment, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Deployment is not found")
@@ -127,17 +135,7 @@ func makeGitPath(repoID, path, cfgFilename string, piped *model.Piped, logger *z
 	}, nil
 }
 
-func listEnvironments(ctx context.Context, store datastore.EnvironmentStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Environment, error) {
-	envs, err := store.List(ctx, opts)
-	if err != nil {
-		logger.Error("failed to list environments", zap.Error(err))
-		return nil, status.Error(codes.Internal, "Failed to list environments")
-	}
-
-	return envs, nil
-}
-
-func getEnvironment(ctx context.Context, store datastore.EnvironmentStore, id string, logger *zap.Logger) (*model.Environment, error) {
+func getEnvironment(ctx context.Context, store environmentGetter, id string, logger *zap.Logger) (*model.Environment, error) {
 	env, err := store.Get(ctx, id)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "Environment is not found")

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -50,16 +50,75 @@ type encrypter interface {
 	Encrypt(text string) (string, error)
 }
 
+type webApiApplicationStore interface {
+	Add(ctx context.Context, app *model.Application) error
+	Get(ctx context.Context, id string) (*model.Application, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
+	Delete(ctx context.Context, id string) error
+	UpdateConfiguration(ctx context.Context, id, pipedID, cloudProvider, configFilename string) error
+	Enable(ctx context.Context, id string) error
+	Disable(ctx context.Context, id string) error
+}
+
+type webApiEnvironmentStore interface {
+	Get(ctx context.Context, id string) (*model.Environment, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Environment, error)
+	Delete(ctx context.Context, id string) error
+	EnableEnvironment(ctx context.Context, id string) error
+	DisableEnvironment(ctx context.Context, id string) error
+}
+
+type webApiDeploymentChainStore interface {
+	Get(ctx context.Context, id string) (*model.DeploymentChain, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.DeploymentChain, string, error)
+}
+
+type webApiDeploymentStore interface {
+	Get(ctx context.Context, id string) (*model.Deployment, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error)
+}
+
+type webApiPipedStore interface {
+	Add(ctx context.Context, piped *model.Piped) error
+	Get(ctx context.Context, id string) (*model.Piped, error)
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Piped, error)
+	AddKey(ctx context.Context, id, keyHash, creator string, createdAt time.Time) error
+	DeleteOldKeys(ctx context.Context, id string) error
+	UpdateInfo(ctx context.Context, id, name, desc string, envIds []string) error
+	EnablePiped(ctx context.Context, id string) error
+	DisablePiped(ctx context.Context, id string) error
+	UpdateDesiredVersion(ctx context.Context, id, version string) error
+}
+
+type webApiProjectStore interface {
+	Get(ctx context.Context, id string) (*model.Project, error)
+	UpdateProjectStaticAdmin(ctx context.Context, id, username, password string) error
+	EnableStaticAdmin(ctx context.Context, id string) error
+	DisableStaticAdmin(ctx context.Context, id string) error
+	UpdateProjectSSOConfig(ctx context.Context, id string, sso *model.ProjectSSOConfig) error
+	UpdateProjectRBACConfig(ctx context.Context, id string, sso *model.ProjectRBACConfig) error
+}
+
+type webApiEventStore interface {
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Event, string, error)
+}
+
+type webApiAPIKeyStore interface {
+	Add(ctx context.Context, k *model.APIKey) error
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.APIKey, error)
+	Disable(ctx context.Context, id, projectID string) error
+}
+
 // WebAPI implements the behaviors for the gRPC definitions of WebAPI.
 type WebAPI struct {
-	applicationStore          datastore.ApplicationStore
-	environmentStore          datastore.EnvironmentStore
-	deploymentChainStore      datastore.DeploymentChainStore
-	deploymentStore           datastore.DeploymentStore
-	pipedStore                datastore.PipedStore
-	projectStore              datastore.ProjectStore
-	apiKeyStore               datastore.APIKeyStore
-	eventStore                datastore.EventStore
+	applicationStore          webApiApplicationStore
+	environmentStore          webApiEnvironmentStore
+	deploymentChainStore      webApiDeploymentChainStore
+	deploymentStore           webApiDeploymentStore
+	pipedStore                webApiPipedStore
+	projectStore              webApiProjectStore
+	apiKeyStore               webApiAPIKeyStore
+	eventStore                webApiEventStore
 	stageLogStore             stagelogstore.Store
 	applicationLiveStateStore applicationlivestatestore.Store
 	commandStore              commandstore.Store


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR creates separated models store interface for each API (piped, web, pipectl) to prepare for adding writer to models store interface.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
