### PR TITLE
Allow using Annotations to sort Kubernetes manifests before applying

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -32,7 +32,7 @@ const (
 	LabelIgnoreDriftDirection = "pipecd.dev/ignore-drift-detection" // Whether the drift detection should ignore this resource.
 	LabelSyncReplace          = "pipecd.dev/sync-by-replace"        // Use replace instead of apply.
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
-	AnnotationIndex           = "pipecd.dev/index"                  // The index of resource used to sort them before using.
+	AnnotationOrder           = "pipecd.dev/order"                  // The order number of resource used to sort them before using.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
 	UseReplaceEnabled         = "enabled"

--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -32,6 +32,7 @@ const (
 	LabelIgnoreDriftDirection = "pipecd.dev/ignore-drift-detection" // Whether the drift detection should ignore this resource.
 	LabelSyncReplace          = "pipecd.dev/sync-by-replace"        // Use replace instead of apply.
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
+	AnnotationIndex           = "pipecd.dev/index"                  // The index of resource used to sort them before using.
 	ManagedByPiped            = "piped"
 	IgnoreDriftDetectionTrue  = "true"
 	UseReplaceEnabled         = "enabled"

--- a/pkg/app/piped/platformprovider/kubernetes/loader.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader.go
@@ -173,11 +173,11 @@ func sortManifests(manifests []Manifest) {
 	sort.Slice(manifests, func(i, j int) bool {
 		iAns := manifests[i].GetAnnotations()
 		// Ignore the converting error since it is not so much important.
-		iIndex, _ := strconv.Atoi(iAns[AnnotationIndex])
+		iIndex, _ := strconv.Atoi(iAns[AnnotationOrder])
 
 		jAns := manifests[j].GetAnnotations()
 		// Ignore the converting error since it is not so much important.
-		jIndex, _ := strconv.Atoi(jAns[AnnotationIndex])
+		jIndex, _ := strconv.Atoi(jAns[AnnotationOrder])
 
 		return iIndex < jIndex
 	})

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -44,27 +44,27 @@ func TestSortManifests(t *testing.T) {
 		{
 			name: "one manifest",
 			manifests: []Manifest{
-				maker("name-1", map[string]string{AnnotationIndex: "0"}),
+				maker("name-1", map[string]string{AnnotationOrder: "0"}),
 			},
 			want: []Manifest{
-				maker("name-1", map[string]string{AnnotationIndex: "0"}),
+				maker("name-1", map[string]string{AnnotationOrder: "0"}),
 			},
 		},
 		{
 			name: "multiple manifests",
 			manifests: []Manifest{
-				maker("name-2", map[string]string{AnnotationIndex: "2"}),
-				maker("name--1", map[string]string{AnnotationIndex: "-1"}),
+				maker("name-2", map[string]string{AnnotationOrder: "2"}),
+				maker("name--1", map[string]string{AnnotationOrder: "-1"}),
 				maker("name-nil", nil),
-				maker("name-0", map[string]string{AnnotationIndex: "0"}),
-				maker("name-1", map[string]string{AnnotationIndex: "1"}),
+				maker("name-0", map[string]string{AnnotationOrder: "0"}),
+				maker("name-1", map[string]string{AnnotationOrder: "1"}),
 			},
 			want: []Manifest{
-				maker("name--1", map[string]string{AnnotationIndex: "-1"}),
+				maker("name--1", map[string]string{AnnotationOrder: "-1"}),
 				maker("name-nil", nil),
-				maker("name-0", map[string]string{AnnotationIndex: "0"}),
-				maker("name-1", map[string]string{AnnotationIndex: "1"}),
-				maker("name-2", map[string]string{AnnotationIndex: "2"}),
+				maker("name-0", map[string]string{AnnotationOrder: "0"}),
+				maker("name-1", map[string]string{AnnotationOrder: "1"}),
+				maker("name-2", map[string]string{AnnotationOrder: "2"}),
 			},
 		},
 	}

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -17,9 +17,8 @@ package kubernetes
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestSortManifests(t *testing.T) {

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortManifests(t *testing.T) {
+	maker := func(name string, annotations map[string]string) Manifest {
+		m := Manifest{
+			Key: ResourceKey{Name: name},
+			u: &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+		}
+		m.AddAnnotations(annotations)
+		return m
+	}
+
+	testcases := []struct {
+		name      string
+		manifests []Manifest
+		want      []Manifest
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "one manifest",
+			manifests: []Manifest{
+				maker("name-1", map[string]string{AnnotationIndex: "0"}),
+			},
+			want: []Manifest{
+				maker("name-1", map[string]string{AnnotationIndex: "0"}),
+			},
+		},
+		{
+			name: "multiple manifests",
+			manifests: []Manifest{
+				maker("name-2", map[string]string{AnnotationIndex: "2"}),
+				maker("name--1", map[string]string{AnnotationIndex: "-1"}),
+				maker("name-nil", nil),
+				maker("name-0", map[string]string{AnnotationIndex: "0"}),
+				maker("name-1", map[string]string{AnnotationIndex: "1"}),
+			},
+			want: []Manifest{
+				maker("name--1", map[string]string{AnnotationIndex: "-1"}),
+				maker("name-nil", nil),
+				maker("name-0", map[string]string{AnnotationIndex: "0"}),
+				maker("name-1", map[string]string{AnnotationIndex: "1"}),
+				maker("name-2", map[string]string{AnnotationIndex: "2"}),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			sortManifests(tc.manifests)
+			assert.Equal(t, tc.want, tc.manifests)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This feature has been requested many times by some teams.
Now users can use a predefined annotation to specify the order of manifests.
All manifests of an application will be sorted before use. This helps users control the applying order as they want.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow using Annotations to sort Kubernetes manifests before applying
```
