### PR TITLE
Support the event watcher in the app config

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -232,9 +232,6 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 				// Return a last scanned application if there is no new commit pushed from last scanned time for this application.
 				if v, ok := w.lastScannedConfig.Load(app.Id); ok {
 					c := v.(eventWatcherCache)
-					if c.HeadCommit == headCommit.Hash && c.Configs == nil {
-						continue
-					}
 					if c.HeadCommit == headCommit.Hash {
 						cfgs = append(cfgs, c.Configs...)
 						continue

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -204,14 +204,14 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 					cfgs = append(cfgs, cfg)
 				}
 				for _, cfg := range cfgs {
-					if cfg.EventWatchers == nil {
+					if cfg.EventWatcher == nil {
 						w.logger.Info("configuration for Event Watcher in application configuration not found",
 							zap.String("repo-id", repoCfg.RepoID),
 							zap.String("app-name", cfg.Name),
 						)
 						continue
 					}
-					if err := w.execute(ctx, repo, repoCfg.RepoID, cfg.EventWatchers); err != nil {
+					if err := w.execute(ctx, repo, repoCfg.RepoID, cfg.EventWatcher); err != nil {
 						w.logger.Error("failed to execute the event from application configuration",
 							zap.String("repo-id", repoCfg.RepoID),
 							zap.Error(err),
@@ -252,7 +252,7 @@ func (w *watcher) cloneRepo(ctx context.Context, repoCfg config.PipedRepository)
 }
 
 // execute inspects all Event-definition and handles the events per EventWatcherHandlerType if there are.
-func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eventCfgs []config.EventWatcher) error {
+func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eventCfgs []config.EventWatcherConfig) error {
 	// Copy the repo to another directory to modify local file to avoid reverting previous changes.
 	tmpDir, err := os.MkdirTemp(w.workingDir, "repo")
 	if err != nil {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -182,7 +182,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 			}
 			cfg, err := config.LoadEventWatcher(repo.GetPath(), includedCfgs, excludedCfgs)
 			if errors.Is(err, config.ErrNotFound) {
-				w.logger.Info("configuration file for Event Watcher in ./pipe not found",
+				w.logger.Info("configuration file for Event Watcher in .pipe/ not found",
 					zap.String("repo-id", repoCfg.RepoID),
 					zap.Error(err),
 				)

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -67,7 +67,7 @@ type GenericApplicationSpec struct {
 	// Deprecated.
 	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
 	// List of the configuration for event watcher.
-	EventWatchers []EventWatcher `json:"eventWatchers"`
+	EventWatcher []EventWatcherConfig `json:"eventWatcher"`
 }
 
 type DeploymentPlanner struct {

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -66,6 +66,8 @@ type GenericApplicationSpec struct {
 	// The list of sealed secrets that should be decrypted.
 	// Deprecated.
 	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
+	// List of events for event watcher.
+	Events []EventWatcherEvent `json:"events"`
 }
 
 type DeploymentPlanner struct {

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -66,8 +66,8 @@ type GenericApplicationSpec struct {
 	// The list of sealed secrets that should be decrypted.
 	// Deprecated.
 	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
-	// List of events for event watcher.
-	Events []EventWatcherEvent `json:"events"`
+	// List of the configuration for event watcher.
+	EventWatchers []EventWatcher `json:"eventWatchers"`
 }
 
 type DeploymentPlanner struct {

--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -36,8 +36,36 @@ type EventWatcherEvent struct {
 	Labels map[string]string `json:"labels"`
 	// List of places where will be replaced when the new event matches.
 	Replacements []EventWatcherReplacement `json:"replacements"`
-	// The configuration of push event.
-	PushHandler EventWatcherPushHandler `json:"pushHandler"`
+}
+
+type EventWatcher struct {
+	// Matcher represents which event will be handled.
+	Matcher EventWatcherMatcher `json:"matcher"`
+	// Handler represents how the matched event will be handled.
+	Handler EventWatcherHandler `json:"handler"`
+}
+
+type EventWatcherMatcher struct {
+	// The handled event name.
+	Name string `json:"name"`
+	// Additional attributes of event. This can make an event definition
+	// unique even if the one with the same name exists.
+	Labels map[string]string `json:"labels"`
+}
+
+type EventWatcherHandler struct {
+	// The handler type of event watcher.
+	Type EventWatcherHandlerType `json:"type,omitempty"`
+	// The config for the event watcher handler.
+	Config EventWatcherHandlerConfig `json:"config"`
+}
+
+type EventWatcherHandlerConfig struct {
+	// The commit message used to push after replacing values.
+	// Default message is used if not given.
+	CommitMessage string `json:"commitMessage,omitempty"`
+	// List of places where will be replaced when the new event matches.
+	Replacements []EventWatcherReplacement `json:"replacements"`
 }
 
 type EventWatcherReplacement struct {
@@ -58,13 +86,13 @@ type EventWatcherReplacement struct {
 	Regex string `json:"regex"`
 }
 
-type EventWatcherPushHandler struct {
-	// The commit message used to push after replacing values.
-	// Default message is used if not given.
-	CommitMessage string `json:"commitMessage,omitempty"`
-	// List of places where will be replaced when the new event matches.
-	Replacements []EventWatcherReplacement `json:"replacements"`
-}
+// EventWatcherHandlerType represents the type of an event watcher handler.
+type EventWatcherHandlerType string
+
+const (
+	// EventWatcherHandlerTypeGitUpdate represents the handler type for git updating.
+	EventWatcherHandlerTypeGitUpdate = "GIT_UPDATE"
+)
 
 // LoadEventWatcher gives back parsed EventWatcher config after merging config files placed under
 // the .pipe directory. With "includes" and "excludes", you can filter the files included the result.

--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -36,6 +36,8 @@ type EventWatcherEvent struct {
 	Labels map[string]string `json:"labels"`
 	// List of places where will be replaced when the new event matches.
 	Replacements []EventWatcherReplacement `json:"replacements"`
+	// The configuration of push event.
+	PushHandler EventWatcherPushHandler `json:"pushHandler"`
 }
 
 type EventWatcherReplacement struct {
@@ -54,6 +56,14 @@ type EventWatcherReplacement struct {
 	// Only the first capturing group enclosed by `()` will be replaced with the new value.
 	// e.g. "host.xz/foo/bar:(v[0-9].[0-9].[0-9])"
 	Regex string `json:"regex"`
+}
+
+type EventWatcherPushHandler struct {
+	// The commit message used to push after replacing values.
+	// Default message is used if not given.
+	CommitMessage string `json:"commitMessage,omitempty"`
+	// List of places where will be replaced when the new event matches.
+	Replacements []EventWatcherReplacement `json:"replacements"`
 }
 
 // LoadEventWatcher gives back parsed EventWatcher config after merging config files placed under

--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -38,7 +38,7 @@ type EventWatcherEvent struct {
 	Replacements []EventWatcherReplacement `json:"replacements"`
 }
 
-type EventWatcher struct {
+type EventWatcherConfig struct {
 	// Matcher represents which event will be handled.
 	Matcher EventWatcherMatcher `json:"matcher"`
 	// Handler represents how the matched event will be handled.


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows settings related to EventWatcher to be defined in the application configuration file as well as `./pipe`.
Both configurations of the EventWatcher under ./pipe and under the application configuration file are referred to.

NOTE: *In the future ./pipe will be Deprecated.*

```yaml
apiVersion: pipecd.dev/v1beta1
kind: ApplicationKind
spec:
  name: foo
  labels:
    team: bar
  eventWatcher:
    - matcher:
        name: helloworld-image-update
        labels:
          env: dev
          appName: helloworld
      handler:
        type: GIT_UPDATE
        config:
          replacements:
            - file: deployment.yaml
              yamlField: $.spec.template.spec.containers[0].image
          commitMessage: Update values by Event watcher
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
