### PR TITLE
Add ability to filter notification event based on Labels

### DIFF
--- a/pkg/app/piped/notifier/matcher.go
+++ b/pkg/app/piped/notifier/matcher.go
@@ -73,7 +73,7 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 		labels = md.GetLabels()
 	}
 	for k, v := range labels {
-		if iv, ok := m.ignoreLabels[k]; ok && iv == v {
+		if m.ignoreLabels[k] == v {
 			return false
 		}
 	}
@@ -96,7 +96,7 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 	// Should count current event as matched if it contains any of listening labels.
 	if len(m.labels) > 0 && len(labels) > 0 {
 		for k, v := range m.labels {
-			if ev, ok := labels[k]; ok && ev == v {
+			if labels[k] == v {
 				return true
 			}
 		}

--- a/pkg/app/piped/notifier/matcher.go
+++ b/pkg/app/piped/notifier/matcher.go
@@ -68,12 +68,12 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 	}
 
 	var (
-		labels    = make(map[string]string)
-		hasLabels = false
+		labels        = make(map[string]string)
+		supportLabels = false
 	)
 	if md, ok := event.Metadata.(labelsMetadata); ok {
 		labels = md.GetLabels()
-		hasLabels = true
+		supportLabels = true
 	}
 	for k, v := range labels {
 		if m.ignoreLabels[k] == v {
@@ -96,7 +96,7 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 			return false
 		}
 	}
-	if len(m.labels) > 0 && hasLabels {
+	if len(m.labels) > 0 && supportLabels {
 		if len(labels) < len(m.labels) {
 			return false
 		}

--- a/pkg/app/piped/notifier/matcher.go
+++ b/pkg/app/piped/notifier/matcher.go
@@ -101,13 +101,11 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 			return false
 		}
 
-		contains := 0
 		for k, v := range m.labels {
-			if labels[k] == v {
-				contains++
+			if labels[k] != v {
+				return false
 			}
 		}
-		return contains == len(m.labels)
 	}
 
 	return true

--- a/pkg/app/piped/notifier/matcher.go
+++ b/pkg/app/piped/notifier/matcher.go
@@ -67,9 +67,13 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 		return false
 	}
 
-	labels := make(map[string]string)
+	var (
+		labels    = make(map[string]string)
+		hasLabels = false
+	)
 	if md, ok := event.Metadata.(labelsMetadata); ok {
 		labels = md.GetLabels()
+		hasLabels = true
 	}
 	for k, v := range labels {
 		if m.ignoreLabels[k] == v {
@@ -92,7 +96,11 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 			return false
 		}
 	}
-	if len(m.labels) > 0 && len(labels) > 0 {
+	if len(m.labels) > 0 && hasLabels {
+		if len(labels) < len(m.labels) {
+			return false
+		}
+
 		contains := 0
 		for k, v := range m.labels {
 			if labels[k] == v {

--- a/pkg/app/piped/notifier/matcher.go
+++ b/pkg/app/piped/notifier/matcher.go
@@ -67,7 +67,6 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 		return false
 	}
 
-	// Ignore if the current event contains any of ignored labels.
 	labels := make(map[string]string)
 	if md, ok := event.Metadata.(labelsMetadata); ok {
 		labels = md.GetLabels()
@@ -93,14 +92,14 @@ func (m *matcher) Match(event model.NotificationEvent) bool {
 			return false
 		}
 	}
-	// Should count current event as matched if it contains any of listening labels.
 	if len(m.labels) > 0 && len(labels) > 0 {
+		contains := 0
 		for k, v := range m.labels {
 			if labels[k] == v {
-				return true
+				contains++
 			}
 		}
-		return false
+		return contains == len(m.labels)
 	}
 
 	return true

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -116,6 +116,56 @@ func TestMatch(t *testing.T) {
 				}: true,
 			},
 		},
+		{
+			name: "filter by labels",
+			config: config.NotificationRoute{
+				Labels: map[string]string{
+					"env":  "dev",
+					"team": "pipecd",
+				},
+				IgnoreLabels: map[string]string{
+					"env": "local",
+				},
+			},
+			matchings: map[model.NotificationEvent]bool{
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
+					Metadata: &model.NotificationEventDeploymentTriggered{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"team": "pipecd",
+								"env":  "stg",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
+					Metadata: &model.NotificationEventDeploymentTriggered{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env": "stg",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
+					Metadata: &model.NotificationEventDeploymentTriggered{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "local",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type:     model.NotificationEventType_EVENT_PIPED_STARTED,
+					Metadata: &model.NotificationEventPipedStarted{},
+				}: true,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -134,8 +134,9 @@ func TestMatch(t *testing.T) {
 					Metadata: &model.NotificationEventDeploymentTriggered{
 						Deployment: &model.Deployment{
 							Labels: map[string]string{
-								"team": "pipecd",
-								"env":  "dev",
+								"team":    "pipecd",
+								"env":     "dev",
+								"project": "pipecd",
 							},
 						},
 					},

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -144,6 +144,12 @@ func TestMatch(t *testing.T) {
 				{
 					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
 					Metadata: &model.NotificationEventDeploymentTriggered{
+						Deployment: &model.Deployment{},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
+					Metadata: &model.NotificationEventDeploymentTriggered{
 						Deployment: &model.Deployment{
 							Labels: map[string]string{
 								"team": "pipecd",

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -124,7 +124,8 @@ func TestMatch(t *testing.T) {
 					"team": "pipecd",
 				},
 				IgnoreLabels: map[string]string{
-					"env": "local",
+					"env":  "local",
+					"team": "not-pipecd",
 				},
 			},
 			matchings: map[model.NotificationEvent]bool{
@@ -134,11 +135,22 @@ func TestMatch(t *testing.T) {
 						Deployment: &model.Deployment{
 							Labels: map[string]string{
 								"team": "pipecd",
-								"env":  "stg",
+								"env":  "dev",
 							},
 						},
 					},
 				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
+					Metadata: &model.NotificationEventDeploymentTriggered{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"team": "pipecd",
+								"env":  "prod",
+							},
+						},
+					},
+				}: false,
 				{
 					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
 					Metadata: &model.NotificationEventDeploymentTriggered{

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -582,16 +582,16 @@ type Notifications struct {
 }
 
 type NotificationRoute struct {
-	Name         string   `json:"name"`
-	Receiver     string   `json:"receiver"`
-	Events       []string `json:"events"`
-	IgnoreEvents []string `json:"ignoreEvents"`
-	Groups       []string `json:"groups"`
-	IgnoreGroups []string `json:"ignoreGroups"`
-	Apps         []string `json:"apps"`
-	IgnoreApps   []string `json:"ignoreApps"`
-	Envs         []string `json:"envs"`
-	IgnoreEnvs   []string `json:"ignoreEnvs"`
+	Name         string            `json:"name"`
+	Receiver     string            `json:"receiver"`
+	Events       []string          `json:"events"`
+	IgnoreEvents []string          `json:"ignoreEvents"`
+	Groups       []string          `json:"groups"`
+	IgnoreGroups []string          `json:"ignoreGroups"`
+	Apps         []string          `json:"apps"`
+	IgnoreApps   []string          `json:"ignoreApps"`
+	Labels       map[string]string `json:"labels"`
+	IgnoreLabels map[string]string `json:"ignoreLabels"`
 }
 
 type NotificationReceiver struct {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -592,6 +592,9 @@ type NotificationRoute struct {
 	IgnoreApps   []string          `json:"ignoreApps"`
 	Labels       map[string]string `json:"labels"`
 	IgnoreLabels map[string]string `json:"ignoreLabels"`
+	// Deprecated: Should use labels instead.
+	Envs       []string `json:"envs"`
+	IgnoreEnvs []string `json:"ignoreEnvs"`
 }
 
 type NotificationReceiver struct {

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -160,13 +160,18 @@ func TestPipedConfig(t *testing.T) {
 				Notifications: Notifications{
 					Routes: []NotificationRoute{
 						{
-							Name:     "dev-slack",
-							Envs:     []string{"dev"},
+							Name: "dev-slack",
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
 							Receiver: "dev-slack-channel",
 						},
 						{
-							Name:     "prod-slack",
-							Envs:     []string{"dev"},
+							Name: "prod-slack",
+							Labels: map[string]string{
+								"env": "dev",
+							},
 							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
 							Receiver: "prod-slack-channel",
 						},

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -84,15 +84,16 @@ spec:
   notifications:
     routes:
       - name: dev-slack
-        envs:
-          - dev
+        labels:
+          env: dev
+          team: pipecd
         receiver: dev-slack-channel
       - name: prod-slack
         events:
           - DEPLOYMENT_STARTED
           - DEPLOYMENT_COMPLETED
-        envs:
-          - dev
+        labels:
+          env: dev
         receiver: prod-slack-channel
       - name: all-events-to-ci
         receiver: ci-webhook

--- a/pkg/model/notificationevent.go
+++ b/pkg/model/notificationevent.go
@@ -38,30 +38,62 @@ func (e *NotificationEventDeploymentTriggered) GetAppName() string {
 	return e.Deployment.ApplicationName
 }
 
+func (e *NotificationEventDeploymentTriggered) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
 func (e *NotificationEventDeploymentPlanned) GetAppName() string {
 	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentPlanned) GetLabels() map[string]string {
+	return e.Deployment.Labels
 }
 
 func (e *NotificationEventDeploymentApproved) GetAppName() string {
 	return e.Deployment.ApplicationName
 }
 
+func (e *NotificationEventDeploymentApproved) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
 func (e *NotificationEventDeploymentRollingBack) GetAppName() string {
 	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentRollingBack) GetLabels() map[string]string {
+	return e.Deployment.Labels
 }
 
 func (e *NotificationEventDeploymentSucceeded) GetAppName() string {
 	return e.Deployment.ApplicationName
 }
 
+func (e *NotificationEventDeploymentSucceeded) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
 func (e *NotificationEventDeploymentFailed) GetAppName() string {
 	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentFailed) GetLabels() map[string]string {
+	return e.Deployment.Labels
 }
 
 func (e *NotificationEventApplicationSynced) GetAppName() string {
 	return e.Application.Name
 }
 
+func (e *NotificationEventApplicationSynced) GetLabels() map[string]string {
+	return e.Application.Labels
+}
+
 func (e *NotificationEventApplicationOutOfSync) GetAppName() string {
 	return e.Application.Name
+}
+
+func (e *NotificationEventApplicationOutOfSync) GetLabels() map[string]string {
+	return e.Application.Labels
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #3230 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable filter notifications based on application/deployment's labels
```
