### PR TITLE
Show artifact versions

### DIFF
--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -134,7 +134,7 @@ const MostRecentlySuccessfulDeployment: FC<{
                     <>
                       {i > 0 && ","}
                       <Link
-                        href={`//${v.url}`}
+                        href={v.url.includes("://") ? v.url : `//${v.url}`}
                         target="_blank"
                         rel="noreferrer"
                       >

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -125,7 +125,30 @@ const MostRecentlySuccessfulDeployment: FC<{
             label="Deployed At"
             value={<span title={date.format()}>{date.fromNow()}</span>}
           />
-          <DetailTableRow label="Version" value={deployment.version} />
+          <DetailTableRow
+            label="Version"
+            value={
+              deployment.versionsList.length !== 0 ? (
+                <>
+                  {deployment.versionsList.map((v, i) => (
+                    <>
+                      {i > 0 && ","}
+                      <Link
+                        href={`//${v.url}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {v.version} ({v.name})
+                        <OpenInNewIcon className={classes.linkIcon} />
+                      </Link>
+                    </>
+                  ))}
+                </>
+              ) : (
+                <span>{deployment.version}</span>
+              )
+            }
+          />
           <DetailTableRow label="Summary" value={deployment.summary} />
         </tbody>
       </table>

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -130,20 +130,16 @@ const MostRecentlySuccessfulDeployment: FC<{
             value={
               deployment.versionsList.length !== 0 ? (
                 <>
-                  {deployment.versionsList.map((v, i) => (
+                  {deployment.versionsList.map((v) => (
                     <>
-                      {i > 0 && ","}
                       <Link
                         href={v.url.includes("://") ? v.url : `//${v.url}`}
                         target="_blank"
                         rel="noreferrer"
                       >
-                        {/* Trim first 7 characters like commit hash in case it is too long */}
-                        {v.name}:
-                        {v.version.length > 7
-                          ? `${v.version.slice(0, 7)}...`
-                          : v.version}
+                        {v.name}:{v.version}
                         <OpenInNewIcon className={classes.linkIcon} />
+                        <br />
                       </Link>
                     </>
                   ))}

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -138,7 +138,11 @@ const MostRecentlySuccessfulDeployment: FC<{
                         target="_blank"
                         rel="noreferrer"
                       >
-                        {v.version} ({v.name})
+                        {/* Trim first 7 characters like commit hash in case it is too long */}
+                        {v.name}:
+                        {v.version.length > 7
+                          ? `${v.version.slice(0, 7)}...`
+                          : v.version}
                         <OpenInNewIcon className={classes.linkIcon} />
                       </Link>
                     </>

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -139,8 +139,8 @@ const MostRecentlySuccessfulDeployment: FC<{
                       >
                         {v.name}:{v.version}
                         <OpenInNewIcon className={classes.linkIcon} />
-                        <br />
                       </Link>
+                      <br />
                     </>
                   ))}
                 </>

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/MoreVert";
+import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import clsx from "clsx";
 import dayjs from "dayjs";
 import { FC, memo, useState } from "react";
@@ -36,6 +37,11 @@ const useStyles = makeStyles((theme) => ({
   deployedBy: {
     maxWidth: 300,
     wordBreak: "break-word",
+  },
+  linkIcon: {
+    fontSize: 16,
+    verticalAlign: "text-bottom",
+    marginLeft: theme.spacing(0.5),
   },
 }));
 
@@ -146,7 +152,21 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
           {recentlyDeployment ? (
             <>
               <TableCell className={classes.version}>
-                {recentlyDeployment.version.includes(",") ? (
+                {recentlyDeployment.versionsList.length !== 0 ? (
+                  recentlyDeployment.versionsList.map((v) => (
+                    <>
+                      <Link
+                        href={`//${v.url}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {v.version} ({v.name})
+                        <OpenInNewIcon className={classes.linkIcon} />
+                      </Link>
+                      <br />
+                    </>
+                  ))
+                ) : recentlyDeployment.version.includes(",") ? (
                   recentlyDeployment.version
                     .split(",")
                     .filter((item, index, arr) => arr.indexOf(item) === index)

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -156,7 +156,7 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
                   recentlyDeployment.versionsList.map((v) => (
                     <>
                       <Link
-                        href={`//${v.url}`}
+                        href={v.url.includes("://") ? v.url : `//${v.url}`}
                         target="_blank"
                         rel="noreferrer"
                       >

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -160,7 +160,11 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
                         target="_blank"
                         rel="noreferrer"
                       >
-                        {v.version} ({v.name})
+                        {/* Trim first 7 characters like commit hash in case it is too long */}
+                        {v.name}:
+                        {v.version.length > 7
+                          ? `${v.version.slice(0, 7)}...`
+                          : v.version}
                         <OpenInNewIcon className={classes.linkIcon} />
                       </Link>
                       <br />


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes to show artifact versions with links.

<img width="947" alt="PipeCD" src="https://user-images.githubusercontent.com/40124947/157580528-39feb59d-c96f-467f-a2c6-7d7b74380634.png">

<img width="1300" alt="PipeCD" src="https://user-images.githubusercontent.com/40124947/157580604-b2b1de14-6319-4407-9997-94780c8e012c.png">


**Which issue(s) this PR fixes**:

A part of https://github.com/pipe-cd/pipecd/issues/3303

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Be able to show artifact versions with links
```
