### PR TITLE
Uncomment release workflow to avoid GH notification

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,20 @@
-# name: release
+name: release
 
-# on:
-#   push:
-#     branches:    
-#       - master
-#     paths:
-#       - 'RELEASE'
+on:
+  push:
+    branches:    
+      - master
+    paths:
+      - 'RELEASE'
 
-# jobs:
-#   gh-release:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 0
-#       - uses: pipe-cd/actions-gh-release@v2.3.4
-#         with:
-#           release_file: 'RELEASE'
-#           token: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  gh-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # - uses: pipe-cd/actions-gh-release@v2.3.4
+      #   with:
+      #     release_file: 'RELEASE'
+      #     token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

GitHub reports notifications about empty workflow files.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
