### PR TITLE
Fixed bug that Cloud Provider is always Kubernetes in "Show Piped config" dialog

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -451,7 +453,7 @@ func (r *HelmChartRegistry) Mask() {
 
 type PipedCloudProvider struct {
 	Name string                `json:"name,omitempty"`
-	Type model.ApplicationKind `json:"type,string,omitempty"`
+	Type model.ApplicationKind `json:"type,string"`
 
 	KubernetesConfig *CloudProviderKubernetesConfig `json:"kubernetesConfig,omitempty"`
 	TerraformConfig  *CloudProviderTerraformConfig  `json:"terraformConfig,omitempty"`
@@ -473,7 +475,17 @@ func (p *PipedCloudProvider) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	p.Name = gp.Name
-	p.Type = model.ApplicationKind(model.ApplicationKind_value[gp.Type])
+
+	digitMatcher := regexp.MustCompile(`^\d$`)
+	if digitMatcher.MatchString(gp.Type) {
+		i, err := strconv.Atoi(gp.Type)
+		if err != nil {
+			return err
+		}
+		p.Type = model.ApplicationKind(i)
+	} else {
+		p.Type = model.ApplicationKind(model.ApplicationKind_value[gp.Type])
+	}
 
 	switch p.Type {
 	case model.ApplicationKind_KUBERNETES:

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -476,6 +476,8 @@ func (p *PipedCloudProvider) UnmarshalJSON(data []byte) error {
 	}
 	p.Name = gp.Name
 
+	// Consider the case where the Cloud Provider Type
+	// has already been converted to a int32.
 	digitMatcher := regexp.MustCompile(`^\d$`)
 	if digitMatcher.MatchString(gp.Type) {
 		i, err := strconv.Atoi(gp.Type)

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -853,7 +854,10 @@ func TestPipedCloudProviderUnmarshal(t *testing.T) {
 	for _, tc := range testcase {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &PipedCloudProvider{}
-			json.Unmarshal(tc.spec, p)
+			err := json.Unmarshal(tc.spec, p)
+			if err != nil {
+				assert.Fail(t, fmt.Sprint(err))
+			}
 			assert.Equal(t, tc.want, p)
 		})
 	}

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -736,6 +737,124 @@ func TestPipedConfigMask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.spec.Mask()
 			assert.Equal(t, tc.want, tc.spec)
+		})
+	}
+}
+
+func TestPipedCloudProviderUnmarshal(t *testing.T) {
+	testcase := []struct {
+		name    string
+		spec    []byte
+		want    *PipedCloudProvider
+		wantErr bool
+	}{
+		{
+			name: "Kubernetes, key string",
+			spec: []byte(`{"name":"kubernetes","type":"KUBERNETES"}`),
+			want: &PipedCloudProvider{
+				Name:             "kubernetes",
+				Type:             model.ApplicationKind_KUBERNETES,
+				KubernetesConfig: &CloudProviderKubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Kubernetes, number",
+			spec: []byte(`{"name":"kubernetes","type":"0"}`),
+			want: &PipedCloudProvider{
+				Name:             "kubernetes",
+				Type:             model.ApplicationKind_KUBERNETES,
+				KubernetesConfig: &CloudProviderKubernetesConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Terraform, key string",
+			spec: []byte(`{"name":"terraform","type":"TERRAFORM"}`),
+			want: &PipedCloudProvider{
+				Name:            "terraform",
+				Type:            model.ApplicationKind_TERRAFORM,
+				TerraformConfig: &CloudProviderTerraformConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Terraform, number",
+			spec: []byte(`{"name":"terraform","type":"1"}`),
+			want: &PipedCloudProvider{
+				Name:            "terraform",
+				Type:            model.ApplicationKind_TERRAFORM,
+				TerraformConfig: &CloudProviderTerraformConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Lambda and key string",
+			spec: []byte(`{"name":"lambda","type":"LAMBDA"}`),
+			want: &PipedCloudProvider{
+				Name:         "lambda",
+				Type:         model.ApplicationKind_LAMBDA,
+				LambdaConfig: &CloudProviderLambdaConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Lambda and number",
+			spec: []byte(`{"name":"lambda","type":"3"}`),
+			want: &PipedCloudProvider{
+				Name:         "lambda",
+				Type:         model.ApplicationKind_LAMBDA,
+				LambdaConfig: &CloudProviderLambdaConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CloudRun and key string",
+			spec: []byte(`{"name":"cloudrun","type":"CLOUDRUN"}`),
+			want: &PipedCloudProvider{
+				Name:           "cloudrun",
+				Type:           model.ApplicationKind_CLOUDRUN,
+				CloudRunConfig: &CloudProviderCloudRunConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CloudRun and number",
+			spec: []byte(`{"name":"cloudrun","type":"4"}`),
+			want: &PipedCloudProvider{
+				Name:           "cloudrun",
+				Type:           model.ApplicationKind_CLOUDRUN,
+				CloudRunConfig: &CloudProviderCloudRunConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ECS and key string",
+			spec: []byte(`{"name":"ECS","type":"ECS"}`),
+			want: &PipedCloudProvider{
+				Name:      "ECS",
+				Type:      model.ApplicationKind_ECS,
+				ECSConfig: &CloudProviderECSConfig{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ECS and number",
+			spec: []byte(`{"name":"ECS","type":"5"}`),
+			want: &PipedCloudProvider{
+				Name:      "ECS",
+				Type:      model.ApplicationKind_ECS,
+				ECSConfig: &CloudProviderECSConfig{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testcase {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &PipedCloudProvider{}
+			json.Unmarshal(tc.spec, p)
+			assert.Equal(t, tc.want, p)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed bug that Cloud Provider is always Kubernetes in "Show Piped config" dialog (also add unit test to check that the bug has been resolved) .

This bug occurred because the `UnmarshalJSON` method of the `PipedCloudProvider` structure (the method called when `json.Unmarshal` is invoked) did not consider the case where the type of `type` value is int32.
(cf. https://github.com/pipe-cd/pipecd/blob/master/pkg/config/piped.go#L476)

So I have modified the `type` unmarshal logic so that it works fine when a number representing a certain Cloud Provider type is directly specified in the `type`.

After this PR merged, the Cloud Provider will be displayed correctly.

![image](https://user-images.githubusercontent.com/26561120/172121230-7af9d8d8-4630-4d61-aa33-2603046d29e9.png)

**Consideration**

The Cloud Provider Type displayed in the dialog shows an int32 value, but it might be more user-friendly to display a string converted from the numerical value.

**Which issue(s) this PR fixes**:

Fixes #3731

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fixed bug that Cloud Provider is always Kubernetes in "Show Piped config" dialog
```
