### PR TITLE
Add launcher_version to Piped metrics

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -497,8 +497,12 @@ func (l *launcher) createAPIClient(ctx context.Context, address, projectID, pipe
 
 // makePipedArgs generates arguments for Piped from the ones passed to Launcher.
 func makePipedArgs(launcherArgs []string, configFile string) []string {
-	pipedArgs := make([]string, 0, len(launcherArgs)+2)
-	pipedArgs = append(pipedArgs, "piped", "--config-file="+configFile)
+	pipedArgs := make([]string, 0, len(launcherArgs)+3)
+	pipedArgs = append(pipedArgs,
+		"piped",
+		"--config-file="+configFile,
+		"--launcher-version="+version.Get().Version,
+	)
 
 	for _, a := range launcherArgs {
 		normalizedArg := strings.TrimLeft(a, "-")


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the operator can know which Piped was started by Launcher.
The monitoring dashboard will be updated in another PR.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
