### PR TITLE
Update action menu on applications list page

### DIFF
--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles((theme) => ({
     verticalAlign: "text-bottom",
     marginLeft: theme.spacing(0.5),
   },
+  warning: {
+    color: "red",
+  },
 }));
 
 const EmptyDeploymentData: FC<{ displayAllProperties: boolean }> = ({
@@ -258,14 +261,18 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
             },
           }}
         >
-          <MenuItem onClick={handleEdit}>Edit</MenuItem>
-          <MenuItem onClick={handleGenerateSecret}>Encrypt Secret</MenuItem>
           {app && app.disabled ? (
             <MenuItem onClick={handleEnable}>Enable</MenuItem>
           ) : (
-            <MenuItem onClick={handleDisable}>Disable</MenuItem>
+            <>
+              <MenuItem onClick={handleEdit}>Edit</MenuItem>
+              <MenuItem onClick={handleGenerateSecret}>Encrypt Secret</MenuItem>
+              <MenuItem onClick={handleDisable}>Disable</MenuItem>
+            </>
           )}
-          <MenuItem onClick={handleDelete}>Delete</MenuItem>
+          <MenuItem className={classes.warning} onClick={handleDelete}>
+            Delete
+          </MenuItem>
         </Menu>
       </>
     );


### PR DESCRIPTION
**What this PR does / why we need it**:

Only show the `Edit` and `Encrypt Secret` options in case of the application is enabled.

Before

https://user-images.githubusercontent.com/32532742/176085291-8d7570d3-5a98-40d4-9a20-686ec353a6b5.mp4

After

https://user-images.githubusercontent.com/32532742/176085412-46469ef4-422f-41c3-b233-3425ea645aa4.mp4


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
