### PR TITLE
Make target group configuration as not required in ECS application configuration 

### DIFF
--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -92,7 +92,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !sync(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, *primary) {
+	if !sync(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, primary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -113,8 +113,12 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 	if !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}
+	if primary == nil {
+		e.LogPersister.Error("Primary target group is required to enable rolling out PRIMARY variant")
+		return model.StageStatus_STAGE_FAILURE
+	}
 
-	if !rollout(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, *primary) {
+	if !rollout(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, primary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -140,7 +144,7 @@ func (e *deployExecutor) ensureCanaryRollout(ctx context.Context) model.StageSta
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !rollout(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, *canary) {
+	if !rollout(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, taskDefinition, servicedefinition, canary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -152,8 +156,8 @@ func (e *deployExecutor) ensureTrafficRouting(ctx context.Context) model.StageSt
 	if !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}
-	if canary == nil {
-		e.LogPersister.Error("Canary target group is required to enable traffic routing")
+	if primary == nil || canary == nil {
+		e.LogPersister.Error("Primary/Canary target group are required to enable traffic routing")
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -130,7 +130,7 @@ func loadTargetGroups(in *executor.Input, appCfg *config.ECSApplicationSpec, ds 
 func applyTaskDefinition(ctx context.Context, cli provider.Client, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error) {
 	td, err := cli.RegisterTaskDefinition(ctx, taskDefinition)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to register ECS task definition of family %s: %v", *taskDefinition.Family, err)
 	}
 	return td, nil
 }
@@ -198,7 +198,7 @@ func sync(ctx context.Context, in *executor.Input, cloudProviderName string, clo
 	in.LogPersister.Infof("Start applying the ECS task definition")
 	td, err := applyTaskDefinition(ctx, client, taskDefinition)
 	if err != nil {
-		in.LogPersister.Errorf("Failed to register ECS task definition of family %s: %v", *taskDefinition.Family, err)
+		in.LogPersister.Errorf("Failed to apply ECS task definition: %v", err)
 		return false
 	}
 
@@ -229,7 +229,7 @@ func rollout(ctx context.Context, in *executor.Input, cloudProviderName string, 
 	in.LogPersister.Infof("Start applying the ECS task definition")
 	td, err := applyTaskDefinition(ctx, client, taskDefinition)
 	if err != nil {
-		in.LogPersister.Errorf("Failed to register ECS task definition of family %s: %v", *taskDefinition.Family, err)
+		in.LogPersister.Errorf("Failed to apply ECS task definition: %v", err)
 		return false
 	}
 

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -87,14 +87,14 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !rollback(ctx, &e.Input, cloudProviderName, cloudProviderCfg, taskDefinition, serviceDefinition, *primary) {
+	if !rollback(ctx, &e.Input, cloudProviderName, cloudProviderCfg, taskDefinition, serviceDefinition, primary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup types.LoadBalancer) bool {
+func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup *types.LoadBalancer) bool {
 	in.LogPersister.Infof("Start rollback the ECS service and task family: %s and %s to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -150,7 +150,7 @@ func (c *client) RegisterTaskDefinition(ctx context.Context, taskDefinition type
 	return output.TaskDefinition, nil
 }
 
-func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer, scale int) (*types.TaskSet, error) {
+func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup *types.LoadBalancer, scale int) (*types.TaskSet, error) {
 	if taskDefinition.TaskDefinitionArn == nil {
 		return nil, fmt.Errorf("failed to create task set of task family %s: no task definition provided", *taskDefinition.Family)
 	}
@@ -163,7 +163,9 @@ func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskD
 		// and you must specify a NetworkConfiguration when run a task with the task definition.
 		NetworkConfiguration: service.NetworkConfiguration,
 		LaunchType:           service.LaunchType,
-		LoadBalancers:        []types.LoadBalancer{targetGroup},
+	}
+	if targetGroup != nil {
+		input.LoadBalancers = []types.LoadBalancer{*targetGroup}
 	}
 	output, err := c.ecsClient.CreateTaskSet(ctx, input)
 	if err != nil {

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -38,7 +38,7 @@ type ECS interface {
 	UpdateService(ctx context.Context, service types.Service) (*types.Service, error)
 	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
 	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
-	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer, scale int) (*types.TaskSet, error)
+	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup *types.LoadBalancer, scale int) (*types.TaskSet, error)
 	DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 }

--- a/pkg/app/piped/platformprovider/ecs/target_groups.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups.go
@@ -17,6 +17,7 @@ package ecs
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -24,9 +25,11 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/config"
 )
 
+var ErrNoTargetGroup = errors.New("no target group")
+
 func loadTargetGroups(targetGroups config.ECSTargetGroups) (*types.LoadBalancer, *types.LoadBalancer, error) {
 	if len(targetGroups.Primary) == 0 {
-		return nil, nil, fmt.Errorf("primary target group definition is required")
+		return nil, nil, ErrNoTargetGroup
 	}
 
 	// Decode Primary target group config.


### PR DESCRIPTION
**What this PR does / why we need it**:

In some specified cases, users want to be able to run an ECS task without exposing it to the net through LB. So we should accept ECS application configuration without targetGroups configuration.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Make target group configuration as not required in ECS application configuration
```
