### PR TITLE
Revert CloudRun examples to use GCR images

### DIFF
--- a/examples/cloudrun/analysis/service.yaml
+++ b/examples/cloudrun/analysis/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: gcr.io/pipecd/piped:v0.27.4
+        image: gcr.io/pipecd/helloworld:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/analysis/service.yaml
+++ b/examples/cloudrun/analysis/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: ghcr.io/pipe-cd/helloworld:v0.30.0
+        image: gcr.io/pipecd/piped:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/canary/service.yaml
+++ b/examples/cloudrun/canary/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: gcr.io/pipecd/piped:v0.27.4
+        image: gcr.io/pipecd/helloworld:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/canary/service.yaml
+++ b/examples/cloudrun/canary/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: ghcr.io/pipe-cd/helloworld:v0.30.0
+        image: gcr.io/pipecd/piped:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/secret-management/service.yaml
+++ b/examples/cloudrun/secret-management/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
           - server
-        image: gcr.io/pipecd/piped:v0.27.4
+        image: gcr.io/pipecd/helloworld:v0.27.4
         env:
           - name: KEY
             value: "{{ .encryptedSecrets.key }}"

--- a/examples/cloudrun/secret-management/service.yaml
+++ b/examples/cloudrun/secret-management/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
           - server
-        image: ghcr.io/pipe-cd/helloworld:v0.30.0
+        image: gcr.io/pipecd/piped:v0.27.4
         env:
           - name: KEY
             value: "{{ .encryptedSecrets.key }}"

--- a/examples/cloudrun/simple/service.yaml
+++ b/examples/cloudrun/simple/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: gcr.io/pipecd/piped:v0.27.4
+        image: gcr.io/pipecd/helloworld:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/simple/service.yaml
+++ b/examples/cloudrun/simple/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: ghcr.io/pipe-cd/helloworld:v0.30.0
+        image: gcr.io/pipecd/piped:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/wait-approval/service.yaml
+++ b/examples/cloudrun/wait-approval/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: gcr.io/pipecd/piped:v0.27.4
+        image: gcr.io/pipecd/helloworld:v0.27.4
         ports:
         - containerPort: 9085
         resources:

--- a/examples/cloudrun/wait-approval/service.yaml
+++ b/examples/cloudrun/wait-approval/service.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - args:
         - server
-        image: ghcr.io/pipe-cd/helloworld:v0.30.0
+        image: gcr.io/pipecd/piped:v0.27.4
         ports:
         - containerPort: 9085
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

In the last PR, I updated all examples to use GHCR container images, but unfortunately, Google CloudRun only allows using GCR images so this PR reverts the changes.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
