### PR TITLE
Ensure to have PlatformProvider value in application model on adding new application

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -138,14 +138,15 @@ func (a *API) AddApplication(ctx context.Context, req *apiservice.AddApplication
 	}
 
 	app := model.Application{
-		Id:            uuid.New().String(),
-		Name:          req.Name,
-		PipedId:       req.PipedId,
-		ProjectId:     key.ProjectId,
-		GitPath:       gitpath,
-		Kind:          req.Kind,
-		CloudProvider: req.CloudProvider,
-		Description:   req.Description,
+		Id:               uuid.New().String(),
+		Name:             req.Name,
+		PipedId:          req.PipedId,
+		ProjectId:        key.ProjectId,
+		GitPath:          gitpath,
+		Kind:             req.Kind,
+		CloudProvider:    req.CloudProvider,
+		PlatformProvider: req.CloudProvider,
+		Description:      req.Description,
 	}
 	if err := a.applicationStore.Add(ctx, &app); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add application %s", app.Id))

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -496,15 +496,16 @@ func (a *WebAPI) AddApplication(ctx context.Context, req *webservice.AddApplicat
 	}
 
 	app := model.Application{
-		Id:            uuid.New().String(),
-		Name:          req.Name,
-		PipedId:       req.PipedId,
-		ProjectId:     claims.Role.ProjectId,
-		GitPath:       gitpath,
-		Kind:          req.Kind,
-		CloudProvider: req.CloudProvider,
-		Description:   req.Description,
-		Labels:        req.Labels,
+		Id:               uuid.New().String(),
+		Name:             req.Name,
+		PipedId:          req.PipedId,
+		ProjectId:        claims.Role.ProjectId,
+		GitPath:          gitpath,
+		Kind:             req.Kind,
+		CloudProvider:    req.CloudProvider,
+		PlatformProvider: req.CloudProvider,
+		Description:      req.Description,
+		Labels:           req.Labels,
 	}
 	if err = a.applicationStore.Add(ctx, &app); err != nil {
 		return nil, gRPCEntityOperationError(err, fmt.Sprintf("add application %s", app.Id))


### PR DESCRIPTION
**What this PR does / why we need it**:

By PR #3767 we only ensure that applications that already existed in the pipecd datastore will have the value PlatformProvider based on CloudProvider value, this PR ensures that all new adding applications will have that value for PlatformProvider field too.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
