### PR TITLE
Remove deprecated fields from piped notification config

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -897,9 +897,6 @@ type NotificationRoute struct {
 	IgnoreApps   []string          `json:"ignoreApps,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	IgnoreLabels map[string]string `json:"ignoreLabels,omitempty"`
-	// Deprecated: Should use labels instead.
-	Envs       []string `json:"envs,omitempty"`
-	IgnoreEnvs []string `json:"ignoreEnvs,omitempty"`
 }
 
 type NotificationReceiver struct {

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -502,8 +502,6 @@ func TestPipedConfigMask(t *testing.T) {
 							IgnoreApps:   []string{"foo"},
 							Labels:       map[string]string{"foo": "foo"},
 							IgnoreLabels: map[string]string{"foo": "foo"},
-							Envs:         []string{"foo"},
-							IgnoreEnvs:   []string{"foo"},
 						},
 					},
 					Receivers: []NotificationReceiver{
@@ -662,8 +660,6 @@ func TestPipedConfigMask(t *testing.T) {
 							IgnoreApps:   []string{"foo"},
 							Labels:       map[string]string{"foo": "foo"},
 							IgnoreLabels: map[string]string{"foo": "foo"},
-							Envs:         []string{"foo"},
-							IgnoreEnvs:   []string{"foo"},
 						},
 					},
 					Receivers: []NotificationReceiver{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
