### PR TITLE
Add built in labels to CloudRun revision

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest.go
@@ -69,6 +69,11 @@ func (m ServiceManifest) Labels() map[string]string {
 	return m.u.GetLabels()
 }
 
+func (m ServiceManifest) RevisionLabels() map[string]string {
+	v, _, _ := unstructured.NestedStringMap(m.u.Object, "spec", "template", "metadata", "labels")
+	return v
+}
+
 func (m ServiceManifest) AppID() (string, bool) {
 	v := m.Labels()
 	if v == nil || v[LabelApplication] == "" {

--- a/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/servicemanifest_test.go
@@ -136,6 +136,10 @@ func TestServiceManifest(t *testing.T) {
 	labels[LabelRevisionName] = "revision"
 	err = sm.AddRevisionLabels(labels)
 	require.NoError(t, err)
+
+	// RevisionLabels
+	v := sm.RevisionLabels()
+	assert.Equal(t, labels, v)
 }
 
 func TestParseServiceManifest(t *testing.T) {

--- a/pkg/app/piped/executor/cloudrun/BUILD.bazel
+++ b/pkg/app/piped/executor/cloudrun/BUILD.bazel
@@ -24,4 +24,9 @@ go_test(
     size = "small",
     srcs = ["cloudrun_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//pkg/app/piped/cloudprovider/cloudrun:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -148,7 +148,7 @@ func revisionExists(ctx context.Context, client provider.Client, revisionName st
 	return false, err
 }
 
-func addBuiltinLabels(sm provider.ServiceManifest, lp executor.LogPersister, hash, pipedID, appID, revisionName string) bool {
+func addBuiltinLabels(sm provider.ServiceManifest, hash, pipedID, appID, revisionName string, lp executor.LogPersister) bool {
 	labels := map[string]string{
 		provider.LabelManagedBy:   provider.ManagedByPiped,
 		provider.LabelPiped:       pipedID,

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -148,12 +148,21 @@ func revisionExists(ctx context.Context, client provider.Client, revisionName st
 	return false, err
 }
 
-func addBuiltinLabels(sm provider.ServiceManifest, hash, pipedID, appID string) {
+func addBuiltinLabels(sm provider.ServiceManifest, lp executor.LogPersister, hash, pipedID, appID, revisionName string) bool {
 	labels := map[string]string{
 		provider.LabelManagedBy:   provider.ManagedByPiped,
 		provider.LabelPiped:       pipedID,
 		provider.LabelApplication: appID,
 		provider.LabelCommitHash:  hash,
 	}
+	// Set builtinLabels for Service.
 	sm.AddLabels(labels)
+
+	// Set buildinLabels for Revision.
+	labels[provider.LabelRevisionName] = revisionName
+	if err := sm.AddRevisionLabels(labels); err != nil {
+		lp.Errorf("Unable to add revision labels for the service manifest %s (%v)", sm.Name, err)
+		return false
+	}
+	return true
 }

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -106,7 +106,9 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 
 	// Add builtin labels for tracking application live state
 	commit := e.Deployment.CommitHash()
-	addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId)
+	if !addBuiltinLabels(sm, e.LogPersister, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision) {
+		return model.StageStatus_STAGE_FAILURE
+	}
 
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -106,7 +106,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 
 	// Add builtin labels for tracking application live state
 	commit := e.Deployment.CommitHash()
-	if !addBuiltinLabels(sm, e.LogPersister, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision) {
+	if !addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/cloudrun/rollback.go
+++ b/pkg/app/piped/executor/cloudrun/rollback.go
@@ -99,7 +99,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 
 	// Add builtin labels for tracking application live state
 	commit := e.Deployment.CommitHash()
-	if !addBuiltinLabels(sm, e.LogPersister, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision) {
+	if !addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/cloudrun/rollback.go
+++ b/pkg/app/piped/executor/cloudrun/rollback.go
@@ -99,7 +99,9 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 
 	// Add builtin labels for tracking application live state
 	commit := e.Deployment.CommitHash()
-	addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId)
+	if !addBuiltinLabels(sm, e.LogPersister, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, revision) {
+		return model.StageStatus_STAGE_FAILURE
+	}
 
 	if !apply(ctx, e.client, sm, e.LogPersister) {
 		return model.StageStatus_STAGE_FAILURE


### PR DESCRIPTION
**What this PR does / why we need it**:
Add built-in-labels to CloudRun revision in order to filter revisions by revision name.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
