### PR TITLE
Submit application description on add application

### DIFF
--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -70,6 +70,7 @@ func (a *applicationCollection) Decode(e interface{}, parts map[Shard][]byte) er
 	var (
 		kind           model.ApplicationKind
 		name           string
+		desc           string
 		pipedId        string
 		configFilename string
 		cloudProvider  string
@@ -94,14 +95,17 @@ func (a *applicationCollection) Decode(e interface{}, parts map[Shard][]byte) er
 		// Values of below fields from AgentShard have a higher priority:
 		// - Kind
 		// - Name
+		// - Description
 		if shard == AgentShard {
 			kind = app.Kind
 			name = app.Name
+			desc = app.Description
 		}
 	}
 
 	app.Kind = kind
 	app.Name = name
+	app.Description = desc
 	app.PipedId = pipedId
 	app.CloudProvider = cloudProvider
 	app.GitPath.ConfigFilename = configFilename
@@ -132,8 +136,9 @@ func (a *applicationCollection) Encode(e interface{}) (map[Shard][]byte, error) 
 		UpdatedAt: me.UpdatedAt,
 		// Fields which exist in both AgentShard and ClientShard but AgentShard has
 		// a higher priority since those fields can only be updated by PipedCommander.
-		Kind: me.Kind,
-		Name: me.Name,
+		Kind:        me.Kind,
+		Name:        me.Name,
+		Description: me.Description,
 		// Fields which exist in both AgentShard and ClientShard but ClientShard has
 		// a higher priority since those fields can only be updated by WebCommander.
 		PipedId:       me.PipedId,
@@ -158,15 +163,15 @@ func (a *applicationCollection) Encode(e interface{}) (map[Shard][]byte, error) 
 		UpdatedAt: me.UpdatedAt,
 		// Fields which exist in both AgentShard and ClientShard but AgentShard has
 		// a higher priority since those fields can only be updated by PipedCommander.
-		Kind: me.Kind,
-		Name: me.Name,
+		Kind:        me.Kind,
+		Name:        me.Name,
+		Description: me.Description,
 		// Fields which exist in both AgentShard and ClientShard but ClientShard has
 		// a higher priority since those fields can only be updated by WebCommander.
 		PipedId:       me.PipedId,
 		GitPath:       me.GitPath,
 		CloudProvider: me.CloudProvider,
 		// Fields which exist only in AgentShard.
-		Description:                      me.Description,
 		Labels:                           me.Labels,
 		SyncState:                        me.SyncState,
 		Deploying:                        me.Deploying,

--- a/web/src/components/application-form/index.tsx
+++ b/web/src/components/application-form/index.tsx
@@ -308,6 +308,7 @@ export interface ApplicationFormValue {
     branch: string;
   };
   labels: Array<[string, string]>;
+  description: string;
 }
 
 export type ApplicationFormProps = FormikProps<ApplicationFormValue> & {
@@ -329,6 +330,7 @@ export const emptyFormValues: ApplicationFormValue = {
     branch: "",
   },
   labels: new Array<[string, string]>(),
+  description: "",
 };
 
 export const ApplicationForm: FC<ApplicationFormProps> = memo(
@@ -631,6 +633,7 @@ const SelectFromSuggestionsForm: FC<ApplicationFormProps> = memo(
       kind: ApplicationKind.KUBERNETES,
       cloudProvider: "",
       labels: new Array<[string, string]>(),
+      description: "",
     });
 
     const handleFilterChange = useCallback(
@@ -769,6 +772,7 @@ const SelectFromSuggestionsForm: FC<ApplicationFormProps> = memo(
                   kind: selectedApp.kind,
                   cloudProvider: selectedCloudProvider,
                   labels: selectedApp.labelsMap,
+                  description: selectedApp.description,
                 });
                 setShowConfirm(true);
               }}

--- a/web/src/components/applications-page/edit-application-drawer/index.tsx
+++ b/web/src/components/applications-page/edit-application-drawer/index.tsx
@@ -42,7 +42,7 @@ export const EditApplicationDrawer: FC<EditApplicationDrawerProps> = memo(
             configFilename: app.gitPath?.configFilename || "",
             cloudProvider: app.cloudProvider,
             labels: app.labelsMap,
-            description: app.description,
+            description: app.description || "",
           }
         : emptyFormValues,
       validationSchema,

--- a/web/src/components/applications-page/edit-application-drawer/index.tsx
+++ b/web/src/components/applications-page/edit-application-drawer/index.tsx
@@ -42,6 +42,7 @@ export const EditApplicationDrawer: FC<EditApplicationDrawerProps> = memo(
             configFilename: app.gitPath?.configFilename || "",
             cloudProvider: app.cloudProvider,
             labels: app.labelsMap,
+            description: app.description,
           }
         : emptyFormValues,
       validationSchema,

--- a/web/src/modules/applications/index.ts
+++ b/web/src/modules/applications/index.ts
@@ -102,6 +102,7 @@ export const addApplication = createAsyncThunk<
     kind: ApplicationKind;
     cloudProvider: string;
     labels: Array<[string, string]>;
+    description: string;
   }
 >(`${MODULE_NAME}/add`, async (props) => {
   const { applicationId } = await applicationsAPI.addApplication({
@@ -116,7 +117,7 @@ export const addApplication = createAsyncThunk<
     },
     cloudProvider: props.cloudProvider,
     kind: props.kind,
-    description: "",
+    description: props.description,
     labelsMap: props.labels,
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, even the description was available in the application configuration file; if we added the application via the web console, the application description would not be reflected until the next deployment. The root cause of this issue is that the description field is only available in `AgentShard`, which is only updated by piped, not the web console. This PR adds the description field of the application model to both AgentShard and ClientShard so that adding the application via web console also reflects its description to the database.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bugs that application description does not be reflected when adding application via web console
```
