### PR TITLE
Fix unable to filter object correctly in case the object value field of type int64

### DIFF
--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -149,6 +149,11 @@ func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datast
 			return nil, err
 		}
 
+		f.logger.Info("filtering...",
+			zap.Any("entity", e),
+			zap.Any("filter", opts.Filters),
+		)
+
 		pass, err := filter(col, e, opts.Filters)
 		if err != nil {
 			f.logger.Error("failed to filter entity",
@@ -158,6 +163,12 @@ func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datast
 			)
 			return nil, err
 		}
+
+		f.logger.Info("check filter result",
+			zap.Any("entity", e),
+			zap.Any("filter", opts.Filters),
+			zap.Bool("result", pass),
+		)
 
 		if pass {
 			entities = append(entities, e)

--- a/pkg/datastore/filedb/filedb.go
+++ b/pkg/datastore/filedb/filedb.go
@@ -149,6 +149,7 @@ func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datast
 			return nil, err
 		}
 
+		// TODO: Remove this unnecessary log print.
 		f.logger.Info("filtering...",
 			zap.Any("entity", e),
 			zap.Any("filter", opts.Filters),
@@ -164,6 +165,7 @@ func (f *FileDB) Find(ctx context.Context, col datastore.Collection, opts datast
 			return nil, err
 		}
 
+		// TODO: Remove this unnecessary log print.
 		f.logger.Info("check filter result",
 			zap.Any("entity", e),
 			zap.Any("filter", opts.Filters),

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -103,7 +103,7 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 		valNum = float64(reflect.ValueOf(v).Uint())
 	default:
 		if op.IsNumericOperator() {
-			return false, fmt.Errorf("value of type unsupported")
+			return false, fmt.Errorf("value of type unsupported: %v", reflect.TypeOf(v))
 		}
 		valCasted = false
 	}
@@ -116,7 +116,7 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 		operandNum = float64(reflect.ValueOf(o).Uint())
 	default:
 		if op.IsNumericOperator() {
-			return false, fmt.Errorf("operand of type unsupported")
+			return false, fmt.Errorf("operand of type unsupported: %v", reflect.TypeOf(o))
 		}
 		operandCasted = false
 	}
@@ -184,7 +184,7 @@ func compare(val, operand interface{}, op datastore.Operator) (bool, error) {
 func makeSliceOfInterfaces(v interface{}) ([]interface{}, error) {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
-		return nil, fmt.Errorf("value is not a slide or array")
+		return nil, fmt.Errorf("value type %v is not a slide or array", rv.Kind())
 	}
 
 	vs := make([]interface{}, rv.Len())

--- a/pkg/datastore/filedb/filter_test.go
+++ b/pkg/datastore/filedb/filter_test.go
@@ -296,6 +296,23 @@ func TestFilter(t *testing.T) {
 			},
 			expect: false,
 		},
+		{
+			name:   "filter multiple conditions with numberic operator - passed",
+			entity: &model.Application{Id: "app_1", UpdatedAt: 1649219699},
+			filters: []datastore.ListFilter{
+				{
+					Field:    "Id",
+					Operator: datastore.OperatorEqual,
+					Value:    "app_1",
+				},
+				{
+					Field:    "UpdatedAt",
+					Operator: datastore.OperatorGreaterThanOrEqual,
+					Value:    1646648937,
+				},
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**: 

JSON mapping for int64 value will be of type String, which makes current value compare logic for filedb return error. This PR updates the typecasting logic in compare value function to handle that case.

ref: [proto3 docs](https://developers.google.com/protocol-buffers/docs/proto3#:~:text=JSON%20value%20will%20be%20a%20decimal%20string.%20Either%20numbers%20or%20strings%20are%20accepted.)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
