### PR TITLE
Fix to add builtin labels for Cloud Run service every deployment

### DIFF
--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -158,6 +158,9 @@ func addBuiltinLabels(sm provider.ServiceManifest, hash, pipedID, appID, revisio
 	// Set builtinLabels for Service.
 	sm.AddLabels(labels)
 
+	if revisionName == "" {
+		return true
+	}
 	// Set buildinLabels for Revision.
 	labels[provider.LabelRevisionName] = revisionName
 	if err := sm.AddRevisionLabels(labels); err != nil {

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -196,10 +196,8 @@ func (e *deployExecutor) ensurePromote(ctx context.Context) model.StageStatus {
 	}
 
 	commit := e.Deployment.CommitHash()
-	if newRevision != "" {
-		if !addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, newRevision, e.LogPersister) {
-			return model.StageStatus_STAGE_FAILURE
-		}
+	if !addBuiltinLabels(sm, commit, e.PipedConfig.PipedID, e.Deployment.ApplicationId, newRevision, e.LogPersister) {
+		return model.StageStatus_STAGE_FAILURE
 	}
 
 	if !apply(ctx, e.client, sm, e.LogPersister) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to add builtin labels for Cloud Run service every deployment.
we should update service builtin labels even if revisionName is empty.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
