### PR TITLE
Add filedb filter logic

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -51,11 +51,11 @@ const (
 	OperatorContains
 )
 
-func IsNumericOperator(op Operator) bool {
-	return op == OperatorGreaterThan ||
-		op == OperatorGreaterThanOrEqual ||
-		op == OperatorLessThan ||
-		op == OperatorLessThanOrEqual
+func (o Operator) IsNumericOperator() bool {
+	return o == OperatorGreaterThan ||
+		o == OperatorGreaterThanOrEqual ||
+		o == OperatorLessThan ||
+		o == OperatorLessThanOrEqual
 }
 
 var (

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -51,6 +51,13 @@ const (
 	OperatorContains
 )
 
+func IsNumericOperator(op Operator) bool {
+	return op == OperatorGreaterThan ||
+		op == OperatorGreaterThanOrEqual ||
+		op == OperatorLessThan ||
+		op == OperatorLessThanOrEqual
+}
+
 var (
 	ErrNotFound        = errors.New("not found")
 	ErrInvalidArgument = errors.New("invalid argument")

--- a/pkg/datastore/filedb/BUILD.bazel
+++ b/pkg/datastore/filedb/BUILD.bazel
@@ -22,7 +22,14 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["codec_test.go"],
+    srcs = [
+        "codec_test.go",
+        "filter_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+    deps = [
+        "//pkg/datastore:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/datastore/filedb/BUILD.bazel
+++ b/pkg/datastore/filedb/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/datastore:go_default_library",
+        "//pkg/model:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -29,6 +29,11 @@ type filterable interface {
 }
 
 func filter(col datastore.Collection, e interface{}, filters []datastore.ListFilter) (bool, error) {
+	// Always pass, if there is no filter.
+	if len(filters) == 0 {
+		return true, nil
+	}
+
 	// If the collection implement filterable interface, use it.
 	fcol, ok := col.(filterable)
 	if ok {

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -15,19 +15,121 @@
 package filedb
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/pipe-cd/pipecd/pkg/datastore"
 )
 
-// TODO: Implement filterable interface for each collection.
 type filterable interface {
 	Match(e interface{}, filters []datastore.ListFilter) (bool, error)
 }
 
 func filter(col datastore.Collection, e interface{}, filters []datastore.ListFilter) (bool, error) {
 	fcol, ok := col.(filterable)
-	if !ok {
-		return false, datastore.ErrUnsupported
+	if ok {
+		return fcol.Match(e, filters)
 	}
 
-	return fcol.Match(e, filters)
+	// remarshal entity as map[string]interface{} struct.
+	raw, _ := json.Marshal(e)
+	var omap map[string]interface{}
+	if err := json.Unmarshal(raw, &omap); err != nil {
+		return false, err
+	}
+
+	for _, filter := range filters {
+		if strings.Contains(filter.Field, ".") {
+			// TODO: Handle nested field name such as SyncState.Status.
+			return false, datastore.ErrUnsupported
+		}
+
+		val, ok := omap[filter.Field]
+		// If the object does not contain given field name in filter, return false immidiately.
+		if !ok {
+			return false, nil
+		}
+
+		cmp, err := compare(val, filter.Value, filter.Operator)
+		if err != nil {
+			return false, err
+		}
+
+		if !cmp {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
+	switch op {
+	case datastore.OperatorEqual:
+		return val == operand, nil
+	case datastore.OperatorNotEqual:
+		return val != operand, nil
+	case datastore.OperatorGreaterThan:
+		return val.(int64) > operand.(int64), nil
+	case datastore.OperatorGreaterThanOrEqual:
+		return val.(int64) >= operand.(int64), nil
+	case datastore.OperatorLessThan:
+		return val.(int64) < operand.(int64), nil
+	case datastore.OperatorLessThanOrEqual:
+		return val.(int64) <= operand.(int64), nil
+	case datastore.OperatorIn:
+		os, err := makeSliceOfInterfaces(operand)
+		if err != nil {
+			return false, fmt.Errorf("operand error: %w", err)
+		}
+
+		for _, o := range os {
+			if o == val {
+				return true, nil
+			}
+		}
+		return false, nil
+	case datastore.OperatorNotIn:
+		os, err := makeSliceOfInterfaces(operand)
+		if err != nil {
+			return false, fmt.Errorf("operand error: %w", err)
+		}
+
+		for _, o := range os {
+			if o == val {
+				return false, nil
+			}
+		}
+		return true, nil
+	case datastore.OperatorContains:
+		vs, err := makeSliceOfInterfaces(val)
+		if err != nil {
+			return false, fmt.Errorf("value error: %w", err)
+		}
+
+		for _, v := range vs {
+			if v == operand {
+				return true, nil
+			}
+		}
+		return false, nil
+	default:
+		return false, datastore.ErrUnsupported
+	}
+}
+
+func makeSliceOfInterfaces(v interface{}) ([]interface{}, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("value is not a slide")
+	}
+
+	vs := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		vs[i] = rv.Index(i).Interface()
+	}
+
+	return vs, nil
 }

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -77,7 +77,7 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 	case int, int8, int16, int32, int64:
 		valNum = reflect.ValueOf(v).Int()
 	case uint, uint8, uint16, uint32:
-		valNum = reflect.ValueOf(v).Int()
+		valNum = int64(reflect.ValueOf(v).Uint())
 	default:
 		if op.IsNumericOperator() {
 			return false, fmt.Errorf("value of type unsupported")
@@ -87,7 +87,7 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 	case int, int8, int16, int32, int64:
 		operandNum = reflect.ValueOf(o).Int()
 	case uint, uint8, uint16, uint32:
-		operandNum = reflect.ValueOf(o).Int()
+		operandNum = int64(reflect.ValueOf(o).Uint())
 	default:
 		if op.IsNumericOperator() {
 			return false, fmt.Errorf("operand of type unsupported")

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -122,8 +122,8 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 
 func makeSliceOfInterfaces(v interface{}) ([]interface{}, error) {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("value is not a slide")
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, fmt.Errorf("value is not a slide or array")
 	}
 
 	vs := make([]interface{}, rv.Len())

--- a/pkg/datastore/filedb/filter_test.go
+++ b/pkg/datastore/filedb/filter_test.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+)
+
+func TestCompare(t *testing.T) {
+	testcases := []struct {
+		name     string
+		val      interface{}
+		operand  interface{}
+		operator datastore.Operator
+		expect   bool
+	}{
+		{
+			name:     "equal number int",
+			val:      5,
+			operand:  5,
+			operator: datastore.OperatorEqual,
+			expect:   true,
+		},
+		{
+			name:     "equal string",
+			val:      "text",
+			operand:  "text",
+			operator: datastore.OperatorEqual,
+			expect:   true,
+		},
+		{
+			name:     "not equal int",
+			val:      3,
+			operand:  2,
+			operator: datastore.OperatorNotEqual,
+			expect:   true,
+		},
+		{
+			name:     "not equal string",
+			val:      "text_val",
+			operand:  "text_operand",
+			operator: datastore.OperatorNotEqual,
+			expect:   true,
+		},
+		// {
+		// 	name:     "greater than int",
+		// 	val:      3,
+		// 	operand:  1,
+		// 	operator: datastore.OperatorGreaterThan,
+		// 	expect:   true,
+		// },
+		// {
+		// 	name:     "greater than string",
+		// 	val:      "text_2",
+		// 	operand:  "text_1",
+		// 	operator: datastore.OperatorGreaterThan,
+		// 	expect:   true,
+		// },
+		{
+			name:     "in int",
+			val:      1,
+			operand:  []int{1, 2, 3},
+			operator: datastore.OperatorIn,
+			expect:   true,
+		},
+		{
+			name:     "in int false",
+			val:      4,
+			operand:  []int{1, 2, 3},
+			operator: datastore.OperatorIn,
+			expect:   false,
+		},
+		{
+			name:     "not in int",
+			val:      4,
+			operand:  []int{1, 2, 3},
+			operator: datastore.OperatorNotIn,
+			expect:   true,
+		},
+		{
+			name:     "not in int false",
+			val:      1,
+			operand:  []int{1, 2, 3},
+			operator: datastore.OperatorNotIn,
+			expect:   false,
+		},
+		{
+			name:     "contains int",
+			val:      []int{1, 2, 3},
+			operand:  1,
+			operator: datastore.OperatorContains,
+			expect:   true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := compare(tc.val, tc.operand, tc.operator)
+			require.Nil(t, err)
+			assert.Equal(t, tc.expect, res)
+		})
+	}
+}

--- a/pkg/datastore/filedb/filter_test.go
+++ b/pkg/datastore/filedb/filter_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestConvertCamelToSnake(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name  string
 		camel string
@@ -61,6 +63,8 @@ func TestConvertCamelToSnake(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name      string
 		val       interface{}
@@ -175,6 +179,8 @@ func TestCompare(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name    string
 		entity  interface{}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds filter logic which is used in the Find interface. Previously, I planned to make filter logic as part of collection logic and implement it for each model kind. Since the filter logic accepts `Filter.Field` (a string) as its input. If we make that filter logic as part of collections, we may have to use reflect to list up struct's fields name as string, it's complicated and not worth it. In this PR, instead of making filter logic as part of collections, it will be addressed in filedb layer, with a more generic interface `map[string]interface{}` as the input entity.

We still accept filter logic in collections (if exists) and only use this generic filter logic in case the collection does not implement the `filterable` interface.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
