### PR TITLE
Adjust `Deployed By` field in application list

### DIFF
--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: 150,
     overflow: "hidden",
     textOverflow: "ellipsis",
-    whiteSpace: "nowrap"
+    whiteSpace: "nowrap",
   },
   linkIcon: {
     fontSize: 16,

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   deployedBy: {
-    maxWidth: 200,
+    maxWidth: 150,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap"

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -47,8 +47,10 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   deployedBy: {
-    maxWidth: 300,
-    wordBreak: "break-word",
+    maxWidth: 200,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap"
   },
   linkIcon: {
     fontSize: 16,


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adjust maximum width of Deployed By field
- Omit the long Deployed By field value with ellipsis

<img width="1572" src="https://user-images.githubusercontent.com/26561120/169768805-b86ab03c-83d8-4743-8c72-3a8662914975.png">


**Which issue(s) this PR fixes**:

Fixes #3031 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Adjust `Deployed By` field width and add ellipsis to a long value
```
