### PR TITLE
Fix wrong path to Helm values file in the quickstart

### DIFF
--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -20,7 +20,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ``` console
 helm install pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} \
   --namespace pipecd --create-namespace \
-  --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
+  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
 ```
 
 Once installed, use `kubectl port-forward` to expose the web console on your localhost:

--- a/docs/content/en/docs-v0.30.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.30.x/quickstart/_index.md
@@ -20,7 +20,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ``` console
 helm install pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} \
   --namespace pipecd --create-namespace \
-  --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
+  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
 ```
 
 Once installed, use `kubectl port-forward` to expose the web console on your localhost:

--- a/docs/content/en/docs-v0.31.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.31.x/quickstart/_index.md
@@ -20,7 +20,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ``` console
 helm install pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} \
   --namespace pipecd --create-namespace \
-  --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
+  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
 ```
 
 Once installed, use `kubectl port-forward` to expose the web console on your localhost:

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -20,7 +20,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ``` console
 helm install pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} \
   --namespace pipecd --create-namespace \
-  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
+  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
 ```
 
 Once installed, use `kubectl port-forward` to expose the web console on your localhost:

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -20,7 +20,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ``` console
 helm install pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} \
   --namespace pipecd --create-namespace \
-  --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
+  --values https://raw.githubusercontent.com/pipe-cd/pipecd/{< blocks/latest_version >}}/quickstart/control-plane-values.yaml
 ```
 
 Once installed, use `kubectl port-forward` to expose the web console on your localhost:


### PR DESCRIPTION
**What this PR does / why we need it**:

I fixed quick start guide.
`https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/control-plane-values.yaml` is incorrect path. (404)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
None
```
