### PR TITLE
Fix missing method on the struct notification event

### DIFF
--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -116,6 +116,38 @@ func TestMatch(t *testing.T) {
 					Type:     model.NotificationEventType_EVENT_PIPED_STARTED,
 					Metadata: &model.NotificationEventPipedStarted{},
 				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_CANCELLED,
+					Metadata: &model.NotificationEventDeploymentCancelled{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_WAIT_APPROVAL,
+					Metadata: &model.NotificationEventDeploymentWaitApproval{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+					Metadata: &model.NotificationEventDeploymentTriggerFailed{
+						Application: &model.Application{
+							Name: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+					Metadata: &model.NotificationEventDeploymentTriggerFailed{
+						Application: &model.Application{
+							Name: "canary",
+						},
+					},
+				}: true,
 			},
 		},
 		{

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -185,6 +185,50 @@ func TestMatch(t *testing.T) {
 					Type:     model.NotificationEventType_EVENT_PIPED_STARTED,
 					Metadata: &model.NotificationEventPipedStarted{},
 				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_CANCELLED,
+					Metadata: &model.NotificationEventDeploymentCancelled{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_WAIT_APPROVAL,
+					Metadata: &model.NotificationEventDeploymentWaitApproval{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+					Metadata: &model.NotificationEventDeploymentTriggerFailed{
+						Application: &model.Application{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+					Metadata: &model.NotificationEventDeploymentTriggerFailed{
+						Application: &model.Application{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
 			},
 		},
 	}

--- a/pkg/model/notificationevent.go
+++ b/pkg/model/notificationevent.go
@@ -82,6 +82,30 @@ func (e *NotificationEventDeploymentFailed) GetLabels() map[string]string {
 	return e.Deployment.Labels
 }
 
+func (e *NotificationEventDeploymentCancelled) GetAppName() string {
+	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentCancelled) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
+func (e *NotificationEventDeploymentWaitApproval) GetAppName() string {
+	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentWaitApproval) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
+func (e *NotificationEventDeploymentTriggerFailed) GetAppName() string {
+	return e.Application.Name
+}
+
+func (e *NotificationEventDeploymentTriggerFailed) GetLabels() map[string]string {
+	return e.Application.Labels
+}
+
 func (e *NotificationEventApplicationSynced) GetAppName() string {
 	return e.Application.Name
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When I tried slack notification I found the lack of the feature of filtering notification by labels on 
- EVENT_DEPLOYMENT_CANCELLED
- EVENT_DEPLOYMENT_WAIT_APPROVAL
- EVENT_DEPLOYMENT_TRIGGER_FAILED

I fixed filter by app name as well.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable to filter notification of types: EVENT_DEPLOYMENT_CANCELLED, EVENT_DEPLOYMENT_WAIT_APPROVAL, EVENT_DEPLOYMENT_TRIGGER_FAILED
```
