### PR TITLE
Handle declared type

### DIFF
--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -75,7 +75,12 @@ func filter(col datastore.Collection, e interface{}, filters []datastore.ListFil
 			return false, nil
 		}
 
-		cmp, err := compare(val, filter.Value, filter.Operator)
+		operand, err := normalizeFieldValue(filter.Value)
+		if err != nil {
+			return false, err
+		}
+
+		cmp, err := compare(val, operand, filter.Operator)
 		if err != nil {
 			return false, err
 		}
@@ -219,4 +224,33 @@ func normalizeFieldName(key string) string {
 		return strings.ToLower(key)
 	}
 	return strings.ToLower(string(key[0])) + key[1:]
+}
+
+// normalizeFieldValue converts value of any type to the primitive type
+// Note: Find a better way to handle this instead of marshal/unmarshal.
+func normalizeFieldValue(val interface{}) (interface{}, error) {
+	var needConvert = false
+	switch val.(type) {
+	case int, int8, int16, int32, int64:
+	case uint, uint8, uint16, uint32:
+	case float32, float64:
+	case string:
+	default:
+		needConvert = true
+	}
+
+	if !needConvert {
+		return val, nil
+	}
+
+	raw, err := json.Marshal(val)
+	if err != nil {
+		return nil, err
+	}
+
+	var out interface{}
+	if err = json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -235,6 +235,7 @@ func normalizeFieldValue(val interface{}) (interface{}, error) {
 	case uint, uint8, uint16, uint32:
 	case float32, float64:
 	case string:
+	case bool:
 	default:
 		needConvert = true
 	}

--- a/pkg/datastore/filedb/filter_test.go
+++ b/pkg/datastore/filedb/filter_test.go
@@ -328,6 +328,18 @@ func TestFilter(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			name:   "filter with IN operator - not passed",
+			entity: &model.Deployment{Status: model.DeploymentStatus_DEPLOYMENT_CANCELLED},
+			filters: []datastore.ListFilter{
+				{
+					Field:    "Status",
+					Operator: datastore.OperatorIn,
+					Value:    model.GetNotCompletedDeploymentStatuses(),
+				},
+			},
+			expect: false,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/datastore/filedb/filter_test.go
+++ b/pkg/datastore/filedb/filter_test.go
@@ -243,7 +243,7 @@ func TestFilter(t *testing.T) {
 				{
 					Field:    "Kind",
 					Operator: datastore.OperatorEqual,
-					Value:    0,
+					Value:    model.ApplicationKind_KUBERNETES,
 				},
 			},
 			expect: true,
@@ -312,6 +312,18 @@ func TestFilter(t *testing.T) {
 					Field:    "UpdatedAt",
 					Operator: datastore.OperatorGreaterThanOrEqual,
 					Value:    1646648937,
+				},
+			},
+			expect: true,
+		},
+		{
+			name:   "filter with IN operator - passed",
+			entity: &model.Deployment{Status: model.DeploymentStatus_DEPLOYMENT_PENDING},
+			filters: []datastore.ListFilter{
+				{
+					Field:    "Status",
+					Operator: datastore.OperatorIn,
+					Value:    model.GetNotCompletedDeploymentStatuses(),
 				},
 			},
 			expect: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, for queries of kind
```go
{
	Field:    "Kind",
	Operator: datastore.OperatorEqual,
	Value:    model.ApplicationKind_KUBERNETES,
}
```
the filter logic of filedb will return false event the model object is of has field Kind of the same value. That is caused by the unmarshaled model object only contains primitive types (to keep filedb layer generic, only case raw byte of models to map[string]interface{}, not it true type), and the operand value from queries is of its wrapped type (for instance `model.ApplicationKind`). As the result, comparing those two values will return `(mismatched type model.ApplicationKind and float64)` error. This PR provides logic to convert types which not a primitive type of filter.Value to primitive types, so the filter compare logic could work.

**Which issue(s) this PR fixes**:

Fixes #3494 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
