### PR TITLE
Update protobuf-go version

### DIFF
--- a/tool/codegen/protoc-gen-auth/go.mod
+++ b/tool/codegen/protoc-gen-auth/go.mod
@@ -2,4 +2,4 @@ module github.com/pipe-cd/pipecd/tool/codegen/protoc-gen-auth
 
 go 1.17
 
-require google.golang.org/protobuf v1.28.0
+require google.golang.org/protobuf v1.28.1

--- a/tool/codegen/protoc-gen-auth/go.sum
+++ b/tool/codegen/protoc-gen-auth/go.sum
@@ -4,5 +4,5 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=


### PR DESCRIPTION
**What this PR does / why we need it**:
I faced a weird issue whose behavior is different in pattern A and pattern B although I just only added one comment.
Hence I updated protobuf version in order to avoid this issue.

```
// Pattarn A	
opts.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
	if !fd.IsExtension() || fd.Name() != methodOptionsRBAC || v.String() == "" {
		return true
	}

	vs := strings.Split(v.String(), "  ")
	for _, v := range vs {
		kv := strings.SplitN(v, ":", 2)
		key, value := kv[0], kv[1]

		switch key {
		case keyMethodOptionsRBACResouce:
			method.Resource = value
		case keyMethodOptionsRBACAction:
			method.Action = value
		case keyMethodOptionsRBACIgnored:
			if v, err := strconv.ParseBool(value); err == nil {
				method.Ignored = v
			}
		}
	}
	return true
})

// Pattarn B
opts.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
	if !fd.IsExtension() || fd.Name() != methodOptionsRBAC || v.String() == "" {
		return true
	}

	vs := strings.Split(v.String(), "  ")
	for _, v := range vs {
                 // hello
		kv := strings.SplitN(v, ":", 2)
		key, value := kv[0], kv[1]

		switch key {
		case keyMethodOptionsRBACResouce:
			method.Resource = value
		case keyMethodOptionsRBACAction:
			method.Action = value
		case keyMethodOptionsRBACIgnored:
			if v, err := strconv.ParseBool(value); err == nil {
				method.Ignored = v
			}
		}
	}
	return true
})

```


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
