### PR TITLE
Update landing page

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -6,9 +6,17 @@
     }
 }
 
+@media screen and (min-width: 1000px) {
+    .lp-cover-container {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+    }
+}
+
 .headline {
     font-size: 1.5rem;
-    margin-bottom: 5px;
+    font-weight: 600;
+    margin-bottom: 25px;
 }
 
 .description {
@@ -16,6 +24,7 @@
 }
 
 .long-description {
+    font-weight: 600;
     color: $gray-500;
     margin-bottom: 2.5rem;
 }
@@ -44,7 +53,7 @@
 .release-panel {
     padding: 0 1.5rem;
     display: inline-block;
-    line-height: 4.25rem;
+    line-height: 3.5rem;
     text-align: center;
     min-width: 4.5rem;
     border-radius: .5rem;

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -4,10 +4,13 @@ linkTitle = "PipeCD"
 
 +++
 
-{{< blocks/cover description="Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications" height="med" image_anchor="top" color="primary" >}}
+{{< blocks/cover height="med" image_anchor="top" color="primary" >}}
 <div class="container">
+    <p class="headline">
+        The One CD for All {applications, platforms, operations}
+    </p>
     <p class="h5 long-description">
-        A unified continuous delivery solution for multiple application kinds on multi-cloud that empowers engineers to deploy faster with more confidence. A GitOps tool that enables doing deployment operations by pull request on Git.
+        A GitOps style continuous delivery platform that provides <br/> consistent deployment and operations experience for any applications
     </p>
 </div>
 
@@ -28,7 +31,6 @@ linkTitle = "PipeCD"
 		PipeCD <span class="bolder">{{< blocks/latest_version >}}</span> is now available
 	</a>
 </div>
-
 {{< /blocks/cover >}}
 
 <div class="row justify-content-md-center">

--- a/docs/content/ja/_index.html
+++ b/docs/content/ja/_index.html
@@ -6,12 +6,18 @@ linkTitle = "PipeCD"
 
 {{< blocks/cover description="Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications" height="med" image_anchor="top" color="primary" >}}
 <div class="container">
+    <p class="headline">
+        The One CD for All {applications, platforms, operations}
+    </p>
     <p class="h5 long-description">
-        A unified continuous delivery solution for multiple application kinds on multi-cloud that empowers engineers to deploy faster with more confidence. A GitOps tool that enables doing deployment operations by pull request on Git.
+        A GitOps style continuous delivery platform that provides <br/> consistent deployment and operations experience for any applications
     </p>
 </div>
 
 <div class="mx-auto">
+	<a class="btn btn-lg btn-primary mr-3 mb-4" target="_blank" href="https://play.pipecd.dev?project=play">
+		Live Demo <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	</a>
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>

--- a/docs/layouts/shortcodes/blocks/cover.html
+++ b/docs/layouts/shortcodes/blocks/cover.html
@@ -11,29 +11,23 @@
   <div class="container td-overlay__inner">
     <div class="row">
       <div class="col-12">
-        <div class="text-center">
-            <h1 class="display-1 mt-0 mt-md-5 pb-4">
-              {{ with $logo_image }}
-              {{ $logo_image_resized := (.Fit (printf "320x159 %s" $logo_anchor)) }}
-              {{ $logo_image_resized_1_5x := (.Fit (printf "480x238 %s" $logo_anchor)) }}
-              {{ $logo_image_resized_2x := (.Fit (printf "640x318 %s" $logo_anchor)) }}
-                <img 
-                  class="td-cover-logo"
-                  src="{{ $logo_image_resized.RelPermalink }}"
-                  width="320"
-                  height="159"
-                  srcset="{{ $logo_image_resized.RelPermalink }},
-                          {{ $logo_image_resized_1_5x.RelPermalink }} 1.5x,
-                          {{ $logo_image_resized_2x.RelPermalink }} 2x"
-                  alt="PipeCD Logo" >
-              {{ end }}
-            </h1>
-          {{ with .Get "description" }}
-            {{ $description := . }}
-            <p class="headline">
-              {{ $description | html }}
-            </p>
-          {{ end }}
+        <div class="text-center lp-cover-container">
+          <div class="display-1 mt-0 mt-md-5 pb-4">
+            {{ with $logo_image }}
+            {{ $logo_image_resized := (.Fit (printf "320x159 %s" $logo_anchor)) }}
+            {{ $logo_image_resized_1_5x := (.Fit (printf "480x238 %s" $logo_anchor)) }}
+            {{ $logo_image_resized_2x := (.Fit (printf "640x318 %s" $logo_anchor)) }}
+              <img
+                class="td-cover-logo"
+                src="{{ $logo_image_resized.RelPermalink }}"
+                width="320"
+                height="159"
+                srcset="{{ $logo_image_resized.RelPermalink }},
+                        {{ $logo_image_resized_1_5x.RelPermalink }} 1.5x,
+                        {{ $logo_image_resized_2x.RelPermalink }} 2x"
+                alt="PipeCD Logo" >
+            {{ end }}
+          </div>
           {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
           <div class="lead">
             {{ .Inner | markdownify}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the new pipecd vision and statement to the landing page as follow
<img width="1439" alt="Screen Shot 2022-05-31 at 15 16 35" src="https://user-images.githubusercontent.com/32532742/171127692-4c4afa0d-d02f-4846-956a-5fd504d0e89a.png">

The mobile version design has remained as it is currently, only the text is changed.
<img width="348" alt="Screen Shot 2022-05-31 at 15 17 26" src="https://user-images.githubusercontent.com/32532742/171127824-c12708f9-3b11-49f3-ba40-9401acba4c01.png">

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
