### PR TITLE
Add platformProviders config to piped

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -75,7 +75,7 @@ type ListRevisionsOptions struct {
 }
 
 type Registry interface {
-	Client(ctx context.Context, name string, cfg *config.CloudProviderCloudRunConfig, logger *zap.Logger) (Client, error)
+	Client(ctx context.Context, name string, cfg *config.PlatformProviderCloudRunConfig, logger *zap.Logger) (Client, error)
 }
 
 func LoadServiceManifest(appDir, serviceFilename string) (ServiceManifest, error) {
@@ -101,7 +101,7 @@ type registry struct {
 	newGroup *singleflight.Group
 }
 
-func (r *registry) Client(ctx context.Context, name string, cfg *config.CloudProviderCloudRunConfig, logger *zap.Logger) (Client, error) {
+func (r *registry) Client(ctx context.Context, name string, cfg *config.PlatformProviderCloudRunConfig, logger *zap.Logger) (Client, error) {
 	r.mu.RLock()
 	client, ok := r.clients[name]
 	r.mu.RUnlock()

--- a/pkg/app/piped/cloudprovider/ecs/ecs.go
+++ b/pkg/app/piped/cloudprovider/ecs/ecs.go
@@ -50,7 +50,7 @@ type ELB interface {
 
 // Registry holds a pool of aws client wrappers.
 type Registry interface {
-	Client(name string, cfg *config.CloudProviderECSConfig, logger *zap.Logger) (Client, error)
+	Client(name string, cfg *config.PlatformProviderECSConfig, logger *zap.Logger) (Client, error)
 }
 
 // LoadServiceDefinition returns ServiceDefinition object from a given service definition file.
@@ -76,7 +76,7 @@ type registry struct {
 	newGroup *singleflight.Group
 }
 
-func (r *registry) Client(name string, cfg *config.CloudProviderECSConfig, logger *zap.Logger) (Client, error) {
+func (r *registry) Client(name string, cfg *config.PlatformProviderECSConfig, logger *zap.Logger) (Client, error) {
 	r.mu.RLock()
 	client, ok := r.clients[name]
 	r.mu.RUnlock()

--- a/pkg/app/piped/cloudprovider/kubernetes/applier.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/applier.go
@@ -39,7 +39,7 @@ type Applier interface {
 
 type applier struct {
 	input         config.KubernetesDeploymentInput
-	cloudProvider config.CloudProviderKubernetesConfig
+	cloudProvider config.PlatformProviderKubernetesConfig
 	logger        *zap.Logger
 
 	kubectl  *Kubectl
@@ -47,7 +47,7 @@ type applier struct {
 	initErr  error
 }
 
-func NewApplier(input config.KubernetesDeploymentInput, cp config.CloudProviderKubernetesConfig, logger *zap.Logger) Applier {
+func NewApplier(input config.KubernetesDeploymentInput, cp config.PlatformProviderKubernetesConfig, logger *zap.Logger) Applier {
 	return &applier{
 		input:         input,
 		cloudProvider: cp,

--- a/pkg/app/piped/cloudprovider/lambda/lambda.go
+++ b/pkg/app/piped/cloudprovider/lambda/lambda.go
@@ -41,7 +41,7 @@ type Client interface {
 
 // Registry holds a pool of aws client wrappers.
 type Registry interface {
-	Client(name string, cfg *config.CloudProviderLambdaConfig, logger *zap.Logger) (Client, error)
+	Client(name string, cfg *config.PlatformProviderLambdaConfig, logger *zap.Logger) (Client, error)
 }
 
 // LoadFunctionManifest returns FunctionManifest object from a given Function config manifest file.
@@ -56,7 +56,7 @@ type registry struct {
 	newGroup *singleflight.Group
 }
 
-func (r *registry) Client(name string, cfg *config.CloudProviderLambdaConfig, logger *zap.Logger) (Client, error) {
+func (r *registry) Client(name string, cfg *config.PlatformProviderLambdaConfig, logger *zap.Logger) (Client, error) {
 	r.mu.RLock()
 	client, ok := r.clients[name]
 	r.mu.RUnlock()

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -56,7 +56,7 @@ type Detector interface {
 }
 
 type detector struct {
-	provider          config.PipedCloudProvider
+	provider          config.PipedPlatformProvider
 	appLister         applicationLister
 	gitClient         gitClient
 	stateGetter       cloudrun.Getter
@@ -71,7 +71,7 @@ type detector struct {
 }
 
 func NewDetector(
-	cp config.PipedCloudProvider,
+	cp config.PipedPlatformProvider,
 	appLister applicationLister,
 	gitClient gitClient,
 	stateGetter cloudrun.Getter,

--- a/pkg/app/piped/driftdetector/detector.go
+++ b/pkg/app/piped/driftdetector/detector.go
@@ -96,7 +96,7 @@ func NewDetector(
 
 	for _, cp := range cfg.CloudProviders {
 		switch cp.Type {
-		case model.CloudProviderKubernetes:
+		case model.PlatformProviderKubernetes:
 			sg, ok := stateGetter.KubernetesGetter(cp.Name)
 			if !ok {
 				return nil, fmt.Errorf(format, cp.Name)
@@ -113,7 +113,7 @@ func NewDetector(
 				logger,
 			))
 
-		case model.CloudProviderCloudRun:
+		case model.PlatformProviderCloudRun:
 			sg, ok := stateGetter.CloudRunGetter(cp.Name)
 			if !ok {
 				return nil, fmt.Errorf(format, cp.Name)

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -56,7 +56,7 @@ type Detector interface {
 }
 
 type detector struct {
-	provider          config.PipedCloudProvider
+	provider          config.PipedPlatformProvider
 	appLister         applicationLister
 	gitClient         gitClient
 	stateGetter       kubernetes.Getter
@@ -72,7 +72,7 @@ type detector struct {
 }
 
 func NewDetector(
-	cp config.PipedCloudProvider,
+	cp config.PipedPlatformProvider,
 	appLister applicationLister,
 	gitClient gitClient,
 	stateGetter kubernetes.Getter,

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -58,7 +58,7 @@ func loadServiceManifest(in *executor.Input, serviceManifestFile string, ds *dep
 	return sm, true
 }
 
-func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProviderCloudRunConfig, found bool) {
+func findCloudProvider(in *executor.Input) (name string, cfg *config.PlatformProviderCloudRunConfig, found bool) {
 	name = in.Application.CloudProvider
 	if name == "" {
 		in.LogPersister.Error("Missing the CloudProvider name in the application configuration")

--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -29,7 +29,7 @@ type deployExecutor struct {
 	deploySource      *deploysource.DeploySource
 	appCfg            *config.ECSApplicationSpec
 	cloudProviderName string
-	cloudProviderCfg  *config.CloudProviderECSConfig
+	cloudProviderCfg  *config.PlatformProviderECSConfig
 }
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -66,7 +66,7 @@ func Register(r registerer) {
 	})
 }
 
-func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProviderECSConfig, found bool) {
+func findCloudProvider(in *executor.Input) (name string, cfg *config.PlatformProviderECSConfig, found bool) {
 	name = in.Application.CloudProvider
 	if name == "" {
 		in.LogPersister.Errorf("Missing the CloudProvider name in the application configuration")
@@ -184,7 +184,7 @@ func createPrimaryTaskSet(ctx context.Context, client provider.Client, service t
 	return nil
 }
 
-func sync(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
+func sync(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", cloudProviderName, err)
@@ -215,7 +215,7 @@ func sync(ctx context.Context, in *executor.Input, cloudProviderName string, clo
 	return true
 }
 
-func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
+func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", cloudProviderName, err)
@@ -286,7 +286,7 @@ func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, 
 	return true
 }
 
-func clean(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig) bool {
+func clean(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig) bool {
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", cloudProviderName, err)
@@ -317,7 +317,7 @@ func clean(ctx context.Context, in *executor.Input, cloudProviderName string, cl
 	return true
 }
 
-func routing(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig, primaryTargetGroup types.LoadBalancer, canaryTargetGroup types.LoadBalancer) bool {
+func routing(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, primaryTargetGroup types.LoadBalancer, canaryTargetGroup types.LoadBalancer) bool {
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", cloudProviderName, err)

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -94,7 +94,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
+func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
 	in.LogPersister.Infof("Start rollback the ECS service and task family: %s and %s to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {

--- a/pkg/app/piped/executor/lambda/deploy.go
+++ b/pkg/app/piped/executor/lambda/deploy.go
@@ -34,7 +34,7 @@ type deployExecutor struct {
 	deploySource      *deploysource.DeploySource
 	appCfg            *config.LambdaApplicationSpec
 	cloudProviderName string
-	cloudProviderCfg  *config.CloudProviderLambdaConfig
+	cloudProviderCfg  *config.PlatformProviderLambdaConfig
 }
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {

--- a/pkg/app/piped/executor/lambda/lambda.go
+++ b/pkg/app/piped/executor/lambda/lambda.go
@@ -55,7 +55,7 @@ func Register(r registerer) {
 	})
 }
 
-func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProviderLambdaConfig, found bool) {
+func findCloudProvider(in *executor.Input) (name string, cfg *config.PlatformProviderLambdaConfig, found bool) {
 	name = in.Application.CloudProvider
 	if name == "" {
 		in.LogPersister.Errorf("Missing the CloudProvider name in the application configuration")
@@ -86,7 +86,7 @@ func loadFunctionManifest(in *executor.Input, functionManifestFile string, ds *d
 	return fm, true
 }
 
-func sync(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderLambdaConfig, fm provider.FunctionManifest) bool {
+func sync(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderLambdaConfig, fm provider.FunctionManifest) bool {
 	in.LogPersister.Infof("Start applying the lambda function manifest")
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
@@ -144,7 +144,7 @@ func sync(ctx context.Context, in *executor.Input, cloudProviderName string, clo
 	return true
 }
 
-func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderLambdaConfig, fm provider.FunctionManifest) bool {
+func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderLambdaConfig, fm provider.FunctionManifest) bool {
 	in.LogPersister.Infof("Start rolling out the lambda function: %s", fm.Spec.Name)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
@@ -184,7 +184,7 @@ func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, 
 	return true
 }
 
-func promote(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderLambdaConfig, fm provider.FunctionManifest) bool {
+func promote(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderLambdaConfig, fm provider.FunctionManifest) bool {
 	in.LogPersister.Infof("Start promote new version of the lambda function: %s", fm.Spec.Name)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {

--- a/pkg/app/piped/executor/lambda/rollback.go
+++ b/pkg/app/piped/executor/lambda/rollback.go
@@ -82,7 +82,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderLambdaConfig, fm provider.FunctionManifest) bool {
+func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderLambdaConfig, fm provider.FunctionManifest) bool {
 	in.LogPersister.Infof("Start rollback the lambda function: %s to original stage", fm.Spec.Name)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {

--- a/pkg/app/piped/executor/terraform/deploy.go
+++ b/pkg/app/piped/executor/terraform/deploy.go
@@ -34,7 +34,7 @@ type deployExecutor struct {
 }
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
-	_, cloudProviderCfg, found := findCloudProvider(&e.Input)
+	cloudProviderCfg, found := findCloudProvider(&e.Input)
 	if !found {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/rollback.go
+++ b/pkg/app/piped/executor/terraform/rollback.go
@@ -52,7 +52,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	_, cloudProviderCfg, found := findCloudProvider(&e.Input)
+	cloudProviderCfg, found := findCloudProvider(&e.Input)
 	if !found {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/terraform.go
+++ b/pkg/app/piped/executor/terraform/terraform.go
@@ -80,8 +80,8 @@ func findTerraform(ctx context.Context, version string, lp executor.LogPersister
 	return path, true
 }
 
-func findCloudProvider(in *executor.Input) (name string, cfg *config.PlatformProviderTerraformConfig, found bool) {
-	name = in.Application.CloudProvider
+func findCloudProvider(in *executor.Input) (cfg *config.PlatformProviderTerraformConfig, found bool) {
+	var name = in.Application.CloudProvider
 	if name == "" {
 		in.LogPersister.Error("Missing the CloudProvider name in the application configuration")
 		return

--- a/pkg/app/piped/executor/terraform/terraform.go
+++ b/pkg/app/piped/executor/terraform/terraform.go
@@ -80,7 +80,7 @@ func findTerraform(ctx context.Context, version string, lp executor.LogPersister
 	return path, true
 }
 
-func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProviderTerraformConfig, found bool) {
+func findCloudProvider(in *executor.Input) (name string, cfg *config.PlatformProviderTerraformConfig, found bool) {
 	name = in.Application.CloudProvider
 	if name == "" {
 		in.LogPersister.Error("Missing the CloudProvider name in the application configuration")

--- a/pkg/app/piped/livestatereporter/cloudrun/report.go
+++ b/pkg/app/piped/livestatereporter/cloudrun/report.go
@@ -43,7 +43,7 @@ type Reporter interface {
 }
 
 type reporter struct {
-	provider              config.PipedCloudProvider
+	provider              config.PipedPlatformProvider
 	appLister             applicationLister
 	stateGetter           cloudrun.Getter
 	apiClient             apiClient
@@ -53,7 +53,7 @@ type reporter struct {
 	snapshotVersions map[string]model.ApplicationLiveStateVersion
 }
 
-func NewReporter(cp config.PipedCloudProvider, appLister applicationLister, stateGetter cloudrun.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
+func NewReporter(cp config.PipedPlatformProvider, appLister applicationLister, stateGetter cloudrun.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
 	logger = logger.Named("cloudrun-reporter").With(
 		zap.String("cloud-provider", cp.Name),
 	)

--- a/pkg/app/piped/livestatereporter/kubernetes/reporter.go
+++ b/pkg/app/piped/livestatereporter/kubernetes/reporter.go
@@ -47,7 +47,7 @@ type Reporter interface {
 }
 
 type reporter struct {
-	provider              config.PipedCloudProvider
+	provider              config.PipedPlatformProvider
 	appLister             applicationLister
 	stateGetter           kubernetes.Getter
 	eventIterator         kubernetes.EventIterator
@@ -59,7 +59,7 @@ type reporter struct {
 	snapshotVersions map[string]model.ApplicationLiveStateVersion
 }
 
-func NewReporter(cp config.PipedCloudProvider, appLister applicationLister, stateGetter kubernetes.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
+func NewReporter(cp config.PipedPlatformProvider, appLister applicationLister, stateGetter kubernetes.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
 	logger = logger.Named("kubernetes-reporter").With(
 		zap.String("cloud-provider", cp.Name),
 	)

--- a/pkg/app/piped/livestatereporter/reporter.go
+++ b/pkg/app/piped/livestatereporter/reporter.go
@@ -65,14 +65,14 @@ func NewReporter(appLister applicationLister, stateGetter livestatestore.Getter,
 	for _, cp := range cfg.CloudProviders {
 		errFmt := fmt.Sprintf("unable to find live state getter for cloud provider: %s", cp.Name)
 		switch cp.Type {
-		case model.CloudProviderKubernetes:
+		case model.PlatformProviderKubernetes:
 			sg, ok := stateGetter.KubernetesGetter(cp.Name)
 			if !ok {
 				r.logger.Error(errFmt)
 				continue
 			}
 			r.reporters = append(r.reporters, kubernetes.NewReporter(cp, appLister, sg, apiClient, logger))
-		case model.CloudProviderCloudRun:
+		case model.PlatformProviderCloudRun:
 			sg, ok := stateGetter.CloudRunGetter(cp.Name)
 			if !ok {
 				r.logger.Error(errFmt)

--- a/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
+++ b/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
@@ -44,7 +44,7 @@ type State struct {
 	Version   model.ApplicationLiveStateVersion
 }
 
-func NewStore(ctx context.Context, cfg *config.CloudProviderCloudRunConfig, cloudProvider string, logger *zap.Logger) (*Store, error) {
+func NewStore(ctx context.Context, cfg *config.PlatformProviderCloudRunConfig, cloudProvider string, logger *zap.Logger) (*Store, error) {
 	logger = logger.Named("cloudrun").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/app/piped/livestatestore/ecs/store.go
+++ b/pkg/app/piped/livestatestore/ecs/store.go
@@ -34,7 +34,7 @@ type Store struct {
 type Getter interface {
 }
 
-func NewStore(cfg *config.CloudProviderECSConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
+func NewStore(cfg *config.PlatformProviderECSConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("ecs").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/app/piped/livestatestore/kubernetes/kubernetes.go
+++ b/pkg/app/piped/livestatestore/kubernetes/kubernetes.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Store struct {
-	config                *config.CloudProviderKubernetesConfig
+	config                *config.PlatformProviderKubernetesConfig
 	pipedConfig           *config.PipedSpec
 	kubeConfig            *restclient.Config
 	store                 *store
@@ -64,7 +64,7 @@ func (it EventIterator) Next(maxNum int) []model.KubernetesResourceStateEvent {
 	return it.store.nextEvents(it.id, maxNum)
 }
 
-func NewStore(cfg *config.CloudProviderKubernetesConfig, pipedConfig *config.PipedSpec, cloudProvider string, logger *zap.Logger) *Store {
+func NewStore(cfg *config.PlatformProviderKubernetesConfig, pipedConfig *config.PipedSpec, cloudProvider string, logger *zap.Logger) *Store {
 	logger = logger.Named("kubernetes").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/app/piped/livestatestore/kubernetes/reflector.go
+++ b/pkg/app/piped/livestatestore/kubernetes/reflector.go
@@ -137,7 +137,7 @@ var (
 // reflector watches the live state of application with the cluster
 // and triggers the specified callbacks.
 type reflector struct {
-	config      *config.CloudProviderKubernetesConfig
+	config      *config.PlatformProviderKubernetesConfig
 	kubeConfig  *restclient.Config
 	pipedConfig *config.PipedSpec
 

--- a/pkg/app/piped/livestatestore/lambda/store.go
+++ b/pkg/app/piped/livestatestore/lambda/store.go
@@ -34,7 +34,7 @@ type Store struct {
 type Getter interface {
 }
 
-func NewStore(cfg *config.CloudProviderLambdaConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
+func NewStore(cfg *config.PlatformProviderLambdaConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("lambda").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/app/piped/livestatestore/livestatestore.go
+++ b/pkg/app/piped/livestatestore/livestatestore.go
@@ -105,15 +105,15 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 	}
 	for _, cp := range cfg.CloudProviders {
 		switch cp.Type {
-		case model.CloudProviderKubernetes:
+		case model.PlatformProviderKubernetes:
 			store := kubernetes.NewStore(cp.KubernetesConfig, cfg, cp.Name, logger)
 			s.kubernetesStores[cp.Name] = store
 
-		case model.CloudProviderTerraform:
+		case model.PlatformProviderTerraform:
 			store := terraform.NewStore(cp.TerraformConfig, cp.Name, appLister, logger)
 			s.terraformStores[cp.Name] = store
 
-		case model.CloudProviderCloudRun:
+		case model.PlatformProviderCloudRun:
 			store, err := cloudrun.NewStore(ctx, cp.CloudRunConfig, cp.Name, logger)
 			if err != nil {
 				logger.Error("failed to create a new cloudrun's livestatestore", zap.Error(err))
@@ -121,11 +121,11 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 			}
 			s.cloudrunStores[cp.Name] = store
 
-		case model.CloudProviderLambda:
+		case model.PlatformProviderLambda:
 			store := lambda.NewStore(cp.LambdaConfig, cp.Name, appLister, logger)
 			s.lambdaStores[cp.Name] = store
 
-		case model.CloudProviderECS:
+		case model.PlatformProviderECS:
 			store := ecs.NewStore(cp.ECSConfig, cp.Name, appLister, logger)
 			s.ecsStores[cp.Name] = store
 		}

--- a/pkg/app/piped/livestatestore/terraform/store.go
+++ b/pkg/app/piped/livestatestore/terraform/store.go
@@ -34,7 +34,7 @@ type Store struct {
 type Getter interface {
 }
 
-func NewStore(cfg *config.CloudProviderTerraformConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
+func NewStore(cfg *config.PlatformProviderTerraformConfig, cloudProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("terraform").
 		With(zap.String("cloud-provider", cloudProvider))
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -66,7 +66,7 @@ type PipedSpec struct {
 	// List of helm chart registries that should be logged in while starting up.
 	ChartRegistries []HelmChartRegistry `json:"chartRegistries,omitempty"`
 	// List of cloud providers can be used by this piped.
-	// deprecated: use PlatformProvider instead.
+	// Deprecated: use PlatformProvider instead.
 	CloudProviders []PipedPlatformProvider `json:"cloudProviders,omitempty"`
 	// List of platform providers can be used by this piped.
 	PlatformProviders []PipedPlatformProvider `json:"platformProviders,omitempty"`

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -84,11 +84,11 @@ func TestPipedConfig(t *testing.T) {
 						Password: "sample-password",
 					},
 				},
-				CloudProviders: []PipedCloudProvider{
+				CloudProviders: []PipedPlatformProvider{
 					{
 						Name: "kubernetes-default",
-						Type: model.CloudProviderKubernetes,
-						KubernetesConfig: &CloudProviderKubernetesConfig{
+						Type: model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							AppStateInformer: KubernetesAppStateInformer{
 								IncludeResources: []KubernetesResourceMatcher{
 									{
@@ -110,13 +110,13 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name:             "kubernetes-dev",
-						Type:             model.CloudProviderKubernetes,
-						KubernetesConfig: &CloudProviderKubernetesConfig{},
+						Type:             model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{},
 					},
 					{
 						Name: "terraform",
-						Type: model.CloudProviderTerraform,
-						TerraformConfig: &CloudProviderTerraformConfig{
+						Type: model.PlatformProviderTerraform,
+						TerraformConfig: &PlatformProviderTerraformConfig{
 							Vars: []string{
 								"project=gcp-project",
 								"region=us-centra1",
@@ -125,8 +125,8 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name: "cloudrun",
-						Type: model.CloudProviderCloudRun,
-						CloudRunConfig: &CloudProviderCloudRunConfig{
+						Type: model.PlatformProviderCloudRun,
+						CloudRunConfig: &PlatformProviderCloudRunConfig{
 							Project:         "gcp-project-id",
 							Region:          "cloud-run-region",
 							CredentialsFile: "/etc/piped-secret/gcp-service-account.json",
@@ -134,8 +134,8 @@ func TestPipedConfig(t *testing.T) {
 					},
 					{
 						Name: "lambda",
-						Type: model.CloudProviderLambda,
-						LambdaConfig: &CloudProviderLambdaConfig{
+						Type: model.PlatformProviderLambda,
+						LambdaConfig: &PlatformProviderLambdaConfig{
 							Region: "us-east-1",
 						},
 					},
@@ -428,11 +428,11 @@ func TestPipedConfigMask(t *testing.T) {
 						Password: "foo",
 					},
 				},
-				CloudProviders: []PipedCloudProvider{
+				CloudProviders: []PipedPlatformProvider{
 					{
 						Name: "foo",
-						Type: model.CloudProviderKubernetes,
-						KubernetesConfig: &CloudProviderKubernetesConfig{
+						Type: model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							MasterURL:      "foo",
 							KubeConfigPath: "foo",
 							AppStateInformer: KubernetesAppStateInformer{
@@ -579,11 +579,11 @@ func TestPipedConfigMask(t *testing.T) {
 						Password: maskString,
 					},
 				},
-				CloudProviders: []PipedCloudProvider{
+				CloudProviders: []PipedPlatformProvider{
 					{
 						Name: "foo",
-						Type: model.CloudProviderKubernetes,
-						KubernetesConfig: &CloudProviderKubernetesConfig{
+						Type: model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							MasterURL:      "foo",
 							KubeConfigPath: "foo",
 							AppStateInformer: KubernetesAppStateInformer{

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -89,20 +89,20 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
-func (k *ApplicationKind) CompatibleCloudProviderType() CloudProviderType {
+func (k *ApplicationKind) CompatibleCloudProviderType() PlatformProviderType {
 	switch *k {
 	case ApplicationKind_KUBERNETES:
-		return CloudProviderKubernetes
+		return PlatformProviderKubernetes
 	case ApplicationKind_TERRAFORM:
-		return CloudProviderTerraform
+		return PlatformProviderTerraform
 	case ApplicationKind_LAMBDA:
-		return CloudProviderLambda
+		return PlatformProviderLambda
 	case ApplicationKind_CLOUDRUN:
-		return CloudProviderCloudRun
+		return PlatformProviderCloudRun
 	case ApplicationKind_ECS:
-		return CloudProviderECS
+		return PlatformProviderECS
 	default:
-		return CloudProviderKubernetes
+		return PlatformProviderKubernetes
 	}
 }
 

--- a/pkg/model/platformprovider.go
+++ b/pkg/model/platformprovider.go
@@ -14,16 +14,16 @@
 
 package model
 
-type CloudProviderType string
+type PlatformProviderType string
 
 const (
-	CloudProviderKubernetes CloudProviderType = "KUBERNETES"
-	CloudProviderTerraform  CloudProviderType = "TERRAFORM"
-	CloudProviderLambda     CloudProviderType = "LAMBDA"
-	CloudProviderCloudRun   CloudProviderType = "CLOUDRUN"
-	CloudProviderECS        CloudProviderType = "ECS"
+	PlatformProviderKubernetes PlatformProviderType = "KUBERNETES"
+	PlatformProviderTerraform  PlatformProviderType = "TERRAFORM"
+	PlatformProviderLambda     PlatformProviderType = "LAMBDA"
+	PlatformProviderCloudRun   PlatformProviderType = "CLOUDRUN"
+	PlatformProviderECS        PlatformProviderType = "ECS"
 )
 
-func (t CloudProviderType) String() string {
+func (t PlatformProviderType) String() string {
 	return string(t)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR only adds PlatformProviders as piped configuration option, all logic around usage of CloudProviders are remained and will be addressed by another PR.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
