### PR TITLE
Fix to use the pointer type in showCommitter

### DIFF
--- a/tool/actions-gh-release/release.go
+++ b/tool/actions-gh-release/release.go
@@ -54,7 +54,7 @@ type ReleaseCommitCategoryConfig struct {
 
 type ReleaseNoteGeneratorConfig struct {
 	ShowAbbrevHash         bool                       `json:"showAbbrevHash,omitempty" default:"false"`
-	ShowCommitter          bool                       `json:"showCommitter,omitempty" default:"false"`
+	ShowCommitter          *bool                      `json:"showCommitter,omitempty" default:"true"`
 	UseReleaseNoteBlock    bool                       `json:"useReleaseNoteBlock,omitempty" default:"false"`
 	UsePullRequestMetadata bool                       `json:"usePullRequestMetadata,omitempty" default:"false"`
 	CommitInclude          ReleaseCommitMatcherConfig `json:"commitInclude,omitempty"`
@@ -359,7 +359,7 @@ func renderReleaseNote(p ReleaseProposal, cfg ReleaseConfig) []byte {
 		if gen.ShowAbbrevHash {
 			b.WriteString(fmt.Sprintf(" [%s](https://github.com/%s/%s/commit/%s)", c.AbbreviatedHash, p.Owner, p.Repo, c.Hash))
 		}
-		if gen.ShowCommitter {
+		if gen.ShowCommitter != nil && *gen.ShowCommitter {
 			b.WriteString(fmt.Sprintf(" - by %s", c.Committer))
 		}
 		b.WriteString("\n")

--- a/tool/actions-gh-release/release.go
+++ b/tool/actions-gh-release/release.go
@@ -54,7 +54,7 @@ type ReleaseCommitCategoryConfig struct {
 
 type ReleaseNoteGeneratorConfig struct {
 	ShowAbbrevHash         bool                       `json:"showAbbrevHash,omitempty" default:"false"`
-	ShowCommitter          bool                       `json:"showCommitter,omitempty" default:"true"`
+	ShowCommitter          bool                       `json:"showCommitter,omitempty" default:"false"`
 	UseReleaseNoteBlock    bool                       `json:"useReleaseNoteBlock,omitempty" default:"false"`
 	UsePullRequestMetadata bool                       `json:"usePullRequestMetadata,omitempty" default:"false"`
 	CommitInclude          ReleaseCommitMatcherConfig `json:"commitInclude,omitempty"`

--- a/tool/actions-gh-release/release_test.go
+++ b/tool/actions-gh-release/release_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestParseReleaseConfig(t *testing.T) {
+	fakeShowCommitter := true
 	testcases := []struct {
 		name        string
 		configFile  string
@@ -80,7 +81,7 @@ func TestParseReleaseConfig(t *testing.T) {
 					},
 				},
 				ReleaseNoteGenerator: ReleaseNoteGeneratorConfig{
-					ShowCommitter:       true,
+					ShowCommitter:       &fakeShowCommitter,
 					UseReleaseNoteBlock: true,
 				},
 			},
@@ -101,6 +102,7 @@ func TestParseReleaseConfig(t *testing.T) {
 
 func TestBuildReleaseCommits(t *testing.T) {
 	ctx := context.Background()
+	fakeShowCommitter := true
 	config := ReleaseConfig{
 		Tag:  "v1.1.0",
 		Name: "hello",
@@ -143,7 +145,7 @@ func TestBuildReleaseCommits(t *testing.T) {
 			},
 		},
 		ReleaseNoteGenerator: ReleaseNoteGeneratorConfig{
-			ShowCommitter:       true,
+			ShowCommitter:       &fakeShowCommitter,
 			UseReleaseNoteBlock: true,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**
The library `github.com/creasty/defaults` used within actions-gh-release does not recognize false as having a value set, so it is overwritten by true. Hence I fixed to use the pointer type.

https://github.com/creasty/defaults/issues/30#issuecomment-942435138

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
