### PR TITLE
Remove env-id option from pipectl's add-application command

### DIFF
--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -30,7 +30,6 @@ type add struct {
 
 	appName       string
 	appKind       string
-	envID         string
 	pipedID       string
 	cloudProvider string
 	description   string
@@ -53,7 +52,6 @@ func newAddCommand(root *command) *cobra.Command {
 
 	cmd.Flags().StringVar(&c.appName, "app-name", c.appName, "The application name.")
 	cmd.Flags().StringVar(&c.appKind, "app-kind", c.appKind, "The kind of application. (KUBERNETES|TERRAFORM|LAMBDA|CLOUDRUN)")
-	cmd.Flags().StringVar(&c.envID, "env-id", c.envID, "The ID of environment where this application should belong to.")
 	cmd.Flags().StringVar(&c.pipedID, "piped-id", c.pipedID, "The ID of piped that should handle this application.")
 	cmd.Flags().StringVar(&c.cloudProvider, "cloud-provider", c.cloudProvider, "The cloud provider name. One of the registered providers in the piped configuration.")
 
@@ -86,7 +84,6 @@ func (c *add) run(ctx context.Context, input cli.Input) error {
 
 	req := &apiservice.AddApplicationRequest{
 		Name:    c.appName,
-		EnvId:   c.envID,
 		PipedId: c.pipedID,
 		GitPath: &model.ApplicationGitPath{
 			Repo: &model.ApplicationGitRepository{

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -144,7 +144,6 @@ func (a *API) AddApplication(ctx context.Context, req *apiservice.AddApplication
 	app := model.Application{
 		Id:            uuid.New().String(),
 		Name:          req.Name,
-		EnvId:         req.EnvId,
 		PipedId:       req.PipedId,
 		ProjectId:     key.ProjectId,
 		GitPath:       gitpath,

--- a/pkg/app/server/service/apiservice/service.proto
+++ b/pkg/app/server/service/apiservice/service.proto
@@ -50,7 +50,7 @@ service APIService {
 
 message AddApplicationRequest {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2;
+    string env_id = 2 [deprecated = true];
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     model.ApplicationGitPath git_path = 4 [(validate.rules).message.required = true];
     model.ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Remove env-id option from pipectl's add-application command
```
