### PR TITLE
Add merge shards data for multiple shards stored object

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -97,6 +97,17 @@ type ShardStorable interface {
 	GetUpdatableShard() (Shard, error)
 }
 
+type ShardEncoder interface {
+	// Encode accepts an object as its input and returns a map which key is the shard and
+	// value is the raw data which should be stored in that shard.
+	Encode(e interface{}) (map[Shard][]byte, error)
+}
+
+type ShardDecoder interface {
+	// Decode accepts an entity and all parts of raw data which should be unmarshaled into.
+	Decode(e interface{}, parts ...[]byte) error
+}
+
 type Factory func() interface{}
 type Updater func(interface{}) error
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -99,12 +99,12 @@ type ShardStorable interface {
 
 type ShardEncoder interface {
 	// Encode accepts an object as its input and returns a map which key is the shard and
-	// value is the raw data which should be stored in that shard.
+	// value is the raw data which should be stored under the key shard.
 	Encode(e interface{}) (map[Shard][]byte, error)
 }
 
 type ShardDecoder interface {
-	// Decode accepts an entity and all parts of raw data which should be unmarshaled into.
+	// Decode unmarshals all given raw data parts to a given entity e.
 	Decode(e interface{}, parts ...[]byte) error
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -97,12 +97,6 @@ type ShardStorable interface {
 	GetUpdatableShard() (Shard, error)
 }
 
-type ShardEncoder interface {
-	// Encode accepts an object as its input and returns a map which key is the shard and
-	// value is the raw data which should be stored under the key shard.
-	Encode(e interface{}) (map[Shard][]byte, error)
-}
-
 type ShardDecoder interface {
 	// Decode unmarshals all given raw data parts to a given entity e.
 	Decode(e interface{}, parts ...[]byte) error

--- a/pkg/datastore/filedb/BUILD.bazel
+++ b/pkg/datastore/filedb/BUILD.bazel
@@ -1,13 +1,32 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["filedb.go"],
+    srcs = [
+        "codec.go",
+        "filedb.go",
+    ],
     importpath = "github.com/pipe-cd/pipecd/pkg/datastore/filedb",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/datastore:go_default_library",
         "//pkg/filestore:go_default_library",
         "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "codec_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/datastore:go_default_library",
+        "//pkg/filestore:go_default_library",
+        "//pkg/filestore/gcs:go_default_library",
+        "//pkg/model:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/pkg/datastore/filedb/codec.go
+++ b/pkg/datastore/filedb/codec.go
@@ -21,7 +21,11 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/datastore"
 )
 
+// decode checks for the given collection object. If the given collection
+// implements the `datastore.ShardDecoder` interface, its implementation will
+// be used. If not, time order regardless merge logic will be used.
 func decode(col datastore.Collection, e interface{}, parts ...[]byte) error {
+	// In case it's single part contained object, unmarshal it directly.
 	if len(parts) == 1 {
 		return json.Unmarshal(parts[0], e)
 	}
@@ -33,6 +37,9 @@ func decode(col datastore.Collection, e interface{}, parts ...[]byte) error {
 	return dcol.Decode(e, parts...)
 }
 
+// merge function unmarshal all parts of the given data to entity e.
+// The data will be merged regardless of its time order, after be merged,
+// the latest UpdatedAt time will be used as the entity UpdatedAt value.
 func merge(e interface{}, parts ...[]byte) error {
 	type model interface {
 		GetUpdatedAt() int64

--- a/pkg/datastore/filedb/codec.go
+++ b/pkg/datastore/filedb/codec.go
@@ -28,12 +28,12 @@ func decode(col datastore.Collection, e interface{}, parts ...[]byte) error {
 	if ok {
 		return dcol.Decode(e, parts...)
 	}
-	
+
 	// In case it's single part contained object, unmarshal it directly.
 	if len(parts) == 1 {
 		return json.Unmarshal(parts[0], e)
 	}
-	
+
 	return merge(e, parts...)
 }
 

--- a/pkg/datastore/filedb/codec.go
+++ b/pkg/datastore/filedb/codec.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filedb
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+)
+
+func decode(col datastore.Collection, e interface{}, parts ...[]byte) error {
+	if len(parts) == 1 {
+		return json.Unmarshal(parts[0], e)
+	}
+
+	dcol, ok := col.(datastore.ShardDecoder)
+	if !ok {
+		return merge(e, parts...)
+	}
+	return dcol.Decode(e, parts...)
+}
+
+func merge(e interface{}, parts ...[]byte) error {
+	type model interface {
+		GetUpdatedAt() int64
+	}
+
+	var latest int64
+	for _, p := range parts {
+		if err := json.Unmarshal(p, e); err != nil {
+			return err
+		}
+		me, ok := e.(model)
+		if !ok {
+			return datastore.ErrUnsupported
+		}
+		if latest < me.GetUpdatedAt() {
+			latest = me.GetUpdatedAt()
+		}
+	}
+	// TODO: Find a better way to set value of field UpdatedAt.
+	reflect.ValueOf(e).Elem().FieldByName("UpdatedAt").SetInt(latest)
+	return nil
+}

--- a/pkg/datastore/filedb/codec_test.go
+++ b/pkg/datastore/filedb/codec_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeModel struct {
+	Data      string `json:"data"`
+	UpdatedAt int64  `json:"updated_at"`
+}
+
+func (fm *fakeModel) GetUpdatedAt() int64 {
+	return fm.UpdatedAt
+}
+
+func TestMerge(t *testing.T) {
+	testcases := []struct {
+		name     string
+		parts    [][]byte
+		expected *fakeModel
+	}{
+		{
+			name: "should merge correctly with ordered data",
+			parts: [][]byte{
+				[]byte(`{"data":"1","updated_at":1}`),
+				[]byte(`{"data":"1","updated_at":2}`),
+				[]byte(`{"data":"1","updated_at":3}`),
+			},
+			expected: &fakeModel{
+				Data:      "1",
+				UpdatedAt: 3,
+			},
+		},
+		{
+			name: "should merge correctly with ordered data",
+			parts: [][]byte{
+				[]byte(`{"data":"1","updated_at":2}`),
+				[]byte(`{"data":"1","updated_at":3}`),
+				[]byte(`{"data":"1","updated_at":1}`),
+			},
+			expected: &fakeModel{
+				Data:      "1",
+				UpdatedAt: 3,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &fakeModel{}
+			merge(m, tc.parts...)
+			assert.Equal(t, tc.expected, m)
+		})
+	}
+}

--- a/pkg/datastore/filedb/codec_test.go
+++ b/pkg/datastore/filedb/codec_test.go
@@ -36,7 +36,7 @@ func TestMerge(t *testing.T) {
 		expected *fakeModel
 	}{
 		{
-			name: "should merge correctly with ordered data",
+			name: "should merge correctly with time ordered data",
 			parts: [][]byte{
 				[]byte(`{"data":"1","updated_at":1}`),
 				[]byte(`{"data":"1","updated_at":2}`),
@@ -48,7 +48,7 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
-			name: "should merge correctly with ordered data",
+			name: "should merge correctly with time non ordered data",
 			parts: [][]byte{
 				[]byte(`{"data":"1","updated_at":2}`),
 				[]byte(`{"data":"1","updated_at":3}`),

--- a/pkg/datastore/filedb/codec_test.go
+++ b/pkg/datastore/filedb/codec_test.go
@@ -29,6 +29,10 @@ func (fm *fakeModel) GetUpdatedAt() int64 {
 	return fm.UpdatedAt
 }
 
+func (fm *fakeModel) SetUpdatedAt(t int64) {
+	fm.UpdatedAt = t
+}
+
 func TestMerge(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -16,7 +16,6 @@ package filedb
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -96,13 +95,11 @@ func (f *FileDB) Get(ctx context.Context, col datastore.Collection, id string, v
 		parts = append(parts, part)
 	}
 
-	if len(parts) == 1 {
-		return json.Unmarshal(parts[0], v)
+	if len(parts) != len(fcol.ListInUsedShards()) {
+		return fmt.Errorf("shards count miss matched")
 	}
 
-	// TODO: Add merge based on UpdatedAt field in case there are multiple parts of object are fetched.
-
-	return datastore.ErrUnsupported
+	return decode(col, v, parts...)
 }
 
 func (f *FileDB) Create(ctx context.Context, col datastore.Collection, id string, entity interface{}) error {

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -95,10 +95,6 @@ func (f *FileDB) Get(ctx context.Context, col datastore.Collection, id string, v
 		parts = append(parts, part)
 	}
 
-	if len(parts) != len(fcol.ListInUsedShards()) {
-		return fmt.Errorf("shards count miss matched")
-	}
-
 	return decode(col, v, parts...)
 }
 

--- a/pkg/model/apikey.go
+++ b/pkg/model/apikey.go
@@ -67,3 +67,7 @@ func (k *APIKey) CompareKey(key string) error {
 func (k *APIKey) RedactSensitiveData() {
 	k.KeyHash = redactedMessage
 }
+
+func (k *APIKey) SetUpdatedAt(t int64) {
+	k.UpdatedAt = t
+}

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -85,6 +85,10 @@ func (a *Application) IsOutOfSync() bool {
 	return a.SyncState.Status == ApplicationSyncStatus_OUT_OF_SYNC
 }
 
+func (a *Application) SetUpdatedAt(t int64) {
+	a.UpdatedAt = t
+}
+
 func IsApplicationConfigFile(filename string) bool {
 	return filename == DefaultApplicationConfigFilename || strings.HasSuffix(filename, applicationConfigFileExtention) || filename == oldDefaultApplicationConfigFilename
 }

--- a/pkg/model/command.go
+++ b/pkg/model/command.go
@@ -36,3 +36,7 @@ func (c *Command) IsSyncApplicationCmd() bool {
 func (c *Command) IsChainSyncApplicationCmd() bool {
 	return c.GetChainSyncApplication() != nil
 }
+
+func (c *Command) SetUpdatedAt(t int64) {
+	c.UpdatedAt = t
+}

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -225,3 +225,7 @@ func (d *Deployment) ContainLabels(labels map[string]string) bool {
 func (d *Deployment) IsInChainDeployment() bool {
 	return d.DeploymentChainId != ""
 }
+
+func (d *Deployment) SetUpdatedAt(t int64) {
+	d.UpdatedAt = t
+}

--- a/pkg/model/deployment_chain.go
+++ b/pkg/model/deployment_chain.go
@@ -101,6 +101,10 @@ func (dc *DeploymentChain) ListAllInChainApplications() []*ChainApplicationRef {
 	return applications
 }
 
+func (dc *DeploymentChain) SetUpdatedAt(t int64) {
+	dc.UpdatedAt = t
+}
+
 func (b *ChainBlock) IsCompleted() bool {
 	switch b.Status {
 	case ChainBlockStatus_DEPLOYMENT_BLOCK_SUCCESS,

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -29,13 +29,13 @@ func (e *Event) IsHandled() bool {
 }
 
 // ContainLabels checks if it has all the given labels.
-func (d *Event) ContainLabels(labels map[string]string) bool {
-	if len(d.Labels) < len(labels) {
+func (e *Event) ContainLabels(labels map[string]string) bool {
+	if len(e.Labels) < len(labels) {
 		return false
 	}
 
 	for k, v := range labels {
-		value, ok := d.Labels[k]
+		value, ok := e.Labels[k]
 		if !ok {
 			return false
 		}
@@ -44,6 +44,10 @@ func (d *Event) ContainLabels(labels map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func (e *Event) SetUpdatedAt(t int64) {
+	e.UpdatedAt = t
 }
 
 // MakeEventKey builds a fixed-length identifier based on the given name

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -139,6 +139,10 @@ func (p *Piped) RedactSensitiveData() {
 	}
 }
 
+func (p *Piped) SetUpdatedAt(t int64) {
+	p.UpdatedAt = t
+}
+
 func MakePipedURL(baseURL, pipedID string) string {
 	return fmt.Sprintf("%s/settings/piped", strings.TrimSuffix(baseURL, "/"))
 }

--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -59,6 +59,10 @@ func (p *Project) RedactSensitiveData() {
 	}
 }
 
+func (p *Project) SetUpdatedAt(t int64) {
+	p.UpdatedAt = t
+}
+
 // RedactSensitiveData redacts sensitive data.
 func (p *ProjectStaticUser) RedactSensitiveData() {
 	p.PasswordHash = redactedMessage


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a way to merge raw data for multiple shards stored objects. I defined a new interface `ShardDecoder`, which will be used in case of building object from fetched data in filedb.

The PR also contains the implementation of the `ShardDecoder` interface for only `commandCollection` since the Command model is the only model which is multiple shards stored and there is a collision on its field named `Status` (should be stored in 2 shards: agent and piped)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
