### PR TITLE
Add piped agent shard

### DIFF
--- a/pkg/datastore/commandstore_test.go
+++ b/pkg/datastore/commandstore_test.go
@@ -169,7 +169,7 @@ func TestListCommands(t *testing.T) {
 	}
 }
 
-func TestDecode(t *testing.T) {
+func TestCommandDecode(t *testing.T) {
 	col := &commandCollection{requestedBy: TestCommander}
 
 	testcases := []struct {

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -118,6 +118,8 @@ func (p *pipedCollection) Encode(e interface{}) (map[Shard][]byte, error) {
 		Id:        me.Id,
 		Name:      me.Name,
 		ProjectId: me.ProjectId,
+		CreatedAt: me.CreatedAt,
+		UpdatedAt: me.UpdatedAt,
 		// Fields which value only available in AgentShard.
 		CloudProviders: me.CloudProviders,
 		Repositories:   me.Repositories,

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -114,9 +114,14 @@ func (p *pipedCollection) Encode(e interface{}) (map[Shard][]byte, error) {
 	}
 
 	agentShardStruct := model.Piped{
+		// Fields which must exists due to the validation check on update.
+		Id:   me.Id,
+		Name: me.Name,
+		// Fields which value only available in AgentShard.
 		CloudProviders: me.CloudProviders,
 		Repositories:   me.Repositories,
-		// Below fields will be committed by Piped once at it start, after that
+		StartedAt:      me.StartedAt,
+		// Fields which be committed by Piped once at it start, after that
 		// those fields value can be updated by WebCommander so we should use
 		// those values from ClientShard with a higher priority.
 		Version:          me.Version,

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -115,8 +115,9 @@ func (p *pipedCollection) Encode(e interface{}) (map[Shard][]byte, error) {
 
 	agentShardStruct := model.Piped{
 		// Fields which must exists due to the validation check on update.
-		Id:   me.Id,
-		Name: me.Name,
+		Id:        me.Id,
+		Name:      me.Name,
+		ProjectId: me.ProjectId,
 		// Fields which value only available in AgentShard.
 		CloudProviders: me.CloudProviders,
 		Repositories:   me.Repositories,

--- a/pkg/datastore/pipedstore_test.go
+++ b/pkg/datastore/pipedstore_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -166,59 +165,6 @@ func TestListPipeds(t *testing.T) {
 			s := NewPipedStore(tc.ds, TestCommander)
 			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
-		})
-	}
-}
-
-func TestPipedDecode(t *testing.T) {
-	col := &pipedCollection{requestedBy: TestCommander}
-
-	testcases := []struct {
-		name        string
-		parts       map[Shard][]byte
-		expectPiped *model.Piped
-		expectErr   bool
-	}{
-		{
-			name:      "parts count miss matched",
-			parts:     make(map[Shard][]byte),
-			expectErr: true,
-		},
-		{
-			name: "in case client shard has no version",
-			parts: map[Shard][]byte{
-				ClientShard: []byte(`{"id":"1","name":"piped"}`),
-				AgentShard:  []byte(`{"version":"1"}`),
-			},
-			expectPiped: &model.Piped{
-				Id:      "1",
-				Name:    "piped",
-				Version: "1",
-			},
-		},
-		{
-			name: "in case client shard has version",
-			parts: map[Shard][]byte{
-				ClientShard: []byte(`{"id":"1","name":"piped","version":"1"}`),
-				AgentShard:  []byte(`{"version":"3"}`),
-			},
-			expectPiped: &model.Piped{
-				Id:      "1",
-				Name:    "piped",
-				Version: "1",
-			},
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			piped := &model.Piped{}
-			err := col.Decode(piped, tc.parts)
-			require.Equal(t, tc.expectErr, err != nil)
-
-			if err == nil {
-				assert.Equal(t, tc.expectPiped, piped)
-			}
 		})
 	}
 }

--- a/pkg/datastore/pipedstore_test.go
+++ b/pkg/datastore/pipedstore_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -165,6 +166,59 @@ func TestListPipeds(t *testing.T) {
 			s := NewPipedStore(tc.ds, TestCommander)
 			_, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}
+
+func TestPipedDecode(t *testing.T) {
+	col := &pipedCollection{requestedBy: TestCommander}
+
+	testcases := []struct {
+		name        string
+		parts       map[Shard][]byte
+		expectPiped *model.Piped
+		expectErr   bool
+	}{
+		{
+			name:      "parts count miss matched",
+			parts:     make(map[Shard][]byte),
+			expectErr: true,
+		},
+		{
+			name: "in case client shard has no version",
+			parts: map[Shard][]byte{
+				ClientShard: []byte(`{"id":"1","name":"piped"}`),
+				AgentShard:  []byte(`{"version":"1"}`),
+			},
+			expectPiped: &model.Piped{
+				Id:      "1",
+				Name:    "piped",
+				Version: "1",
+			},
+		},
+		{
+			name: "in case client shard has version",
+			parts: map[Shard][]byte{
+				ClientShard: []byte(`{"id":"1","name":"piped","version":"1"}`),
+				AgentShard:  []byte(`{"version":"3"}`),
+			},
+			expectPiped: &model.Piped{
+				Id:      "1",
+				Name:    "piped",
+				Version: "1",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			piped := &model.Piped{}
+			err := col.Decode(piped, tc.parts)
+			require.Equal(t, tc.expectErr, err != nil)
+
+			if err == nil {
+				assert.Equal(t, tc.expectPiped, piped)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`pipedService.ReportPipedMeta` rpc, which be called by piped need to write piped meta to the datastore, so we should have AgentShard for piped collection as well (currently, only ClientShard for piped collection exists)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
