### PR TITLE
Remove alpha note in the doc of event-watcher feature

### DIFF
--- a/docs/content/en/docs-dev/user-guide/event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/event-watcher.md
@@ -6,8 +6,6 @@ description: >
   A helper facility to automatically update files when it finds out a new event.
 ---
 
->NOTE: This feature is currently alpha status.
-
 ![](/images/diff-by-eventwatcher.png)
 
 The only way to upgrade your application with PipeCD is modifying configuration files managed by the Git repositories.

--- a/docs/content/en/docs-v0.25.x/user-guide/event-watcher.md
+++ b/docs/content/en/docs-v0.25.x/user-guide/event-watcher.md
@@ -6,7 +6,7 @@ description: >
   A helper facility to automatically update files when it finds out a new event.
 ---
 
->NOTE: This feature is currently alpha status.
+![](/images/diff-by-eventwatcher.png)
 
 The only way to upgrade your application with PipeCD is modifying configuration files managed by the Git repositories.
 It brings benefits quite a bit, but it can be painful to manually update them every time in some cases (e.g. continuous deployment to your development environment for debugging, the latest prerelease to the staging environment).

--- a/docs/content/en/docs-v0.25.x/user-guide/event-watcher.md
+++ b/docs/content/en/docs-v0.25.x/user-guide/event-watcher.md
@@ -8,8 +8,6 @@ description: >
 
 >NOTE: This feature is currently alpha status.
 
-![](/images/diff-by-eventwatcher.png)
-
 The only way to upgrade your application with PipeCD is modifying configuration files managed by the Git repositories.
 It brings benefits quite a bit, but it can be painful to manually update them every time in some cases (e.g. continuous deployment to your development environment for debugging, the latest prerelease to the staging environment).
 

--- a/docs/content/en/docs/user-guide/event-watcher.md
+++ b/docs/content/en/docs/user-guide/event-watcher.md
@@ -6,8 +6,6 @@ description: >
   A helper facility to automatically update files when it finds out a new event.
 ---
 
->NOTE: This feature is currently alpha status.
-
 ![](/images/diff-by-eventwatcher.png)
 
 The only way to upgrade your application with PipeCD is modifying configuration files managed by the Git repositories.


### PR DESCRIPTION
**What this PR does / why we need it**:

That feature was already escalated to Alpha before.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
