### PR TITLE
Using filedb as datastore for quickstart

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -287,45 +287,6 @@ spec:
 
 {{- if .Values.quickstart.enabled }}
 ---
-# MySQL datastore
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "pipecd.fullname" . }}-mysql
-  labels:
-    {{- include "pipecd.labels" . | nindent 4 }}
-    app.kubernetes.io/component: mysql
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      {{- include "pipecd.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: mysql
-  template:
-    metadata:
-      labels:
-        {{- include "pipecd.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: mysql
-    spec:
-      containers:
-        - name: mysql
-          image: mysql:{{ .Values.mysql.imageTag }}
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: MYSQL_ROOT_PASSWORD
-              value: {{ .Values.mysql.rootPassword }}
-            - name: MYSQL_DATABASE
-              value: {{ .Values.mysql.database }}
-          ports:
-            - name: mysql
-              containerPort: 3306
-              protocol: TCP
-{{- if .Values.mysql.resources }}
-          resources:
-            {{- toYaml .Values.mysql.resources | nindent 12 }}
-{{- end }}
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/pipecd/templates/service.yaml
+++ b/manifests/pipecd/templates/service.yaml
@@ -121,24 +121,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "pipecd.fullname" . }}-mysql
-  labels:
-    {{- include "pipecd.labels" . | nindent 4 }}
-    app.kubernetes.io/component: mysql
-spec:
-  type: ClusterIP
-  ports:
-    - name: service
-      port: 3306
-      targetPort: mysql
-  selector:
-    {{- include "pipecd.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: mysql
-
----
-apiVersion: v1
-kind: Service
-metadata:
   name: {{ include "pipecd.fullname" . }}-minio
   labels:
     {{- include "pipecd.labels" . | nindent 4 }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -55,10 +55,6 @@ cloudSQLProxy:
     port: 3306
   resources: {}
 
-mysql:
-  imageTag: "8.0.23"
-  resources: {}
-
 minio:
   imageTag: "RELEASE.2020-08-26T00-00-49Z"
   resources: {}

--- a/quickstart/control-plane-values.yaml
+++ b/quickstart/control-plane-values.yaml
@@ -7,10 +7,7 @@ config:
     kind: ControlPlane
     spec:
       datastore:
-        type: MYSQL
-        config:
-          url: root:test@tcp(pipecd-mysql:3306)
-          database: quickstart
+        type: FILEDB
       filestore:
         type: MINIO
         config:
@@ -32,7 +29,3 @@ secret:
     data: quickstart-access-key
   minioSecretKey:
     data: quickstart-secret-key
-
-mysql:
-  rootPassword: "test"
-  database: "quickstart"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Able to use FILEDB as datastore for quickstart
```
