### PR TITLE
Fix the wrong way to configure datadog key while starting Piped agent

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/adding-an-analysis-provider.md
@@ -49,8 +49,7 @@ The full list of configurable fields are [here](/docs/operator-manual/piped/conf
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](/docs/operator-manual/piped/installation/#installing-on-kubernetes-cluster):
 
+```console
+--set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \
+--set-file secret.data.datadog-application-key={PATH_TO_APPLICATION_KEY_FILE}
 ```
---set-file secret.datadogApiKey.data={PATH_TO_API_KEY_FILE} \
---set-file secret.datadogApplicationKey.data={PATH_TO_APPLICATION_KEY_FILE}
-```
-

--- a/docs/content/en/docs-v0.27.x/operator-manual/piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.27.x/operator-manual/piped/adding-an-analysis-provider.md
@@ -49,8 +49,7 @@ The full list of configurable fields are [here](/docs/operator-manual/piped/conf
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](/docs/operator-manual/piped/installation/#installing-on-kubernetes-cluster):
 
+```console
+--set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \
+--set-file secret.data.datadog-application-key={PATH_TO_APPLICATION_KEY_FILE}
 ```
---set-file secret.datadogApiKey.data={PATH_TO_API_KEY_FILE} \
---set-file secret.datadogApplicationKey.data={PATH_TO_APPLICATION_KEY_FILE}
-```
-

--- a/docs/content/en/docs-v0.30.x/operator-manual/piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.30.x/operator-manual/piped/adding-an-analysis-provider.md
@@ -49,8 +49,7 @@ The full list of configurable fields are [here](/docs/operator-manual/piped/conf
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](/docs/operator-manual/piped/installation/#installing-on-kubernetes-cluster):
 
+```console
+--set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \
+--set-file secret.data.datadog-application-key={PATH_TO_APPLICATION_KEY_FILE}
 ```
---set-file secret.datadogApiKey.data={PATH_TO_API_KEY_FILE} \
---set-file secret.datadogApplicationKey.data={PATH_TO_APPLICATION_KEY_FILE}
-```
-


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
