### PR TITLE
Support PodDisruptionBudget

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -77,6 +77,7 @@ const (
 	KindClusterRole              = "ClusterRole"
 	KindClusterRoleBinding       = "ClusterRoleBinding"
 	KindNameSpace                = "NameSpace"
+	KindPodDisruptionBudget      = "PodDisruptionBudget"
 	KindCustomResourceDefinition = "CustomResourceDefinition"
 
 	DefaultNamespace = "default"

--- a/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go
@@ -47,6 +47,7 @@ var builtInApiVersions = map[string]struct{}{
 	"networking.k8s.io/v1":                 {},
 	"networking.k8s.io/v1beta1":            {},
 	"node.k8s.io/v1beta1":                  {},
+	"policy/v1":                            {},
 	"policy/v1beta1":                       {},
 	"rbac.authorization.k8s.io/v1":         {},
 	"rbac.authorization.k8s.io/v1beta1":    {},

--- a/pkg/app/piped/cloudprovider/kubernetes/state.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/state.go
@@ -110,6 +110,8 @@ func determineResourceHealth(key ResourceKey, obj *unstructured.Unstructured) (s
 		return determineClusterRoleBindingHealth(obj)
 	case KindNameSpace:
 		return determineNameSpace(obj)
+	case KindPodDisruptionBudget:
+		return determinePodDisruptionBudgetHealth(obj)
 	default:
 		desc = "Unimplemented or unknown resource"
 		return
@@ -533,6 +535,12 @@ func determinePVCHealth(obj *unstructured.Unstructured) (status model.Kubernetes
 }
 
 func determineServiceAccountHealth(obj *unstructured.Unstructured) (status model.KubernetesResourceState_HealthStatus, desc string) {
+	desc = fmt.Sprintf("%q was applied successfully", obj.GetName())
+	status = model.KubernetesResourceState_HEALTHY
+	return
+}
+
+func determinePodDisruptionBudgetHealth(obj *unstructured.Unstructured) (status model.KubernetesResourceState_HealthStatus, desc string) {
 	desc = fmt.Sprintf("%q was applied successfully", obj.GetName())
 	status = model.KubernetesResourceState_HEALTHY
 	return


### PR DESCRIPTION
**What this PR does / why we need it**:
PodDisruptionBudget is not supported to show health status in an application view.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/3526

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Show health status of PodDisruptionBudget resource
```
