### PR TITLE
Update filedb cursor implementation

### DIFF
--- a/pkg/datastore/filedb/iterator.go
+++ b/pkg/datastore/filedb/iterator.go
@@ -43,5 +43,6 @@ func (it *Iterator) Next(dst interface{}) error {
 }
 
 func (it *Iterator) Cursor() (string, error) {
-	return "", datastore.ErrUnsupported
+	// TODO: Implement cursor for filedb datastore.
+	return "", nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, in order to use the datastore List interface in models' stores, `Iterator.Cursor` interface must be implemented (for instance: [applicationstore](https://github.com/pipe-cd/pipecd/blob/master/pkg/datastore/applicationstore.go#L187-L190)). We're not required filedb to have Cursor implementation for now so this PR change to implementation for it from return error to dummy cursor (empty string).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
