### PR TITLE
Fix the hack command for cherry-pick

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -59,8 +59,8 @@ echo
 # Check whether remote branch exists
 echo "+++ Checking whether remote branch exists..."
 BASE_TAG=$(echo ${BRANCH} | sed -e 's/.*-//' -e 's/x/0/g')
-git ls-remote --exit-code --heads origin ${BRANCH} > /dev/null 2>&1
-if [ $? -ne 0 ]; then
+IS_EXIST=$(git ls-remote --heads origin ${BRANCH} | wc -l)
+if [ $IS_EXIST -ne 1 ]; then
   git checkout -b ${BRANCH} ${BASE_TAG}
   git push origin ${BRANCH}
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
The `git ls-remote` command returns 0 status code regardless of the results without `--exit-code` option.
But we don't want to use one because we want to use `set -o errexit`.
Hence I fixed to handle the output result instead of that.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
