### PR TITLE
Add id to condition

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -310,6 +310,38 @@
     ]
   },
   {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "CompletedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "CreatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
     "collectionGroup": "Event",
     "queryScope": "COLLECTION",
     "fields": [

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -334,6 +334,38 @@ func TestParseIndexes(t *testing.T) {
 			},
 		},
 		{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "CompletedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "CreatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
 			CollectionGroup: "Event",
 			QueryScope:      "COLLECTION",
 			Fields: []field{

--- a/pkg/app/ops/insightcollector/deployments.go
+++ b/pkg/app/ops/insightcollector/deployments.go
@@ -93,6 +93,10 @@ func (c *Collector) findDeploymentsCreatedInRange(ctx context.Context, from, to 
 					Field:     "CreatedAt",
 					Direction: datastore.Desc,
 				},
+				{
+					Field:     "Id",
+					Direction: datastore.Asc,
+				},
 			},
 		})
 		if err != nil {
@@ -132,6 +136,10 @@ func (c *Collector) findDeploymentsCompletedInRange(ctx context.Context, from, t
 				{
 					Field:     "CompletedAt",
 					Direction: datastore.Desc,
+				},
+				{
+					Field:     "Id",
+					Direction: datastore.Asc,
 				},
 			},
 		})

--- a/pkg/app/ops/insightcollector/deployments_test.go
+++ b/pkg/app/ops/insightcollector/deployments_test.go
@@ -496,6 +496,10 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 							Field:     "CreatedAt",
 							Direction: datastore.Desc,
 						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
+						},
 					},
 				}).Return([]*model.Deployment{
 					{
@@ -530,6 +534,10 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 							Field:     "CreatedAt",
 							Direction: datastore.Desc,
 						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
+						},
 					},
 				}).Return([]*model.Deployment{
 					{
@@ -563,6 +571,10 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 						{
 							Field:     "CreatedAt",
 							Direction: datastore.Desc,
+						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
 						},
 					},
 					Cursor: "",
@@ -620,6 +632,10 @@ func TestFindDeploymentsCreatedInRange(t *testing.T) {
 						{
 							Field:     "CreatedAt",
 							Direction: datastore.Desc,
+						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
 						},
 					},
 				}).Return([]*model.Deployment{}, "", fmt.Errorf("something wrong happens in ListDeployments"))
@@ -692,6 +708,10 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 							Field:     "CompletedAt",
 							Direction: datastore.Desc,
 						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
+						},
 					},
 				}).Return([]*model.Deployment{
 					{
@@ -726,6 +746,10 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 							Field:     "CompletedAt",
 							Direction: datastore.Desc,
 						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
+						},
 					},
 				}).Return([]*model.Deployment{
 					{
@@ -759,6 +783,10 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 						{
 							Field:     "CompletedAt",
 							Direction: datastore.Desc,
+						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
 						},
 					},
 					Cursor: "",
@@ -816,6 +844,10 @@ func TestFindDeploymentsCompletedInRange(t *testing.T) {
 						{
 							Field:     "CompletedAt",
 							Direction: datastore.Desc,
+						},
+						{
+							Field:     "Id",
+							Direction: datastore.Asc,
 						},
 					},
 				}).Return([]*model.Deployment{}, "", fmt.Errorf("something wrong happens in ListDeployments"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Order option must include id field.
https://github.com/pipe-cd/pipecd/blob/9a1ba99f9aadd483997f8d60a6187a71969f1ac7/pkg/datastore/mysql/query.go#L165

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
