### PR TITLE
Unify workload name as command name in Makefile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: build
 
 on:
   push:
@@ -15,7 +15,6 @@ env:
 
 jobs:
   go:
-    name: Go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +25,6 @@ jobs:
         run: make build/go
 
   web:
-    name: Web
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,7 +47,6 @@ jobs:
         run: make build/web
 
   chart:
-    name: Helm Chart
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,11 +1,6 @@
-name: CodeQL
+name: codeql
 
 on:
-#   push:
-#     branches: [ master ]
-#   pull_request:
-#     # The branches below must be a subset of the branches above
-#     branches: [ master ]
   schedule:
     - cron: '00 5 * * 1'
 
@@ -17,39 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go', 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+    - uses: actions/checkout@v2
+    - uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
+    - uses: github/codeql-action/autobuild@v1
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -1,4 +1,4 @@
-name: Gen
+name: gen
 
 on:
   pull_request:
@@ -6,7 +6,6 @@ on:
 
 jobs:
   code:
-    name: Validate Generated Code
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -23,7 +22,6 @@ jobs:
       run: test -z "$(git status --porcelain)"
 
   docs:
-    name: Validate Generated Docs
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,9 +1,9 @@
-name: Labeler
+name: labeler
 on:
 - pull_request_target
 
 jobs:
-  triage:
+  assign:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: lint
 
 on:
   push:
@@ -13,7 +13,6 @@ env:
 
 jobs:
   go:
-    name: Go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +20,6 @@ jobs:
         run: make lint/go
 
   web:
-    name: Web
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: publish
 
 on:
   push:
@@ -13,7 +13,6 @@ env:
 
 jobs:
   artifacts:
-    name: Artifacts
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,61 +132,3 @@ jobs:
           event-name: helm-release
           labels: helmRepo=pipecd
           data: ${{ env.PIPECD_VERSION }}
-
-  site:
-    name: Site Artifacts
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Determine version
-        run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6 #v2.5.0
-        with:
-          hugo-version: '0.92.1'
-          extended: true
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      # Build site.
-      - name: Build site
-        run: |
-          cd docs
-          npm install autoprefixer
-          npm install postcss-cli
-          env HUGO_ENV="production" RELEASE="$(cut -c10- ../release/RELEASE)" hugo
-
-      # Building and pushing container images.
-      - name: Log in to the container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push site image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: docs
-          file: docs/Dockerfile
-          tags: ${{ env.REGISTRY }}/pipe-cd/site:${{ env.PIPECD_VERSION }}
-
-      # Building and pushing Helm charts.
-      - name: Install helm
-        uses: Azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-      - name: Login to OCI using Helm
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.REGISTRY }} --username ${{ github.repository_owner }} --password-stdin
-      - name: Publish site chart
-        run: |
-          make build/chart MOD=site VERSION=${{ env.PIPECD_VERSION }}
-          helm push .artifacts/site-${{ env.PIPECD_VERSION }}.tgz oci://${{ env.REGISTRY }}/pipe-cd/chart

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -1,0 +1,68 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  HELM_VERSION: 3.8.2
+
+jobs:
+  site:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine version
+        run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6 #v2.5.0
+        with:
+          hugo-version: '0.92.1'
+          extended: true
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      # Build site.
+      - name: Build site
+        run: |
+          cd docs
+          npm install autoprefixer
+          npm install postcss-cli
+          env HUGO_ENV="production" RELEASE="$(cut -c10- ../release/RELEASE)" hugo
+
+      # Building and pushing container images.
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push site image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          push: true
+          context: docs
+          file: docs/Dockerfile
+          tags: ${{ env.REGISTRY }}/pipe-cd/site:${{ env.PIPECD_VERSION }}
+
+      # Building and pushing Helm charts.
+      - name: Install helm
+        uses: Azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - name: Login to OCI using Helm
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.REGISTRY }} --username ${{ github.repository_owner }} --password-stdin
+      - name: Publish site chart
+        run: |
+          make build/chart MOD=site VERSION=${{ env.PIPECD_VERSION }}
+          helm push .artifacts/site-${{ env.PIPECD_VERSION }}.tgz oci://${{ env.REGISTRY }}/pipe-cd/chart

--- a/.github/workflows/publish_tag.yaml
+++ b/.github/workflows/publish_tag.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: publish
 
 on:
   push:
@@ -10,13 +10,11 @@ env:
 
 jobs:
   gh_release:
-    name: GitHub Release
     runs-on: ubuntu-latest
     steps:
       - run: echo "not implemented"
 
   binary:
-    name: Binary
     runs-on: ubuntu-latest
     needs: gh_release
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: test
 
 on:
   push:
@@ -14,7 +14,6 @@ env:
 
 jobs:
   go:
-    name: Go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +24,6 @@ jobs:
         run: make test/go
 
   web:
-    name: Web
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +46,6 @@ jobs:
         run: make test/web
 
   integration:
-    name: Integration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: test
 
 on:
   push:
@@ -17,8 +17,7 @@ env:
   NODE_VERSION: 16.13.0
 
 jobs:
-  backend:
-    name: Tool
+  tool:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors workflow directory:
- rename workloads as same as command names in Makefile
- split publish_site to a separate file

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
