### PR TITLE
Add error message to GetInsightData API

### DIFF
--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -1434,7 +1434,7 @@ func (a *WebAPI) ListAPIKeys(ctx context.Context, req *webservice.ListAPIKeysReq
 
 // GetInsightData returns the accumulated insight data.
 func (a *WebAPI) GetInsightData(ctx context.Context, req *webservice.GetInsightDataRequest) (*webservice.GetInsightDataResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	return nil, status.Error(codes.Unimplemented, "GetInsightData API is not yet implemented.")
 
 	// claims, err := rpcauth.ExtractClaims(ctx)
 	// if err != nil {

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -1434,7 +1434,7 @@ func (a *WebAPI) ListAPIKeys(ctx context.Context, req *webservice.ListAPIKeysReq
 
 // GetInsightData returns the accumulated insight data.
 func (a *WebAPI) GetInsightData(ctx context.Context, req *webservice.GetInsightDataRequest) (*webservice.GetInsightDataResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetInsightData API is not yet implemented.")
+	return nil, status.Error(codes.Unimplemented, "Not available")
 
 	// claims, err := rpcauth.ExtractClaims(ctx)
 	// if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add "GetInsightData API is not yet implemented" error message to GetInsightData API.

Before
![image](https://user-images.githubusercontent.com/26561120/170913125-d90d30e4-5a94-425d-8a78-e7dc3eb11d39.png)

After
![スクリーンショット 2022-05-30 12 40 07](https://user-images.githubusercontent.com/26561120/170913141-6fa92c6a-06f5-4f1e-b10b-92c641450d49.png)


**Which issue(s) this PR fixes**:

Fixes #3650 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
