### PR TITLE
Publish piped-okd container image to GH package registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,6 +60,13 @@ jobs:
           context: .
           file: cmd/piped/Dockerfile
           tags: ${{ env.REGISTRY }}/pipe-cd/piped:${{ env.PIPECD_VERSION }}
+      - name: Build and push piped-okd image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          push: true
+          context: .
+          file: cmd/piped/Dockerfile-okd
+          tags: ${{ env.REGISTRY }}/pipe-cd/piped-okd:${{ env.PIPECD_VERSION }}
       - name: Build and push launcher image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,3 +1,4 @@
+# pipecd/pipecd-base:0.1.0
 FROM gcr.io/pipecd/pipecd-base@sha256:f3e98a27b85b8ead610c4f93cec8d936c760a43866cf817d32563daf9b198358
 
 ADD .artifacts/pipecd .

--- a/cmd/pipectl/Dockerfile
+++ b/cmd/pipectl/Dockerfile
@@ -1,3 +1,4 @@
+# pipecd/pipectl-base:0.2.0
 FROM gcr.io/pipecd/pipectl-base@sha256:0cf7eacedb0cc8d759248f0e25bd8eddf659de6f2c1db315ac95a272ec2e60cc
 
 ADD .artifacts/pipectl .

--- a/cmd/piped/Dockerfile
+++ b/cmd/piped/Dockerfile
@@ -1,3 +1,4 @@
+# pipecd/piped-base:0.2.2
 FROM gcr.io/pipecd/piped-base@sha256:be303a0bc87480a26ee90c91288d47498e5742e90e7803cc4f2e11bfcbffb118
 
 ADD .artifacts/piped .

--- a/cmd/piped/Dockerfile-okd
+++ b/cmd/piped/Dockerfile-okd
@@ -1,0 +1,6 @@
+# pipecd/piped-base-okd:0.1.0
+FROM gcr.io/pipecd/piped-base-okd@sha256:54f11a2701a5ad8c9d9fbf1f1c3232fa02f30c4fa399c98e7c2df1640fdb4f0d
+
+ADD .artifacts/piped .
+
+ENTRYPOINT ["./piped"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This [one](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/BUILD.bazel#L65-L84) was missing from the last commit.
Therefore this PR fixes that missing.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
