### PR TITLE
Add labels field to platformProvider config struct

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -476,6 +476,7 @@ type PipedPlatformProvider struct {
 type genericPipedPlatformProvider struct {
 	Name   string                     `json:"name"`
 	Type   model.PlatformProviderType `json:"type"`
+	Labels map[string]string          `json:"labels,omitempty"`
 	Config json.RawMessage            `json:"config"`
 }
 
@@ -507,6 +508,7 @@ func (p *PipedPlatformProvider) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&genericPipedPlatformProvider{
 		Name:   p.Name,
 		Type:   p.Type,
+		Labels: p.Labels,
 		Config: config,
 	})
 }
@@ -519,6 +521,7 @@ func (p *PipedPlatformProvider) UnmarshalJSON(data []byte) error {
 	}
 	p.Name = gp.Name
 	p.Type = gp.Type
+	p.Labels = gp.Labels
 
 	switch p.Type {
 	case model.PlatformProviderKubernetes:

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -462,8 +462,9 @@ func (r *HelmChartRegistry) Mask() {
 }
 
 type PipedPlatformProvider struct {
-	Name string                     `json:"name"`
-	Type model.PlatformProviderType `json:"type"`
+	Name   string                     `json:"name"`
+	Type   model.PlatformProviderType `json:"type"`
+	Labels map[string]string          `json:"labels,omitempty"`
 
 	KubernetesConfig *PlatformProviderKubernetesConfig
 	TerraformConfig  *PlatformProviderTerraformConfig

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -777,6 +777,9 @@ func TestPipedSpecClone(t *testing.T) {
 					{
 						Name: "kubernetes-default",
 						Type: model.PlatformProviderKubernetes,
+						Labels: map[string]string{
+							"group": "workload",
+						},
 						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							MasterURL:      "https://example.com",
 							KubeConfigPath: "/etc/kube/config",
@@ -800,7 +803,10 @@ func TestPipedSpecClone(t *testing.T) {
 						},
 					},
 					{
-						Name:             "kubernetes-dev",
+						Name: "kubernetes-dev",
+						Labels: map[string]string{
+							"group": "config",
+						},
 						Type:             model.PlatformProviderKubernetes,
 						KubernetesConfig: &PlatformProviderKubernetesConfig{},
 					},

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -88,6 +88,9 @@ func TestPipedConfig(t *testing.T) {
 					{
 						Name: "kubernetes-default",
 						Type: model.PlatformProviderKubernetes,
+						Labels: map[string]string{
+							"group": "workload",
+						},
 						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							MasterURL:      "https://example.com",
 							KubeConfigPath: "/etc/kube/config",
@@ -111,8 +114,11 @@ func TestPipedConfig(t *testing.T) {
 						},
 					},
 					{
-						Name:             "kubernetes-dev",
-						Type:             model.PlatformProviderKubernetes,
+						Name: "kubernetes-dev",
+						Type: model.PlatformProviderKubernetes,
+						Labels: map[string]string{
+							"group": "config",
+						},
 						KubernetesConfig: &PlatformProviderKubernetesConfig{},
 					},
 					{
@@ -777,9 +783,6 @@ func TestPipedSpecClone(t *testing.T) {
 					{
 						Name: "kubernetes-default",
 						Type: model.PlatformProviderKubernetes,
-						Labels: map[string]string{
-							"group": "workload",
-						},
 						KubernetesConfig: &PlatformProviderKubernetesConfig{
 							MasterURL:      "https://example.com",
 							KubeConfigPath: "/etc/kube/config",
@@ -803,10 +806,7 @@ func TestPipedSpecClone(t *testing.T) {
 						},
 					},
 					{
-						Name: "kubernetes-dev",
-						Labels: map[string]string{
-							"group": "config",
-						},
+						Name:             "kubernetes-dev",
 						Type:             model.PlatformProviderKubernetes,
 						KubernetesConfig: &PlatformProviderKubernetesConfig{},
 					},

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -39,6 +39,8 @@ spec:
   platformProviders:
     - name: kubernetes-default
       type: KUBERNETES
+      labels:
+        group: workload
       config:
         masterURL: https://example.com
         kubeConfigPath: /etc/kube/config
@@ -53,6 +55,8 @@ spec:
 
     - name: kubernetes-dev
       type: KUBERNETES
+      labels:
+        group: config
 
     - name: terraform
       type: TERRAFORM


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows labeling platformProvider as well as allow selecting the provider via the label mechanism.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
