### PR TITLE
Fix invalid lambda example

### DIFF
--- a/examples/lambda/analysis/app.pipecd.yaml
+++ b/examples/lambda/analysis/app.pipecd.yaml
@@ -21,6 +21,8 @@ spec:
       # If this stage finds any not good metrics of the new version,
       # a rollback process to the previous version will be executed.
       - name: ANALYSIS
+        with:
+          duration: 10m
       # Promote new version to receive all traffic.
       - name: LAMBDA_PROMOTE
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspends this error

> failed to read unregistered application info	{"repo-id": "examples", "config-file-path": "lambda/analysis/app.pipecd.yaml", "error": "failed to decode configuration file: the ANALYSIS stage requires duration field"}


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
