### PR TITLE
Fix documentation to use secret.data instead of secret.secretManagementKeyPair

### DIFF
--- a/docs/content/en/docs-dev/user-guide/secret-management.md
+++ b/docs/content/en/docs-dev/user-guide/secret-management.md
@@ -27,8 +27,8 @@ openssl pkey -in private-key -pubout -out public-key
 Then specify them while [installing](http://localhost:1313/docs/operator-manual/piped/installation/#installing-on-a-kubernetes-cluster) the `Piped` with these options:
 
 ``` console
---set-file secret.secretManagementKeyPair.publicKey.data=PATH_TO_PUBLIC_KEY_FILE \
---set-file secret.secretManagementKeyPair.privateKey.data=PATH_TO_PRIVATE_KEY_FILE
+--set-file secret.data.secret-public-key=PATH_TO_PUBLIC_KEY_FILE \
+--set-file secret.data.secret-private-key=PATH_TO_PRIVATE_KEY_FILE
 ```
 
 Finally, enable this feature in Piped configuration file with `secretManagement` field as below:
@@ -42,8 +42,8 @@ spec:
   secretManagement:
     type: KEY_PAIR
     config:
-      privateKeyFile: /etc/piped-secret/secret-management-private-key
-      publicKeyFile: /etc/piped-secret/secret-management-public-key
+      privateKeyFile: /etc/piped-secret/secret-private-key
+      publicKeyFile: /etc/piped-secret/secret-public-key
 ```
 
 ## Encrypting secret data

--- a/docs/content/en/docs-v0.25.x/user-guide/secret-management.md
+++ b/docs/content/en/docs-v0.25.x/user-guide/secret-management.md
@@ -27,8 +27,8 @@ openssl pkey -in private-key -pubout -out public-key
 Then specify them while [installing](http://localhost:1313/docs/operator-manual/piped/installation/#installing-on-a-kubernetes-cluster) the `Piped` with these options:
 
 ``` console
---set-file secret.secretManagementKeyPair.publicKey.data=PATH_TO_PUBLIC_KEY_FILE \
---set-file secret.secretManagementKeyPair.privateKey.data=PATH_TO_PRIVATE_KEY_FILE
+--set-file secret.data.secret-public-key=PATH_TO_PUBLIC_KEY_FILE \
+--set-file secret.data.secret-private-key=PATH_TO_PRIVATE_KEY_FILE
 ```
 
 Finally, enable this feature in Piped configuration file with `secretManagement` field as below:
@@ -42,8 +42,8 @@ spec:
   secretManagement:
     type: KEY_PAIR
     config:
-      privateKeyFile: /etc/piped-secret/secret-management-private-key
-      publicKeyFile: /etc/piped-secret/secret-management-public-key
+      privateKeyFile: /etc/piped-secret/secret-private-key
+      publicKeyFile: /etc/piped-secret/secret-public-key
 ```
 
 ## Encrypting secret data

--- a/docs/content/en/docs/user-guide/secret-management.md
+++ b/docs/content/en/docs/user-guide/secret-management.md
@@ -27,8 +27,8 @@ openssl pkey -in private-key -pubout -out public-key
 Then specify them while [installing](http://localhost:1313/docs/operator-manual/piped/installation/#installing-on-a-kubernetes-cluster) the `Piped` with these options:
 
 ``` console
---set-file secret.secretManagementKeyPair.publicKey.data=PATH_TO_PUBLIC_KEY_FILE \
---set-file secret.secretManagementKeyPair.privateKey.data=PATH_TO_PRIVATE_KEY_FILE
+--set-file secret.data.secret-public-key=PATH_TO_PUBLIC_KEY_FILE \
+--set-file secret.data.secret-private-key=PATH_TO_PRIVATE_KEY_FILE
 ```
 
 Finally, enable this feature in Piped configuration file with `secretManagement` field as below:
@@ -42,8 +42,8 @@ spec:
   secretManagement:
     type: KEY_PAIR
     config:
-      privateKeyFile: /etc/piped-secret/secret-management-private-key
-      publicKeyFile: /etc/piped-secret/secret-management-public-key
+      privateKeyFile: /etc/piped-secret/secret-private-key
+      publicKeyFile: /etc/piped-secret/secret-public-key
 ```
 
 ## Encrypting secret data

--- a/docs/content/ja/docs/user-guide/secret-management.md
+++ b/docs/content/ja/docs/user-guide/secret-management.md
@@ -25,8 +25,8 @@ openssl pkey -in private-key -pubout -out public-key
 作成後、`Piped` の[インストール](http://localhost:1313/docs/operator-manual/piped/installation/#installing-on-a-kubernetes-cluster)時に以下のオプションを追加します。
 
 ``` console
---set-file secret.secretManagementKeyPair.publicKey.data=PATH_TO_PUBLIC_KEY_FILE \
---set-file secret.secretManagementKeyPair.privateKey.data=PATH_TO_PRIVATE_KEY_FILE
+--set-file secret.data.secret-public-key=PATH_TO_PUBLIC_KEY_FILE \
+--set-file secret.data.secret-private-key=PATH_TO_PRIVATE_KEY_FILE
 ```
 
 Piped の設定ファイルに `secretManagement` フィールドを追加すれば準備は完了です。
@@ -40,8 +40,8 @@ spec:
   secretManagement:
     type: KEY_PAIR
     config:
-      privateKeyFile: /etc/piped-secret/secret-management-private-key
-      publicKeyFile: /etc/piped-secret/secret-management-public-key
+      privateKeyFile: /etc/piped-secret/secret-private-key
+      publicKeyFile: /etc/piped-secret/secret-public-key
 ```
 
 ## 機密データの暗号化


### PR DESCRIPTION

**What this PR does / why we need it**:

It does not work as described in this document. You will get an error like the following.

```
piped-5dc74ff6cf-w5h2w piped 2022/02/11 10:30:51 failed to read public key for secret management (open /etc/piped-secret/secret-management-public-key: no such file or directory)
```

`secret.secretManagementKeyPair` was outdated in helm chart since v0.23.0
ref: https://github.com/pipe-cd/pipecd/pull/2878

**Which issue(s) this PR fixes**:

Modify the documentation to use `secret.data`

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
