### PR TITLE
Add kube-version option for helm

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -316,6 +316,7 @@ One of `yamlField` or `regex` is required.
 | releaseName | string | The release name of helm deployment. By default, the release name is equal to the application name. | No |
 | valueFiles | []string | List of value files should be loaded. | No |
 | setFiles | map[string]string | List of file path for values. | No |
+| kubeVersion | string | Kubernetes version used for Capabilities.KubeVersion. | No |
 
 ## KubernetesQuickSync
 

--- a/docs/content/en/docs-v0.25.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.25.x/user-guide/configuration-reference.md
@@ -316,7 +316,6 @@ One of `yamlField` or `regex` is required.
 | releaseName | string | The release name of helm deployment. By default, the release name is equal to the application name. | No |
 | valueFiles | []string | List of value files should be loaded. | No |
 | setFiles | map[string]string | List of file path for values. | No |
-| kubeVersion | string | Kubernetes version used for Capabilities.KubeVersion. | No |
 
 ## KubernetesQuickSync
 

--- a/docs/content/en/docs-v0.25.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.25.x/user-guide/configuration-reference.md
@@ -316,6 +316,7 @@ One of `yamlField` or `regex` is required.
 | releaseName | string | The release name of helm deployment. By default, the release name is equal to the application name. | No |
 | valueFiles | []string | List of value files should be loaded. | No |
 | setFiles | map[string]string | List of file path for values. | No |
+| kubeVersion | string | Kubernetes version used for Capabilities.KubeVersion. | No |
 
 ## KubernetesQuickSync
 

--- a/pkg/app/piped/cloudprovider/kubernetes/helm.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/helm.go
@@ -68,6 +68,9 @@ func (c *Helm) TemplateLocalChart(ctx context.Context, appName, appDir, namespac
 		for k, v := range opts.SetFiles {
 			args = append(args, "--set-file", fmt.Sprintf("%s=%s", k, v))
 		}
+		if opts.KubeVersion != "" {
+			args = append(args, "--kube-version", opts.KubeVersion)
+		}
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -151,6 +154,9 @@ func (c *Helm) TemplateRemoteChart(ctx context.Context, appName, appDir, namespa
 		}
 		for k, v := range opts.SetFiles {
 			args = append(args, "--set-file", fmt.Sprintf("%s=%s", k, v))
+		}
+		if opts.KubeVersion != "" {
+			args = append(args, "--kube-version", opts.KubeVersion)
 		}
 	}
 

--- a/pkg/config/application_kubernetes.go
+++ b/pkg/config/application_kubernetes.go
@@ -115,6 +115,8 @@ type InputHelmOptions struct {
 	ValueFiles []string `json:"valueFiles"`
 	// List of file path for values.
 	SetFiles map[string]string
+	// Kubernetes version used for Capabilities.KubeVersion
+	KubeVersion string `json"kubeVersion"`
 }
 
 type KubernetesTrafficRoutingMethod string


### PR DESCRIPTION
**What this PR does / why we need it**:
Add options to specify kube-version for helm command.

**Which issue(s) this PR fixes**:

Fixes #3260

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to specify kube-version for helm by using pipecd application configurations
```
