### PR TITLE
Add link to the PipeCD GitHub repository at the Header

### DIFF
--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -246,7 +246,7 @@ export const Header: FC = memo(function Header() {
           target="_blank"
           rel="noreferrer"
         >
-          Repository
+          GitHub
           <OpenInNew className={classes.iconOpenInNew} />
         </MenuItem>
         <MenuItem disabled={true} dense={true} button={false}>

--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -240,6 +240,15 @@ export const Header: FC = memo(function Header() {
           Documentation
           <OpenInNew className={classes.iconOpenInNew} />
         </MenuItem>
+        <MenuItem
+          component={Link}
+          href="https://github.com/pipe-cd/pipecd"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Repository
+          <OpenInNew className={classes.iconOpenInNew} />
+        </MenuItem>
         <MenuItem disabled={true} dense={true} button={false}>
           {process.env.PIPECD_VERSION}
         </MenuItem>


### PR DESCRIPTION
**What this PR does / why we need it**:

Add link to the PipeCD GitHub repository at the Header

Before
![スクリーンショット 2022-05-25 14 43 00](https://user-images.githubusercontent.com/26561120/170190785-c7408fb4-7d0b-4715-94ad-a094b93165d9.png)

After
![スクリーンショット 2022-05-25 15 02 58](https://user-images.githubusercontent.com/26561120/170191077-99c05202-78c5-4006-a4de-b948023abb42.png)

**Which issue(s) this PR fixes**:

Fixes #906

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add link to the PipeCD GitHub repository at the Header
```
