### PR TITLE
Make header menu item clickable

### DIFF
--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -85,6 +85,10 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: "-2px",
     color: "rgba(0, 0, 0, 0.5)",
   },
+  menuItem: {
+    color: "#283778",
+    textDecorationLine: "none",
+  },
 }));
 
 export const Header: FC = memo(function Header() {
@@ -205,30 +209,36 @@ export const Header: FC = memo(function Header() {
           setMoreAnchorEl(null);
         }}
       >
-        <MenuItem>
-          <Link component={RouterLink} to={PAGE_PATH_INSIGHTS}>
-            Insights
-          </Link>
+        <MenuItem
+          className={classes.menuItem}
+          component={RouterLink}
+          to={PAGE_PATH_INSIGHTS}
+        >
+          Insights
         </MenuItem>
-        <MenuItem>
-          <Link component={RouterLink} to={PAGE_PATH_EVENTS}>
-            Events
-          </Link>
+        <MenuItem
+          className={classes.menuItem}
+          component={RouterLink}
+          to={PAGE_PATH_EVENTS}
+        >
+          Events
         </MenuItem>
-        <MenuItem divider={true}>
-          <Link component={RouterLink} to={PAGE_PATH_SETTINGS}>
-            Settings
-          </Link>
+        <MenuItem
+          className={classes.menuItem}
+          component={RouterLink}
+          to={PAGE_PATH_SETTINGS}
+          divider
+        >
+          Settings
         </MenuItem>
-        <MenuItem>
-          <Link
-            href="https://pipecd.dev/docs/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Documentation
-            <OpenInNew className={classes.iconOpenInNew} />
-          </Link>
+        <MenuItem
+          component={Link}
+          href="https://pipecd.dev/docs/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Documentation
+          <OpenInNew className={classes.iconOpenInNew} />
         </MenuItem>
         <MenuItem disabled={true} dense={true} button={false}>
           {process.env.STABLE_VERSION}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, we have to click on the link on the menu item to make it works, this PR makes the whole item clickable

before
https://user-images.githubusercontent.com/32532742/159645269-4cfbcd5d-e301-453a-8062-82c6778881d0.mp4

after
https://user-images.githubusercontent.com/32532742/159645342-a52108e9-539c-4fe2-9ee9-36a2f2cc88a0.mp4

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
