### PR TITLE
Enable to filter suggested applications when you add an application from controlplane

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
@@ -34,7 +34,7 @@ spec:
 | eventWatcher | [EventWatcher](/docs/operator-manual/piped/configuration-reference/#eventwatcher) | Optional Event watcher settings. | No |
 | secretManagement | [SecretManagement](/docs/operator-manual/piped/configuration-reference/#secretmanagement) | The using secret management method. | No |
 | notifications | [Notifications](/docs/operator-manual/piped/configuration-reference/#notifications) | Sending notifications to Slack, Webhook... | No |
-| appSelector | map[string]string | List of labels to filter all applications this piped will handle. | No |
+| appSelector | map[string]string | List of labels to filter all applications this piped will handle. Currently, it is only be used to filter the applications suggested for adding from the control plane. | No |
 
 ## Git
 

--- a/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
@@ -34,6 +34,7 @@ spec:
 | eventWatcher | [EventWatcher](/docs/operator-manual/piped/configuration-reference/#eventwatcher) | Optional Event watcher settings. | No |
 | secretManagement | [SecretManagement](/docs/operator-manual/piped/configuration-reference/#secretmanagement) | The using secret management method. | No |
 | notifications | [Notifications](/docs/operator-manual/piped/configuration-reference/#notifications) | Sending notifications to Slack, Webhook... | No |
+| appSelector | map[string]string | List of labels to filter all applications this piped will handle. | No |
 
 ## Git
 

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -307,7 +307,10 @@ func (r *Reporter) isSynced(appInfo *model.ApplicationInfo, app *model.Applicati
 // findUnregisteredApps finds out unregistered application info in the given git repository.
 // The file name must be default name in order to be recognized as an Application config.
 func (r *Reporter) findUnregisteredApps(repoPath, repoID string) ([]*model.ApplicationInfo, error) {
-	apps := r.applicationLister.List()
+	var (
+		apps     = r.applicationLister.List()
+		selector = r.config.AppSelector
+	)
 	// Create a map to determine the app is registered by GitPath.
 	registeredAppPaths := make(map[string]struct{}, len(apps))
 	for _, app := range apps {
@@ -355,6 +358,12 @@ func (r *Reporter) findUnregisteredApps(repoPath, repoID string) ([]*model.Appli
 			// Continue reading so that it can return apps as much as possible.
 			return nil
 		}
+
+		// Filter the apps by appSelector if appSelector set.
+		if len(selector) != 0 && !appInfo.ContainLabels(selector) {
+			return nil
+		}
+
 		out = append(out, appInfo)
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
If you want piped to monitor only certain applications, `appSelector` is useful.
If not specified, all application will be suggested when you add an application.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow filtering suggested applications by using a new appSelector field in Piped config
```
