### PR TITLE
Fix not to return an error when the data point of metrics was empty

### DIFF
--- a/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
+++ b/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
@@ -129,9 +129,6 @@ func (p *Provider) QueryPoints(ctx context.Context, query string, queryRange met
 	if httpResp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected HTTP status code from %s: %d", httpResp.Request.URL, httpResp.StatusCode)
 	}
-	if resp.Series == nil || len(*resp.Series) == 0 {
-		return nil, fmt.Errorf("no query metadata found: %w", metrics.ErrNoDataFound)
-	}
 
 	// Collect data points given by the provider.
 	var size int

--- a/pkg/app/piped/executor/analysis/metrics_analyzer.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer.go
@@ -354,7 +354,11 @@ func (a *metricsAnalyzer) analyzeWithCanaryPrimary(ctx context.Context) (bool, e
 
 // compare compares the given two samples using Mann-Whitney U test.
 // Considered as failure if it deviates in the specified direction as the third argument.
+// If both of the point values is empty, this returns true.
 func compare(experiment, control []float64, deviation string) (acceptable bool, err error) {
+	if len(experiment) == 0 && len(control) == 0 {
+		return true, nil
+	}
 	if len(experiment) == 0 {
 		return false, fmt.Errorf("no data points of Experiment found")
 	}

--- a/pkg/app/piped/executor/analysis/metrics_analyzer.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer.go
@@ -361,7 +361,7 @@ func (a *metricsAnalyzer) analyzeWithCanaryPrimary(ctx context.Context) (bool, e
 // If both of the point values is empty, this returns true.
 func (a *metricsAnalyzer) compare(experiment, control []float64, deviation string) (acceptable bool, err error) {
 	if len(experiment) == 0 && len(control) == 0 {
-		a.logPersister.Infof("[%s] The two data points required for comparison is empty, so this analysis is exited", a.id)
+		a.logPersister.Infof("[%s] The analysis stage will be skipped since there was no data point to compare", a.id)
 		return true, nil
 	}
 	if len(experiment) == 0 {

--- a/pkg/app/piped/executor/analysis/metrics_analyzer.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer.go
@@ -137,7 +137,7 @@ func (a *metricsAnalyzer) analyzeWithThreshold(ctx context.Context) (bool, error
 		return false, fmt.Errorf("failed to run query: %w", err)
 	}
 	if len(points) == 0 {
-		a.logPersister.Infof("[%s] The data point of the metrics is empty, so this analysis is exited", a.id)
+		a.logPersister.Infof("[%s] This analysis stage will be skipped since there was no data point to compare", a.id)
 		return true, nil
 	}
 

--- a/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
@@ -138,7 +138,7 @@ func Test_metricsAnalyzer_analyzeWithThreshold(t *testing.T) {
 	}
 }
 
-func Test_compare(t *testing.T) {
+func Test_metricsAnalyzer_compare(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
@@ -147,13 +147,24 @@ func Test_compare(t *testing.T) {
 		deviation  string
 	}
 	testcases := []struct {
-		name         string
-		args         args
-		wantExpected bool
-		wantErr      bool
+		name            string
+		metricsAnalyzer *metricsAnalyzer
+		args            args
+		wantExpected    bool
+		wantErr         bool
 	}{
 		{
 			name: "empty data points given",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{},
 				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
@@ -164,6 +175,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "no significance",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
 				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
@@ -174,6 +195,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "deviation on high direction as expected",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{10.1, 10.2, 10.3, 10.4, 10.5},
 				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
@@ -184,6 +215,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "deviation on low direction as expected",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
 				control:    []float64{10.1, 10.2, 10.3, 10.4, 10.5},
@@ -194,6 +235,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "deviation on high direction as unexpected",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{10.1, 10.2, 10.3, 10.4, 10.5},
 				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
@@ -204,6 +255,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "deviation on low direction as unexpected",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
 				control:    []float64{10.1, 10.2, 10.3, 10.4, 10.5},
@@ -214,6 +275,16 @@ func Test_compare(t *testing.T) {
 		},
 		{
 			name: "deviation as unexpected",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
 			args: args{
 				experiment: []float64{0.1, 0.2, 5.3, 0.2, 0.5},
 				control:    []float64{0.1, 0.1, 0.1, 0.1, 0.1},
@@ -222,10 +293,30 @@ func Test_compare(t *testing.T) {
 			wantExpected: false,
 			wantErr:      false,
 		},
+		{
+			name: "the data points is empty",
+			metricsAnalyzer: &metricsAnalyzer{
+				id: "id",
+				cfg: config.AnalysisMetrics{
+					Provider: "provider",
+					Query:    "query",
+				},
+				provider:     &fakeMetricsProvider{},
+				logger:       zap.NewNop(),
+				logPersister: &fakeLogPersister{},
+			},
+			args: args{
+				experiment: nil,
+				control:    nil,
+				deviation:  "EITHER",
+			},
+			wantExpected: true,
+			wantErr:      false,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := compare(tc.args.experiment, tc.args.control, tc.args.deviation)
+			got, err := tc.metricsAnalyzer.compare(tc.args.experiment, tc.args.control, tc.args.deviation)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.wantExpected, got)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, every analysis stage returns an error if the data point of metrics was empty.
But there are some cases in which this one is empty intentionally.
(ex. the cases in which the user only handles an error log as metrics and so on.)
Hence, I fixed not to return an error when that data was empty.

**Which issue(s) this PR fixes**:
https://github.com/pipe-cd/pipecd/issues/3661

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
