### PR TITLE
Fix duplicated providers listed in application form

### DIFF
--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -224,6 +224,7 @@ func (s *pipedStore) UpdateDesiredVersion(ctx context.Context, id, version strin
 
 func (s *pipedStore) UpdateMetadata(ctx context.Context, id, version, config string, pps []*model.Piped_PlatformProvider, repos []*model.ApplicationGitRepository, se *model.Piped_SecretEncryption, startedAt int64) error {
 	return s.update(ctx, id, func(piped *model.Piped) error {
+		piped.CloudProviders = nil
 		piped.PlatformProviders = pps
 		piped.Repositories = repos
 		piped.SecretEncryption = se


### PR DESCRIPTION
**What this PR does / why we need it**:

The root cause of this issue is that when the currently running piped reports its metadata to the controlplane, only piped's platformProviders values in controlplane database are updated, but we forget to remove the old cloudProviders value, such that it exists and will be returned later in the web console application adding form.

<img width="602" alt="Screen Shot 2022-08-09 at 11 20 09" src="https://user-images.githubusercontent.com/32532742/183549331-2637bda4-c34e-43ee-b3ca-e432c1a159fa.png">

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix platform providers shows duplicated values in application form
```
