### PR TITLE
Fix linebreak follow common mark convention

### DIFF
--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -320,7 +320,7 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
             display="flex"
           >
             <ReactMarkdown linkTarget="_blank" className={classes.markdown}>
-              {description || "No description."}
+              {description}
             </ReactMarkdown>
           </Box>
         )}

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -184,6 +184,7 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
 
     const piped = useAppSelector(selectPipedById(app?.pipedId));
     const isSyncing = useIsSyncingApplication(app?.id);
+    const description = app?.description.replace(/\\\n/g, "  \n");
 
     const handleSync = (index: number): void => {
       if (app) {
@@ -319,7 +320,7 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
             display="flex"
           >
             <ReactMarkdown linkTarget="_blank" className={classes.markdown}>
-              {app.description}
+              {description || "No description."}
             </ReactMarkdown>
           </Box>
         )}


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, I added
- logic to show `No description.` text in case the application configuration does not contain any description value.
- logic to convert hard line break with `\` (follow commonMark convention) to markdown best practice hard line break (with two or more spaces at the end of line)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
