### PR TITLE
Add etag to the object attribute struct

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -27,6 +27,7 @@ var (
 type ObjectAttrs struct {
 	Path      string
 	Size      int64
+	Etag      string
 	UpdatedAt int64
 }
 

--- a/pkg/filestore/gcs/gcs.go
+++ b/pkg/filestore/gcs/gcs.go
@@ -144,6 +144,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]filestore.ObjectAttr
 		object := filestore.ObjectAttrs{
 			Path:      attrs.Name,
 			Size:      attrs.Size,
+			Etag:      attrs.Etag,
 			UpdatedAt: attrs.Updated.Unix(),
 		}
 		objects = append(objects, object)

--- a/pkg/filestore/minio/minio.go
+++ b/pkg/filestore/minio/minio.go
@@ -154,6 +154,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]filestore.ObjectAttr
 		objects = append(objects, filestore.ObjectAttrs{
 			Path:      o.Key,
 			Size:      o.Size,
+			Etag:      o.ETag,
 			UpdatedAt: o.LastModified.Unix(),
 		})
 	}

--- a/pkg/filestore/s3/s3.go
+++ b/pkg/filestore/s3/s3.go
@@ -184,6 +184,7 @@ func (s *Store) List(ctx context.Context, prefix string) ([]filestore.ObjectAttr
 			objects = append(objects, filestore.ObjectAttrs{
 				Path:      aws.ToString(obj.Key),
 				Size:      obj.Size,
+				Etag:      aws.ToString(obj.ETag),
 				UpdatedAt: aws.ToTime(obj.LastModified).Unix(),
 			})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need this attribute to detect whether the object content is updated or not. It will be used to reduce the number of unnecessary fetch file content requests to the filestore service.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
