### PR TITLE
Fix the image of firestore-emulator

### DIFF
--- a/tool/firestore-emulator/Dockerfile
+++ b/tool/firestore-emulator/Dockerfile
@@ -1,19 +1,13 @@
-FROM openjdk:8-jre-alpine3.9
+ARG GOOGLE_CLOUD_SDK_VERSION=392.0.0-alpine
 
-ARG GOOGLE_CLOUD_SDK_VERSION=392.0.0
+FROM google/cloud-sdk:$GOOGLE_CLOUD_SDK_VERSION
 
-RUN apk add --no-cache \
-        python3 \
-        curl && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
-    tar -C /usr/local -xvzf google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
-    rm google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86.tar.gz && \
-    /usr/local/google-cloud-sdk/install.sh --quiet
+RUN apk add --update --no-cache openjdk11-jre-headless
 
-ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
+ENV FIRESTORE_PROJECT_ID "project"
+RUN gcloud config set project $FIRESTORE_PROJECT_ID && gcloud components install cloud-firestore-emulator beta --quiet
 
-RUN gcloud components install cloud-firestore-emulator
+ENV PORT 8080
+EXPOSE "$PORT"
 
-EXPOSE 8080
-ENTRYPOINT ["gcloud", "beta", "emulators", "firesotre", "start"]
-CMD ["--host-port=0.0.0.0:8080"]
+ENTRYPOINT gcloud beta emulators firestore start --host-port="0.0.0.0:${PORT}"

--- a/tool/firestore-emulator/Dockerfile
+++ b/tool/firestore-emulator/Dockerfile
@@ -4,7 +4,7 @@ FROM google/cloud-sdk:$GOOGLE_CLOUD_SDK_VERSION
 
 RUN apk add --update --no-cache openjdk11-jre-headless
 
-ENV FIRESTORE_PROJECT_ID "project"
+ENV FIRESTORE_PROJECT_ID "pipecd-test"
 RUN gcloud config set project $FIRESTORE_PROJECT_ID && gcloud components install cloud-firestore-emulator beta --quiet
 
 ENV PORT 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
I faced an error like the one below.
This is thought to be caused by some omission in the configuration but we were able to avoid this by using google-sdk base image. Hence I applied.

```
Executing: /usr/local/google-cloud-sdk/platform/cloud-firestore-emulator/cloud_firestore_emulator start --host=0.0.0.0 --port=8080
ERROR: gcloud crashed (FileNotFoundError): [Errno 2] No such file or directory: '/usr/local/google-cloud-sdk/platform/cloud-firestore-emulator/cloud_firestore_emulator': '/usr/local/google-cloud-sdk/platform/cloud-firestore-emulator/cloud_firestore_emulator'

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
