### PR TITLE
Update decode interface

### DIFF
--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -55,7 +55,7 @@ func (c *commandCollection) GetUpdatableShard() (Shard, error) {
 	}
 }
 
-func (c *commandCollection) Decode(e interface{}, parts ...[]byte) error {
+func (c *commandCollection) Decode(e interface{}, parts map[Shard][]byte) error {
 	if len(parts) != len(c.ListInUsedShards()) {
 		return fmt.Errorf("failed while decode Command object: shards count not matched")
 	}

--- a/pkg/datastore/commandstore_test.go
+++ b/pkg/datastore/commandstore_test.go
@@ -174,20 +174,20 @@ func TestDecode(t *testing.T) {
 
 	testcases := []struct {
 		name      string
-		parts     [][]byte
+		parts     map[Shard][]byte
 		expectCmd *model.Command
 		expectErr bool
 	}{
 		{
 			name:      "parts count miss matched",
-			parts:     [][]byte{},
+			parts:     make(map[Shard][]byte),
 			expectErr: true,
 		},
 		{
 			name: "should merge correctly",
-			parts: [][]byte{
-				[]byte(`{"id":"1","status":3,"updated_at":4}`),
-				[]byte(`{"id":"1","status":0,"updated_at":1}`),
+			parts: map[Shard][]byte{
+				AgentShard: []byte(`{"id":"1","status":3,"updated_at":4}`),
+				OpsShard:   []byte(`{"id":"1","status":0,"updated_at":1}`),
 			},
 			expectCmd: &model.Command{
 				Id:        "1",
@@ -201,7 +201,7 @@ func TestDecode(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := &model.Command{}
-			err := col.Decode(cmd, tc.parts...)
+			err := col.Decode(cmd, tc.parts)
 			require.Equal(t, tc.expectErr, err != nil)
 
 			if err == nil {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -112,7 +112,7 @@ type ShardEncoder interface {
 
 type ShardDecoder interface {
 	// Decode unmarshals all given raw data parts to a given entity e.
-	Decode(e interface{}, parts ...[]byte) error
+	Decode(e interface{}, parts map[Shard][]byte) error
 }
 
 type Factory func() interface{}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the decode interface is
```go
type ShardDecoder interface {
	// Decode unmarshals all given raw data parts to a given entity e.
	Decode(e interface{}, parts ...[]byte) error
}
```
But in some case, we need to know which shard these parts of data belongs to in order to merge (decode) those data correctly. This PR updates the decode interface to
```go
type ShardDecoder interface {
	// Decode unmarshals all given raw data parts to a given entity e.
	Decode(e interface{}, parts map[Shard][]byte) error
}
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
