### PR TITLE
Make commit clickable on the application list page

### DIFF
--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -193,21 +193,15 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
               </TableCell>
               {displayAllProperties && (
                 <TableCell>
-                  {recentlyDeployment.trigger?.commit?.url !== "" ? (
+                  {recentlyDeployment.trigger?.commit && (
                     <Link
-                      href={recentlyDeployment.trigger?.commit?.url}
+                      href={recentlyDeployment.trigger.commit.url}
                       target="_blank"
                       rel="noreferrer"
                     >
-                      {recentlyDeployment.trigger?.commit?.hash.slice(0, 8) ??
-                        UI_TEXT_NOT_AVAILABLE_TEXT}
+                      {recentlyDeployment.trigger.commit.hash.slice(0, 8)}
                       <OpenInNewIcon className={classes.linkIcon} />
                     </Link>
-                  ) : (
-                    <>
-                      {recentlyDeployment.trigger?.commit?.hash.slice(0, 8) ??
-                        UI_TEXT_NOT_AVAILABLE_TEXT}
-                    </>
                   )}
                 </TableCell>
               )}

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -193,8 +193,22 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
               </TableCell>
               {displayAllProperties && (
                 <TableCell>
-                  {recentlyDeployment.trigger?.commit?.hash.slice(0, 8) ??
-                    UI_TEXT_NOT_AVAILABLE_TEXT}
+                  {recentlyDeployment.trigger?.commit?.url !== "" ? (
+                    <Link
+                      href={recentlyDeployment.trigger?.commit?.url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {recentlyDeployment.trigger?.commit?.hash.slice(0, 8) ??
+                        UI_TEXT_NOT_AVAILABLE_TEXT}
+                      <OpenInNewIcon className={classes.linkIcon} />
+                    </Link>
+                  ) : (
+                    <>
+                      {recentlyDeployment.trigger?.commit?.hash.slice(0, 8) ??
+                        UI_TEXT_NOT_AVAILABLE_TEXT}
+                    </>
+                  )}
                 </TableCell>
               )}
               {displayAllProperties && (


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/pipe-cd/pipecd/issues/3310

| before | after |
| ------------- | ------------- |
| ![Screen Shot 2022-03-24 at 20 10 56](https://user-images.githubusercontent.com/50069775/159904251-fc1384ba-e2d9-4595-b75c-9c7112ac8d59.png) | ![Screen Shot 2022-03-24 at 20 09 41](https://user-images.githubusercontent.com/50069775/159904082-d750f95e-5803-447f-b31a-4ded26115f92.png)|


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Make commit clickable on the application list page 
```
