### PR TITLE
Decoupling ops with models store interface

### DIFF
--- a/pkg/app/ops/deploymentchaincontroller/updater.go
+++ b/pkg/app/ops/deploymentchaincontroller/updater.go
@@ -37,9 +37,8 @@ type updater struct {
 	// of that in chain application.
 	deploymentRefs map[string]*model.ChainDeploymentRef
 
-	applicationStore     datastore.ApplicationStore
-	deploymentStore      datastore.DeploymentStore
-	deploymentChainStore datastore.DeploymentChainStore
+	deploymentStore      deploymentStore
+	deploymentChainStore deploymentChainStore
 
 	done          bool
 	doneTimestamp time.Time
@@ -50,16 +49,14 @@ type updater struct {
 
 func newUpdater(
 	dc *model.DeploymentChain,
-	as datastore.ApplicationStore,
-	ds datastore.DeploymentStore,
-	dcs datastore.DeploymentChainStore,
+	ds deploymentStore,
+	dcs deploymentChainStore,
 	lg *zap.Logger,
 ) *updater {
 	return &updater{
 		deploymentChainID:    dc.Id,
 		applicationRefs:      dc.ListAllInChainApplications(),
 		deploymentRefs:       dc.ListAllInChainApplicationDeploymentsMap(),
-		applicationStore:     as,
 		deploymentStore:      ds,
 		deploymentChainStore: dcs,
 		logger:               lg,

--- a/pkg/app/ops/insightcollector/collector.go
+++ b/pkg/app/ops/insightcollector/collector.go
@@ -32,10 +32,17 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
+type applicationStore interface {
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
+}
+
+type deploymentStore interface {
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error)
+}
+
 type Collector struct {
-	projectStore     datastore.ProjectStore
-	applicationStore datastore.ApplicationStore
-	deploymentStore  datastore.DeploymentStore
+	applicationStore applicationStore
+	deploymentStore  deploymentStore
 	insightstore     insightstore.Store
 
 	applicationsHandlers              []func(ctx context.Context, applications []*model.Application, target time.Time) error
@@ -48,7 +55,6 @@ type Collector struct {
 
 func NewCollector(ds datastore.DataStore, fs filestore.Store, cfg config.ControlPlaneInsightCollector, logger *zap.Logger) *Collector {
 	c := &Collector{
-		projectStore:     datastore.NewProjectStore(ds),
 		applicationStore: datastore.NewApplicationStore(ds),
 		deploymentStore:  datastore.NewDeploymentStore(ds),
 		insightstore:     insightstore.NewStore(fs),

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -30,8 +30,13 @@ var (
 	interval       = 6 * time.Hour
 )
 
+type commandStore interface {
+	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Command, error)
+	UpdateStatus(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error
+}
+
 type OrphanCommandCleaner struct {
-	commandstore datastore.CommandStore
+	commandstore commandStore
 	logger       *zap.Logger
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as PR #3234 but for ops

**Which issue(s) this PR fixes**:

Follow PR #3234 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
