### PR TITLE
Fix unable to register event

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -99,12 +99,12 @@ ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$
 CREATE INDEX event_event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, CreatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
 ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
 ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
 
@@ -113,7 +113,7 @@ ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.nam
 CREATE INDEX event_name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
 ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_name_project_id_status_updated_at_desc ON Event (Name, ProjectId, Status, UpdatedAt DESC);
 

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -99,11 +99,11 @@ ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$
 CREATE INDEX event_event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, CreatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `UpdatedAt` DESC
@@ -111,7 +111,7 @@ ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.nam
 CREATE INDEX event_name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_name_project_id_status_updated_at_desc ON Event (Name, ProjectId, Status, UpdatedAt DESC);
 
 --

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -99,11 +99,13 @@ ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$
 CREATE INDEX event_event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, CreatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_created_at_desc ON Event (ProjectId, Status, CreatedAt DESC);
 
 -- index on `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_project_id_status_updated_at_desc ON Event (ProjectId, Status, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `UpdatedAt` DESC
@@ -111,7 +113,8 @@ ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.nam
 CREATE INDEX event_name_project_id_updated_at_desc ON Event (Name, ProjectId, UpdatedAt DESC);
 
 -- index on `Name` ASC, `ProjectId` ASC, `Status` ASC, UpdatedAt DESC
-ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
+ALTER TABLE Event ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL, ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status", 0) VIRTUAL NOT NULL;
+ALTER TABLE Event MODIFY COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX event_name_project_id_status_updated_at_desc ON Event (Name, ProjectId, Status, UpdatedAt DESC);
 
 --


### PR DESCRIPTION
**What this PR does / why we need it**:

The newly registered event with the default value for `status` field as `NOT_HANDLED` (value = 0) is treated as a zero value and will be omitted when an entity of that kind is added to MySQL datastore.

**Which issue(s) this PR fixes**:

Fixes #3244

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix unable to register event in case of using MySQL as datastore
```
