### PR TITLE
Delete login name check

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.5.0
+version: 1.6.0
 registry: gcr.io/pipecd/actions-plan-preview

--- a/dockers/actions-plan-preview/github.go
+++ b/dockers/actions-plan-preview/github.go
@@ -174,11 +174,10 @@ func findLatestPlanPreviewComment(ctx context.Context, client *githubv4.Client, 
 // Expect comments to be sorted in ascending order by created_at
 func filterLatestPlanPreviewComment(comments []issueCommentQuery) *issueCommentQuery {
 	const planPreviewCommentStart = "<!-- pipecd-plan-preview-->"
-	const commentLogin = "github-actions"
 
 	for i := range comments {
 		comment := comments[len(comments)-i-1]
-		if strings.HasPrefix(string(comment.Body), planPreviewCommentStart) && comment.Author.Login == commentLogin {
+		if strings.HasPrefix(string(comment.Body), planPreviewCommentStart) {
 			return &comment
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Stop checking github login name to find previous plan-preview comment in case the bot name is changed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a bug that previous plan-preview comments are not hidden if a customized bot name was used
```
