### PR TITLE
Fix to retry when the error failed to push some ref occurred

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -242,9 +242,10 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		firstRead = false
 	}
 	var (
-		handledEvents  = make([]*pipedservice.ReportEventStatusesRequest_Event, 0, len(eventCfgs))
-		outDatedEvents = make([]*pipedservice.ReportEventStatusesRequest_Event, 0)
-		maxTimestamp   int64
+		handledEvents    = make([]*pipedservice.ReportEventStatusesRequest_Event, 0, len(eventCfgs))
+		outDatedEvents   = make([]*pipedservice.ReportEventStatusesRequest_Event, 0)
+		maxTimestamp     int64
+		outDatedDuration = time.Hour
 	)
 	for _, e := range eventCfgs {
 		notHandledEvents := w.eventLister.ListNotHandled(e.Name, e.Labels, milestone+1, numToMakeOutdated)
@@ -280,6 +281,14 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 				})
 				continue
 			}
+		}
+		if time.Since(time.Unix(latestEvent.CreatedAt, 0)) > outDatedDuration {
+			outDatedEvents = append(outDatedEvents, &pipedservice.ReportEventStatusesRequest_Event{
+				Id:                latestEvent.Id,
+				Status:            model.EventStatus_EVENT_OUTDATED,
+				StatusDescription: fmt.Sprintf("Too much time has passed since the event %q was created", latestEvent.Id),
+			})
+			continue
 		}
 		if err := w.commitFiles(ctx, latestEvent.Data, e, tmpRepo, commitMsg); err != nil {
 			w.logger.Error("failed to commit outdated files", zap.Error(err))
@@ -319,6 +328,11 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 			return fmt.Errorf("failed to report event statuses: %w", err)
 		}
 		w.milestoneMap.Store(repoID, maxTimestamp)
+		return nil
+	}
+
+	if err == git.ErrBranchNotFresh {
+		w.logger.Warn("failed to push commits", zap.Error(err))
 		return nil
 	}
 

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -331,7 +331,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		return nil
 	}
 
-	// If push fails because the branch is not fresh, retries to updateVelues in the next interval.
+	// If push fails because the local branch was not fresh, exit to retry again in the next interval.
 	if err == git.ErrBranchNotFresh {
 		w.logger.Warn("failed to push commits", zap.Error(err))
 		return nil

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -331,12 +331,13 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		return nil
 	}
 
+	// If push fails because the branch is not fresh, retries to updateVelues in the next interval.
 	if err == git.ErrBranchNotFresh {
 		w.logger.Warn("failed to push commits", zap.Error(err))
 		return nil
 	}
 
-	// If push fails, re-set all statuses to FAILURE.
+	// If push fails because of the other reason, re-set all statuses to FAILURE.
 	for i := range handledEvents {
 		if handledEvents[i].Status == model.EventStatus_EVENT_FAILURE {
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to retry when the error failed to push some ref occurred because the local branch was not updated.
If that error occurred, it returns nil after displaying a warning log.

**Which issue(s) this PR fixes**:
https://github.com/pipe-cd/pipecd/issues/3605

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
