### PR TITLE
Do not show the detail block in plan-preview comment when its content was empty

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.6.0
+version: 1.7.0
 registry: gcr.io/pipecd/actions-plan-preview

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -205,8 +205,10 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 			continue
 		}
 
-		detailLen += l
-		fmt.Fprintf(&b, detailsFormat, lang, app.PlanDetails)
+		if l > 0 {
+			detailLen += l
+			fmt.Fprintf(&b, detailsFormat, lang, details)
+		}
 	}
 
 	if len(pipelineApps)+len(quickSyncApps) > 0 {
@@ -245,7 +247,9 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 				lang = "hcl"
 			}
 
-			fmt.Fprintf(&b, detailsFormat, lang, app.PlanDetails)
+			if len(app.PlanDetails) > 0 {
+				fmt.Fprintf(&b, detailsFormat, lang, app.PlanDetails)
+			}
 		}
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
