### PR TITLE
Fix typos on notification event

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.32.x/operator-manual/piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.32.x/operator-manual/piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.33.x/operator-manual/piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.33.x/operator-manual/piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.34.x/operator-manual/piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.34.x/operator-manual/piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.35.x/operator-manual/piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.35.x/operator-manual/piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.36.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.36.x/user-guide/managing-piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.37.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.37.x/user-guide/managing-piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs-v0.38.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.38.x/user-guide/managing-piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/docs/content/en/docs/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs/user-guide/managing-piped/configuring-notifications.md
@@ -51,7 +51,7 @@ spec:
       # labels `env: prod` and `team: pipecd` to prod-slack-channel.
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: prod

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -188,7 +188,7 @@ func TestPipedConfig(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
 							Receiver: "prod-slack-channel",
 						},
 						{
@@ -877,7 +877,7 @@ func TestPipedSpecClone(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
 							Receiver: "prod-slack-channel",
 						},
 						{
@@ -1072,7 +1072,7 @@ func TestPipedSpecClone(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_STARTED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
 							Receiver: "prod-slack-channel",
 						},
 						{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -102,7 +102,7 @@ spec:
         receiver: dev-slack-channel
       - name: prod-slack
         events:
-          - DEPLOYMENT_STARTED
+          - DEPLOYMENT_TRIGGERED
           - DEPLOYMENT_COMPLETED
         labels:
           env: dev


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix notification event name in docs and test from `DEPLOYMENT_STARTED` to `DEPLOYMENT_TRIGGERED`.
