### PR TITLE
Introduce pipectl quickstart command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hashicorp/hcl/v2 v2.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/manifoldco/promptui v0.9.0
 	github.com/minio/minio-go/v7 v7.0.5
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/ory/dockertest/v3 v3.9.1

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,11 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -459,6 +462,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -788,6 +793,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -256,7 +256,6 @@ func getPromptInput(label string) string {
 	}
 
 	result, err := prompt.Run()
-
 	if err != nil {
 		return ""
 	}

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -47,6 +47,10 @@ const (
 	pipecdDefaultNamespace = "pipecd"
 
 	controlPlaneLocalhost = "http://localhost:8080/settings/piped?project=quickstart"
+
+	pipedIDLabel       = "ID"
+	pipedKeyLabel      = "Key"
+	pipedGitRemoteRepo = "GitRemoteRepo"
 )
 
 type command struct {
@@ -161,9 +165,9 @@ func (c *command) installPiped(ctx context.Context, helm string, input cli.Input
 
 	input.Logger.Info("Fill up your registered Piped information:")
 
-	pipedID := getPromptInput("ID")
-	pipedKey := getPromptInput("Key")
-	sourceRepo := getPromptInput("Apps manifest repo")
+	pipedID := getPromptInput(pipedIDLabel)
+	pipedKey := getPromptInput(pipedKeyLabel)
+	sourceRepo := getPromptInput(pipedGitRemoteRepo)
 
 	args := []string{
 		"upgrade",
@@ -229,7 +233,20 @@ func (c *command) exposeService(ctx context.Context) error {
 
 func getPromptInput(label string) string {
 	validate := func(input string) error {
-		// TODO: Add validation based on input length for instance.
+		switch label {
+		case pipedIDLabel:
+			if len(input) != 36 {
+				return fmt.Errorf("invalid ID")
+			}
+		case pipedKeyLabel:
+			if len(input) != 50 {
+				return fmt.Errorf("invalid Key")
+			}
+		default:
+			if len(input) == 0 {
+				return fmt.Errorf("missing value: %s", label)
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The quickstart command for pipecd try out will run like this

https://user-images.githubusercontent.com/32532742/195658913-ab18145c-3932-4222-8504-151b518460f7.mp4


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
New pipectl quickstart command
```
