### PR TITLE
Add flag for launcher to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,18 @@ stop/pipecd:
 .PHONY: run/piped
 run/piped: CONFIG_FILE ?=
 run/piped: INSECURE ?= false
+run/piped: LAUNCHER ?= false
 run/piped:
+ifeq ($(LAUNCHER),true)
+	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
+else
 	go run cmd/piped/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
+endif
 
 .PHONY: run/launcher
 run/launcher: CONFIG_FILE ?=
 run/launcher: INSECURE ?= false
-run/launcher: 
+run/launcher:
 	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
 
 .PHONY: run/web

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,12 @@ run/piped: INSECURE ?= false
 run/piped:
 	go run cmd/piped/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
 
+.PHONY: run/launcher
+run/launcher: CONFIG_FILE ?=
+run/launcher: INSECURE ?= false
+run/launcher: 
+	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
+
 .PHONY: run/web
 run/web:
 	yarn --cwd web dev

--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,6 @@ else
 	go run cmd/piped/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
 endif
 
-.PHONY: run/launcher
-run/launcher: CONFIG_FILE ?=
-run/launcher: INSECURE ?= false
-run/launcher:
-	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
-
 .PHONY: run/web
 run/web:
 	yarn --cwd web dev


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `LAUNCHER` flag to `run/piped` to execute the launcher more easily.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
