### PR TITLE
Fix unable to click back in login form

### DIFF
--- a/web/src/components/login-page/login-form/index.tsx
+++ b/web/src/components/login-page/login-form/index.tsx
@@ -6,6 +6,7 @@ import {
   PAGE_PATH_LOGIN,
 } from "~/constants/path";
 import { MarkGithubIcon } from "@primer/octicons-react";
+import { LOGGING_IN_PROJECT } from "~/constants/localstorage";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,6 +68,7 @@ export const LoginForm: FC<LoginFormProps> = memo(function LoginForm({
   const classes = useStyles();
 
   const handleOnBack = (): void => {
+    localStorage.removeItem(LOGGING_IN_PROJECT);
     window.location.href = PAGE_PATH_LOGIN;
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if users logged out using the switch projects button, they can only log in to the project they chose in the switch projects drop-down list. Even click to the back button on the form, the console automatically redirects again to this form. This PR fix that

https://user-images.githubusercontent.com/32532742/185859486-41358035-1a19-4658-bacd-673a9744a7a1.mp4


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix unable to click back on login form
```
