### PR TITLE
Fix to add safe.directory before running git command

### DIFF
--- a/tool/actions-gh-release/git.go
+++ b/tool/actions-gh-release/git.go
@@ -171,3 +171,21 @@ func readFileAtCommit(ctx context.Context, gitExecPath, repoDir, filePath, commi
 
 	return bytes.TrimSpace(out), nil
 }
+
+func addSafeDirectory(ctx context.Context, gitExecPath, repoDir string) error {
+	args := []string{
+		"config",
+		"--global",
+		"--add",
+		"safe.directory",
+		repoDir,
+	}
+
+	cmd := exec.CommandContext(ctx, gitExecPath, args...)
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("err: %w, out: %s", err, string(out))
+	}
+	return nil
+}

--- a/tool/actions-gh-release/main.go
+++ b/tool/actions-gh-release/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if err := addSafeDirectory(ctx, gitExecPath, workspace); err != nil {
-		log.Fatalf("Failed to add safe directory: %v\n", err)
+		log.Fatalf("Failed to add %s as a safe directory: %v\n", workspace, err)
 	}
 
 	cfg := &githubClientConfig{Token: args.Token}

--- a/tool/actions-gh-release/main.go
+++ b/tool/actions-gh-release/main.go
@@ -49,6 +49,10 @@ func main() {
 		log.Fatal("GITHUB_WORKSPACE was not defined")
 	}
 
+	if err := addSafeDirectory(ctx, gitExecPath, workspace); err != nil {
+		log.Fatalf("Failed to add safe directory: %v\n", err)
+	}
+
 	cfg := &githubClientConfig{Token: args.Token}
 	ghClient := newGitHubClient(ctx, cfg)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We got an [error](https://github.com/pipe-cd/pipecd/runs/6872568012?check_suite_focus=true) like we could not run the git command on a docker container in actions-gh-release due to [this](https://github.com/actions/checkout/issues/760).
Hence added the workspace as a safe directory before running the git command.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
