### PR TITLE
Fix bug that Cloud Provider is always Kubernetes in "Show Piped config" dialog 

### DIFF
--- a/pkg/app/piped/driftdetector/detector.go
+++ b/pkg/app/piped/driftdetector/detector.go
@@ -96,7 +96,7 @@ func NewDetector(
 
 	for _, cp := range cfg.CloudProviders {
 		switch cp.Type {
-		case model.ApplicationKind_KUBERNETES:
+		case model.CloudProviderKubernetes:
 			sg, ok := stateGetter.KubernetesGetter(cp.Name)
 			if !ok {
 				return nil, fmt.Errorf(format, cp.Name)
@@ -113,7 +113,7 @@ func NewDetector(
 				logger,
 			))
 
-		case model.ApplicationKind_CLOUDRUN:
+		case model.CloudProviderCloudRun:
 			sg, ok := stateGetter.CloudRunGetter(cp.Name)
 			if !ok {
 				return nil, fmt.Errorf(format, cp.Name)

--- a/pkg/app/piped/livestatereporter/reporter.go
+++ b/pkg/app/piped/livestatereporter/reporter.go
@@ -65,14 +65,14 @@ func NewReporter(appLister applicationLister, stateGetter livestatestore.Getter,
 	for _, cp := range cfg.CloudProviders {
 		errFmt := fmt.Sprintf("unable to find live state getter for cloud provider: %s", cp.Name)
 		switch cp.Type {
-		case model.ApplicationKind_KUBERNETES:
+		case model.CloudProviderKubernetes:
 			sg, ok := stateGetter.KubernetesGetter(cp.Name)
 			if !ok {
 				r.logger.Error(errFmt)
 				continue
 			}
 			r.reporters = append(r.reporters, kubernetes.NewReporter(cp, appLister, sg, apiClient, logger))
-		case model.ApplicationKind_CLOUDRUN:
+		case model.CloudProviderCloudRun:
 			sg, ok := stateGetter.CloudRunGetter(cp.Name)
 			if !ok {
 				r.logger.Error(errFmt)

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -105,15 +105,15 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 	}
 	for _, cp := range cfg.CloudProviders {
 		switch cp.Type {
-		case model.ApplicationKind_KUBERNETES:
+		case model.CloudProviderKubernetes:
 			store := kubernetes.NewStore(cp.KubernetesConfig, cfg, cp.Name, logger)
 			s.kubernetesStores[cp.Name] = store
 
-		case model.ApplicationKind_TERRAFORM:
+		case model.CloudProviderTerraform:
 			store := terraform.NewStore(cp.TerraformConfig, cp.Name, appLister, logger)
 			s.terraformStores[cp.Name] = store
 
-		case model.ApplicationKind_CLOUDRUN:
+		case model.CloudProviderCloudRun:
 			store, err := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, logger)
 			if err != nil {
 				logger.Error("failed to create a new cloudrun's livestatestore", zap.Error(err))
@@ -121,11 +121,11 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 			}
 			s.cloudrunStores[cp.Name] = store
 
-		case model.ApplicationKind_LAMBDA:
+		case model.CloudProviderLambda:
 			store := lambda.NewStore(cp.LambdaConfig, cp.Name, appLister, logger)
 			s.lambdaStores[cp.Name] = store
 
-		case model.ApplicationKind_ECS:
+		case model.CloudProviderECS:
 			store := ecs.NewStore(cp.ECSConfig, cp.Name, appLister, logger)
 			s.ecsStores[cp.Name] = store
 		}

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -87,7 +87,7 @@ func TestPipedConfig(t *testing.T) {
 				CloudProviders: []PipedCloudProvider{
 					{
 						Name: "kubernetes-default",
-						Type: model.ApplicationKind_KUBERNETES,
+						Type: model.CloudProviderKubernetes,
 						KubernetesConfig: &CloudProviderKubernetesConfig{
 							AppStateInformer: KubernetesAppStateInformer{
 								IncludeResources: []KubernetesResourceMatcher{
@@ -110,12 +110,12 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name:             "kubernetes-dev",
-						Type:             model.ApplicationKind_KUBERNETES,
+						Type:             model.CloudProviderKubernetes,
 						KubernetesConfig: &CloudProviderKubernetesConfig{},
 					},
 					{
 						Name: "terraform",
-						Type: model.ApplicationKind_TERRAFORM,
+						Type: model.CloudProviderTerraform,
 						TerraformConfig: &CloudProviderTerraformConfig{
 							Vars: []string{
 								"project=gcp-project",
@@ -125,7 +125,7 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name: "cloudrun",
-						Type: model.ApplicationKind_CLOUDRUN,
+						Type: model.CloudProviderCloudRun,
 						CloudRunConfig: &CloudProviderCloudRunConfig{
 							Project:         "gcp-project-id",
 							Region:          "cloud-run-region",
@@ -134,7 +134,7 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name: "lambda",
-						Type: model.ApplicationKind_LAMBDA,
+						Type: model.CloudProviderLambda,
 						LambdaConfig: &CloudProviderLambdaConfig{
 							Region: "us-east-1",
 						},
@@ -431,7 +431,7 @@ func TestPipedConfigMask(t *testing.T) {
 				CloudProviders: []PipedCloudProvider{
 					{
 						Name: "foo",
-						Type: 1,
+						Type: model.CloudProviderKubernetes,
 						KubernetesConfig: &CloudProviderKubernetesConfig{
 							MasterURL:      "foo",
 							KubeConfigPath: "foo",
@@ -450,28 +450,6 @@ func TestPipedConfigMask(t *testing.T) {
 									},
 								},
 							},
-						},
-						TerraformConfig: &CloudProviderTerraformConfig{
-							Vars: []string{"foo"},
-						},
-						CloudRunConfig: &CloudProviderCloudRunConfig{
-							Project:         "foo",
-							Region:          "foo",
-							CredentialsFile: "foo",
-						},
-						LambdaConfig: &CloudProviderLambdaConfig{
-							Region:          "foo",
-							CredentialsFile: "foo",
-							RoleARN:         "foo",
-							TokenFile:       "foo",
-							Profile:         "foo",
-						},
-						ECSConfig: &CloudProviderECSConfig{
-							Region:          "foo",
-							CredentialsFile: "foo",
-							RoleARN:         "foo",
-							TokenFile:       "foo",
-							Profile:         "foo",
 						},
 					},
 				},
@@ -604,7 +582,7 @@ func TestPipedConfigMask(t *testing.T) {
 				CloudProviders: []PipedCloudProvider{
 					{
 						Name: "foo",
-						Type: 1,
+						Type: model.CloudProviderKubernetes,
 						KubernetesConfig: &CloudProviderKubernetesConfig{
 							MasterURL:      "foo",
 							KubeConfigPath: "foo",
@@ -623,28 +601,6 @@ func TestPipedConfigMask(t *testing.T) {
 									},
 								},
 							},
-						},
-						TerraformConfig: &CloudProviderTerraformConfig{
-							Vars: []string{"foo"},
-						},
-						CloudRunConfig: &CloudProviderCloudRunConfig{
-							Project:         "foo",
-							Region:          "foo",
-							CredentialsFile: maskString,
-						},
-						LambdaConfig: &CloudProviderLambdaConfig{
-							Region:          "foo",
-							CredentialsFile: maskString,
-							RoleARN:         maskString,
-							TokenFile:       maskString,
-							Profile:         "foo",
-						},
-						ECSConfig: &CloudProviderECSConfig{
-							Region:          "foo",
-							CredentialsFile: maskString,
-							RoleARN:         maskString,
-							TokenFile:       maskString,
-							Profile:         "foo",
 						},
 					},
 				},

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -89,6 +89,23 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
+func (k *ApplicationKind) CompatibleCloudProviderType() CloudProviderType {
+	switch *k {
+	case ApplicationKind_KUBERNETES:
+		return CloudProviderKubernetes
+	case ApplicationKind_TERRAFORM:
+		return CloudProviderTerraform
+	case ApplicationKind_LAMBDA:
+		return CloudProviderLambda
+	case ApplicationKind_CLOUDRUN:
+		return CloudProviderCloudRun
+	case ApplicationKind_ECS:
+		return CloudProviderECS
+	default:
+		return CloudProviderKubernetes
+	}
+}
+
 func IsApplicationConfigFile(filename string) bool {
 	return filename == DefaultApplicationConfigFilename || strings.HasSuffix(filename, applicationConfigFileExtention) || filename == oldDefaultApplicationConfigFilename
 }

--- a/pkg/model/cloudprovider.go
+++ b/pkg/model/cloudprovider.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+type CloudProviderType string
+
+const (
+	CloudProviderKubernetes CloudProviderType = "KUBERNETES"
+	CloudProviderTerraform  CloudProviderType = "TERRAFORM"
+	CloudProviderLambda     CloudProviderType = "LAMBDA"
+	CloudProviderCloudRun   CloudProviderType = "CLOUDRUN"
+	CloudProviderECS        CloudProviderType = "ECS"
+)
+
+func (t CloudProviderType) String() string {
+	return string(t)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

![Screen Shot 2022-06-07 at 17 35 48](https://user-images.githubusercontent.com/32532742/172360686-1417b9ab-9710-4aba-bde2-69b82d8e3e26.png)

The root cause of this issue is that we use the ApplicationKind (an enum) as the cloud provider type in the application configuration. Before submitting the piped configuration to the control plane, we do unmarshal/marshal the piped configuration, an enum value is cast to int32 and when we need to cast it back, it turns out not working (the below image shows the error in detail - thx @Szarny )

<img width="765" alt="image" src="https://user-images.githubusercontent.com/32532742/172361189-70281340-8e18-45d8-8a29-d67fb8743ee4.png">

To resolve that, this PR added a new type CloudProviderType (define it equal to string) and use that in all places refer to pipedCfg.cloudProvider.

**Which issue(s) this PR fixes**:

Fixes #3731 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
