### PR TITLE
Add the tool of firestore-emulator

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -49,3 +49,9 @@ jobs:
         with:
           context: tool/piped-base-okd
           tags: ${{ env.REGISTRY }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}
+
+      - name: Build firestore-emulator image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/firestore-emulator
+          tags: ${{ env.REGISTRY }}/pipe-cd/firestore-emulator:${{ env.PIPECD_VERSION }}

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -65,3 +65,10 @@ jobs:
           context: tool/piped-base-okd
           tags: ${{ env.GHCR }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}
           push: true
+
+      - name: Build and push firestore-emulator image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: tool/firestore-emulator
+          tags: ${{ env.GHCR }}/pipe-cd/firestore-emulator:${{ env.PIPECD_VERSION }}
+          push: true

--- a/tool/firestore-emulator/Dockerfile
+++ b/tool/firestore-emulator/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:8-jre-alpine3.9
+
+ARG GOOGLE_CLOUD_SDK_VERSION=392.0.0
+
+RUN apk add --no-cache \
+        python3 \
+        curl && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
+    tar -C /usr/local -xvzf google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
+    rm google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
+    /usr/local/google-cloud-sdk/install.sh --quiet
+
+ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
+
+RUN gcloud components install cloud-firestore-emulator
+
+EXPOSE 8080
+ENTRYPOINT ["gcloud", "beta", "emulators", "firesotre", "start"]
+CMD ["--host-port=0.0.0.0:8080"]


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to test firestore integration test in CI, added the image of firestore emulator.
We'll test integration test around firestore with dockertest like [this](https://docs.docker.com/language/golang/run-tests/).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
