### PR TITLE
Allow customizing the ServiceAccount for workload of PipeCD Helm chart

### DIFF
--- a/manifests/pipecd/templates/_helpers.tpl
+++ b/manifests/pipecd/templates/_helpers.tpl
@@ -72,3 +72,14 @@ Name of Secret containing sensitive data
 {{- .Values.secret.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Name of ServiceAccount
+*/}}
+{{- define "pipecd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ include "pipecd.fullname" . }}
+{{- else }}
+{{- .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/manifests/pipecd/templates/_helpers.tpl
+++ b/manifests/pipecd/templates/_helpers.tpl
@@ -80,6 +80,6 @@ Name of ServiceAccount
 {{- if .Values.serviceAccount.create -}}
 {{ include "pipecd.fullname" . }}
 {{- else }}
-{{- .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/manifests/pipecd/templates/_helpers.tpl
+++ b/manifests/pipecd/templates/_helpers.tpl
@@ -80,6 +80,6 @@ Name of ServiceAccount
 {{- if .Values.serviceAccount.create -}}
 {{ include "pipecd.fullname" . }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -227,6 +227,9 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ops
     spec:
+      {{- if .Values.serviceAccount.create -}}
+      serviceAccountName: {{ include "pipecd.fullname" . }}-server
+      {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -84,7 +84,9 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: server
     spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "pipecd.serviceAccountName" . }}
+      {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: server
     spec:
+      serviceAccountName: {{ include "pipecd.serviceAccountName" . }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy
@@ -227,9 +228,6 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ops
     spec:
-      {{- if .Values.serviceAccount.create -}}
-      serviceAccountName: {{ include "pipecd.fullname" . }}-server
-      {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy

--- a/manifests/pipecd/templates/serviceaccount.yaml
+++ b/manifests/pipecd/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "pipecd.fullname" . }}-server
+  name: {{ include "pipecd.fullname" . }}
   labels:
     {{- include "pipecd.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/manifests/pipecd/templates/serviceaccount.yaml
+++ b/manifests/pipecd/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pipecd.fullname" . }}-server
+  labels:
+    {{- include "pipecd.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -14,6 +14,8 @@ ingress:
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # The name of existing ServiceAccount to use when create is false.
+  name: ""
   # Annotations to add to the service account
   annotations: {}
 

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -10,6 +10,13 @@ ingress:
     # kubernetes.io/ingress.allow-http: "false"
     # kubernetes.io/ingress.global-static-ip-name: pipecd
 
+# ServiceAccount
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+
 # Workloads.
 gateway:
   replicasCount: 1

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -13,7 +13,7 @@ ingress:
 # ServiceAccount
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # The name of existing ServiceAccount to use when create is false.
   name: ""
   # Annotations to add to the service account

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
         sidecar.istio.io/inject: "false"
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "piped.serviceAccountName" . }}
-      {{- end }}
       containers:
         - name: piped
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Hi team, PipeCD is very good software.
Currently, the default service account annotation must be edited in order to use GCP Workload Identity or AWS WebIdentity.
This change should improve convenience by allowing k8s service accounts dedicated to PipeCD Server to be created from the helm chart.

**Which issue(s) this PR fixes**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow customizing the ServiceAccount for workload of PipeCD Helm chart
```
