### PR TITLE
Make gen/release-docs command ouput consistent

### DIFF
--- a/hack/gen-release-docs.sh
+++ b/hack/gen-release-docs.sh
@@ -40,6 +40,7 @@ menu:
 EOT
 
 # Create new $CONTENT_DIR/docs-$1
+rm -rf $CONTENT_DIR/docs-$1
 cp -rf $CONTENT_DIR/docs-dev $CONTENT_DIR/docs-$1
 cp -rf docs/themes/docsy/layouts/docs/ docs/layouts/docs-$1
 cat <<EOT > $CONTENT_DIR/docs-$1/_index.md

--- a/hack/gen-release-docs.sh
+++ b/hack/gen-release-docs.sh
@@ -17,8 +17,8 @@
 # parse params
 while [[ -z "$1" ]]
 do
-    echo "Missing docs version..."
-    exit 1
+  echo "Missing docs version..."
+  exit 1
 done
 
 echo "Prepare version docs"
@@ -50,6 +50,15 @@ linkTitle: "Documentation [$1]"
 type: docs
 ---
 EOT
+
+# Check whether docs/config.toml file contains route for new version docs /docs-$1/
+# If it contained already, skip updating docs/config.toml
+grep "/docs-$1/" docs/config.toml > /dev/null
+if [ $? -eq 0 ]
+then
+  echo "Version docs has been prepared successfully at $CONTENT_DIR/docs-$1/"
+  exit 0
+fi
 
 # Update docs/config.toml
 tail -r docs/config.toml | tail -n +5 | tail -r >> docs/config.toml.tmp


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the output of `make gen/release-docs` consistent. Previously, once the command run, if we run that command again, a new directory `docs-dev/` will be copied and stored under `docs-v0.x.x` directory which is annoying. Besides, I added logic to ensure update `docs/config.toml` file to add a route to the new version docs only if the version docs route has not existed yet.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
