### PR TITLE
Remove google-cloud-sdk-324.0.0-linux-x86.tar.gz from pipecd base image

### DIFF
--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -8,6 +8,7 @@ RUN \
         curl && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
     tar -zxvf ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
+    rm ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
     ./google-cloud-sdk/install.sh --quiet
 
 ENV PATH="/google-cloud-sdk/bin:${PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `rm` command to remove used tar file.

```
# BEFORE
$ kubectl exec -it pipecd-server-99885cc9f-x9xlq -- ls
bin                                        proc
dev                                        root
etc                                        run
google-cloud-sdk                           sbin
google-cloud-sdk-324.0.0-linux-x86.tar.gz  srv
home                                       sys
lib                                        tmp
media                                      usr
mnt                                        var
opt                                        web

# AFTER
# google-cloud-sdk-324.0.0-linux-x86.tar.gz is removed
$ kubectl exec -it pipecd-server-ddb5747c9-2m6q4 -- ls
bin               lib               root              tmp
dev               media             run               usr
etc               mnt               sbin              var
google-cloud-sdk  opt               srv               web
home              proc              sys
```

**Which issue(s) this PR fixes**:

Fixes #3558

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
