### PR TITLE
Implement sync-by-replace option

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -45,6 +45,7 @@ const (
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
+	UserReplaceTrue           = "true"
 
 	kustomizationFileName = "kustomization.yaml"
 )

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -45,7 +45,7 @@ const (
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
-	UseReplaceTrue            = "true"
+	UseReplaceEnabled         = "enabled"
 
 	kustomizationFileName = "kustomization.yaml"
 )

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -45,7 +45,7 @@ const (
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
-	UserReplaceTrue           = "true"
+	UseReplaceTrue            = "true"
 
 	kustomizationFileName = "kustomization.yaml"
 )

--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -183,18 +183,6 @@ func (k ResourceKey) IsSecret() bool {
 	return true
 }
 
-func (k ResourceKey) IsCRD() bool {
-	if k.Kind != KindCustomResourceDefinition {
-		return false
-	}
-
-	if !IsKubernetesBuiltInResource(k.APIVersion) {
-		return false
-	}
-
-	return true
-}
-
 // IsLess reports whether the key should sort before the given key.
 func (k ResourceKey) IsLess(a ResourceKey) bool {
 	if k.APIVersion < a.APIVersion {

--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -58,25 +58,26 @@ var builtInApiVersions = map[string]struct{}{
 }
 
 const (
-	KindDeployment            = "Deployment"
-	KindStatefulSet           = "StatefulSet"
-	KindDaemonSet             = "DaemonSet"
-	KindReplicaSet            = "ReplicaSet"
-	KindPod                   = "Pod"
-	KindJob                   = "Job"
-	KindCronJob               = "CronJob"
-	KindConfigMap             = "ConfigMap"
-	KindSecret                = "Secret"
-	KindPersistentVolume      = "PersistentVolume"
-	KindPersistentVolumeClaim = "PersistentVolumeClaim"
-	KindService               = "Service"
-	KindIngress               = "Ingress"
-	KindServiceAccount        = "ServiceAccount"
-	KindRole                  = "Role"
-	KindRoleBinding           = "RoleBinding"
-	KindClusterRole           = "ClusterRole"
-	KindClusterRoleBinding    = "ClusterRoleBinding"
-	KindNameSpace             = "NameSpace"
+	KindDeployment               = "Deployment"
+	KindStatefulSet              = "StatefulSet"
+	KindDaemonSet                = "DaemonSet"
+	KindReplicaSet               = "ReplicaSet"
+	KindPod                      = "Pod"
+	KindJob                      = "Job"
+	KindCronJob                  = "CronJob"
+	KindConfigMap                = "ConfigMap"
+	KindSecret                   = "Secret"
+	KindPersistentVolume         = "PersistentVolume"
+	KindPersistentVolumeClaim    = "PersistentVolumeClaim"
+	KindService                  = "Service"
+	KindIngress                  = "Ingress"
+	KindServiceAccount           = "ServiceAccount"
+	KindRole                     = "Role"
+	KindRoleBinding              = "RoleBinding"
+	KindClusterRole              = "ClusterRole"
+	KindClusterRoleBinding       = "ClusterRoleBinding"
+	KindNameSpace                = "NameSpace"
+	KindCustomResourceDefinition = "CustomResourceDefinition"
 
 	DefaultNamespace = "default"
 )
@@ -179,6 +180,18 @@ func (k ResourceKey) IsSecret() bool {
 	if !IsKubernetesBuiltInResource(k.APIVersion) {
 		return false
 	}
+	return true
+}
+
+func (k ResourceKey) IsCRD() bool {
+	if k.Kind != KindCustomResourceDefinition {
+		return false
+	}
+
+	if !IsKubernetesBuiltInResource(k.APIVersion) {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -214,26 +214,26 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 	for _, m := range manifests {
 		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
 		// Do not replace CRD because replace might delete CRD instance
-                if annotation != provider.UserReplaceTrue || m.Key.IsCRD() {
-	                if err := applier.ApplyManifest(ctx, m); err != nil {
-		                lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
-		                return err
-	                }
-	                lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
-	                continue
-                }
-                // Always try to replace first and create if it fails due to resource not found error.
-                // This is because we cannot know whether resource already exists before executing command.
-                err := applier.ReplaceManifest(ctx, m)
-                if errors.Is(err, provider.ErrNotFound) {
-	                lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
-	                err = applier.CreateManifest(ctx, m)
-                }
-                if err != nil {
-	                lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
-	                return err
-                }
-                lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
+		if annotation != provider.UserReplaceTrue || m.Key.IsCRD() {
+			if err := applier.ApplyManifest(ctx, m); err != nil {
+				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				return err
+			}
+			lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
+			continue
+		}
+		// Always try to replace first and create if it fails due to resource not found error.
+		// This is because we cannot know whether resource already exists before executing command.
+		err := applier.ReplaceManifest(ctx, m)
+		if errors.Is(err, provider.ErrNotFound) {
+			lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
+			err = applier.CreateManifest(ctx, m)
+		}
+		if err != nil {
+			lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
+			return err
+		}
+		lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
 
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -214,26 +214,27 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 	for _, m := range manifests {
 		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
 		// Do not replace CRD because replace might delete CRD instance
-		if annotation == provider.UserReplaceTrue && !m.Key.IsCRD() {
-			// Always try to replace first and create if it fails due to resource not found error.
-			// This is because we cannot know whether resource already exists before executing command.
-			err := applier.ReplaceManifest(ctx, m)
-			if errors.Is(err, provider.ErrNotFound) {
-				lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
-				err = applier.CreateManifest(ctx, m)
-			}
-			if err != nil {
-				lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
-				return err
-			}
-			lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
-		} else {
-			if err := applier.ApplyManifest(ctx, m); err != nil {
-				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
-				return err
-			}
-			lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
-		}
+                if annotation != provider.UserReplaceTrue || m.Key.IsCRD() {
+	                if err := applier.ApplyManifest(ctx, m); err != nil {
+		                lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
+		                return err
+	                }
+	                lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
+	                continue
+                }
+                // Always try to replace first and create if it fails due to resource not found error.
+                // This is because we cannot know whether resource already exists before executing command.
+                err := applier.ReplaceManifest(ctx, m)
+                if errors.Is(err, provider.ErrNotFound) {
+	                lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
+	                err = applier.CreateManifest(ctx, m)
+                }
+                if err != nil {
+	                lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
+	                return err
+                }
+                lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
+
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))
 	return nil

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -212,11 +212,25 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 		lp.Infof("Start applying %d manifests to %q namespace", len(manifests), namespace)
 	}
 	for _, m := range manifests {
-		if err := applier.ApplyManifest(ctx, m); err != nil {
-			lp.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableLogString(), err)
-			return err
+		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
+		if annotation == provider.UserReplaceTrue {
+			err := applier.ReplaceManifest(ctx, m)
+			if errors.Is(err, provider.ErrNotFound) {
+				lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
+				err = applier.CreateManifest(ctx, m)
+			}
+			if err != nil {
+				lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				return err
+			}
+			lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
+		} else {
+			if err := applier.ApplyManifest(ctx, m); err != nil {
+				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				return err
+			}
+			lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
 		}
-		lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))
 	return nil

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -213,8 +213,7 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 	}
 	for _, m := range manifests {
 		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
-		// Do not replace CRD because replace might delete CRD instance
-		if annotation != provider.UseReplaceTrue || m.Key.IsCRD() {
+		if annotation != provider.UseReplaceEnabled {
 			if err := applier.ApplyManifest(ctx, m); err != nil {
 				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
 				return err

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -214,7 +214,7 @@ func applyManifests(ctx context.Context, applier provider.Applier, manifests []p
 	for _, m := range manifests {
 		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
 		// Do not replace CRD because replace might delete CRD instance
-		if annotation != provider.UserReplaceTrue || m.Key.IsCRD() {
+		if annotation != provider.UseReplaceTrue || m.Key.IsCRD() {
 			if err := applier.ApplyManifest(ctx, m); err != nil {
 				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
 				return err

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -338,7 +338,7 @@ kind: Deployment
 metadata:
   name: simple
   annotations:
-    pipecd.dev/sync-by-replace: "true"
+    pipecd.dev/sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:
@@ -365,7 +365,7 @@ kind: Deployment
 metadata:
   name: simple
   annotations:
-    pipecd.dev/sync-by-replace: "true"
+    pipecd.dev/sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:
@@ -403,32 +403,6 @@ spec:
 			wantErr:   false,
 		},
 		{
-			name: "successfully apply crd manifest",
-			applier: func() provider.Applier {
-				p := providertest.NewMockProvider(ctrl)
-				p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
-				return p
-			}(),
-			manifest: `
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: simple
-  annotations:
-    pipecd.dev/sync-by-replace: "true"
-spec:
-  selector:
-    matchLabels:
-      app: simple
-  template:
-    metadata:
-      labels:
-        app: simple
-`,
-			namespace: "",
-			wantErr:   false,
-		},
-		{
 			name: "successfully replace manifest",
 			applier: func() provider.Applier {
 				p := providertest.NewMockProvider(ctrl)
@@ -441,7 +415,7 @@ kind: Deployment
 metadata:
   name: simple
   annotations:
-    pipecd.dev/sync-by-replace: "true"
+    pipecd.dev/sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:
@@ -468,7 +442,7 @@ kind: Deployment
 metadata:
   name: simple
   annotations:
-    pipecd.dev/sync-by-replace: "true"
+    pipecd.dev/sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -290,6 +290,211 @@ spec:
 
 }
 
+func TestApplyManifests(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := []struct {
+		name      string
+		applier   provider.Applier
+		manifest  string
+		namespace string
+		wantErr   bool
+	}{
+
+		{
+			name: "unable to apply manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(errors.New("unexpected error"))
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   true,
+		},
+		{
+			name: "unable to replace manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ReplaceManifest(gomock.Any(), gomock.Any()).Return(errors.New("unexpected error"))
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/sync-by-replace: "true"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   true,
+		},
+		{
+			name: "unable to create manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ReplaceManifest(gomock.Any(), gomock.Any()).Return(provider.ErrNotFound)
+				p.EXPECT().CreateManifest(gomock.Any(), gomock.Any()).Return(errors.New("unexpected error"))
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/sync-by-replace: "true"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   true,
+		},
+		{
+			name: "successfully apply manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+		{
+			name: "successfully apply crd manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/sync-by-replace: "true"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+		{
+			name: "successfully replace manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ReplaceManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/sync-by-replace: "true"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+		{
+			name: "successfully create manifest",
+			applier: func() provider.Applier {
+				p := providertest.NewMockProvider(ctrl)
+				p.EXPECT().ReplaceManifest(gomock.Any(), gomock.Any()).Return(provider.ErrNotFound)
+				p.EXPECT().CreateManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/sync-by-replace: "true"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			manifests, err := provider.ParseManifests(tc.manifest)
+			require.NoError(t, err)
+			err = applyManifests(ctx, tc.applier, manifests, tc.namespace, &fakeLogPersister{})
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}
+
 func TestDeleteResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -292,7 +292,6 @@ spec:
 
 func TestApplyManifests(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	testcases := []struct {
 		name      string
@@ -497,7 +496,6 @@ spec:
 
 func TestDeleteResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	testcases := []struct {
 		name      string


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement pipecd.dev/sync-by-replace: "true" option. This enable use of kubectl replace/create instead of kubectl apply.
With this change, CRD is not supported for simplicity.

**Which issue(s) this PR fixes**:

Fixes #3173

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to use `pipecd.dev/sync-by-replace: "enabled"` annotation in Kubernetes manifests to use `kubectl replace/create` instead of `kubectl apply` while applying it 
```
