### PR TITLE
Rename labels matcher function and update test

### DIFF
--- a/pkg/app/piped/executor/kubernetes/applier_group.go
+++ b/pkg/app/piped/executor/kubernetes/applier_group.go
@@ -68,9 +68,9 @@ func newApplierGroup(defaultProvider string, appCfg config.KubernetesApplication
 			continue
 		}
 		if labels := r.Provider.Labels; len(labels) > 0 {
-			cps, found := pipedCfg.FindPlatformProvidersByLabels(labels, model.ApplicationKind_KUBERNETES)
-			if !found {
-				return nil, fmt.Errorf("there are no provider that matches the specified labels (%v)", labels)
+			cps := pipedCfg.FindPlatformProvidersByLabels(labels, model.ApplicationKind_KUBERNETES)
+			if len(cps) == 0 {
+				return nil, fmt.Errorf("there is no provider that matches the specified labels (%v)", labels)
 			}
 			names := make([]string, 0, len(cps))
 			for _, cp := range cps {

--- a/pkg/app/piped/executor/kubernetes/applier_group.go
+++ b/pkg/app/piped/executor/kubernetes/applier_group.go
@@ -60,16 +60,16 @@ func newApplierGroup(defaultProvider string, appCfg config.KubernetesApplication
 			if _, ok := d.appliers[name]; ok {
 				continue
 			}
-			cp, ok := pipedCfg.FindPlatformProvider(name, model.ApplicationKind_KUBERNETES)
-			if !ok {
+			cp, found := pipedCfg.FindPlatformProvider(name, model.ApplicationKind_KUBERNETES)
+			if !found {
 				return nil, fmt.Errorf("provider %s specified in resourceRoutes was not found", name)
 			}
 			d.appliers[name] = provider.NewApplier(appCfg.Input, *cp.KubernetesConfig, logger)
 			continue
 		}
 		if labels := r.Provider.Labels; len(labels) > 0 {
-			cps := pipedCfg.FindPlatformProvidersByLabel(labels, model.ApplicationKind_KUBERNETES)
-			if len(cps) == 0 {
+			cps, found := pipedCfg.FindPlatformProvidersByLabels(labels, model.ApplicationKind_KUBERNETES)
+			if !found {
 				return nil, fmt.Errorf("there are no provider that matches the specified labels (%v)", labels)
 			}
 			names := make([]string, 0, len(cps))

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -218,12 +218,16 @@ func (s *PipedSpec) FindPlatformProvider(name string, t model.ApplicationKind) (
 	return PipedPlatformProvider{}, false
 }
 
-// FindPlatformProvidersByLabel finds all PlatformProviders which match the provided labels.
-func (s *PipedSpec) FindPlatformProvidersByLabel(labels map[string]string, t model.ApplicationKind) []PipedPlatformProvider {
+// FindPlatformProvidersByLabels finds all PlatformProviders which match the provided labels.
+func (s *PipedSpec) FindPlatformProvidersByLabels(labels map[string]string, t model.ApplicationKind) ([]PipedPlatformProvider, bool) {
 	requiredProviderType := t.CompatiblePlatformProviderType()
 	out := make([]PipedPlatformProvider, 0)
 
 	labelMatch := func(providerLabels map[string]string) bool {
+		if len(providerLabels) < len(labels) {
+			return false
+		}
+
 		for k, v := range labels {
 			if v != providerLabels[k] {
 				return false
@@ -241,7 +245,7 @@ func (s *PipedSpec) FindPlatformProvidersByLabel(labels map[string]string, t mod
 		}
 		out = append(out, p)
 	}
-	return out
+	return out, len(out) > 0
 }
 
 // GetRepositoryMap returns a map of repositories where key is repo id.

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -219,7 +219,7 @@ func (s *PipedSpec) FindPlatformProvider(name string, t model.ApplicationKind) (
 }
 
 // FindPlatformProvidersByLabels finds all PlatformProviders which match the provided labels.
-func (s *PipedSpec) FindPlatformProvidersByLabels(labels map[string]string, t model.ApplicationKind) ([]PipedPlatformProvider, bool) {
+func (s *PipedSpec) FindPlatformProvidersByLabels(labels map[string]string, t model.ApplicationKind) []PipedPlatformProvider {
 	requiredProviderType := t.CompatiblePlatformProviderType()
 	out := make([]PipedPlatformProvider, 0)
 
@@ -245,7 +245,7 @@ func (s *PipedSpec) FindPlatformProvidersByLabels(labels map[string]string, t mo
 		}
 		out = append(out, p)
 	}
-	return out, len(out) > 0
+	return out
 }
 
 // GetRepositoryMap returns a map of repositories where key is repo id.

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -1138,7 +1138,7 @@ func TestPipedSpecClone(t *testing.T) {
 func TestFindPlatformProvidersByLabel(t *testing.T) {
 	pipedSpec := &PipedSpec{
 		PlatformProviders: []PipedPlatformProvider{
-			PipedPlatformProvider{
+			{
 				Name: "provider-1",
 				Type: model.PlatformProviderKubernetes,
 				Labels: map[string]string{
@@ -1146,7 +1146,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 					"foo":   "foo-1",
 				},
 			},
-			PipedPlatformProvider{
+			{
 				Name: "provider-2",
 				Type: model.PlatformProviderKubernetes,
 				Labels: map[string]string{
@@ -1154,7 +1154,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 					"foo":   "foo-2",
 				},
 			},
-			PipedPlatformProvider{
+			{
 				Name: "provider-3",
 				Type: model.PlatformProviderCloudRun,
 				Labels: map[string]string{
@@ -1162,7 +1162,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 					"foo":   "foo-3",
 				},
 			},
-			PipedPlatformProvider{
+			{
 				Name: "provider-4",
 				Type: model.PlatformProviderKubernetes,
 				Labels: map[string]string{
@@ -1191,7 +1191,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 				"group": "group-1",
 			},
 			want: []PipedPlatformProvider{
-				PipedPlatformProvider{
+				{
 					Name: "provider-1",
 					Type: model.PlatformProviderKubernetes,
 					Labels: map[string]string{
@@ -1207,7 +1207,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 				"group": "group-1",
 			},
 			want: []PipedPlatformProvider{
-				PipedPlatformProvider{
+				{
 					Name: "provider-1",
 					Type: model.PlatformProviderKubernetes,
 					Labels: map[string]string{
@@ -1221,7 +1221,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := pipedSpec.FindPlatformProvidersByLabel(tc.labels, model.ApplicationKind_KUBERNETES)
+			got, _ := pipedSpec.FindPlatformProvidersByLabels(tc.labels, model.ApplicationKind_KUBERNETES)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -1221,7 +1221,7 @@ func TestFindPlatformProvidersByLabel(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _ := pipedSpec.FindPlatformProvidersByLabels(tc.labels, model.ApplicationKind_KUBERNETES)
+			got := pipedSpec.FindPlatformProvidersByLabels(tc.labels, model.ApplicationKind_KUBERNETES)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does:
- Rename FindPlatformProvidersByLabel to FindPlatformProvidersByLabels
- Change the FindPlatformProvidersByLabels function signature to same as FindPlatformProviderByName
- Fix warning unrequired typedef in test (lint warn)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
