### PR TITLE
Add actions log badge

### DIFF
--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -156,7 +156,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		b.WriteString(failureBadgeURL)
 	}
 
-	if actionLogURL := getActionsURL(); actionLogURL != "" {
+	if actionLogURL := makeActionLogURL(); actionLogURL != "" {
 		fmt.Fprintf(&b, " ")
 		fmt.Fprintf(&b, actionBadgeURLFormat, actionLogURL)
 	}
@@ -265,7 +265,7 @@ func groupApplicationResults(apps []ApplicationResult) (changes, pipelines, quic
 	return
 }
 
-func getActionsURL() string {
+func makeActionLogURL() string {
 	serverURL := os.Getenv(githubServerURLEnv)
 	if serverURL == "" {
 		return ""

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -142,9 +142,9 @@ const (
 	// Limit of details
 	detailsLenLimit = ghMessageLenLimit - 5000 // 5000 characters could be used for other parts in the comment message.
 
-	githubServerURLEnv = "GITHUB_SERVER_URL"
+	githubServerURLEnv  = "GITHUB_SERVER_URL"
 	githubRepositoryEnv = "GITHUB_REPOSITORY"
-	githubRunIDEnv     = "GITHUB_RUN_ID"
+	githubRunIDEnv      = "GITHUB_RUN_ID"
 )
 
 func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
@@ -157,7 +157,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 	}
 
 	if actionLogURL := getActionsURL(); actionLogURL != "" {
-	        fmt.Fprintf(&b, " ")
+		fmt.Fprintf(&b, " ")
 		fmt.Fprintf(&b, actionBadgeURLFormat, actionLogURL)
 	}
 	b.WriteString("\n\n")
@@ -266,17 +266,17 @@ func groupApplicationResults(apps []ApplicationResult) (changes, pipelines, quic
 }
 
 func getActionsURL() string {
-	serverURL := os.Getenv(GITHUB_SERVER_URL)
+	serverURL := os.Getenv(githubServerURLEnv)
 	if serverURL == "" {
 		return ""
 	}
 
-	repoURL := os.Getenv(GITHUB_REPOSITORY)
+	repoURL := os.Getenv(githubRepositoryEnv)
 	if repoURL == "" {
 		return ""
 	}
 
-	runID := os.Getenv(GITHUB_RUN_ID)
+	runID := os.Getenv(githubRunIDEnv)
 	if runID == "" {
 		return ""
 	}

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -156,8 +156,8 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		b.WriteString(failureBadgeURL)
 	}
 
-	b.WriteRune(' ')
 	if actionLogURL := getActionsURL(); actionLogURL != "" {
+	        fmt.Fprintf(&b, " ")
 		fmt.Fprintf(&b, actionBadgeURLFormat, actionLogURL)
 	}
 	b.WriteString("\n\n")

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -143,7 +143,7 @@ const (
 	detailsLenLimit = ghMessageLenLimit - 5000 // 5000 characters could be used for other parts in the comment message.
 
 	githubServerURLEnv = "GITHUB_SERVER_URL"
-	GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
+	githubRepositoryEnv = "GITHUB_REPOSITORY"
 	GITHUB_RUN_ID     = "GITHUB_RUN_ID"
 )
 

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -127,13 +127,10 @@ func retrievePlanPreview(
 
 const (
 	successBadgeURL = `<!-- pipecd-plan-preview-->
-[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
-
-`
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)`
 	failureBadgeURL = `<!-- pipecd-plan-preview-->
-[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
-
-`
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)`
+	actionBadgeURLFormat = "[![ACTIONS](https://img.shields.io/static/v1?label=PipeCD&message=Action_Log&style=flat)](%s)"
 
 	noChangeTitleFormat   = "Ran plan-preview against head commit %s of this pull request. PipeCD detected `0` updated application. It means no deployment will be triggered once this pull request got merged.\n"
 	hasChangeTitleFormat  = "Ran plan-preview against head commit %s of this pull request. PipeCD detected `%d` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.\n"
@@ -144,6 +141,10 @@ const (
 
 	// Limit of details
 	detailsLenLimit = ghMessageLenLimit - 5000 // 5000 characters could be used for other parts in the comment message.
+
+	GITHUB_SERVER_URL = "GITHUB_SERVER_URL"
+	GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
+	GITHUB_RUN_ID     = "GITHUB_RUN_ID"
 )
 
 func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
@@ -154,6 +155,12 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 	} else {
 		b.WriteString(failureBadgeURL)
 	}
+
+	b.WriteRune(' ')
+	if actionLogURL := getActionsURL(); actionLogURL != "" {
+		fmt.Fprintf(&b, actionBadgeURLFormat, actionLogURL)
+	}
+	b.WriteString("\n\n")
 
 	if event.IsComment {
 		b.WriteString(fmt.Sprintf("@%s ", event.SenderLogin))
@@ -256,4 +263,23 @@ func groupApplicationResults(apps []ApplicationResult) (changes, pipelines, quic
 		quicks = append(quicks, app)
 	}
 	return
+}
+
+func getActionsURL() string {
+	serverURL := os.Getenv(GITHUB_SERVER_URL)
+	if serverURL == "" {
+		return ""
+	}
+
+	repoURL := os.Getenv(GITHUB_REPOSITORY)
+	if repoURL == "" {
+		return ""
+	}
+
+	runID := os.Getenv(GITHUB_RUN_ID)
+	if runID == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s/actions/runs/%s", serverURL, repoURL, runID)
 }

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -144,7 +144,7 @@ const (
 
 	githubServerURLEnv = "GITHUB_SERVER_URL"
 	githubRepositoryEnv = "GITHUB_REPOSITORY"
-	GITHUB_RUN_ID     = "GITHUB_RUN_ID"
+	githubRunIDEnv     = "GITHUB_RUN_ID"
 )
 
 func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -142,7 +142,7 @@ const (
 	// Limit of details
 	detailsLenLimit = ghMessageLenLimit - 5000 // 5000 characters could be used for other parts in the comment message.
 
-	GITHUB_SERVER_URL = "GITHUB_SERVER_URL"
+	githubServerURLEnv = "GITHUB_SERVER_URL"
 	GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
 	GITHUB_RUN_ID     = "GITHUB_RUN_ID"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new badge that refers GitHub actions log to the GitHub comment of actions-plan-preview.

**Which issue(s) this PR fixes**:

Fixes #3262

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
