### PR TITLE
Introduce ShardStorable interface

### DIFF
--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -37,13 +37,13 @@ func (a *apiKeyCollection) Factory() Factory {
 }
 
 func (a *apiKeyCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (a *apiKeyCollection) GetUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
 	case WebCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -36,11 +36,11 @@ func (a *apiKeyCollection) Factory() Factory {
 	}
 }
 
-func (a *apiKeyCollection) GetStoredFileNames(id string) []string {
+func (a *apiKeyCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (a *apiKeyCollection) GetUpdatableFileName(id string) (string, error) {
+func (a *apiKeyCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
 	case WebCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -23,6 +23,7 @@ import (
 )
 
 type apiKeyCollection struct {
+	requestedBy Commander
 }
 
 func (a *apiKeyCollection) Kind() string {
@@ -32,6 +33,21 @@ func (a *apiKeyCollection) Kind() string {
 func (a *apiKeyCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.APIKey{}
+	}
+}
+
+func (a *apiKeyCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (a *apiKeyCollection) GetUpdatableFileName(id string) (string, error) {
+	switch a.requestedBy {
+	case TestCommander:
+		fallthrough
+	case WebCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -52,7 +68,7 @@ func NewAPIKeyStore(ds DataStore, c Commander) APIKeyStore {
 	return &apiKeyStore{
 		backend: backend{
 			ds:  ds,
-			col: &apiKeyCollection{},
+			col: &apiKeyCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -42,8 +42,6 @@ func (a *apiKeyCollection) GetStoredFileNames(id string) []string {
 
 func (a *apiKeyCollection) GetUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
-	case TestCommander:
-		fallthrough
 	case WebCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -36,14 +36,16 @@ func (a *apiKeyCollection) Factory() Factory {
 	}
 }
 
-func (a *apiKeyCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (a *apiKeyCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		ClientShard,
+	}
 }
 
-func (a *apiKeyCollection) MakeUpdatableFileName(id string) (string, error) {
+func (a *apiKeyCollection) GetUpdatableShard() (Shard, error) {
 	switch a.requestedBy {
 	case WebCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return ClientShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -36,22 +36,19 @@ func (a *applicationCollection) Factory() Factory {
 	}
 }
 
-func (a *applicationCollection) MakeStoredFileNames(id string) []string {
-	return []string{
-		fmt.Sprintf("%s_api.json", id),
-		fmt.Sprintf("%s_ops.json", id),
-		fmt.Sprintf("%s_piped.json", id),
+func (a *applicationCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		ClientShard,
+		AgentShard,
 	}
 }
 
-func (a *applicationCollection) MakeUpdatableFileName(id string) (string, error) {
+func (a *applicationCollection) GetUpdatableShard() (Shard, error) {
 	switch a.requestedBy {
 	case WebCommander, PipectlCommander:
-		return fmt.Sprintf("%s_api.json", id), nil
-	case OpsCommander:
-		return fmt.Sprintf("%s_ops.json", id), nil
+		return ClientShard, nil
 	case PipedCommander:
-		return fmt.Sprintf("%s_piped.json", id), nil
+		return AgentShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -46,9 +46,6 @@ func (a *applicationCollection) GetStoredFileNames(id string) []string {
 
 func (a *applicationCollection) GetUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
-	case TestCommander:
-		// Fixme: Find a way to make the filename dynamically for test commander.
-		fallthrough
 	case WebCommander, PipectlCommander:
 		return fmt.Sprintf("%s_api", id), nil
 	case OpsCommander:

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -38,20 +38,20 @@ func (a *applicationCollection) Factory() Factory {
 
 func (a *applicationCollection) GetStoredFileNames(id string) []string {
 	return []string{
-		fmt.Sprintf("%s_api", id),
-		fmt.Sprintf("%s_ops", id),
-		fmt.Sprintf("%s_piped", id),
+		fmt.Sprintf("%s_api.json", id),
+		fmt.Sprintf("%s_ops.json", id),
+		fmt.Sprintf("%s_piped.json", id),
 	}
 }
 
 func (a *applicationCollection) GetUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
 	case WebCommander, PipectlCommander:
-		return fmt.Sprintf("%s_api", id), nil
+		return fmt.Sprintf("%s_api.json", id), nil
 	case OpsCommander:
-		return fmt.Sprintf("%s_ops", id), nil
+		return fmt.Sprintf("%s_ops.json", id), nil
 	case PipedCommander:
-		return fmt.Sprintf("%s_piped", id), nil
+		return fmt.Sprintf("%s_piped.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -36,7 +36,7 @@ func (a *applicationCollection) Factory() Factory {
 	}
 }
 
-func (a *applicationCollection) GetStoredFileNames(id string) []string {
+func (a *applicationCollection) MakeStoredFileNames(id string) []string {
 	return []string{
 		fmt.Sprintf("%s_api.json", id),
 		fmt.Sprintf("%s_ops.json", id),
@@ -44,7 +44,7 @@ func (a *applicationCollection) GetStoredFileNames(id string) []string {
 	}
 }
 
-func (a *applicationCollection) GetUpdatableFileName(id string) (string, error) {
+func (a *applicationCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch a.requestedBy {
 	case WebCommander, PipectlCommander:
 		return fmt.Sprintf("%s_api.json", id), nil

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -41,8 +41,6 @@ func (c *commandCollection) GetStoredFileNames(id string) []string {
 
 func (c *commandCollection) GetUpdatableFileName(id string) (string, error) {
 	switch c.requestedBy {
-	case TestCommander:
-		fallthrough
 	case PipedCommander, OpsCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,13 +37,13 @@ func (c *commandCollection) Factory() Factory {
 }
 
 func (c *commandCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (c *commandCollection) GetUpdatableFileName(id string) (string, error) {
 	switch c.requestedBy {
 	case PipedCommander, OpsCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -36,11 +36,11 @@ func (c *commandCollection) Factory() Factory {
 	}
 }
 
-func (c *commandCollection) GetStoredFileNames(id string) []string {
+func (c *commandCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (c *commandCollection) GetUpdatableFileName(id string) (string, error) {
+func (c *commandCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch c.requestedBy {
 	case PipedCommander, OpsCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,14 +35,19 @@ func (c *commandCollection) Factory() Factory {
 	}
 }
 
-func (c *commandCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (c *commandCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		AgentShard,
+		OpsShard,
+	}
 }
 
-func (c *commandCollection) MakeUpdatableFileName(id string) (string, error) {
+func (c *commandCollection) GetUpdatableShard() (Shard, error) {
 	switch c.requestedBy {
-	case PipedCommander, OpsCommander:
-		return fmt.Sprintf("%s.json", id), nil
+	case PipedCommander:
+		return AgentShard, nil
+	case OpsCommander:
+		return OpsShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -43,7 +43,7 @@ func (c *commandCollection) GetUpdatableFileName(id string) (string, error) {
 	switch c.requestedBy {
 	case TestCommander:
 		fallthrough
-	case WebCommander, PipectlCommander, PipedCommander, OpsCommander:
+	case PipedCommander, OpsCommander:
 		return id, nil
 	default:
 		return "", ErrUnsupported

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -59,6 +59,7 @@ var (
 	ErrIteratorDone    = errors.New("iterator is done")
 	ErrInternal        = errors.New("internal")
 	ErrUnimplemented   = errors.New("unimplemented")
+	ErrUnsupported     = errors.New("unsupported")
 )
 
 type Commander string

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -78,6 +78,25 @@ const (
 	OpsCommander Commander = "ops"
 )
 
+type Shard string
+
+const (
+	// ClientShard indicates that object will be store in client (web or pipectl) used shard.
+	ClientShard Shard = "client"
+	// AgentShard indicates that object will be store in agent (piped) used shard.
+	AgentShard Shard = "agent"
+	// OpsShard indicates that object will be store in ops used shard.
+	OpsShard Shard = "ops"
+)
+
+type ShardStorable interface {
+	// ListInUsedShards returns a list of shard which be used to store object of current collection.
+	ListInUsedShards() []Shard
+	// GetUpdatableShard returns shard which should be referred to on Updating object of current collection.
+	// datastore.ErrUnsupported will be returned if there is no such file name exist.
+	GetUpdatableShard() (Shard, error)
+}
+
 type Factory func() interface{}
 type Updater func(interface{}) error
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -81,11 +81,11 @@ const (
 type Shard string
 
 const (
-	// ClientShard indicates that object will be store in client (web or pipectl) used shard.
+	// ClientShard indicates that object will be stored in client (web or pipectl) used shard.
 	ClientShard Shard = "client"
-	// AgentShard indicates that object will be store in agent (piped) used shard.
+	// AgentShard indicates that object will be stored in agent (piped) used shard.
 	AgentShard Shard = "agent"
-	// OpsShard indicates that object will be store in ops used shard.
+	// OpsShard indicates that object will be stored in ops used shard.
 	OpsShard Shard = "ops"
 )
 

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -42,8 +42,6 @@ func (d *deploymentChainCollection) GetStoredFileNames(id string) []string {
 
 func (d *deploymentChainCollection) GetUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
-	case TestCommander:
-		fallthrough
 	case OpsCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -36,14 +36,16 @@ func (d *deploymentChainCollection) Factory() Factory {
 	}
 }
 
-func (d *deploymentChainCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (d *deploymentChainCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		OpsShard,
+	}
 }
 
-func (d *deploymentChainCollection) MakeUpdatableFileName(id string) (string, error) {
+func (d *deploymentChainCollection) GetUpdatableShard() (Shard, error) {
 	switch d.requestedBy {
 	case OpsCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return OpsShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -36,11 +36,11 @@ func (d *deploymentChainCollection) Factory() Factory {
 	}
 }
 
-func (d *deploymentChainCollection) GetStoredFileNames(id string) []string {
+func (d *deploymentChainCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (d *deploymentChainCollection) GetUpdatableFileName(id string) (string, error) {
+func (d *deploymentChainCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
 	case OpsCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -23,6 +23,7 @@ import (
 )
 
 type deploymentChainCollection struct {
+	requestedBy Commander
 }
 
 func (d *deploymentChainCollection) Kind() string {
@@ -32,6 +33,21 @@ func (d *deploymentChainCollection) Kind() string {
 func (d *deploymentChainCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.DeploymentChain{}
+	}
+}
+
+func (d *deploymentChainCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (d *deploymentChainCollection) GetUpdatableFileName(id string) (string, error) {
+	switch d.requestedBy {
+	case TestCommander:
+		fallthrough
+	case OpsCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -117,7 +133,7 @@ func NewDeploymentChainStore(ds DataStore, c Commander) DeploymentChainStore {
 	return &deploymentChainStore{
 		backend: backend{
 			ds:  ds,
-			col: &deploymentChainCollection{},
+			col: &deploymentChainCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -37,13 +37,13 @@ func (d *deploymentChainCollection) Factory() Factory {
 }
 
 func (d *deploymentChainCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (d *deploymentChainCollection) GetUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
 	case OpsCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -37,13 +37,13 @@ func (d *deploymentCollection) Factory() Factory {
 }
 
 func (d *deploymentCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (d *deploymentCollection) GetUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
 	case PipedCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -36,11 +36,11 @@ func (d *deploymentCollection) Factory() Factory {
 	}
 }
 
-func (d *deploymentCollection) GetStoredFileNames(id string) []string {
+func (d *deploymentCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (d *deploymentCollection) GetUpdatableFileName(id string) (string, error) {
+func (d *deploymentCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
 	case PipedCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -36,14 +36,16 @@ func (d *deploymentCollection) Factory() Factory {
 	}
 }
 
-func (d *deploymentCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (d *deploymentCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		AgentShard,
+	}
 }
 
-func (d *deploymentCollection) MakeUpdatableFileName(id string) (string, error) {
+func (d *deploymentCollection) GetUpdatableShard() (Shard, error) {
 	switch d.requestedBy {
 	case PipedCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return AgentShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -42,8 +42,6 @@ func (d *deploymentCollection) GetStoredFileNames(id string) []string {
 
 func (d *deploymentCollection) GetUpdatableFileName(id string) (string, error) {
 	switch d.requestedBy {
-	case TestCommander:
-		fallthrough
 	case PipedCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -23,6 +23,7 @@ import (
 )
 
 type deploymentCollection struct {
+	requestedBy Commander
 }
 
 func (d *deploymentCollection) Kind() string {
@@ -32,6 +33,21 @@ func (d *deploymentCollection) Kind() string {
 func (d *deploymentCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.Deployment{}
+	}
+}
+
+func (d *deploymentCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (d *deploymentCollection) GetUpdatableFileName(id string) (string, error) {
+	switch d.requestedBy {
+	case TestCommander:
+		fallthrough
+	case PipedCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -118,7 +134,7 @@ func NewDeploymentStore(ds DataStore, c Commander) DeploymentStore {
 	return &deploymentStore{
 		backend: backend{
 			ds:  ds,
-			col: &deploymentCollection{},
+			col: &deploymentCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -36,11 +36,11 @@ func (e *eventCollection) Factory() Factory {
 	}
 }
 
-func (e *eventCollection) GetStoredFileNames(id string) []string {
+func (e *eventCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (e *eventCollection) GetUpdatableFileName(id string) (string, error) {
+func (e *eventCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch e.requestedBy {
 	case PipedCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -41,8 +41,6 @@ func (e *eventCollection) GetStoredFileNames(id string) []string {
 
 func (e *eventCollection) GetUpdatableFileName(id string) (string, error) {
 	switch e.requestedBy {
-	case TestCommander:
-		fallthrough
 	case PipedCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,13 +37,13 @@ func (e *eventCollection) Factory() Factory {
 }
 
 func (e *eventCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (e *eventCollection) GetUpdatableFileName(id string) (string, error) {
 	switch e.requestedBy {
 	case PipedCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -22,6 +22,7 @@ import (
 )
 
 type eventCollection struct {
+	requestedBy Commander
 }
 
 func (e *eventCollection) Kind() string {
@@ -31,6 +32,21 @@ func (e *eventCollection) Kind() string {
 func (e *eventCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.Event{}
+	}
+}
+
+func (e *eventCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (e *eventCollection) GetUpdatableFileName(id string) (string, error) {
+	switch e.requestedBy {
+	case TestCommander:
+		fallthrough
+	case PipedCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -50,7 +66,7 @@ func NewEventStore(ds DataStore, c Commander) EventStore {
 	return &eventStore{
 		backend: backend{
 			ds:  ds,
-			col: &eventCollection{},
+			col: &eventCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,14 +35,16 @@ func (e *eventCollection) Factory() Factory {
 	}
 }
 
-func (e *eventCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (e *eventCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		AgentShard,
+	}
 }
 
-func (e *eventCollection) MakeUpdatableFileName(id string) (string, error) {
+func (e *eventCollection) GetUpdatableShard() (Shard, error) {
 	switch e.requestedBy {
 	case PipedCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return AgentShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -23,6 +23,11 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/filestore"
 )
 
+type FileStorable interface {
+	GetStoredFileNames(id string) []string
+	GetUpdatableFileName(id string) (string, error)
+}
+
 type FileDB struct {
 	backend filestore.Store
 	logger  *zap.Logger
@@ -50,18 +55,34 @@ func NewFileDB(fs filestore.Store, opts ...Option) (*FileDB, error) {
 }
 
 func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datastore.ListOptions) (datastore.Iterator, error) {
+	_, ok := col.(FileStorable)
+	if !ok {
+		return nil, datastore.ErrUnsupported
+	}
 	return nil, datastore.ErrUnimplemented
 }
 
 func (f *FileDB) Get(ctx context.Context, col datastore.Collection, id string, v interface{}) error {
+	_, ok := col.(FileStorable)
+	if !ok {
+		return datastore.ErrUnsupported
+	}
 	return datastore.ErrUnimplemented
 }
 
 func (f *FileDB) Create(ctx context.Context, col datastore.Collection, id string, entity interface{}) error {
+	_, ok := col.(FileStorable)
+	if !ok {
+		return datastore.ErrUnsupported
+	}
 	return datastore.ErrUnimplemented
 }
 
 func (f *FileDB) Update(ctx context.Context, col datastore.Collection, id string, updater datastore.Updater) error {
+	_, ok := col.(FileStorable)
+	if !ok {
+		return datastore.ErrUnsupported
+	}
 	return datastore.ErrUnimplemented
 }
 

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -23,14 +23,6 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/filestore"
 )
 
-type FileStorable interface {
-	// MakeStoredFileNames returns a list of files' name which object of kind currently storing in.
-	MakeStoredFileNames(id string) []string
-	// MakeUpdatableFileName returns the name of the file which should be referred to on Updating object of kind.
-	// datastore.ErrUnsupported will be returned if there is no such file name exist.
-	MakeUpdatableFileName(id string) (string, error)
-}
-
 type FileDB struct {
 	backend filestore.Store
 	logger  *zap.Logger
@@ -58,7 +50,7 @@ func NewFileDB(fs filestore.Store, opts ...Option) (*FileDB, error) {
 }
 
 func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datastore.ListOptions) (datastore.Iterator, error) {
-	_, ok := col.(FileStorable)
+	_, ok := col.(datastore.ShardStorable)
 	if !ok {
 		return nil, datastore.ErrUnsupported
 	}
@@ -66,7 +58,7 @@ func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datast
 }
 
 func (f *FileDB) Get(ctx context.Context, col datastore.Collection, id string, v interface{}) error {
-	_, ok := col.(FileStorable)
+	_, ok := col.(datastore.ShardStorable)
 	if !ok {
 		return datastore.ErrUnsupported
 	}
@@ -74,7 +66,7 @@ func (f *FileDB) Get(ctx context.Context, col datastore.Collection, id string, v
 }
 
 func (f *FileDB) Create(ctx context.Context, col datastore.Collection, id string, entity interface{}) error {
-	_, ok := col.(FileStorable)
+	_, ok := col.(datastore.ShardStorable)
 	if !ok {
 		return datastore.ErrUnsupported
 	}
@@ -82,7 +74,7 @@ func (f *FileDB) Create(ctx context.Context, col datastore.Collection, id string
 }
 
 func (f *FileDB) Update(ctx context.Context, col datastore.Collection, id string, updater datastore.Updater) error {
-	_, ok := col.(FileStorable)
+	_, ok := col.(datastore.ShardStorable)
 	if !ok {
 		return datastore.ErrUnsupported
 	}

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -24,11 +24,11 @@ import (
 )
 
 type FileStorable interface {
-	// GetStoredFileNames returns a list of files' name which object of kind currently storing in.
-	GetStoredFileNames(id string) []string
-	// GetUpdatableFileName returns the name of the file which should be referred to on Updating object of kind.
+	// MakeStoredFileNames returns a list of files' name which object of kind currently storing in.
+	MakeStoredFileNames(id string) []string
+	// MakeUpdatableFileName returns the name of the file which should be referred to on Updating object of kind.
 	// datastore.ErrUnsupported will be returned if there is no such file name exist.
-	GetUpdatableFileName(id string) (string, error)
+	MakeUpdatableFileName(id string) (string, error)
 }
 
 type FileDB struct {

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -24,7 +24,10 @@ import (
 )
 
 type FileStorable interface {
+	// GetStoredFileNames returns a list of files' name which object of kind currently storing in.
 	GetStoredFileNames(id string) []string
+	// GetUpdatableFileName returns the name of the file which should be referred to on Updating object of kind.
+	// datastore.ErrUnsupported will be returned if there is no such file name exist.
 	GetUpdatableFileName(id string) (string, error)
 }
 

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,13 +37,13 @@ func (p *pipedCollection) Factory() Factory {
 }
 
 func (p *pipedCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (p *pipedCollection) GetUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
 	case WebCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,14 +35,16 @@ func (p *pipedCollection) Factory() Factory {
 	}
 }
 
-func (p *pipedCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (p *pipedCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		ClientShard,
+	}
 }
 
-func (p *pipedCollection) MakeUpdatableFileName(id string) (string, error) {
+func (p *pipedCollection) GetUpdatableShard() (Shard, error) {
 	switch p.requestedBy {
 	case WebCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return ClientShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -41,8 +41,6 @@ func (p *pipedCollection) GetStoredFileNames(id string) []string {
 
 func (p *pipedCollection) GetUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
-	case TestCommander:
-		fallthrough
 	case WebCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -36,11 +36,11 @@ func (p *pipedCollection) Factory() Factory {
 	}
 }
 
-func (p *pipedCollection) GetStoredFileNames(id string) []string {
+func (p *pipedCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (p *pipedCollection) GetUpdatableFileName(id string) (string, error) {
+func (p *pipedCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
 	case WebCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -22,6 +22,7 @@ import (
 )
 
 type pipedCollection struct {
+	requestedBy Commander
 }
 
 func (p *pipedCollection) Kind() string {
@@ -31,6 +32,21 @@ func (p *pipedCollection) Kind() string {
 func (p *pipedCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.Piped{}
+	}
+}
+
+func (p *pipedCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (p *pipedCollection) GetUpdatableFileName(id string) (string, error) {
+	switch p.requestedBy {
+	case TestCommander:
+		fallthrough
+	case WebCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -57,7 +73,7 @@ func NewPipedStore(ds DataStore, c Commander) PipedStore {
 	return &pipedStore{
 		backend: backend{
 			ds:  ds,
-			col: &pipedCollection{},
+			col: &pipedCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,14 +35,16 @@ func (p *projectCollection) Factory() Factory {
 	}
 }
 
-func (p *projectCollection) MakeStoredFileNames(id string) []string {
-	return []string{fmt.Sprintf("%s.json", id)}
+func (p *projectCollection) ListInUsedShards() []Shard {
+	return []Shard{
+		ClientShard,
+	}
 }
 
-func (p *projectCollection) MakeUpdatableFileName(id string) (string, error) {
+func (p *projectCollection) GetUpdatableShard() (Shard, error) {
 	switch p.requestedBy {
 	case WebCommander:
-		return fmt.Sprintf("%s.json", id), nil
+		return ClientShard, nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -36,11 +36,11 @@ func (p *projectCollection) Factory() Factory {
 	}
 }
 
-func (p *projectCollection) GetStoredFileNames(id string) []string {
+func (p *projectCollection) MakeStoredFileNames(id string) []string {
 	return []string{fmt.Sprintf("%s.json", id)}
 }
 
-func (p *projectCollection) GetUpdatableFileName(id string) (string, error) {
+func (p *projectCollection) MakeUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
 	case WebCommander:
 		return fmt.Sprintf("%s.json", id), nil

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -41,8 +41,6 @@ func (p *projectCollection) GetStoredFileNames(id string) []string {
 
 func (p *projectCollection) GetUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
-	case TestCommander:
-		fallthrough
 	case WebCommander:
 		return id, nil
 	default:

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -16,6 +16,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -36,13 +37,13 @@ func (p *projectCollection) Factory() Factory {
 }
 
 func (p *projectCollection) GetStoredFileNames(id string) []string {
-	return []string{id}
+	return []string{fmt.Sprintf("%s.json", id)}
 }
 
 func (p *projectCollection) GetUpdatableFileName(id string) (string, error) {
 	switch p.requestedBy {
 	case WebCommander:
-		return id, nil
+		return fmt.Sprintf("%s.json", id), nil
 	default:
 		return "", ErrUnsupported
 	}

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -22,6 +22,7 @@ import (
 )
 
 type projectCollection struct {
+	requestedBy Commander
 }
 
 func (p *projectCollection) Kind() string {
@@ -31,6 +32,21 @@ func (p *projectCollection) Kind() string {
 func (p *projectCollection) Factory() Factory {
 	return func() interface{} {
 		return &model.Project{}
+	}
+}
+
+func (p *projectCollection) GetStoredFileNames(id string) []string {
+	return []string{id}
+}
+
+func (p *projectCollection) GetUpdatableFileName(id string) (string, error) {
+	switch p.requestedBy {
+	case TestCommander:
+		fallthrough
+	case WebCommander:
+		return id, nil
+	default:
+		return "", ErrUnsupported
 	}
 }
 
@@ -55,7 +71,7 @@ func NewProjectStore(ds DataStore, c Commander) ProjectStore {
 	return &projectStore{
 		backend: backend{
 			ds:  ds,
-			col: &projectCollection{},
+			col: &projectCollection{requestedBy: c},
 		},
 		commander: c,
 		nowFunc:   time.Now,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new interface called `ShardStorable` interface which is

```golang
type ShardStorable interface {
	// ListInUsedShards returns a list of shard which be used to store object of current collection.
	ListInUsedShards() []Shard
	// GetUpdatableShard returns shard which should be referred to on Updating object of current collection.
	// datastore.ErrUnsupported will be returned if there is no such file name exist.
	GetUpdatableShard() (Shard, error)
}
```
This interface will be used while implement the filedb database

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
