### PR TITLE
Add appSelector field for piped

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -68,7 +68,7 @@ type PipedSpec struct {
 	SecretManagement *SecretManagement `json:"secretManagement"`
 	// Optional settings for event watcher.
 	EventWatcher PipedEventWatcher `json:"eventWatcher"`
-	// Specify the applications this piped will handle.
+	// List of labels to filter all applications this piped will handle.
 	AppSelector map[string]string `json:"appSelector"`
 }
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -68,6 +68,8 @@ type PipedSpec struct {
 	SecretManagement *SecretManagement `json:"secretManagement"`
 	// Optional settings for event watcher.
 	EventWatcher PipedEventWatcher `json:"eventWatcher"`
+	// Specify the applications this piped will handle.
+	AppSelector map[string]string `json:"appSelector"`
 }
 
 // Validate validates configured data of all fields.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `AppSelector` field in piped configuration since it enable for piped to specify some applications.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
