### PR TITLE
Fix fail clone PipedSpec object

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -152,8 +152,6 @@ func (s *PipedSpec) Clone() (*PipedSpec, error) {
 		return nil, err
 	}
 
-	// fmt.Println(string(js))
-
 	var clone PipedSpec
 	if err = json.Unmarshal(js, &clone); err != nil {
 		return nil, err

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -937,8 +937,8 @@ type SecretManagement struct {
 	// Available values: KEY_PAIR, GCP_KMS, AWS_KMS
 	Type model.SecretManagementType `json:"type"`
 
-	KeyPair *SecretManagementKeyPair `json:"keyPair,omitempty"`
-	GCPKMS  *SecretManagementGCPKMS  `json:"gcpkms,omitempty"`
+	KeyPair *SecretManagementKeyPair
+	GCPKMS  *SecretManagementGCPKMS
 }
 
 type genericSecretManagement struct {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -147,18 +147,19 @@ func (s *PipedSpec) Validate() error {
 
 // Clone generates a cloned PipedSpec object.
 func (s *PipedSpec) Clone() (*PipedSpec, error) {
-	clone := &PipedSpec{}
-
 	js, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = json.Unmarshal(js, clone); err != nil {
+	// fmt.Println(string(js))
+
+	var clone PipedSpec
+	if err = json.Unmarshal(js, &clone); err != nil {
 		return nil, err
 	}
 
-	return clone, nil
+	return &clone, nil
 }
 
 // Mask masks confidential fields.

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -89,6 +89,8 @@ func TestPipedConfig(t *testing.T) {
 						Name: "kubernetes-default",
 						Type: model.PlatformProviderKubernetes,
 						KubernetesConfig: &PlatformProviderKubernetesConfig{
+							MasterURL:      "https://example.com",
+							KubeConfigPath: "/etc/kube/config",
 							AppStateInformer: KubernetesAppStateInformer{
 								IncludeResources: []KubernetesResourceMatcher{
 									{
@@ -452,6 +454,15 @@ func TestPipedConfigMask(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name: "bar",
+						Type: model.PlatformProviderCloudRun,
+						CloudRunConfig: &PlatformProviderCloudRunConfig{
+							Project:         "bar",
+							Region:          "bar",
+							CredentialsFile: "/etc/cloudrun/credentials",
+						},
+					},
 				},
 				AnalysisProviders: []PipedAnalysisProvider{
 					{
@@ -603,6 +614,15 @@ func TestPipedConfigMask(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name: "bar",
+						Type: model.PlatformProviderCloudRun,
+						CloudRunConfig: &PlatformProviderCloudRunConfig{
+							Project:         "bar",
+							Region:          "bar",
+							CredentialsFile: "******",
+						},
+					},
 				},
 				AnalysisProviders: []PipedAnalysisProvider{
 					{
@@ -692,6 +712,419 @@ func TestPipedConfigMask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.spec.Mask()
 			assert.Equal(t, tc.want, tc.spec)
+		})
+	}
+}
+
+func TestPipedSpecClone(t *testing.T) {
+	testcases := []struct {
+		name          string
+		originalSpec  *PipedSpec
+		expectedSpec  *PipedSpec
+		expectedError error
+	}{
+		{
+			name: "clone success",
+			originalSpec: &PipedSpec{
+				ProjectID:             "test-project",
+				PipedID:               "test-piped",
+				PipedKeyFile:          "etc/piped/key",
+				APIAddress:            "your-pipecd.domain",
+				WebAddress:            "https://your-pipecd.domain",
+				SyncInterval:          Duration(time.Minute),
+				AppConfigSyncInterval: Duration(time.Minute),
+				Git: PipedGit{
+					Username:   "username",
+					Email:      "username@email.com",
+					SSHKeyFile: "/etc/piped-secret/ssh-key",
+				},
+				Repositories: []PipedRepository{
+					{
+						RepoID: "repo1",
+						Remote: "git@github.com:org/repo1.git",
+						Branch: "master",
+					},
+					{
+						RepoID: "repo2",
+						Remote: "git@github.com:org/repo2.git",
+						Branch: "master",
+					},
+				},
+				ChartRepositories: []HelmChartRepository{
+					{
+						Type:    HTTPHelmChartRepository,
+						Name:    "fantastic-charts",
+						Address: "https://fantastic-charts.storage.googleapis.com",
+					},
+					{
+						Type:     HTTPHelmChartRepository,
+						Name:     "private-charts",
+						Address:  "https://private-charts.com",
+						Username: "basic-username",
+						Password: "basic-password",
+						Insecure: true,
+					},
+				},
+				ChartRegistries: []HelmChartRegistry{
+					{
+						Type:     OCIHelmChartRegistry,
+						Address:  "registry.example.com",
+						Username: "sample-username",
+						Password: "sample-password",
+					},
+				},
+				PlatformProviders: []PipedPlatformProvider{
+					{
+						Name: "kubernetes-default",
+						Type: model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{
+							MasterURL:      "https://example.com",
+							KubeConfigPath: "/etc/kube/config",
+							AppStateInformer: KubernetesAppStateInformer{
+								IncludeResources: []KubernetesResourceMatcher{
+									{
+										APIVersion: "pipecd.dev/v1beta1",
+									},
+									{
+										APIVersion: "networking.gke.io/v1beta1",
+										Kind:       "ManagedCertificate",
+									},
+								},
+								ExcludeResources: []KubernetesResourceMatcher{
+									{
+										APIVersion: "v1",
+										Kind:       "Endpoints",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name:             "kubernetes-dev",
+						Type:             model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{},
+					},
+					{
+						Name: "terraform",
+						Type: model.PlatformProviderTerraform,
+						TerraformConfig: &PlatformProviderTerraformConfig{
+							Vars: []string{
+								"project=gcp-project",
+								"region=us-centra1",
+							},
+						},
+					},
+					{
+						Name: "cloudrun",
+						Type: model.PlatformProviderCloudRun,
+						CloudRunConfig: &PlatformProviderCloudRunConfig{
+							Project:         "gcp-project-id",
+							Region:          "cloud-run-region",
+							CredentialsFile: "/etc/piped-secret/gcp-service-account.json",
+						},
+					},
+					{
+						Name: "lambda",
+						Type: model.PlatformProviderLambda,
+						LambdaConfig: &PlatformProviderLambdaConfig{
+							Region: "us-east-1",
+						},
+					},
+				},
+				AnalysisProviders: []PipedAnalysisProvider{
+					{
+						Name: "prometheus-dev",
+						Type: model.AnalysisProviderPrometheus,
+						PrometheusConfig: &AnalysisProviderPrometheusConfig{
+							Address: "https://your-prometheus.dev",
+						},
+					},
+					{
+						Name: "datadog-dev",
+						Type: model.AnalysisProviderDatadog,
+						DatadogConfig: &AnalysisProviderDatadogConfig{
+							Address:            "https://your-datadog.dev",
+							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
+							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
+						},
+					},
+					{
+						Name: "stackdriver-dev",
+						Type: model.AnalysisProviderStackdriver,
+						StackdriverConfig: &AnalysisProviderStackdriverConfig{
+							ServiceAccountFile: "/etc/piped-secret/gcp-service-account.json",
+						},
+					},
+				},
+				Notifications: Notifications{
+					Routes: []NotificationRoute{
+						{
+							Name: "dev-slack",
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+							Receiver: "dev-slack-channel",
+						},
+						{
+							Name: "prod-slack",
+							Labels: map[string]string{
+								"env": "dev",
+							},
+							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
+							Receiver: "prod-slack-channel",
+						},
+						{
+							Name:     "all-events-to-ci",
+							Receiver: "ci-webhook",
+						},
+					},
+					Receivers: []NotificationReceiver{
+						{
+							Name: "dev-slack-channel",
+							Slack: &NotificationReceiverSlack{
+								HookURL: "https://slack.com/dev",
+							},
+						},
+						{
+							Name: "prod-slack-channel",
+							Slack: &NotificationReceiverSlack{
+								HookURL: "https://slack.com/prod",
+							},
+						},
+						{
+							Name: "ci-webhook",
+							Webhook: &NotificationReceiverWebhook{
+								URL:            "https://pipecd.dev/dev-hook",
+								SignatureKey:   "PipeCD-Signature",
+								SignatureValue: "random-signature-string",
+							},
+						},
+					},
+				},
+				SecretManagement: &SecretManagement{
+					Type: model.SecretManagementTypeKeyPair,
+					KeyPair: &SecretManagementKeyPair{
+						PrivateKeyFile: "/etc/piped-secret/pair-private-key",
+						PublicKeyFile:  "/etc/piped-secret/pair-public-key",
+					},
+				},
+				EventWatcher: PipedEventWatcher{
+					CheckInterval: Duration(10 * time.Minute),
+					GitRepos: []PipedEventWatcherGitRepo{
+						{
+							RepoID:        "repo-1",
+							CommitMessage: "Update values by Event watcher",
+							Includes:      []string{"event-watcher-dev.yaml", "event-watcher-stg.yaml"},
+						},
+					},
+				},
+			},
+			expectedSpec: &PipedSpec{
+				ProjectID:             "test-project",
+				PipedID:               "test-piped",
+				PipedKeyFile:          "etc/piped/key",
+				APIAddress:            "your-pipecd.domain",
+				WebAddress:            "https://your-pipecd.domain",
+				SyncInterval:          Duration(time.Minute),
+				AppConfigSyncInterval: Duration(time.Minute),
+				Git: PipedGit{
+					Username:   "username",
+					Email:      "username@email.com",
+					SSHKeyFile: "/etc/piped-secret/ssh-key",
+				},
+				Repositories: []PipedRepository{
+					{
+						RepoID: "repo1",
+						Remote: "git@github.com:org/repo1.git",
+						Branch: "master",
+					},
+					{
+						RepoID: "repo2",
+						Remote: "git@github.com:org/repo2.git",
+						Branch: "master",
+					},
+				},
+				ChartRepositories: []HelmChartRepository{
+					{
+						Type:    HTTPHelmChartRepository,
+						Name:    "fantastic-charts",
+						Address: "https://fantastic-charts.storage.googleapis.com",
+					},
+					{
+						Type:     HTTPHelmChartRepository,
+						Name:     "private-charts",
+						Address:  "https://private-charts.com",
+						Username: "basic-username",
+						Password: "basic-password",
+						Insecure: true,
+					},
+				},
+				ChartRegistries: []HelmChartRegistry{
+					{
+						Type:     OCIHelmChartRegistry,
+						Address:  "registry.example.com",
+						Username: "sample-username",
+						Password: "sample-password",
+					},
+				},
+				PlatformProviders: []PipedPlatformProvider{
+					{
+						Name: "kubernetes-default",
+						Type: model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{
+							MasterURL:      "https://example.com",
+							KubeConfigPath: "/etc/kube/config",
+							AppStateInformer: KubernetesAppStateInformer{
+								IncludeResources: []KubernetesResourceMatcher{
+									{
+										APIVersion: "pipecd.dev/v1beta1",
+									},
+									{
+										APIVersion: "networking.gke.io/v1beta1",
+										Kind:       "ManagedCertificate",
+									},
+								},
+								ExcludeResources: []KubernetesResourceMatcher{
+									{
+										APIVersion: "v1",
+										Kind:       "Endpoints",
+									},
+								},
+							},
+						},
+					},
+					{
+						Name:             "kubernetes-dev",
+						Type:             model.PlatformProviderKubernetes,
+						KubernetesConfig: &PlatformProviderKubernetesConfig{},
+					},
+					{
+						Name: "terraform",
+						Type: model.PlatformProviderTerraform,
+						TerraformConfig: &PlatformProviderTerraformConfig{
+							Vars: []string{
+								"project=gcp-project",
+								"region=us-centra1",
+							},
+						},
+					},
+					{
+						Name: "cloudrun",
+						Type: model.PlatformProviderCloudRun,
+						CloudRunConfig: &PlatformProviderCloudRunConfig{
+							Project:         "gcp-project-id",
+							Region:          "cloud-run-region",
+							CredentialsFile: "/etc/piped-secret/gcp-service-account.json",
+						},
+					},
+					{
+						Name: "lambda",
+						Type: model.PlatformProviderLambda,
+						LambdaConfig: &PlatformProviderLambdaConfig{
+							Region: "us-east-1",
+						},
+					},
+				},
+				AnalysisProviders: []PipedAnalysisProvider{
+					{
+						Name: "prometheus-dev",
+						Type: model.AnalysisProviderPrometheus,
+						PrometheusConfig: &AnalysisProviderPrometheusConfig{
+							Address: "https://your-prometheus.dev",
+						},
+					},
+					{
+						Name: "datadog-dev",
+						Type: model.AnalysisProviderDatadog,
+						DatadogConfig: &AnalysisProviderDatadogConfig{
+							Address:            "https://your-datadog.dev",
+							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
+							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
+						},
+					},
+					{
+						Name: "stackdriver-dev",
+						Type: model.AnalysisProviderStackdriver,
+						StackdriverConfig: &AnalysisProviderStackdriverConfig{
+							ServiceAccountFile: "/etc/piped-secret/gcp-service-account.json",
+						},
+					},
+				},
+				Notifications: Notifications{
+					Routes: []NotificationRoute{
+						{
+							Name: "dev-slack",
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+							Receiver: "dev-slack-channel",
+						},
+						{
+							Name: "prod-slack",
+							Labels: map[string]string{
+								"env": "dev",
+							},
+							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
+							Receiver: "prod-slack-channel",
+						},
+						{
+							Name:     "all-events-to-ci",
+							Receiver: "ci-webhook",
+						},
+					},
+					Receivers: []NotificationReceiver{
+						{
+							Name: "dev-slack-channel",
+							Slack: &NotificationReceiverSlack{
+								HookURL: "https://slack.com/dev",
+							},
+						},
+						{
+							Name: "prod-slack-channel",
+							Slack: &NotificationReceiverSlack{
+								HookURL: "https://slack.com/prod",
+							},
+						},
+						{
+							Name: "ci-webhook",
+							Webhook: &NotificationReceiverWebhook{
+								URL:            "https://pipecd.dev/dev-hook",
+								SignatureKey:   "PipeCD-Signature",
+								SignatureValue: "random-signature-string",
+							},
+						},
+					},
+				},
+				SecretManagement: &SecretManagement{
+					Type: model.SecretManagementTypeKeyPair,
+					KeyPair: &SecretManagementKeyPair{
+						PrivateKeyFile: "/etc/piped-secret/pair-private-key",
+						PublicKeyFile:  "/etc/piped-secret/pair-public-key",
+					},
+				},
+				EventWatcher: PipedEventWatcher{
+					CheckInterval: Duration(10 * time.Minute),
+					GitRepos: []PipedEventWatcherGitRepo{
+						{
+							RepoID:        "repo-1",
+							CommitMessage: "Update values by Event watcher",
+							Includes:      []string{"event-watcher-dev.yaml", "event-watcher-stg.yaml"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloned, err := tc.originalSpec.Clone()
+			require.Equal(t, tc.expectedError, err)
+			if err == nil {
+				assert.Equal(t, tc.expectedSpec, cloned)
+			}
 		})
 	}
 }

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -36,10 +36,12 @@ spec:
       username: sample-username
       password: sample-password
 
-  cloudProviders:
+  platformProviders:
     - name: kubernetes-default
       type: KUBERNETES
       config:
+        masterURL: https://example.com
+        kubeConfigPath: /etc/kube/config
         appStateInformer:
           includeResources:
             - apiVersion: pipecd.dev/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

The root cause of this problem is that we use a customized UnmarshalJSON function for objects of kind PlatformProvider (and AnalysisProvider, SecretManagement, etc), while in the Clone function, we implement deep cloning object by marshal the object to JSON then, re-unmarshal it to a new object.
The re-unmarshal logic based on customized UnmarshalJSON and its fields' names are changed, hence the original MarshalJSON can not marshal the object to a correct JSON => the second time we re-unmarshal from wrong JSON to object, the object changed from its original version.

To handle that issue, this PR added customized MarshalJSON logic corresponding to the customized UnmarshalJSON logic, such that we can marshal an object of those kinds correctly.

Thanks @nghialv for pointing out this 👍 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
