### PR TITLE
Update codegen container image

### DIFF
--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -12,8 +12,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Generate code
       uses: docker://ghcr.io/pipe-cd/codegen@sha256:5e10b6416d507d54b8ca9ab58820f11633d88af1d9fdcce65b5e568abbbe3d9e #v0.32.0
-      run: ./tool/codegen/codegen.sh
       with:
+        entrypoint: ./tool/codegen/codegen.sh
         args: /github/workspace
     - name: Show Git status
       shell: bash

--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Generate code
       uses: docker://ghcr.io/pipe-cd/codegen@sha256:5e10b6416d507d54b8ca9ab58820f11633d88af1d9fdcce65b5e568abbbe3d9e #v0.32.0
+      run: ./tool/codegen/codegen.sh
       with:
         args: /github/workspace
     - name: Show Git status

--- a/tool/codegen/Dockerfile
+++ b/tool/codegen/Dockerfile
@@ -55,8 +55,3 @@ RUN go install github.com/golang/mock/mockgen@v${GOMOCK_VER}
 
 VOLUME /repo
 WORKDIR /repo
-
-COPY ./codegen.sh /
-RUN chmod +x /codegen.sh
-
-ENTRYPOINT ["/codegen.sh"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This change the codegen container image by remove its entrypoint, the codegen.sh script will be refer from source code instead of from container image.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
