### PR TITLE
Add pipectl install controlplane command

### DIFF
--- a/cmd/pipectl/main.go
+++ b/cmd/pipectl/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/deployment"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/encrypt"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/event"
+	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/installation"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/piped"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/planpreview"
 	"github.com/pipe-cd/pipecd/pkg/cli"
@@ -40,6 +41,7 @@ func main() {
 		planpreview.NewCommand(),
 		piped.NewCommand(),
 		encrypt.NewCommand(),
+		installation.NewCommand(),
 	)
 
 	if err := app.Run(); err != nil {

--- a/pkg/app/pipectl/cmd/installation/controlplane.go
+++ b/pkg/app/pipectl/cmd/installation/controlplane.go
@@ -65,7 +65,7 @@ func newInstallControlplaneCommand() *cobra.Command {
 	c := &controlplane{
 		version:   version.Get().Version,
 		namespace: pipecdDefaultNamespace,
-		toolsDir:  path.Join(home, ".piped", "tools"),
+		toolsDir:  path.Join(home, ".pipectl", "tools"),
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/app/pipectl/cmd/installation/controlplane.go
+++ b/pkg/app/pipectl/cmd/installation/controlplane.go
@@ -44,6 +44,7 @@ type controlplane struct {
 	namespace  string
 
 	toolsDir          string
+	values            string
 	configFile        string
 	encryptionKeyFile string
 
@@ -81,6 +82,7 @@ func newInstallControlplaneCommand() *cobra.Command {
 	cmd.Flags().StringVar(&c.toolsDir, "tools-dir", c.toolsDir, "The path to directory where to install needed tools such as helm.")
 	cmd.Flags().StringVar(&c.configFile, "config-file", c.configFile, "The path to the Control Plane configuration file.")
 	cmd.Flags().StringVar(&c.encryptionKeyFile, "encryption-key-file", c.encryptionKeyFile, "The path to the Control Plane encryption key file.")
+	cmd.Flags().StringVar(&c.values, "values", c.values, "The Helm chart '--values' flag, which specify values in a YAML file or a URL (can specify multiple).")
 
 	cmd.Flags().StringVar(&c.firestoreServiceAccount, "firestore-service-account-file", c.firestoreServiceAccount, "The path to service account which used to access controlplane Firestore database (if using).")
 	cmd.Flags().StringVar(&c.cloudSQLServiceAccount, "cloud-sql-service-account-file", c.cloudSQLServiceAccount, "The path to service account which used to access controlplane Google cloud SQL database (if using).")
@@ -219,6 +221,10 @@ func (c *controlplane) buildHelmArgs() ([]string, error) {
 			"--set-file",
 			fmt.Sprintf("secret.internalTLSCert.data=%s", c.internalTLSCert),
 		)
+	}
+
+	if c.values != "" {
+		args = append(args, "--values", c.values)
 	}
 
 	return args, nil

--- a/pkg/app/pipectl/cmd/installation/controlplane.go
+++ b/pkg/app/pipectl/cmd/installation/controlplane.go
@@ -1,0 +1,140 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pipe-cd/pipecd/pkg/cli"
+	"github.com/pipe-cd/pipecd/pkg/version"
+)
+
+const (
+	pipecdDefaultNamespace = "default"
+
+	helmBinaryName    = "helm"
+	helmReleaseName   = "pipecd"
+	helmChartRepoName = "oci://ghcr.io/pipe-cd/chart/pipecd"
+
+	helmQuickstartValueRemotePath = "https://raw.githubusercontent.com/pipe-cd/pipecd/%s/quickstart/control-plane-values.yaml"
+)
+
+type controlplane struct {
+	quickstart bool
+	version    string
+	namespace  string
+
+	toolsDir   string
+	configFile string
+}
+
+func newInstallControlplaneCommand() *cobra.Command {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Sprintf("failed to detect the current user's home directory: %v", err))
+	}
+
+	c := &controlplane{
+		version:   version.Get().Version,
+		namespace: pipecdDefaultNamespace,
+		toolsDir:  path.Join(home, ".piped", "tools"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "controlplane",
+		Short: "Install PipeCD Control Plane.",
+		RunE:  cli.WithContext(c.run),
+	}
+
+	cmd.Flags().BoolVar(&c.quickstart, "quickstart", c.quickstart, "Whether installing the Control Plane in quickstart mode.")
+	cmd.Flags().StringVar(&c.version, "version", c.version, "The Control Plane version. Default is the version of pipectl.")
+	cmd.Flags().StringVar(&c.namespace, "namespace", c.namespace, "The cluster namespace where to install Control Plane. Default is 'default'.")
+
+	cmd.Flags().StringVar(&c.toolsDir, "tools-dir", c.toolsDir, "The path to directory where to install needed tools such as helm.")
+	cmd.Flags().StringVar(&c.configFile, "config-file", c.configFile, "The path to the Control Plane configuration file.")
+
+	return cmd
+}
+
+func (c *controlplane) run(ctx context.Context, input cli.Input) error {
+	helm, err := c.findHelm()
+	if err != nil {
+		return fmt.Errorf("failed to check required tools before install: %v", err)
+	}
+
+	input.Logger.Info("Installing the controlplane's components")
+
+	var args []string
+	if c.quickstart {
+		args = c.buildHelmArgsForQuickstart()
+	} else {
+		args = []string{}
+	}
+
+	var stderr, stdout bytes.Buffer
+	cmd := exec.CommandContext(ctx, helm, args...)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+
+	input.Logger.Info(stdout.String())
+
+	return nil
+}
+
+func (c *controlplane) findHelm() (string, error) {
+	fi, err := os.Stat(path.Join(c.toolsDir, helmBinaryName))
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	// If the Helm executable binary exists in tools dir, use it.
+	if fi != nil {
+		return path.Join(c.toolsDir, helmBinaryName), nil
+	}
+
+	// If the Helm executable binary exists in $PATH, use it.
+	path, err := exec.LookPath("helm")
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (c *controlplane) buildHelmArgsForQuickstart() []string {
+	return []string{
+		"upgrade",
+		"--install",
+		helmReleaseName,
+		helmChartRepoName,
+		"--version",
+		c.version,
+		"--namespace",
+		c.namespace,
+		"--create-namespace",
+		"--values",
+		fmt.Sprintf(helmQuickstartValueRemotePath, c.version),
+	}
+}

--- a/pkg/app/pipectl/cmd/installation/installation.go
+++ b/pkg/app/pipectl/cmd/installation/installation.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install pipecd/piped components.",
+	}
+
+	cmd.AddCommand(
+		newInstallControlplaneCommand(),
+	)
+	return cmd
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Note: For this implementation, the pipectl does not install any external tools which are required to install controlplane (such as helm) since users' local may already have the tools installed or they have many different versions but want to use specified one from a path. So I think we should not use pipectl to install tools (like helm) but lets users specified what to use. Will rethink about it and maybe support installing required tools if does not exist later.

Comamnd which used to install PipeCD controlplane in quickstart mode

```bash
$ pipectl install controlplane --quickstart --version v0.35.0
```

Current help print

```bash
$ pipectl install controlplane -h
Install PipeCD Control Plane.

Usage:
  pipectl install controlplane [flags]

Flags:
      --cloud-sql-service-account-file string   The path to service account which used to access controlplane Google cloud SQL database (if using).
      --config-file string                      The path to the Control Plane configuration file.
      --encryption-key-file string              The path to the Control Plane encryption key file.
      --firestore-service-account-file string   The path to service account which used to access controlplane Firestore database (if using).
      --gcs-service-account-file string         The path to service account which used to access controlplane Google Cloud Storage service (if using).
  -h, --help                                    help for controlplane
      --internal-tls-cert-file string           The path to internal TLS certificate file (if using).
      --internal-tls-key-file string            The path to internal TLS key file (if using).
      --minio-access-key-file string            The path to access key which used to connect Minio filestore (if using).
      --minio-secret-key-file string            The path to secret key which used to connect Minio filestore (if using).
      --namespace string                        The cluster namespace where to install Control Plane. Default is 'default'. (default "default")
      --quickstart                              Whether installing the Control Plane in quickstart mode.
      --tools-dir string                        The path to directory where to install needed tools such as helm. (default "/Users/s12228/.piped/tools")
      --version string                          The Control Plane version. Default is the version of pipectl. (default "v0.34.2-15-gca1b82f-dirty")

Global Flags:
      --log-encoding string                The encoding type for logger [json|console|humanize]. (default "humanize")
      --log-level string                   The minimum enabled logging level. (default "info")
      --metrics                            Whether metrics is enabled or not. (default true)
      --profile                            If true enables uploading the profiles to Stackdriver.
      --profile-debug-logging              If true enables logging debug information of profiler.
      --profiler-credentials-file string   The path to the credentials file using while sending profiles to Stackdriver.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to install PipeCD control plane via pipectl cli
```
