### PR TITLE
Fix at the beginning of the sentence for shortening terraform plan details

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.7.0
+version: 1.7.1
 registry: gcr.io/pipecd/actions-plan-preview

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -148,7 +148,7 @@ const (
 	githubRunIDEnv      = "GITHUB_RUN_ID"
 
 	// Terraform plan format
-	startTerraformPlan = "Terraform used the selected providers to generate the following execution"
+	startTerraformPlan = "Terraform will perform the following actions:"
 	endTerraformPlan   = "─────────────────────────────────────────────────────────────────────────────"
 )
 

--- a/dockers/actions-plan-preview/planpreview_test.go
+++ b/dockers/actions-plan-preview/planpreview_test.go
@@ -293,11 +293,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 1 to add, 0 to change, 0 to destroy`,
-			want: `Terraform used the selected providers to generate the following execution
-plan. Resource actions are indicated with the following symbols:
-  + create
-
-Terraform will perform the following actions:
+			want: `Terraform will perform the following actions:
 
   # google_dns_record_set.xxx will be created
   + resource "google_dns_record_set" "xxxxx" {
@@ -394,11 +390,7 @@ version constraint into the required_providers block.
 Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 1 to add, 0 to change, 0 to destroy`,
-			want: `Terraform used the selected providers to generate the following execution
-plan. Resource actions are indicated with the following symbols:
-  + create
-
-Terraform will perform the following actions:
+			want: `Terraform will perform the following actions:
 
   # google_dns_record_set.xxx will be created
   + resource "google_dns_record_set" "xxxxx" {
@@ -529,12 +521,7 @@ Plan: 2 to add, 1 to change, 0 to destroy.
 Note: You didn't use the -out option to save this plan, so Terraform can't
 guarantee to take exactly these actions if you run "terraform apply" now.
 2 to add, 1 to change, 0 to destroy`,
-			want: `Terraform used the selected providers to generate the following execution
-plan. Resource actions are indicated with the following symbols:
-  + create
-  ~ update in-place
-
-Terraform will perform the following actions:
+			want: `Terraform will perform the following actions:
 
   # google_dns_managed_zone.xxxxx will be created
   + resource "google_dns_managed_zone" "xxxxx" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the rule of shortening terraform plan details in actions-plan-preview because the sentence is different for each version of Terraform as the following.


**v0.12.26**
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:
```

**v1.0.3**
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
