### PR TITLE
Delete the deploymentChain from built-in roles

### DIFF
--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -62,18 +62,9 @@ var (
 		{
 			Resources: []*ProjectRBACResource{
 				{Type: ProjectRBACResource_PIPED},
-				{Type: ProjectRBACResource_DEPLOYMENT_CHAIN},
 			},
 			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_GET,
-				ProjectRBACPolicy_LIST,
-			},
-		},
-		{
-			Resources: []*ProjectRBACResource{
-				{Type: ProjectRBACResource_EVENT},
-			},
-			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_LIST,
 			},
 		},
@@ -84,6 +75,14 @@ var (
 			},
 			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_GET,
+			},
+		},
+		{
+			Resources: []*ProjectRBACResource{
+				{Type: ProjectRBACResource_EVENT},
+			},
+			Actions: []ProjectRBACPolicy_Action{
+				ProjectRBACPolicy_LIST,
 			},
 		},
 	}
@@ -98,18 +97,9 @@ var (
 				{Type: ProjectRBACResource_APPLICATION},
 				{Type: ProjectRBACResource_DEPLOYMENT},
 				{Type: ProjectRBACResource_PIPED},
-				{Type: ProjectRBACResource_DEPLOYMENT_CHAIN},
 			},
 			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_GET,
-				ProjectRBACPolicy_LIST,
-			},
-		},
-		{
-			Resources: []*ProjectRBACResource{
-				{Type: ProjectRBACResource_EVENT},
-			},
-			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_LIST,
 			},
 		},
@@ -120,6 +110,14 @@ var (
 			},
 			Actions: []ProjectRBACPolicy_Action{
 				ProjectRBACPolicy_GET,
+			},
+		},
+		{
+			Resources: []*ProjectRBACResource{
+				{Type: ProjectRBACResource_EVENT},
+			},
+			Actions: []ProjectRBACPolicy_Action{
+				ProjectRBACPolicy_LIST,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the DeploymentChain resource is not used to call gPRC, so delete this from built-in roles.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
