### PR TITLE
Add description infor on adding application via suggestion form

### DIFF
--- a/web/src/api/applications.ts
+++ b/web/src/api/applications.ts
@@ -78,6 +78,7 @@ export const addApplication = async ({
   kind,
   gitPath,
   labelsMap,
+  description,
 }: Required<AddApplicationRequest.AsObject>): Promise<
   AddApplicationResponse.AsObject
 > => {
@@ -87,6 +88,7 @@ export const addApplication = async ({
   req.setPipedId(pipedId);
   req.setCloudProvider(cloudProvider);
   req.setKind(kind);
+  req.setDescription(description);
   const appGitPath = new ApplicationGitPath();
   const repository = new ApplicationGitRepository();
   if (gitPath.repo) {

--- a/web/src/components/application-form/index.tsx
+++ b/web/src/components/application-form/index.tsx
@@ -306,6 +306,7 @@ export interface ApplicationFormValue {
     branch: string;
   };
   labels: Array<[string, string]>;
+  description: string;
 }
 
 export type ApplicationFormProps = FormikProps<ApplicationFormValue> & {
@@ -327,6 +328,7 @@ export const emptyFormValues: ApplicationFormValue = {
     branch: "",
   },
   labels: new Array<[string, string]>(),
+  description: "",
 };
 
 export const ApplicationForm: FC<ApplicationFormProps> = memo(
@@ -477,6 +479,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             required
             className={classes.textInput}
           />
+          {/** TODO: Add input fields for labels and description. */}
 
           <Box m={2} />
           <Button
@@ -630,6 +633,7 @@ const SelectFromSuggestionsForm: FC<ApplicationFormProps> = memo(
       kind: ApplicationKind.KUBERNETES,
       cloudProvider: "",
       labels: new Array<[string, string]>(),
+      description: "",
     });
 
     const handleFilterChange = useCallback(
@@ -769,6 +773,7 @@ const SelectFromSuggestionsForm: FC<ApplicationFormProps> = memo(
                   kind: selectedApp.kind,
                   cloudProvider: selectedCloudProvider,
                   labels: selectedApp.labelsMap,
+                  description: selectedApp.description,
                 });
                 setShowConfirm(true);
               }}

--- a/web/src/components/applications-page/edit-application-drawer/index.tsx
+++ b/web/src/components/applications-page/edit-application-drawer/index.tsx
@@ -42,6 +42,7 @@ export const EditApplicationDrawer: FC<EditApplicationDrawerProps> = memo(
             configFilename: app.gitPath?.configFilename || "",
             cloudProvider: app.cloudProvider,
             labels: app.labelsMap,
+            description: app.description,
           }
         : emptyFormValues,
       validationSchema,

--- a/web/src/modules/applications/index.ts
+++ b/web/src/modules/applications/index.ts
@@ -102,6 +102,7 @@ export const addApplication = createAsyncThunk<
     kind: ApplicationKind;
     cloudProvider: string;
     labels: Array<[string, string]>;
+    description: string;
   }
 >(`${MODULE_NAME}/add`, async (props) => {
   const { applicationId } = await applicationsAPI.addApplication({
@@ -117,8 +118,8 @@ export const addApplication = createAsyncThunk<
     },
     cloudProvider: props.cloudProvider,
     kind: props.kind,
-    description: "",
     labelsMap: props.labels,
+    description: props.description,
   });
 
   return applicationId;


### PR DESCRIPTION
**What this PR does / why we need it**:

Add application's description to add application request so that the applications added via suggestion form will be registered with its description.

The manual adding application form still does not have labels and description input fields, so there is no way to add those values on adding right now.

**Which issue(s) this PR fixes**:

Part of #3426

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
