### PR TITLE
Only show latest 6 released versions in piped upgrade dialog

### DIFF
--- a/web/src/components/settings-page/piped/components/upgrade-dialog/index.tsx
+++ b/web/src/components/settings-page/piped/components/upgrade-dialog/index.tsx
@@ -93,7 +93,7 @@ export const UpgradePipedDialog: FC<UpgradePipedProps> = memo(
                 id="version"
                 freeSolo
                 autoSelect
-                options={releasedVersions}
+                options={releasedVersions.slice(0, 6)}
                 onChange={(_, value) => {
                   setUpgradeVersion(value || "");
                 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow PR #3734, this PR makes the selectable versions list shorter (only shows 6 latest versions)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
