### PR TITLE
Add init container to avoid CrashLoopBackOff error on quickstart mode

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -87,6 +87,7 @@ spec:
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "pipecd.serviceAccountName" . }}
       {{- end }}
+      {{- if .Values.quickstart.enabled }}
       initContainers:
         - name: minio-checker
           image: alpine/curl:3.14
@@ -94,6 +95,7 @@ spec:
         - name: mysql-checker
           image: alpine:3.14
           command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
+      {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy
@@ -237,6 +239,7 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ops
     spec:
+      {{- if .Values.quickstart.enabled }}
       initContainers:
         - name: minio-checker
           image: alpine/curl:3.14
@@ -244,6 +247,7 @@ spec:
         - name: mysql-checker
           image: alpine:3.14
           command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
+      {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -87,6 +87,13 @@ spec:
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "pipecd.serviceAccountName" . }}
       {{- end }}
+      initContainers:
+        - name: minio-checker
+          image: alpine/curl:3.14
+          command: ["sh", "-c", "until curl pipecd-minio:9000; do echo waiting for minio; sleep 1; done"]
+        - name: mysql-checker
+          image: alpine:3.14
+          command: ["sh", "-c", "until nc pipecd-mysql 3306; do echo waiting for mysql; sleep 1; done"]
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy
@@ -230,6 +237,13 @@ spec:
         {{- include "pipecd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ops
     spec:
+      initContainers:
+        - name: minio-checker
+          image: alpine/curl:3.14
+          command: ["sh", "-c", "until curl pipecd-minio:9000; do echo waiting for minio; sleep 1; done"]
+        - name: mysql-checker
+          image: alpine:3.14
+          command: ["sh", "-c", "until nc pipecd-mysql 3306; do echo waiting for mysql; sleep 1; done"]
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -90,10 +90,10 @@ spec:
       initContainers:
         - name: minio-checker
           image: alpine/curl:3.14
-          command: ["sh", "-c", "until curl pipecd-minio:9000; do echo waiting for minio; sleep 1; done"]
+          command: ["sh", "-c", "until curl {{ include "pipecd.fullname" . }}-minio:{{ .Values.minio.port }}; do echo waiting for minio; sleep 2; done"]
         - name: mysql-checker
           image: alpine:3.14
-          command: ["sh", "-c", "until nc pipecd-mysql 3306; do echo waiting for mysql; sleep 1; done"]
+          command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy
@@ -240,10 +240,10 @@ spec:
       initContainers:
         - name: minio-checker
           image: alpine/curl:3.14
-          command: ["sh", "-c", "until curl pipecd-minio:9000; do echo waiting for minio; sleep 1; done"]
+          command: ["sh", "-c", "until curl {{ include "pipecd.fullname" . }}-minio:{{ .Values.minio.port }}; do echo waiting for minio; sleep 2; done"]
         - name: mysql-checker
           image: alpine:3.14
-          command: ["sh", "-c", "until nc pipecd-mysql 3306; do echo waiting for mysql; sleep 1; done"]
+          command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
         - name: cloud-sql-proxy
@@ -335,7 +335,7 @@ spec:
               value: {{ .Values.mysql.database }}
           ports:
             - name: mysql
-              containerPort: 3306
+              containerPort: {{ .Values.mysql.port }}
               protocol: TCP
 {{- if .Values.mysql.resources }}
           resources:
@@ -381,7 +381,7 @@ spec:
                 key: {{ .Values.secret.minioSecretKey.fileName }}
           ports:
             - name: minio
-              containerPort: 9000
+              containerPort: {{ .Values.minio.port }}
               protocol: TCP
 {{- if .Values.minio.resources }}
           resources:

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -89,12 +89,15 @@ spec:
       {{- end }}
       {{- if .Values.quickstart.enabled }}
       initContainers:
-        - name: minio-checker
-          image: alpine/curl:3.14
-          command: ["sh", "-c", "until curl {{ include "pipecd.fullname" . }}-minio:{{ .Values.minio.port }}; do echo waiting for minio; sleep 2; done"]
-        - name: mysql-checker
+        - name: dep-waiter
           image: alpine:3.14
-          command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              until nc -z {{ include "pipecd.fullname" . }}-minio {{ .Values.minio.port }} && nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}
+              do
+                sleep 2;
+              done;
       {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}
@@ -241,12 +244,15 @@ spec:
     spec:
       {{- if .Values.quickstart.enabled }}
       initContainers:
-        - name: minio-checker
-          image: alpine/curl:3.14
-          command: ["sh", "-c", "until curl {{ include "pipecd.fullname" . }}-minio:{{ .Values.minio.port }}; do echo waiting for minio; sleep 2; done"]
-        - name: mysql-checker
+        - name: dep-waiter
           image: alpine:3.14
-          command: ["sh", "-c", "until nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}; do echo waiting for mysql; sleep 2; done"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              until nc -z {{ include "pipecd.fullname" . }}-minio {{ .Values.minio.port }} && nc -z {{ include "pipecd.fullname" . }}-mysql {{ .Values.mysql.port }}
+              do
+                sleep 2;
+              done;
       {{- end }}
       containers:
 {{- if .Values.cloudSQLProxy.enabled }}

--- a/manifests/pipecd/templates/service.yaml
+++ b/manifests/pipecd/templates/service.yaml
@@ -129,7 +129,7 @@ spec:
   type: ClusterIP
   ports:
     - name: service
-      port: 3306
+      port: {{ .Values.mysql.port }}
       targetPort: mysql
   selector:
     {{- include "pipecd.selectorLabels" . | nindent 4 }}
@@ -147,7 +147,7 @@ spec:
   type: ClusterIP
   ports:
     - name: service
-      port: 9000
+      port: {{ .Values.minio.port }}
       targetPort: minio
   selector:
     {{- include "pipecd.selectorLabels" . | nindent 4 }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -67,10 +67,12 @@ cloudSQLProxy:
 mysql:
   imageTag: "8.0.23"
   resources: {}
+  port: 3306
 
 minio:
   imageTag: "RELEASE.2020-08-26T00-00-49Z"
   resources: {}
+  port: 9000
 
 # Control Plane Configurations.
 config:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add init container to Helm chart manifest to avoid CrashLoopBackOff error.

Before:
```
$ kubectl get po
NAME                              READY   STATUS             RESTARTS      AGE
pipecd-cache-6cc858bc44-pcvvp     1/1     Running            0             20s
pipecd-gateway-85658b4584-4k5ks   1/1     Running            0             20s
pipecd-minio-7dd5b8b987-tqb76     1/1     Running            0             20s
pipecd-mysql-84cbf4b587-qm76j     1/1     Running            0             20s
pipecd-ops-8587ff6bf4-4ltkc       0/1     CrashLoopBackOff   1 (18s ago)   20s
pipecd-server-87fcc94c-jv5hk      0/1     CrashLoopBackOff   1 (19s ago)   20s
```

After (no restart):
```
$ kubectl get po
NAME                              READY   STATUS    RESTARTS   AGE
pipecd-cache-6cc858bc44-tjht7     1/1     Running   0          61s
pipecd-gateway-85658b4584-kgfpd   1/1     Running   0          61s
pipecd-minio-7dd5b8b987-jwsfd     1/1     Running   0          61s
pipecd-mysql-84cbf4b587-q6b55     1/1     Running   0          61s
pipecd-ops-76bbd94579-qpgrb       1/1     Running   0          61s
pipecd-server-d5dbc67cb-6pvx7     1/1     Running   0          61s
```

**Which issue(s) this PR fixes**:

Fixes #3665 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
