### PR TITLE
Update docs reflect archivement of manifests repository

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/control-plane/installation.md
+++ b/docs/content/en/docs-dev/operator-manual/control-plane/installation.md
@@ -97,7 +97,7 @@ __Caution__: In case of using `MySQL` as Control Plane's datastore, please note 
 
 ### 4. Accessing the PipeCD web
 
-If your installation was including an [ingress](https://github.com/pipe-cd/manifests/blob/master/manifests/pipecd/values.yaml#L6), the PipeCD web can be accessed by the ingress's IP address or domain.
+If your installation was including an [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L7), the PipeCD web can be accessed by the ingress's IP address or domain.
 Otherwise, private PipeCD web can be accessed by using `kubectl port-forward` to expose the installed Control Plane on your localhost:
 
 ``` console
@@ -112,7 +112,7 @@ This part provides guidance for a production hardened deployment of the control 
 
 - Publishing the control plane
 
-    You can allow external access to the control plane by enabling the [ingress](https://github.com/pipe-cd/manifests/blob/master/manifests/pipecd/values.yaml#L6) configuration.
+    You can allow external access to the control plane by enabling the [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L7) configuration.
 
 - End-to-End TLS
 
@@ -123,7 +123,7 @@ This part provides guidance for a production hardened deployment of the control 
     ``` console
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN={YOUR_DOMAIN}"
     ```
-    Those key and cert can be configured via [`secret.internalTLSKey.data`](https://github.com/pipe-cd/manifests/blob/master/manifests/pipecd/values.yaml#L83) and [`secret.internalTLSCert.data`](https://github.com/pipe-cd/manifests/blob/master/manifests/pipecd/values.yaml#L86).
+    Those key and cert can be configured via [`secret.internalTLSKey.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L118) and [`secret.internalTLSCert.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L121).
 
     To enable internal tls connection, please set the `gateway.internalTLS.enabled` parameter to be `true`.
 

--- a/docs/content/en/docs-dev/operator-manual/piped/installation/installing-on-kubernetes.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/installation/installing-on-kubernetes.md
@@ -85,7 +85,7 @@ helm upgrade -i dev-piped oci://ghcr.io/pipe-cd/chart/piped --version={{< blocks
 
   Note: Be sure to set `--set args.insecure=true` if your Control Plane has not TLS-enabled yet.
 
-  See [values.yaml](https://github.com/pipe-cd/manifests/blob/master/manifests/piped/values.yaml) for the full values.
+  See [values.yaml](https://github.com/pipe-cd/pipecd/blob/master/manifests/piped/values.yaml) for the full values.
 
 ## In the namespaced mode
 The previous way requires installing cluster-level resources. If you want to restrict Piped's permission within the namespace where Piped runs on, this way is for you.


### PR DESCRIPTION
**What this PR does / why we need it**:

The github.com/pipe-cd/manifests repository had been archived so I update the docs reflect that change

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
