### PR TITLE
Add breaking changes note about Helm values file restriction

### DIFF
--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -8,12 +8,36 @@ description: >
 
 ## Changelog since v0.32.4
 
+### Breaking Changes
+
+Disallow valueFiles from paths outside the application directory to prevent potential dirtrav vulnerability ([#3726](https://github.com/pipe-cd/pipecd/pull/3726)).
+
+According to a recently discovered [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348), it reveals that the existence of a directory traversal vulnerability when an arbitrary path can be specified as the Helm Values file path.
+
+For this reason, PipeCD has restricted the path that can be specified as the Values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726).
+
+Therefore, for example, in the following specification of Values file paths, the first three are allowed, but the last two are not.
+
+```yaml
+helmOptions:
+  valueFiles:
+    # allowed
+    - values.yaml
+    - ./foo/bar/values.yaml
+    - /path/to/dir-where-application-configuration-file-exists/values.yaml
+
+    # disallowed
+    - ../../../../path/to/dir-where-application-configuration-file-NOT-exists/values.yaml
+    - /path/to/dir-where-application-configuration-file-NOT-exists/values.yaml
+```
+
+For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).
+
 ### Notable Changes
 
 * Sort the application suggestion name in application filter form ([#3740](https://github.com/pipe-cd/pipecd/pull/3740))
 * Make piped upgrade version input box selectable ([#3734](https://github.com/pipe-cd/pipecd/pull/3734))
 * Add feature to show piped config on web console ([#3673](https://github.com/pipe-cd/pipecd/pull/3673))
-* Add validation to helm values file path to prevent potential dirtrav vulnerability ([#3726](https://github.com/pipe-cd/pipecd/pull/3726))
 
 ### Internal Changes
 

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -22,11 +22,11 @@ helmOptions:
     # allowed
     - values.yaml
     - ./foo/bar/values.yaml
-    - /path/to/dir-where-application-configuration-exists/values.yaml
+    - /path/to/application-configuration-dir/values.yaml
 
     # disallowed
-    - ../../../../path/to/dir-where-application-configuration-file-NOT-exists/values.yaml
-    - /path/to/dir-where-application-configuration-NOT-exists/values.yaml
+    - ../../../../path/to/NOT-application-configuration-dir/values.yaml
+    - /path/to/NOT-application-configuration-dir/values.yaml
 ```
 
 For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -12,7 +12,7 @@ description: >
 
 According to a recently discovered [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348), it reveals that the existence of a directory traversal vulnerability when an arbitrary path can be specified as the Helm values file path.
 
-For this reason, PipeCD has restricted the path that can be specified as the values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726)..
+For this reason, PipeCD has restricted the path that can be specified as the values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726).
 
 Therefore, for example, in the following specification of values file paths, the first three are allowed, but the last two are not.
 
@@ -22,11 +22,11 @@ helmOptions:
     # allowed
     - values.yaml
     - ./foo/bar/values.yaml
-    - /path/to/dir-where-application-configuration-file-exists/values.yaml
+    - /path/to/dir-where-application-configuration-exists/values.yaml
 
     # disallowed
     - ../../../../path/to/dir-where-application-configuration-file-NOT-exists/values.yaml
-    - /path/to/dir-where-application-configuration-file-NOT-exists/values.yaml
+    - /path/to/dir-where-application-configuration-NOT-exists/values.yaml
 ```
 
 For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -10,13 +10,11 @@ description: >
 
 ### Breaking Changes
 
-Disallow valueFiles from paths outside the application directory to prevent potential dirtrav vulnerability ([#3726](https://github.com/pipe-cd/pipecd/pull/3726)).
+According to a recently discovered [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348), it reveals that the existence of a directory traversal vulnerability when an arbitrary path can be specified as the Helm values file path.
 
-According to a recently discovered [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348), it reveals that the existence of a directory traversal vulnerability when an arbitrary path can be specified as the Helm Values file path.
+For this reason, PipeCD has restricted the path that can be specified as the values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726)..
 
-For this reason, PipeCD has restricted the path that can be specified as the Values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726).
-
-Therefore, for example, in the following specification of Values file paths, the first three are allowed, but the last two are not.
+Therefore, for example, in the following specification of values file paths, the first three are allowed, but the last two are not.
 
 ```yaml
 helmOptions:

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -12,7 +12,7 @@ description: >
 
 According to a recently discovered [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348), it reveals that the existence of a directory traversal vulnerability when an arbitrary path can be specified as the Helm values file path.
 
-For this reason, PipeCD has restricted the path that can be specified as the values file path to the directory where the application configuration (i.e. `.pipecd.yaml`) exists when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726).
+For this reason, PipeCD has restricted the path that can be specified as the values file path to the directory where the application configuration exists (aka. the application directory) when a local path is specified by [#3726](https://github.com/pipe-cd/pipecd/pull/3726).
 
 Therefore, for example, in the following specification of values file paths, the first three are allowed, but the last two are not.
 
@@ -22,11 +22,11 @@ helmOptions:
     # allowed
     - values.yaml
     - ./foo/bar/values.yaml
-    - /path/to/application-configuration-dir/values.yaml
+    - /path/to/application-directory/values.yaml
 
     # disallowed
-    - ../../../../path/to/OTHER-application-configuration-dir-or-such/values.yaml
-    - /path/to/OTHER-application-configuration-dir-or-such/values.yaml
+    - ../../../../path/to/OTHER-application-directory-or-such/values.yaml
+    - /path/to/OTHER-application-directory-or-such/values.yaml
 ```
 
 For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -25,8 +25,8 @@ helmOptions:
     - /path/to/application-configuration-dir/values.yaml
 
     # disallowed
-    - ../../../../path/to/NOT-application-configuration-dir/values.yaml
-    - /path/to/NOT-application-configuration-dir/values.yaml
+    - ../../../../path/to/OTHER-application-configuration-dir-or-such/values.yaml
+    - /path/to/OTHER-application-configuration-dir-or-such/values.yaml
 ```
 
 For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).

--- a/docs/content/en/blog/releases/v0.33.0.md
+++ b/docs/content/en/blog/releases/v0.33.0.md
@@ -29,7 +29,7 @@ helmOptions:
     - /path/to/OTHER-application-directory-or-such/values.yaml
 ```
 
-For more information, please see [HelmOptions configuration-reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).
+For more information, please see [HelmOptions configuration reference](https://pipecd.dev/docs/user-guide/configuration-reference/#helmoptions).
 
 ### Notable Changes
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add breaking changes note about Helm values file restriction (#3726).

This is because there was an inquiry regarding the path that can be specified as a values file, and we felt it necessary to describe the specifications in more detail.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
