### PR TITLE
Fix react Menu Fragment error

### DIFF
--- a/web/src/components/application-detail-page/index.tsx
+++ b/web/src/components/application-detail-page/index.tsx
@@ -117,12 +117,12 @@ export const ApplicationDetailPage: FC = memo(function ApplicationDetailPage() {
         {app && app.disabled ? (
           <MenuItem onClick={handleEnableClick}>Enable</MenuItem>
         ) : (
-          <>
+          <div>
             <MenuItem onClick={handleEncryptSecretClick}>
               Encrypt Secret
             </MenuItem>
             <MenuItem onClick={handleDisableClick}>Disable</MenuItem>
-          </>
+          </div>
         )}
         <MenuItem className={classes.warning} onClick={handleDeleteClick}>
           Delete

--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -264,11 +264,11 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
           {app && app.disabled ? (
             <MenuItem onClick={handleEnable}>Enable</MenuItem>
           ) : (
-            <>
+            <div>
               <MenuItem onClick={handleEdit}>Edit</MenuItem>
               <MenuItem onClick={handleGenerateSecret}>Encrypt Secret</MenuItem>
               <MenuItem onClick={handleDisable}>Disable</MenuItem>
-            </>
+            </div>
           )}
           <MenuItem className={classes.warning} onClick={handleDelete}>
             Delete


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspend this error
```
    console.error
      Material-UI: The Menu component doesn't accept a Fragment as a child.
      Consider providing an array instead.

      at node_modules/@material-ui/core/Menu/Menu.js:130:17
      at node_modules/react/cjs/react.development.js:1067:17
      at mapIntoArray (node_modules/react/cjs/react.development.js:964:23)
      at mapIntoArray (node_modules/react/cjs/react.development.js:1004:23)
      at Object.mapChildren [as map] (node_modules/react/cjs/react.development.js:1066:3)
      at Menu (node_modules/@material-ui/core/Menu/Menu.js:123:18)
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:14985:18)
      at updateForwardRef (node_modules/react-dom/cjs/react-dom.development.js:17044:20)
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
