### PR TITLE
Add workflow to build and push tool images

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -1,0 +1,51 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - tool/**
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  tool:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine version
+        run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
+
+      - name: Build actions-gh-release image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/actions-gh-release
+          tags: ${{ env.REGISTRY }}/pipe-cd/actions-gh-release:${{ env.PIPECD_VERSION }}
+
+      - name: Build actions-plan-preview image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/actions-plan-preview
+          tags: ${{ env.REGISTRY }}/pipe-cd/actions-plan-preview:${{ env.PIPECD_VERSION }}
+
+      - name: Build codegen image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/codegen
+          tags: ${{ env.REGISTRY }}/pipe-cd/codegen:${{ env.PIPECD_VERSION }}
+
+      - name: Build piped-base image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/piped-base
+          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base:${{ env.PIPECD_VERSION }}
+
+      - name: Build piped-base-okd image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/piped-base-okd
+          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - tool/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -1,0 +1,58 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - tool/**
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  tool:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine version
+        run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
+
+      - name: Build and push actions-gh-release image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/actions-gh-release
+          tags: ${{ env.REGISTRY }}/pipe-cd/actions-gh-release:${{ env.PIPECD_VERSION }}
+          push: true
+
+      - name: Build and push actions-plan-preview image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/actions-plan-preview
+          tags: ${{ env.REGISTRY }}/pipe-cd/actions-plan-preview:${{ env.PIPECD_VERSION }}
+          push: true
+
+      - name: Build and push codegen image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/codegen
+          tags: ${{ env.REGISTRY }}/pipe-cd/codegen:${{ env.PIPECD_VERSION }}
+          push: true
+
+      - name: Build and push piped-base image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/piped-base
+          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base:${{ env.PIPECD_VERSION }}
+          push: true
+
+      - name: Build and push piped-base-okd image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/piped-base-okd
+          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}
+          push: true

--- a/tool/actions-gh-release/DOCKER_BUILD
+++ b/tool/actions-gh-release/DOCKER_BUILD
@@ -1,2 +1,0 @@
-version: 2.3.4
-registry: gcr.io/pipecd/actions-gh-release

--- a/tool/actions-plan-preview/DOCKER_BUILD
+++ b/tool/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,0 @@
-version: 1.8.0
-registry: gcr.io/pipecd/actions-plan-preview

--- a/tool/codegen/DOCKER_BUILD
+++ b/tool/codegen/DOCKER_BUILD
@@ -1,2 +1,0 @@
-version: 0.8.0
-registry: gcr.io/pipecd/codegen

--- a/tool/piped-base-okd/DOCKER_BUILD
+++ b/tool/piped-base-okd/DOCKER_BUILD
@@ -1,2 +1,0 @@
-version: 0.1.0
-registry: gcr.io/pipecd/piped-base-okd

--- a/tool/piped-base/DOCKER_BUILD
+++ b/tool/piped-base/DOCKER_BUILD
@@ -1,2 +1,0 @@
-version: 0.3.0
-registry: gcr.io/pipecd/piped-base


### PR DESCRIPTION
**What this PR does / why we need it**:

This uses GitHub actions to build and publish the images of our tools.
And those image versions also be configured to be the same as the PipeCD version number.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
