### PR TITLE
Add index to CompletedAt

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -78,9 +78,9 @@ CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt 
 ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
--- index on `CompletedAt` ASC
+-- index on `CompletedAt` DESC
 ALTER TABLE Deployment ADD COLUMN CompletedAt INT(11) GENERATED ALWAYS AS (data->>"$.completed_at") VIRTUAL NULL;
-CREATE INDEX deployment_completed_at ON Deployment (CompletedAt);
+CREATE INDEX deployment_completed_at_desc_id ON Deployment (CompletedAt DESC, Id);
 
 -- index on `DeploymentChainId` ASC and `UpdatedAt` DESC
 ALTER TABLE Deployment ADD COLUMN DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.deployment_chain_id") VIRTUAL NOT NULL;

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -78,7 +78,7 @@ CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt 
 ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
--- index on `CompletedAt` DESC
+-- index on `CompletedAt` DESC and `Id` ASC
 ALTER TABLE Deployment ADD COLUMN CompletedAt INT(11) GENERATED ALWAYS AS (data->>"$.completed_at") VIRTUAL NULL;
 CREATE INDEX deployment_completed_at_desc_id ON Deployment (CompletedAt DESC, Id);
 

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -79,7 +79,7 @@ ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data-
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
 -- index on `CompletedAt` ASC
-ALTER TABLE Deployment ADD COLUMN CompletedAt INT(11) GENERATED ALWAYS AS (data->>"$.completed_at") VIRTUAL NOT NULL;
+ALTER TABLE Deployment ADD COLUMN CompletedAt INT(11) GENERATED ALWAYS AS (data->>"$.completed_at") VIRTUAL NULL;
 CREATE INDEX deployment_completed_at ON Deployment (CompletedAt);
 
 -- index on `DeploymentChainId` ASC and `UpdatedAt` DESC

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -78,6 +78,10 @@ CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt 
 ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
+-- index on `CompletedAt` ASC
+ALTER TABLE Deployment ADD COLUMN CompletedAt INT(11) GENERATED ALWAYS AS (data->>"$.completed_at") VIRTUAL NOT NULL;
+CREATE INDEX deployment_completed_at ON Deployment (CompletedAt);
+
 -- index on `DeploymentChainId` ASC and `UpdatedAt` DESC
 ALTER TABLE Deployment ADD COLUMN DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.deployment_chain_id") VIRTUAL NOT NULL;
 ALTER TABLE Deployment MODIFY DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (IFNULL(data->>"$.deployment_chain_id", "")) VIRTUAL NOT NULL;


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, completedAt does not exists on mysql column, and so order by completedAt will be failed.
To fix this, this PR create generated column of completedAt and add index to it. CompletedAt is nullable.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
