### PR TITLE
Refine web console UI/UX related to show Piped configuration feature

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "@types/react-dom": "^17.0.3",
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
+    "@types/react-syntax-highlighter": "^15.5.1",
     "@types/redux-mock-store": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
@@ -95,6 +96,7 @@
     "react-markdown": "^6.0.2",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
+    "react-syntax-highlighter": "^15.5.0",
     "redux": "^4.0.5",
     "yup": "^0.32.9"
   }

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -19,8 +19,8 @@ import {
 import { MoreVert as MoreVertIcon } from "@material-ui/icons";
 import clsx from "clsx";
 import dayjs from "dayjs";
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { coy } from "react-syntax-highlighter/dist/esm/styles/prism";
 import * as React from "react";
 import { FC, memo, useCallback, useState } from "react";
 import { CopyIconButton } from "~/components/copy-icon-button";

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -277,7 +277,12 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
         </DialogActions>
       </Dialog>
 
-      <Dialog open={openConfigAlert} onClose={handleAlertClose}>
+      <Dialog
+        fullWidth
+        maxWidth="md"
+        open={openConfigAlert}
+        onClose={handleAlertClose}
+      >
         <DialogTitle>
           <CopyIconButton name="Piped config" value={`${piped.config}`} />
           Piped configuration

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -19,6 +19,8 @@ import {
 import { MoreVert as MoreVertIcon } from "@material-ui/icons";
 import clsx from "clsx";
 import dayjs from "dayjs";
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import * as React from "react";
 import { FC, memo, useCallback, useState } from "react";
 import { CopyIconButton } from "~/components/copy-icon-button";
@@ -288,11 +290,9 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
           Piped configuration
         </DialogTitle>
         <DialogContent>
-          <DialogContentText>
-            <pre>
-              <code>{piped.config}</code>
-            </pre>
-          </DialogContentText>
+          <SyntaxHighlighter language="yaml" style={coy}>
+            {piped.config}
+          </SyntaxHighlighter>
         </DialogContent>
       </Dialog>
     </>

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -255,6 +255,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
             <MenuItem
               key="piped-menu-open-piped-config"
               onClick={handleOpenPipedConfig}
+              disabled={piped.config.length === 0}
             >
               {UI_TEXT_VIEW_THE_CONFIGURATION}
             </MenuItem>,

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3791,6 +3791,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-syntax-highlighter@^15.5.1":
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.1.tgz#0c459cdd94a882df05778e93a1514430cc641043"
+  integrity sha512-+yD6D8y21JqLf89cRFEyRfptVMqo2ROHyAlysRvFwT28gT5gDo3KOiXHwGilHcq9y/OKTjlWK0f/hZUicrBFPQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@>=16.9.0":
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
@@ -8474,6 +8481,11 @@ highlight.js@^10.1.1, highlight.js@~10.4.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.0.tgz#ef3ce475e5dfa7a48484260b49ea242ddab823a0"
   integrity sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==
 
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
 history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -10402,6 +10414,14 @@ lowlight@^1.14.0:
     fault "^1.0.0"
     highlight.js "~10.4.0"
 
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -11996,6 +12016,16 @@ prismjs@^1.21.0, prismjs@~1.22.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
+prismjs@^1.27.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.28.0.tgz#0d8f561fa0f7cf6ebca901747828b149147044b6"
+  integrity sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==
+
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -12546,6 +12576,17 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
+react-syntax-highlighter@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"
+  integrity sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
+
 react-test-renderer@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
@@ -12690,6 +12731,15 @@ refractor@^3.1.0:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
     prismjs "~1.22.0"
+
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Expand dialog width and add syntax highlighter for yaml
![image](https://user-images.githubusercontent.com/26561120/171595703-798fef49-ca90-4682-bbc1-b53db52c5e68.png)


3. Make "Show the configuration" item disabled when piped config hasn't loaded yet.
![image](https://user-images.githubusercontent.com/26561120/171594737-2d5acf05-9e69-4d3b-8dd3-b62411a42fa3.png)

**Which issue(s) this PR fixes**:

Fixes partially #3712 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Refine web console UI/UX related to show Piped configuration feature
```
