### PR TITLE
Add labels to deployment pages

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Chip,
   CircularProgress,
   Link,
   makeStyles,
@@ -57,6 +58,10 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 16,
     verticalAlign: "text-bottom",
     marginLeft: theme.spacing(0.5),
+  },
+  labelChip: {
+    marginLeft: theme.spacing(1),
+    marginBottom: theme.spacing(0.25),
   },
 }));
 
@@ -128,6 +133,14 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
               <Typography variant="body1" className={classes.age}>
                 {dayjs(deployment.createdAt * 1000).fromNow()}
               </Typography>
+              {deployment.labelsMap.map(([key, value], i) => (
+                <Chip
+                  label={key + ": " + value}
+                  className={classes.labelChip}
+                  variant="outlined"
+                  key={i}
+                />
+              ))}
             </Box>
             <Typography
               variant="body2"

--- a/web/src/components/deployments-page/deployment-item/index.tsx
+++ b/web/src/components/deployments-page/deployment-item/index.tsx
@@ -1,4 +1,4 @@
-import { Box, ListItem, makeStyles, Typography } from "@material-ui/core";
+import { Box, Chip, ListItem, makeStyles, Typography } from "@material-ui/core";
 import dayjs from "dayjs";
 import { FC, memo } from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -19,7 +19,6 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     display: "flex",
     alignItems: "center",
-    height: 72,
     backgroundColor: theme.palette.background.paper,
   },
   info: {
@@ -34,6 +33,10 @@ const useStyles = makeStyles((theme) => ({
   description: {
     ...ellipsis,
     color: theme.palette.text.hint,
+  },
+  labelChip: {
+    marginLeft: theme.spacing(1),
+    marginBottom: theme.spacing(0.25),
   },
 }));
 
@@ -90,6 +93,13 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
               className={classes.info}
             >
               {APPLICATION_KIND_TEXT[deployment.kind]}
+              {deployment?.labelsMap.map(([key, value], i) => (
+                <Chip
+                  label={key + ": " + value}
+                  className={classes.labelChip}
+                  key={i}
+                />
+              ))}
             </Typography>
           </Box>
           <Typography variant="body1" className={classes.description}>


### PR DESCRIPTION
**What this PR does / why we need it**:

deployment list page

<img width="1080" alt="Screen Shot 2022-03-22 at 17 11 17" src="https://user-images.githubusercontent.com/32532742/159457904-4599b872-7cfb-4ad8-bd27-fb7ae3b9357f.png">

deployment detail page

<img width="1060" alt="Screen Shot 2022-03-22 at 17 11 07" src="https://user-images.githubusercontent.com/32532742/159457887-ea1185cc-6eb0-43f6-a594-a4dbb5c6e609.png">

**Which issue(s) this PR fixes**:

Fixes #3419

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add labels information to deployment list page and deployment detail page
```
