### PR TITLE
Fix bug that the specified kubeConfigPath in Piped config was not used while handling manifests

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
@@ -59,12 +59,12 @@ func (c *Kubectl) Apply(ctx context.Context, kubeconfig, namespace string, manif
 		return err
 	}
 
-	args := make([]string, 0, 5)
+	args := make([]string, 0, 7)
 	if kubeconfig != "" {
-		args = append(args, "--kubeconfig="+kubeconfig)
+		args = append(args, "--kubeconfig", kubeconfig)
 	}
 	if namespace != "" {
-		args = append(args, "-n", namespace)
+		args = append(args, "--namespace", namespace)
 	}
 	args = append(args, "apply", "-f", "-")
 
@@ -93,12 +93,12 @@ func (c *Kubectl) Create(ctx context.Context, kubeconfig, namespace string, mani
 		return err
 	}
 
-	args := make([]string, 0, 5)
+	args := make([]string, 0, 7)
 	if kubeconfig != "" {
-		args = append(args, "--kubeconfig="+kubeconfig)
+		args = append(args, "--kubeconfig", kubeconfig)
 	}
 	if namespace != "" {
-		args = append(args, "-n", namespace)
+		args = append(args, "--namespace", namespace)
 	}
 	args = append(args, "create", "-f", "-")
 
@@ -127,12 +127,12 @@ func (c *Kubectl) Replace(ctx context.Context, kubeconfig, namespace string, man
 		return err
 	}
 
-	args := make([]string, 0, 5)
+	args := make([]string, 0, 7)
 	if kubeconfig != "" {
-		args = append(args, "--kubeconfig="+kubeconfig)
+		args = append(args, "--kubeconfig", kubeconfig)
 	}
 	if namespace != "" {
-		args = append(args, "-n", namespace)
+		args = append(args, "--namespace", namespace)
 	}
 	args = append(args, "replace", "-f", "-")
 
@@ -161,12 +161,12 @@ func (c *Kubectl) Delete(ctx context.Context, kubeconfig, namespace string, r Re
 		)
 	}()
 
-	args := make([]string, 0, 5)
+	args := make([]string, 0, 7)
 	if kubeconfig != "" {
-		args = append(args, "--kubeconfig="+kubeconfig)
+		args = append(args, "--kubeconfig", kubeconfig)
 	}
 	if namespace != "" {
-		args = append(args, "-n", namespace)
+		args = append(args, "--namespace", namespace)
 	}
 	args = append(args, "delete", r.Kind, r.Name)
 

--- a/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubectl.go
@@ -45,7 +45,7 @@ func NewKubectl(version, path string) *Kubectl {
 	}
 }
 
-func (c *Kubectl) Apply(ctx context.Context, namespace string, manifest Manifest) (err error) {
+func (c *Kubectl) Apply(ctx context.Context, kubeconfig, namespace string, manifest Manifest) (err error) {
 	defer func() {
 		kubernetesmetrics.IncKubectlCallsCounter(
 			c.version,
@@ -60,6 +60,9 @@ func (c *Kubectl) Apply(ctx context.Context, namespace string, manifest Manifest
 	}
 
 	args := make([]string, 0, 5)
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig="+kubeconfig)
+	}
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
@@ -76,7 +79,7 @@ func (c *Kubectl) Apply(ctx context.Context, namespace string, manifest Manifest
 	return nil
 }
 
-func (c *Kubectl) Create(ctx context.Context, namespace string, manifest Manifest) (err error) {
+func (c *Kubectl) Create(ctx context.Context, kubeconfig, namespace string, manifest Manifest) (err error) {
 	defer func() {
 		kubernetesmetrics.IncKubectlCallsCounter(
 			c.version,
@@ -91,6 +94,9 @@ func (c *Kubectl) Create(ctx context.Context, namespace string, manifest Manifes
 	}
 
 	args := make([]string, 0, 5)
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig="+kubeconfig)
+	}
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
@@ -107,7 +113,7 @@ func (c *Kubectl) Create(ctx context.Context, namespace string, manifest Manifes
 	return nil
 }
 
-func (c *Kubectl) Replace(ctx context.Context, namespace string, manifest Manifest) (err error) {
+func (c *Kubectl) Replace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) (err error) {
 	defer func() {
 		kubernetesmetrics.IncKubectlCallsCounter(
 			c.version,
@@ -122,6 +128,9 @@ func (c *Kubectl) Replace(ctx context.Context, namespace string, manifest Manife
 	}
 
 	args := make([]string, 0, 5)
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig="+kubeconfig)
+	}
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
@@ -143,7 +152,7 @@ func (c *Kubectl) Replace(ctx context.Context, namespace string, manifest Manife
 	return fmt.Errorf("failed to replace: %s (%w)", string(out), err)
 }
 
-func (c *Kubectl) Delete(ctx context.Context, namespace string, r ResourceKey) (err error) {
+func (c *Kubectl) Delete(ctx context.Context, kubeconfig, namespace string, r ResourceKey) (err error) {
 	defer func() {
 		kubernetesmetrics.IncKubectlCallsCounter(
 			c.version,
@@ -153,6 +162,9 @@ func (c *Kubectl) Delete(ctx context.Context, namespace string, r ResourceKey) (
 	}()
 
 	args := make([]string, 0, 5)
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig="+kubeconfig)
+	}
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -94,6 +94,12 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		}
 	}
 
+	cp, ok := e.PipedConfig.FindCloudProvider(e.Deployment.CloudProvider, model.ApplicationKind_KUBERNETES)
+	if !ok {
+		e.LogPersister.Errorf("Not found cloud provider %q", e.Deployment.CloudProvider)
+		return model.StageStatus_STAGE_FAILURE
+	}
+
 	e.loader = provider.NewLoader(
 		e.Deployment.ApplicationName,
 		ds.AppDir,
@@ -105,6 +111,7 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	)
 	e.applier = provider.NewApplier(
 		e.appCfg.Input,
+		*cp.KubernetesConfig,
 		e.Logger,
 	)
 	e.Logger.Info("start executing kubernetes stage",

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -135,8 +135,15 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	cp, ok := e.PipedConfig.FindCloudProvider(e.Deployment.CloudProvider, model.ApplicationKind_KUBERNETES)
+	if !ok {
+		e.LogPersister.Errorf("Not found cloud provider %q", e.Deployment.CloudProvider)
+		return model.StageStatus_STAGE_FAILURE
+	}
+
 	applier := provider.NewApplier(
 		appCfg.Input,
+		*cp.KubernetesConfig,
 		e.Logger,
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1946

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bug that the specified kubeConfigPath in Piped config was not used while handling manifests
```
