### PR TITLE
Add labels to deployments list page

### DIFF
--- a/web/src/components/deployments-page/deployment-item/index.tsx
+++ b/web/src/components/deployments-page/deployment-item/index.tsx
@@ -1,4 +1,4 @@
-import { Box, ListItem, makeStyles, Typography } from "@material-ui/core";
+import { Box, Chip, ListItem, makeStyles, Typography } from "@material-ui/core";
 import dayjs from "dayjs";
 import { FC, memo } from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -33,6 +33,10 @@ const useStyles = makeStyles((theme) => ({
   description: {
     ...ellipsis,
     color: theme.palette.text.hint,
+  },
+  labelChip: {
+    marginLeft: theme.spacing(1),
+    marginBottom: theme.spacing(0.25),
   },
 }));
 
@@ -89,6 +93,13 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
               className={classes.info}
             >
               {APPLICATION_KIND_TEXT[deployment.kind]}
+              {deployment?.labelsMap.map(([key, value], i) => (
+                <Chip
+                  label={key + ": " + value}
+                  className={classes.labelChip}
+                  key={i}
+                />
+              ))}
             </Typography>
           </Box>
           <Typography variant="body1" className={classes.description}>


### PR DESCRIPTION
**What this PR does / why we need it**:

The UI looks like this
<img width="1091" alt="Screen Shot 2022-07-20 at 14 43 16" src="https://user-images.githubusercontent.com/32532742/179926324-612cb3b9-8752-4be9-b85a-2e050a91521a.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
