### PR TITLE
Add WAIT stage into lambda canary-examplae

### DIFF
--- a/examples/lambda/canary/app.pipecd.yaml
+++ b/examples/lambda/canary/app.pipecd.yaml
@@ -14,9 +14,15 @@ spec:
       - name: LAMBDA_PROMOTE
         with:
           percent: 10
+      - name: WAIT
+        with:
+          duration: 30s
       - name: LAMBDA_PROMOTE
         with:
           percent: 50
+      - name: WAIT
+        with:
+          duration: 30s
       # Promote new version to receive all traffic.
       - name: LAMBDA_PROMOTE
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is for the help of users trying out the example.

Without this, it will immediately promote to 100%.
Normally, in a canary release scenario, you should wait for a while.

I've confirmed the pipeline works expectedly.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
