### PR TITLE
Add a dialog for skipping the analysis stage

### DIFF
--- a/web/src/api/deployments.ts
+++ b/web/src/api/deployments.ts
@@ -8,6 +8,8 @@ import {
   CancelDeploymentResponse,
   ApproveStageRequest,
   ApproveStageResponse,
+  SkipStageRequest,
+  SkipStageResponse,
 } from "pipecd/web/api_client/service_pb";
 
 export const getDeployment = ({
@@ -67,4 +69,14 @@ export const approveStage = ({
   req.setDeploymentId(deploymentId);
   req.setStageId(stageId);
   return apiRequest(req, apiClient.approveStage);
+};
+
+export const skipStage = ({
+  deploymentId,
+  stageId,
+}: SkipStageRequest.AsObject): Promise<SkipStageResponse.AsObject> => {
+  const req = new SkipStageRequest();
+  req.setDeploymentId(deploymentId);
+  req.setStageId(stageId);
+  return apiRequest(req, apiClient.skipStage);
 };

--- a/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
@@ -48,6 +48,7 @@ it("should appear stage log in the document if activeState is exists", () => {
         entities: {
           [dummyDeployment.id]: dummyDeployment,
         },
+	skippable: {},
       },
       activeStage: {
         deploymentId: dummyDeployment.id,
@@ -74,6 +75,7 @@ it("should dispatch clearActiveStage action if click `close log` button", () => 
       entities: {
         [dummyDeployment.id]: dummyDeployment,
       },
+      skippable: {},
     },
     activeStage: {
       deploymentId: dummyDeployment.id,

--- a/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
@@ -48,7 +48,7 @@ it("should appear stage log in the document if activeState is exists", () => {
         entities: {
           [dummyDeployment.id]: dummyDeployment,
         },
-	skippable: {},
+        skippable: {},
       },
       activeStage: {
         deploymentId: dummyDeployment.id,

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -157,9 +157,10 @@ export const LogViewer: FC = memo(function LogViewer() {
     }
   };
 
-  const isSkipping = useAppSelector(
-    selectDeploymentStageIsSkipping(activeStage?.id)
-  );
+  const isSkipping = (): boolean => {
+      const stageId = activeStage ? activeStage.id : "";
+      return useAppSelector(selectDeploymentStageIsSkipping(stageId))
+  };
 
   if (!stageLog || !activeStage) {
     return null;
@@ -189,7 +190,7 @@ export const LogViewer: FC = memo(function LogViewer() {
                   onClick={() => setSkipTargetId(activeStage.id)}
                   variant="contained"
                   endIcon={<SkipNext />}
-                  disabled={isSkipping}
+                  disabled={isSkipping()}
                 >
                   SKIP
                 </Button>

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -183,7 +183,7 @@ export const LogViewer: FC = memo(function LogViewer() {
                   onClick={() => setOpenSkipDialog(true)}
                   variant="contained"
                   endIcon={<SkipNext />}
-                  disabled={isSkippable}
+                  disabled={!isSkippable}
                 >
                   SKIP
                 </Button>

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -149,7 +149,7 @@ export const LogViewer: FC = memo(function LogViewer() {
   const handleSkip = (): void => {
     const deploymentId = stageLog ? stageLog.deploymentId : "";
     dispatch(skipStage({ deploymentId: deploymentId, stageId: stageId }));
-    dispatch(updateSkippableState({ stageId: stageId }));
+    dispatch(updateSkippableState({ stageId: stageId, skippable: false }));
     setOpenSkipDialog(false);
   };
 
@@ -176,8 +176,8 @@ export const LogViewer: FC = memo(function LogViewer() {
         <Divider />
         <Toolbar variant="dense" className={classes.toolbar}>
           <div className={classes.toolbarLeft}>
-            {activeStage.name == ANALYSIS_STAGE_NAME &&
-              activeStage.status == StageStatus.STAGE_RUNNING && (
+            {activeStage.name === ANALYSIS_STAGE_NAME &&
+              activeStage.status === StageStatus.STAGE_RUNNING && (
                 <Button
                   className={classes.skipButton}
                   onClick={() => setOpenSkipDialog(true)}

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -16,7 +16,11 @@ import clsx from "clsx";
 import { FC, memo, useCallback, useState } from "react";
 import Draggable from "react-draggable";
 import { APP_HEADER_HEIGHT } from "~/components/header";
-import { useAppDispatch, useShallowEqualSelector } from "~/hooks/redux";
+import {
+  useAppDispatch,
+  useShallowEqualSelector,
+  useAppSelector,
+} from "~/hooks/redux";
 import { clearActiveStage } from "~/modules/active-stage";
 import {
   isStageRunning,
@@ -24,6 +28,8 @@ import {
   Stage,
   StageStatus,
   skipStage,
+  selectDeploymentStageIsSkipping,
+  updateSkippingState,
 } from "~/modules/deployments";
 import { selectStageLogById, StageLog } from "~/modules/stage-logs";
 import { Log } from "./log";
@@ -146,9 +152,14 @@ export const LogViewer: FC = memo(function LogViewer() {
       dispatch(
         skipStage({ deploymentId: deploymentId, stageId: skipTargetId })
       );
+      dispatch(updateSkippingState({ stageId: skipTargetId }));
       setSkipTargetId(null);
     }
   };
+
+  const isSkipping = useAppSelector(
+    selectDeploymentStageIsSkipping(activeStage?.id)
+  );
 
   if (!stageLog || !activeStage) {
     return null;
@@ -178,6 +189,7 @@ export const LogViewer: FC = memo(function LogViewer() {
                   onClick={() => setSkipTargetId(activeStage.id)}
                   variant="contained"
                   endIcon={<SkipNext />}
+                  disabled={isSkipping}
                 >
                   SKIP
                 </Button>

--- a/web/src/components/deployments-detail-page/pipeline/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.tsx
@@ -23,14 +23,12 @@ import {
   selectById,
   Stage,
   StageStatus,
-  skipStage,
 } from "~/modules/deployments";
 import { fetchStageLog } from "~/modules/stage-logs";
 import { ApprovalStage } from "./approval-stage";
 import { PipelineStage } from "./pipeline-stage";
 
 const WAIT_APPROVAL_NAME = "WAIT_APPROVAL";
-const ANALYSIS_NAME = "ANALYSIS";
 const STAGE_HEIGHT = 56;
 const APPROVED_STAGE_HEIGHT = 66;
 
@@ -173,9 +171,6 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
   const [approveTargetId, setApproveTargetId] = useState<string | null>(null);
   const isOpenApproveDialog = Boolean(approveTargetId);
 
-  const [skipTargetId, setSkipTargetId] = useState<string | null>(null);
-  const isOpenSkipDialog = Boolean(skipTargetId);
-
   const defaultActiveStage = findDefaultActiveStage(deployment);
   const stages = createStagesForRendering(deployment);
   const isRunning = isDeploymentRunning(deployment?.status);
@@ -219,13 +214,6 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
     if (approveTargetId) {
       dispatch(approveStage({ deploymentId, stageId: approveTargetId }));
       setApproveTargetId(null);
-    }
-  };
-
-  const handleSkip = (): void => {
-    if (skipTargetId) {
-      dispatch(skipStage({ deploymentId, stageId: skipTargetId }));
-      setSkipTargetId(null);
     }
   };
 
@@ -277,15 +265,7 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
                         name={stage.name}
                         status={stage.status}
                         metadata={stage.metadataMap}
-                        onClick={() => {
-                          if (
-                            stage.name === ANALYSIS_NAME &&
-                            stage.status === StageStatus.STAGE_RUNNING
-                          ) {
-                            setSkipTargetId(stage.id);
-                          }
-                          handleOnClickStage(stage.id, stage.name);
-                        }}
+                        onClick={handleOnClickStage}
                         active={isActive}
                         approver={approver}
                         skipper={skipper}
@@ -315,21 +295,6 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
             <Button onClick={() => setApproveTargetId(null)}>CANCEL</Button>
             <Button color="primary" onClick={handleApprove}>
               APPROVE
-            </Button>
-          </DialogActions>
-        </Dialog>
-
-        <Dialog open={isOpenSkipDialog} onClose={() => setSkipTargetId(null)}>
-          <DialogTitle>Skip stage</DialogTitle>
-          <DialogContent>
-            <DialogContentText>
-              {`To skip this stage, click "SKIP".`}
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setSkipTargetId(null)}>CANCEL</Button>
-            <Button color="primary" onClick={handleSkip}>
-              SKIP
             </Button>
           </DialogActions>
         </Dialog>

--- a/web/src/components/deployments-detail-page/pipeline/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.tsx
@@ -277,12 +277,15 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
                         name={stage.name}
                         status={stage.status}
                         metadata={stage.metadataMap}
-                        onClick={
-                          stage.name === ANALYSIS_NAME &&
-                          stage.status === StageStatus.STAGE_RUNNING
-                            ? () => setSkipTargetId(stage.id)
-                            : handleOnClickStage
-                        }
+                        onClick={() => {
+                          if (
+                            stage.name === ANALYSIS_NAME &&
+                            stage.status === StageStatus.STAGE_RUNNING
+                          ) {
+                            setSkipTargetId(stage.id);
+                          }
+                          handleOnClickStage(stage.id, stage.name);
+                        }}
                         active={isActive}
                         approver={approver}
                         skipper={skipper}

--- a/web/src/components/deployments-detail-page/pipeline/pipeline-stage/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/pipeline-stage/index.tsx
@@ -55,6 +55,7 @@ export interface PipelineStageProps {
   active: boolean;
   isDeploymentRunning: boolean;
   approver?: string;
+  skipper?: string;
   metadata: [string, string][];
   onClick: (stageId: string, stageName: string) => void;
 }
@@ -113,6 +114,7 @@ export const PipelineStage: FC<PipelineStageProps> = memo(
     onClick,
     active,
     approver,
+    skipper,
     metadata,
     isDeploymentRunning,
   }) {
@@ -153,6 +155,13 @@ export const PipelineStage: FC<PipelineStageProps> = memo(
               variant="body2"
               color="inherit"
             >{`Approved by ${approver}`}</Typography>
+          </div>
+        ) : skipper !== undefined ? (
+          <div className={classes.metadata}>
+            <Typography
+              variant="body2"
+              color="inherit"
+            >{`Skipped by ${skipper}`}</Typography>
           </div>
         ) : null}
         {trafficPercentage && (

--- a/web/src/components/deployments-detail-page/pipeline/pipeline-stage/stage-status-icon/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/pipeline-stage/stage-status-icon/index.tsx
@@ -5,7 +5,7 @@ import {
   Error,
   IndeterminateCheckBox,
   Stop,
-  SkipNext,
+  Block,
 } from "@material-ui/icons";
 import { FC } from "react";
 import { StageStatus } from "~/modules/deployments";
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.grey[500],
   },
   [StageStatus.STAGE_SKIPPED]: {
-    color: theme.palette.success.main,
+    color: theme.palette.grey[500],
   },
   "@keyframes running": {
     "0%": {
@@ -59,6 +59,6 @@ export const StageStatusIcon: FC<StageStatusIconProps> = ({ status }) => {
     case StageStatus.STAGE_RUNNING:
       return <Cached className={classes[status]} />;
     case StageStatus.STAGE_SKIPPED:
-      return <SkipNext className={classes[status]} />;
+      return <Block className={classes[status]} />;
   }
 };

--- a/web/src/constants/metadata-keys.ts
+++ b/web/src/constants/metadata-keys.ts
@@ -1,1 +1,2 @@
 export const METADATA_APPROVED_BY = "ApprovedBy";
+export const METADATA_SKIPPED_BY = "SkippedBy";

--- a/web/src/modules/deployments/index.test.ts
+++ b/web/src/modules/deployments/index.test.ts
@@ -13,7 +13,7 @@ import {
   fetchDeployments,
   fetchMoreDeployments,
   cancelDeployment,
-  updateSkippingState,
+  updateSkippableState,
 } from ".";
 
 const initialState = {
@@ -25,7 +25,7 @@ const initialState = {
   status: "idle" as LoadingStatus,
   loading: {},
   cursor: "",
-  skipping: {},
+  skippable: {},
 };
 
 test("isDeploymentRunning", () => {
@@ -275,11 +275,11 @@ describe("deploymentsSlice reducer", () => {
     });
   });
 
-  describe("updateSkippingState", () => {
-    it(`should handle ${updateSkippingState.fulfilled.type}`, () => {
+  describe("updateSkippableState", () => {
+    it(`should handle ${updateSkippableState.fulfilled.type}`, () => {
       expect(
         deploymentsSlice.reducer(initialState, {
-          type: updateSkippingState.fulfilled.type,
+          type: updateSkippableState.fulfilled.type,
           meta: {
             arg: {
               stageId: "stage-id",
@@ -288,7 +288,7 @@ describe("deploymentsSlice reducer", () => {
         })
       ).toEqual({
         ...initialState,
-        skipping: {
+        skippable: {
           "stage-id": true,
         },
       });

--- a/web/src/modules/deployments/index.test.ts
+++ b/web/src/modules/deployments/index.test.ts
@@ -24,6 +24,7 @@ const initialState = {
   status: "idle" as LoadingStatus,
   loading: {},
   cursor: "",
+  skipping: {},
 };
 
 test("isDeploymentRunning", () => {

--- a/web/src/modules/deployments/index.test.ts
+++ b/web/src/modules/deployments/index.test.ts
@@ -283,13 +283,14 @@ describe("deploymentsSlice reducer", () => {
           meta: {
             arg: {
               stageId: "stage-id",
+              skippable: false,
             },
           },
         })
       ).toEqual({
         ...initialState,
         skippable: {
-          "stage-id": true,
+          "stage-id": false,
         },
       });
     });

--- a/web/src/modules/deployments/index.test.ts
+++ b/web/src/modules/deployments/index.test.ts
@@ -13,6 +13,7 @@ import {
   fetchDeployments,
   fetchMoreDeployments,
   cancelDeployment,
+  updateSkippingState,
 } from ".";
 
 const initialState = {
@@ -269,6 +270,26 @@ describe("deploymentsSlice reducer", () => {
         ...initialState,
         canceling: {
           "deployment-1": false,
+        },
+      });
+    });
+  });
+
+  describe("updateSkippingState", () => {
+    it(`should handle ${updateSkippingState.fulfilled.type}`, () => {
+      expect(
+        deploymentsSlice.reducer(initialState, {
+          type: updateSkippingState.fulfilled.type,
+          meta: {
+            arg: {
+              stageId: "stage-id",
+            },
+          },
+        })
+      ).toEqual({
+        ...initialState,
+        skipping: {
+          "stage-id": true,
         },
       });
     });

--- a/web/src/modules/deployments/index.ts
+++ b/web/src/modules/deployments/index.ts
@@ -172,6 +172,14 @@ export const approveStage = createAsyncThunk<
   await thunkAPI.dispatch(fetchCommand(commandId));
 });
 
+export const skipStage = createAsyncThunk<
+  void,
+  { deploymentId: string; stageId: string }
+>("deployments/skip", async (props, thunkAPI) => {
+  const { commandId } = await deploymentsApi.skipStage(props);
+  await thunkAPI.dispatch(fetchCommand(commandId));
+});
+
 export const cancelDeployment = createAsyncThunk<
   void,
   {

--- a/web/src/modules/deployments/index.ts
+++ b/web/src/modules/deployments/index.ts
@@ -182,10 +182,10 @@ export const skipStage = createAsyncThunk<
   await thunkAPI.dispatch(fetchCommand(commandId));
 });
 
-export const updateSkippableState = createAsyncThunk<void, { stageId: string }>(
-  "deployments/skippable",
-  () => {}
-);
+export const updateSkippableState = createAsyncThunk<
+  void,
+  { stageId: string; skippable: boolean }
+>("deployments/skippable", () => {});
 
 export const cancelDeployment = createAsyncThunk<
   void,
@@ -278,11 +278,11 @@ export const deploymentsSlice = createSlice({
           (action.payload.status === CommandStatus.COMMAND_FAILED ||
             action.payload.status === CommandStatus.COMMAND_TIMEOUT)
         ) {
-          state.skippable[action.payload.stageId] = false;
+          state.skippable[action.payload.stageId] = true;
         }
       })
       .addCase(updateSkippableState.fulfilled, (state, action) => {
-        state.skippable[action.meta.arg.stageId] = true;
+        state.skippable[action.meta.arg.stageId] = action.meta.arg.skippable;
       });
   },
 });

--- a/web/src/modules/deployments/index.ts
+++ b/web/src/modules/deployments/index.ts
@@ -79,7 +79,7 @@ const initialState = deploymentsAdapter.getInitialState<{
   hasMore: boolean;
   cursor: string;
   minUpdatedAt: number;
-  skipping: Record<string, boolean>;
+  skippable: Record<string, boolean>;
 }>({
   status: "idle",
   loading: {},
@@ -87,7 +87,7 @@ const initialState = deploymentsAdapter.getInitialState<{
   hasMore: true,
   cursor: "",
   minUpdatedAt: Math.round(Date.now() / 1000 - TIME_RANGE_LIMIT_IN_SECONDS),
-  skipping: {},
+  skippable: {},
 });
 
 export const fetchDeploymentById = createAsyncThunk<
@@ -182,8 +182,8 @@ export const skipStage = createAsyncThunk<
   await thunkAPI.dispatch(fetchCommand(commandId));
 });
 
-export const updateSkippingState = createAsyncThunk<void, { stageId: string }>(
-  "deployments/skipping",
+export const updateSkippableState = createAsyncThunk<void, { stageId: string }>(
+  "deployments/skippable",
   () => {}
 );
 
@@ -278,11 +278,11 @@ export const deploymentsSlice = createSlice({
           (action.payload.status === CommandStatus.COMMAND_FAILED ||
             action.payload.status === CommandStatus.COMMAND_TIMEOUT)
         ) {
-          state.skipping[action.payload.stageId] = false;
+          state.skippable[action.payload.stageId] = false;
         }
       })
-      .addCase(updateSkippingState.fulfilled, (state, action) => {
-        state.skipping[action.meta.arg.stageId] = true;
+      .addCase(updateSkippableState.fulfilled, (state, action) => {
+        state.skippable[action.meta.arg.stageId] = true;
       });
   },
 });
@@ -307,6 +307,6 @@ export {
   PipelineStage,
 } from "pipecd/web/model/deployment_pb";
 
-export const selectDeploymentStageIsSkipping = (id?: EntityId | null) => (
+export const selectDeploymentStageIsSkippable = (id?: EntityId | null) => (
   state: AppState
-): boolean => (id ? state.deployments.skipping[id] : false);
+): boolean => (id ? state.deployments.skippable[id] : false);

--- a/web/src/modules/deployments/index.ts
+++ b/web/src/modules/deployments/index.ts
@@ -79,7 +79,7 @@ const initialState = deploymentsAdapter.getInitialState<{
   hasMore: boolean;
   cursor: string;
   minUpdatedAt: number;
-  skippable: Record<string, boolean>;
+  skippable: Record<string, boolean | undefined>;
 }>({
   status: "idle",
   loading: {},
@@ -309,4 +309,9 @@ export {
 
 export const selectDeploymentStageIsSkippable = (id?: EntityId | null) => (
   state: AppState
-): boolean => (id ? state.deployments.skippable[id] : false);
+): boolean => {
+  if (id && typeof state.deployments.skippable[id] !== "undefined") {
+    return state.deployments.skippable[id]!;
+  }
+  return true;
+};

--- a/web/src/modules/stage-logs/index.test.ts
+++ b/web/src/modules/stage-logs/index.test.ts
@@ -50,6 +50,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [dummyDeployment.id],
           entities: { [dummyDeployment.id]: dummyDeployment },
+          skipping: {},
         },
       });
 
@@ -93,6 +94,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [deployment.id],
           entities: { [deployment.id]: deployment },
+          skipping: {},
         },
       });
 
@@ -127,6 +129,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [dummyDeployment.id],
           entities: { [dummyDeployment.id]: dummyDeployment },
+          skipping: {},
         },
       });
 

--- a/web/src/modules/stage-logs/index.test.ts
+++ b/web/src/modules/stage-logs/index.test.ts
@@ -50,7 +50,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [dummyDeployment.id],
           entities: { [dummyDeployment.id]: dummyDeployment },
-          skipping: {},
+          skippable: {},
         },
       });
 
@@ -94,7 +94,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [deployment.id],
           entities: { [deployment.id]: deployment },
-          skipping: {},
+          skippable: {},
         },
       });
 
@@ -129,7 +129,7 @@ describe("async actions", () => {
           status: "idle",
           ids: [dummyDeployment.id],
           entities: { [dummyDeployment.id]: dummyDeployment },
-          skipping: {},
+          skippable: {},
         },
       });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables it to skip just the analysis stage from web UI.
This means that this doesn't support the other stages.


https://user-images.githubusercontent.com/50069775/164153255-2099e1c4-31b1-4113-8512-e8f7eaad3762.mov


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a dialog for skipping the analysis stage.
```
