### PR TITLE
Fix agent chart to use correct image when starting with launcher

### DIFF
--- a/cmd/launcher/Dockerfile
+++ b/cmd/launcher/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.15
+# pipecd/piped-base:0.2.2
+FROM gcr.io/pipecd/piped-base@sha256:be303a0bc87480a26ee90c91288d47498e5742e90e7803cc4f2e11bfcbffb118
 
 ADD .artifacts/launcher /usr/local/bin/pipecd/launcher
 

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -22,18 +22,16 @@ spec:
       serviceAccountName: {{ include "piped.serviceAccountName" . }}
       containers:
         - name: piped
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           {{- if .Values.launcher.enabled }}
-          command:
-            - /launcher
-          {{- end }}
+          image: "{{ .Values.launcher.image.repository }}:{{ .Chart.AppVersion }}"
           args:
-            {{- if .Values.launcher.enabled }}
-              {{- include "piped.launcherArgs" . | nindent 12 }}
-            {{- else }}
-              {{- include "piped.pipedArgs" . | nindent 12 }}
-            {{- end }}
+            {{- include "piped.launcherArgs" . | nindent 12 }}
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          args:
+            {{- include "piped.pipedArgs" . | nindent 12 }}
+          {{- end }}
           ports:
             - name: admin
               containerPort: 9085

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -13,6 +13,8 @@ args:
 
 launcher:
   enabled: false
+  image:
+    repository: ghcr.io/pipe-cd/launcher
   configFromGitRepo:
     # Whether to load Piped config that is being stored in a git repository.
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Before with Bazel, we published the same image for both Piped and Launcher but after removing Bazel they were built and published separately.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
