### PR TITLE
Fix left sidebar ui on settings page

### DIFF
--- a/web/src/components/settings-page/index.tsx
+++ b/web/src/components/settings-page/index.tsx
@@ -4,7 +4,6 @@ import {
   ListItem,
   ListItemText,
   makeStyles,
-  Toolbar,
 } from "@material-ui/core";
 import { FC, memo } from "react";
 import { NavLink, Redirect, Route, Switch } from "react-router-dom";
@@ -31,6 +30,7 @@ const useStyles = makeStyles((theme) => ({
     flexShrink: 0,
   },
   drawerPaper: {
+    top: "auto",
     width: drawerWidth,
   },
   drawerContainer: {
@@ -64,7 +64,6 @@ export const SettingsIndexPage: FC = memo(function SettingsIndexPage() {
         variant="permanent"
         classes={{ paper: classes.drawerPaper }}
       >
-        <Toolbar variant="dense" />
         <div className={classes.drawerContainer}>
           <List>
             {MENU_ITEMS.map(([text, link]) => (


### PR DESCRIPTION
**What this PR does / why we need it**:

with warning banner
![Screen Shot 2022-05-30 at 16 09 37](https://user-images.githubusercontent.com/32532742/170959220-e186577e-9bac-4cc9-9478-99670dd87a3d.png)

without warning banner
![Screen Shot 2022-05-30 at 16 12 44](https://user-images.githubusercontent.com/32532742/170959196-5114ad68-729d-45dc-abc0-8cc0ec2a92d6.png)


**Which issue(s) this PR fixes**:

Fixes #3695

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
