### PR TITLE
Optimize the number of workers for plan-preview

### DIFF
--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -40,7 +40,8 @@ import (
 
 const (
 	workspacePattern    = "plan-preview-builder-*"
-	defaultAppWorkerNum = 3
+	defaultWorkerAppNum = 3
+	maxWorkerNum        = 100
 )
 
 var (
@@ -167,9 +168,13 @@ func (b *builder) build(ctx context.Context, id string, cmd model.Command_BuildP
 		appCh    = make(chan *model.Application, numApps)
 		resultCh = make(chan *model.ApplicationPlanPreviewResult, numApps)
 	)
-	numWorkers := defaultAppWorkerNum
-	if numWorkers > numApps {
+	// Optimize the number of workers.
+	numWorkers := numApps / defaultWorkerAppNum
+	if numWorkers < 1 {
 		numWorkers = numApps
+	}
+	if numWorkers > maxWorkerNum {
+		numWorkers = maxWorkerNum
 	}
 
 	// Start some workers to speed up building time.


### PR DESCRIPTION
**What this PR does / why we need it**:
In one project, it took about 4 minutes for one worker to build more than a dozen applications, so workers limit of 3 is a severe limitation.
Hence I have modified to limit the number of applications to three per worker and to finish the build in about one minute in this PR.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
