### PR TITLE
Add MakeRevisionNamesSelector to generate the selector of revision names

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -123,8 +124,12 @@ func (r *registry) Client(ctx context.Context, name string, cfg *config.CloudPro
 	return client, nil
 }
 
-func MakeManagedByPipedLabel() string {
+func MakeManagedByPipedSelector() string {
 	return fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByPiped)
+}
+
+func MakeRevisionNamesSelector(names []string) string {
+	return fmt.Sprintf("%s in (%s)", LabelRevisionName, strings.Join(names, ","))
 }
 
 func (s *Service) ServiceManifest() (ServiceManifest, error) {

--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun_test.go
@@ -38,9 +38,16 @@ func TestLoadServiceManifest(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestMakeManagedByPipedLabel(t *testing.T) {
+func TestMakeManagedByPipedSelector(t *testing.T) {
 	want := "pipecd-dev-managed-by=piped"
-	got := MakeManagedByPipedLabel()
+	got := MakeManagedByPipedSelector()
+	assert.Equal(t, want, got)
+}
+
+func TestMakeRevisionNamesSelector(t *testing.T) {
+	names := []string{"test-1", "test-2", "test-3"}
+	got := MakeRevisionNamesSelector(names)
+	want := "pipecd-dev-revision-name in (test-1,test-2,test-3)"
 	assert.Equal(t, want, got)
 }
 

--- a/pkg/app/piped/livestatestore/cloudrun/store.go
+++ b/pkg/app/piped/livestatestore/cloudrun/store.go
@@ -37,7 +37,7 @@ func (s *store) run(ctx context.Context) error {
 	for {
 		ops := &provider.ListOptions{
 			Limit:         maxLimit,
-			LabelSelector: provider.MakeManagedByPipedLabel(),
+			LabelSelector: provider.MakeManagedByPipedSelector(),
 			Cursor:        cursor,
 		}
 		// Cloud Run Admin API rate Limits.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
