### PR TITLE
Fix to return ErrBranchNotFresh when git push failed because some refs were not updated

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	ErrNoChange    = errors.New("no change")
-	ErrForceNeeded = errors.New("some refs were not updated")
+	ErrNoChange       = errors.New("no change")
+	ErrBranchNotFresh = errors.New("some refs were not updated")
 )
 
 // Repo provides functions to get and handle git data.
@@ -211,7 +211,7 @@ func (r *repo) Push(ctx context.Context, branch string) error {
 	}
 	msg := string(out)
 	if strings.Contains(msg, "failed to push some refs to") {
-		return ErrForceNeeded
+		return ErrBranchNotFresh
 	}
 	return formatCommandError(err, out)
 }

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -209,8 +209,7 @@ func (r *repo) Push(ctx context.Context, branch string) error {
 	if err == nil {
 		return nil
 	}
-	msg := string(out)
-	if strings.Contains(msg, "failed to push some refs to") {
+	if strings.Contains(string(out), "failed to push some refs to") {
 		return ErrBranchNotFresh
 	}
 	return formatCommandError(err, out)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `ErrBranchNotFresh` variable to enable to handle whether running `git pull` again is required or not from the caller.

**Which issue(s) this PR fixes**:
https://github.com/pipe-cd/pipecd/issues/3605

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
