### PR TITLE
Move menu to be lower to avoid overlapping the tab bar.

### DIFF
--- a/pkg/app/web/BUILD.bazel
+++ b/pkg/app/web/BUILD.bazel
@@ -80,7 +80,7 @@ genrule(
     cmd = """
     for f in $(SRCS)
     do
-        sed -e "s/unknown/$$(cat ./bazel-out/stable-status.txt | grep STABLE_VERSION | awk '{print $$2}')/g" $$f > $(@D)/gen_$$(basename $$f)
+        sed -e "s/unknown_placeholder/$$(cat ./bazel-out/stable-status.txt | grep STABLE_VERSION | awk '{print $$2}')/g" $$f > $(@D)/gen_$$(basename $$f)
     done
     """,
     output_to_bindir = 1,

--- a/pkg/app/web/src/components/header/index.tsx
+++ b/pkg/app/web/src/components/header/index.tsx
@@ -193,8 +193,8 @@ export const Header: FC = memo(function Header() {
         anchorEl={moreAnchorEl}
         open={Boolean(moreAnchorEl)}
         getContentAnchorEl={null}
-        anchorOrigin={{ vertical: 50, horizontal: "center" }}
-        transformOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorOrigin={{ vertical: 35, horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
         onClose={(): void => {
           setMoreAnchorEl(null);
         }}

--- a/pkg/app/web/src/components/header/index.tsx
+++ b/pkg/app/web/src/components/header/index.tsx
@@ -192,6 +192,9 @@ export const Header: FC = memo(function Header() {
         id="more-menu"
         anchorEl={moreAnchorEl}
         open={Boolean(moreAnchorEl)}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 50, horizontal: "center" }}
+        transformOrigin={{ vertical: "top", horizontal: "center" }}
         onClose={(): void => {
           setMoreAnchorEl(null);
         }}

--- a/pkg/app/web/webpack.config.js
+++ b/pkg/app/web/webpack.config.js
@@ -6,7 +6,7 @@ const path = require("path");
 const webpack = require("webpack");
 
 // overridden by bazel
-const version = "unknown";
+const version = "unknown_placeholder";
 
 module.exports = (env) => {
   return merge(commonConfig(env), {


### PR DESCRIPTION
**What this PR does / why we need it**:
Move the menu for visibility. And fix version placeholder.
before
<img width="377" alt="image" src="https://user-images.githubusercontent.com/49914427/156295069-38ecaa97-facb-4845-8e1b-87d0b745d359.png">

after
<img width="382" alt="image" src="https://user-images.githubusercontent.com/49914427/156294841-49850e17-463c-4b5a-9732-d57ebe8550ff.png">


**Which issue(s) this PR fixes**:

https://github.com/pipe-cd/pipecd/pull/3328#discussion_r817292918

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Move menu to be lower to avoid overlapping the tab bar.
```
