### PR TITLE
Parse terraform local module source

### DIFF
--- a/pkg/app/piped/cloudprovider/terraform/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/terraform/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/cloudprovider/terraform",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "@com_github_hashicorp_hcl_v2//:go_default_library",
         "@com_github_hashicorp_hcl_v2//gohcl:go_default_library",

--- a/pkg/app/piped/cloudprovider/terraform/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/terraform/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pipe-cd/pipecd/pkg/app/piped/cloudprovider/terraform",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/piped/deploysource:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "@com_github_hashicorp_hcl_v2//:go_default_library",
@@ -24,6 +25,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
+        "//pkg/app/piped/deploysource:go_default_library",
         "//pkg/model:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/pkg/app/piped/cloudprovider/terraform/module.go
+++ b/pkg/app/piped/cloudprovider/terraform/module.go
@@ -89,7 +89,7 @@ func LoadTerraformFiles(dir string) ([]File, error) {
 				Name:    m.Name,
 				Source:  m.Source,
 				Version: m.Version,
-				IsLocal: isModuleLocal(m.Source),
+				IsLocal: isLocalModule(m.Source),
 			})
 		}
 
@@ -117,12 +117,8 @@ func FindArtifactVersions(tfs []File) ([]*model.ArtifactVersion, error) {
 	return versions, nil
 }
 
-func isModuleLocal(moduleSrc string) bool {
-	if strings.HasPrefix(moduleSrc, "./") || strings.HasPrefix(moduleSrc, "../") {
-		return true
-	}
-
-	return false
+func isLocalModule(moduleSrc string) bool {
+	return strings.HasPrefix(moduleSrc, "./") || strings.HasPrefix(moduleSrc, "../")
 }
 
 // LocalModuleSourceConverter is a converter from local module source to its URL.

--- a/pkg/app/piped/cloudprovider/terraform/module_test.go
+++ b/pkg/app/piped/cloudprovider/terraform/module_test.go
@@ -242,7 +242,7 @@ func TestMakeURL(t *testing.T) {
 	}
 }
 
-func TestIsModuleLocal(t *testing.T) {
+func TestIsLocalModule(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {
@@ -272,7 +272,7 @@ func TestIsModuleLocal(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, isModuleLocal(tc.moduleSrc), tc.expected)
+			assert.Equal(t, isLocalModule(tc.moduleSrc), tc.expected)
 		})
 	}
 }

--- a/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules/main.tf
+++ b/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules/main.tf
@@ -2,14 +2,14 @@ provider "docker" {
 }
 
 module "helloworld_01" {
-  source = "helloworld"
+  source = "./helloworld"
   version = "v1.0.0"
   image_version = "v1.0.0"
   external_port = 8080
 }
 
 module "helloworld_02" {
-  source = "helloworld"
+  source = "./helloworld"
   version = "v0.9.0"
   image_version = "v0.9.0"
   external_port = 8081

--- a/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules_with_multi_files/helloworld_01.tf
+++ b/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules_with_multi_files/helloworld_01.tf
@@ -2,7 +2,7 @@ provider "docker" {
 }
 
 module "helloworld_01" {
-  source = "helloworld"
+  source = "./helloworld"
   version = "v1.0.0"
   image_version = "v1.0.0"
   external_port = 8080

--- a/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules_with_multi_files/helloworld_02.tf
+++ b/pkg/app/piped/cloudprovider/terraform/testdata/multi_modules_with_multi_files/helloworld_02.tf
@@ -2,7 +2,7 @@ provider "docker" {
 }
 
 module "helloworld_02" {
-  source = "helloworld"
+  source = "./helloworld"
   version = "v0.9.0"
   image_version = "v0.9.0"
   external_port = 8081

--- a/pkg/app/piped/cloudprovider/terraform/testdata/single_module/main.tf
+++ b/pkg/app/piped/cloudprovider/terraform/testdata/single_module/main.tf
@@ -2,7 +2,7 @@ provider "docker" {
 }
 
 module "helloworld" {
-  source = "helloworld"
+  source = "./helloworld"
   version = "v1.0.0"
   image_version = "v1.0.0"
   external_port = 8080

--- a/pkg/app/piped/planner/terraform/terraform.go
+++ b/pkg/app/piped/planner/terraform/terraform.go
@@ -81,24 +81,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
-	// convert module source to URL.
-	for _, f := range files {
-		for _, m := range f.Modules {
-			if m.IsLocal {
-				l := provider.NewLocalModuleSourceConverter(in.GitPath.Repo.Remote, in.GitPath.Repo.Branch, ds.RepoDir, ds.AppDir)
-				url, err := l.MakeURL(m.Source)
-				if err != nil {
-					return out, err
-				}
-
-				m.Source = url
-			} else {
-				// TODO: convert remote module to URL.
-			}
-		}
-	}
-
-	out.Versions, err = provider.FindArtifactVersions(files)
+	out.Versions, err = provider.FindArtifactVersions(files, &in.GitPath, ds)
 	if err != nil {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))
 		out.Versions = []*model.ArtifactVersion{

--- a/pkg/app/piped/planner/terraform/terraform.go
+++ b/pkg/app/piped/planner/terraform/terraform.go
@@ -81,6 +81,23 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
+	// convert module source to URL.
+	for _, f := range files {
+		for _, m := range f.Modules {
+			if m.IsLocal {
+				l := provider.NewLocalModuleSourceConverter(in.GitPath.Repo.Remote, in.GitPath.Repo.Branch, ds.RepoDir, ds.AppDir)
+				url, err := l.MakeURL(m.Source)
+				if err != nil {
+					return out, err
+				}
+
+				m.Source = url
+			} else {
+				// TODO: convert remote module to URL.
+			}
+		}
+	}
+
 	out.Versions, err = provider.FindArtifactVersions(files)
 	if err != nil {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes to show URL for terraform local module.
ref: local module https://www.terraform.io/language/modules/sources#local-paths

**Which issue(s) this PR fixes**:

A part of https://github.com/pipe-cd/pipecd/issues/3303

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Be able to show URL for terraform local module.
```
