### PR TITLE
Output artifact versions for ecs deployment

### DIFF
--- a/pkg/app/piped/cloudprovider/ecs/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/ecs/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/app/piped/cloudprovider:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/model:go_default_library",
         "@com_github_aws_aws_sdk_go_v2//aws:go_default_library",
         "@com_github_aws_aws_sdk_go_v2_config//:go_default_library",
         "@com_github_aws_aws_sdk_go_v2_credentials//stscreds:go_default_library",
@@ -37,6 +38,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/model:go_default_library",
         "@com_github_aws_aws_sdk_go_v2//aws:go_default_library",
         "@com_github_aws_aws_sdk_go_v2_service_ecs//types:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/pkg/app/piped/cloudprovider/ecs/task_test.go
+++ b/pkg/app/piped/cloudprovider/ecs/task_test.go
@@ -278,7 +278,7 @@ func TestFindArtifactVersions(t *testing.T) {
 			td, _ := parseTaskDefinition(tc.input)
 			versions, err := FindArtifactVersions(td)
 			assert.Equal(t, tc.expectedErr, err != nil)
-			assert.Equal(t, tc.expected, versions)
+			assert.ElementsMatch(t, tc.expected, versions)
 		})
 	}
 }

--- a/pkg/app/piped/cloudprovider/ecs/task_test.go
+++ b/pkg/app/piped/cloudprovider/ecs/task_test.go
@@ -82,6 +82,8 @@ cpu: 256
 }
 
 func TestFindArtifactVersions(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name        string
 		input       []byte
@@ -272,9 +274,9 @@ func TestFindArtifactVersions(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+		tc := tc
 
+		t.Run(tc.name, func(t *testing.T) {
 			td, _ := parseTaskDefinition(tc.input)
 			versions, err := FindArtifactVersions(td)
 			assert.Equal(t, tc.expectedErr, err != nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes to output artifact versions for ecs development.

**Which issue(s) this PR fixes**:

A part of https://github.com/pipe-cd/pipecd/issues/3303

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
