### PR TITLE
Fix all links for dev docs

### DIFF
--- a/docs/content/en/docs-dev/concepts/_index.md
+++ b/docs/content/en/docs-dev/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.

--- a/docs/content/en/docs-dev/examples/_index.md
+++ b/docs/content/en/docs-dev/examples/_index.md
@@ -25,7 +25,7 @@ https://github.com/pipe-cd/examples
 | [kustomize-remote-base](https://github.com/pipe-cd/examples/tree/master/kubernetes/kustomize-remote-base) | Deploy a kustomize package that uses remote bases from other Git repositories. |
 | [canary](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary) | Deployment pipeline with canary strategy. |
 | [canary-by-config-change](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary-by-config-change) | Deployment pipeline with canary strategy when ConfigMap was changed. |
-| [canary-patch](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary-patch) | Demonstrate how to customize manifests for Canary variant using [patches](https://pipecd.dev/docs/user-guide/configuration-reference/#kubernetescanaryrolloutstageoptions) option. |
+| [canary-patch](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary-patch) | Demonstrate how to customize manifests for Canary variant using [patches](../user-guide/configuration-reference/#kubernetescanaryrolloutstageoptions) option. |
 | [bluegreen](https://github.com/pipe-cd/examples/tree/master/kubernetes/bluegreen) | Deployment pipeline with bluegreen strategy. This also contains a manual approval stage. |
 | [mesh-istio-canary](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-canary) | Deployment pipeline with canary strategy by using Istio for traffic routing.  |
 | [mesh-istio-bluegreen](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-bluegreen) | Deployment pipeline with bluegreen strategy by using Istio for traffic routing. |
@@ -37,7 +37,7 @@ https://github.com/pipe-cd/examples
 | [analysis-by-http](https://github.com/pipe-cd/examples/tree/master/kubernetes/analysis-by-http) | Deployment pipeline with analysis stage by running http requests. |
 | [analysis-by-log](https://github.com/pipe-cd/examples/tree/master/kubernetes/analysis-by-log) | Deployment pipeline with analysis stage by checking logs. |
 | [analysis-with-baseline](https://github.com/pipe-cd/examples/tree/master/kubernetes/analysis-with-baseline) | Deployment pipeline with analysis stage by comparing baseline and canary. |
-| [secret-management](https://github.com/pipe-cd/examples/tree/master/kubernetes/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](https://pipecd.dev/docs/user-guide/secret-management/) feature. |
+| [secret-management](https://github.com/pipe-cd/examples/tree/master/kubernetes/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 
 ### Terraform Applications
 
@@ -48,7 +48,7 @@ https://github.com/pipe-cd/examples
 | [remote-module](https://github.com/pipe-cd/examples/tree/master/terraform/remote-module) | Deploy application that using remote terraform modules from other Git repositories. |
 | [wait-approval](https://github.com/pipe-cd/examples/tree/master/terraform/wait-approval) | Deployment pipeline that contains a manual approval stage. |
 | [autorollback](https://github.com/pipe-cd/examples/tree/master/terraform/auto-rollback) |  Automatically rollback the changes when deployment was failed.  |
-| [secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](https://pipecd.dev/docs/user-guide/secret-management/) feature. |
+| [secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 
 ### Cloud Run Applications
 
@@ -57,7 +57,7 @@ https://github.com/pipe-cd/examples
 | [simple](https://github.com/pipe-cd/examples/tree/master/cloudrun/simple) | Quick sync by rolling out the new version and switching all traffic to it. |
 | [canary](https://github.com/pipe-cd/examples/tree/master/cloudrun/canary) | Deployment pipeline with canary strategy. |
 | [analysis](https://github.com/pipe-cd/examples/tree/master/cloudrun/analysis) | Deployment pipeline that contains an analysis stage. |
-| [secret-management](https://github.com/pipe-cd/examples/tree/master/cloudrun/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](https://pipecd.dev/docs/user-guide/secret-management/) feature. |
+| [secret-management](https://github.com/pipe-cd/examples/tree/master/cloudrun/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 | [wait-approval](https://github.com/pipe-cd/examples/tree/master/cloudrun/wait-approval) | Deployment pipeline that contains a manual approval stage. |
 
 ### Lambda Applications
@@ -67,7 +67,7 @@ https://github.com/pipe-cd/examples
 | [simple](https://github.com/pipe-cd/examples/tree/master/lambda/simple) | Quick sync by rolling out the new version and switching all traffic to it. |
 | [canary](https://github.com/pipe-cd/examples/tree/master/lambda/canary) | Deployment pipeline with canary strategy. |
 | [analysis](https://github.com/pipe-cd/examples/tree/master/lambda/analysis) | Deployment pipeline that contains an analysis stage. |
-| [secret-management](https://github.com/pipe-cd/examples/tree/master/lambda/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](https://pipecd.dev/docs/user-guide/secret-management/) feature. |
+| [secret-management](https://github.com/pipe-cd/examples/tree/master/lambda/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 | [wait-approval](https://github.com/pipe-cd/examples/tree/master/lambda/wait-approval) | Deployment pipeline that contains a manual approval stage. |
 | [remote-git](https://github.com/pipe-cd/examples/tree/master/lambda/remote-git) | Deploy the lambda code sourced from another Git repository. |
 | [zip-packing-s3](https://github.com/pipe-cd/examples/tree/master/lambda/zip-packing-s3) | Deployment pipeline of kind Lambda which uses s3 stored zip file as function code. |
@@ -79,7 +79,7 @@ https://github.com/pipe-cd/examples
 | [simple](https://github.com/pipe-cd/examples/tree/master/ecs/simple) | Quick sync by rolling out the new version and switching all traffic to it. |
 | [canary](https://github.com/pipe-cd/examples/tree/master/ecs/canary) | Deployment pipeline with canary strategy. |
 | [bluegreen](https://github.com/pipe-cd/examples/tree/master/ecs/bluegreen) | Deployment pipeline with blue-green strategy. |
-| [secret-management](https://github.com/pipe-cd/examples/tree/master/ecs/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](https://pipecd.dev/docs/user-guide/secret-management/) feature. |
+| [secret-management](https://github.com/pipe-cd/examples/tree/master/ecs/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 | [wait-approval](https://github.com/pipe-cd/examples/tree/master/ecs/wait-approval) | Deployment pipeline that contains a manual approval stage. |
 
 ### Deployment chain

--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -25,15 +25,15 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick sync deployment | Beta |
 | Deployment with a defined pipeline (e.g. canary, analysis) | Beta |
-| [Automated rollback](/docs/user-guide/rolling-back-a-deployment/) | Beta |
-| [Automated configuration drift detection](/docs/user-guide/configuration-drift-detection/) | Beta |
-| [Application live state](/docs/user-guide/application-live-state/) | Beta |
+| [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
+| [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Beta |
+| [Application live state](../user-guide/managing-application/application-live-state/) | Beta |
 | Support Helm | Beta |
 | Support Kustomize | Beta |
 | Support Istio service mesh | Beta |
 | Support SMI service mesh | Incubating |
 | Support [AWS App Mesh](https://aws.amazon.com/app-mesh/) | Incubating |
-| [Plan preview](/docs/user-guide/plan-preview) | Beta |
+| [Plan preview](../user-guide/plan-preview) | Beta |
 
 ### Terraform
 
@@ -41,10 +41,10 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick sync deployment | Beta |
 | Deployment with a defined pipeline (e.g. manual-approval) | Beta |
-| [Automated rollback](/docs/user-guide/rolling-back-a-deployment/) | Beta |
-| [Automated configuration drift detection](/docs/user-guide/configuration-drift-detection/) | Incubating |
-| [Application live state](/docs/user-guide/application-live-state/) | Incubating |
-| [Plan preview](/docs/user-guide/plan-preview) | Beta |
+| [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
+| [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Incubating |
+| [Application live state](../user-guide/managing-application/application-live-state/) | Incubating |
+| [Plan preview](../user-guide/plan-preview) | Beta |
 
 ### Cloud Run
 
@@ -52,10 +52,10 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick sync deployment | Beta |
 | Deployment with a defined pipeline (e.g. canary, analysis) | Beta |
-| [Automated rollback](/docs/user-guide/rolling-back-a-deployment/) | Beta |
-| [Automated configuration drift detection](/docs/user-guide/configuration-drift-detection/) | Alpha |
-| [Application live state](/docs/user-guide/application-live-state/) | Alpha |
-| [Plan preview](/docs/user-guide/plan-preview) | Alpha |
+| [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
+| [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Alpha |
+| [Application live state](../user-guide/managing-application/application-live-state/) | Alpha |
+| [Plan preview](../user-guide/plan-preview) | Alpha |
 
 ### Lambda
 
@@ -63,10 +63,10 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick sync deployment | Beta |
 | Deployment with a defined pipeline (e.g. canary, analysis) | Beta |
-| [Automated rollback](/docs/user-guide/rolling-back-a-deployment/) | Beta |
-| [Automated configuration drift detection](/docs/user-guide/configuration-drift-detection/) | Incubating |
-| [Application live state](/docs/user-guide/application-live-state/) | Incubating |
-| [Plan preview](/docs/user-guide/plan-preview) | Alpha |
+| [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
+| [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Incubating |
+| [Application live state](../user-guide/managing-application/application-live-state/) | Incubating |
+| [Plan preview](../user-guide/plan-preview) | Alpha |
 
 ### Amazon ECS
 
@@ -74,33 +74,33 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick sync deployment | Alpha |
 | Deployment with a defined pipeline (e.g. canary, analysis) | Alpha |
-| [Automated rollback](/docs/user-guide/rolling-back-a-deployment/) | Beta |
-| [Automated configuration drift detection](/docs/user-guide/configuration-drift-detection/) | Incubating |
-| [Application live state](/docs/user-guide/application-live-state/) | Incubating |
+| [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
+| [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Incubating |
+| [Application live state](../user-guide/managing-application/application-live-state/) | Incubating |
 | Support [AWS App Mesh](https://aws.amazon.com/app-mesh/) | Incubating |
-| [Plan preview](/docs/user-guide/plan-preview) | Alpha |
+| [Plan preview](../user-guide/plan-preview) | Alpha |
 
 ## Piped Agent
 
 | Feature | Phase |
 |-|-|
-| [Deployment wait stage](/docs/user-guide/adding-a-wait-stage/) | Beta |
-| [Deployment manual approval stage](/docs/user-guide/adding-a-manual-approval/) | Beta |
-| [Notification](/docs/operator-manual/piped/configuring-notifications/) to Slack | Beta |
-| [Notification](/docs/operator-manual/piped/configuring-notifications/) to external service via webhook | Alpha |
-| [Secrets management](/docs/user-guide/secret-management/) - Storing secrets safely in the Git repository | Beta |
-| [Event watcher](/docs/user-guide/event-watcher/) - Updating files in Git automatically for given events | Alpha |
-| [Pipectl](/docs/user-guide/command-line-tool/) - Command-line tool for interacting with Control Plane | Beta |
+| [Deployment wait stage](../user-guide/managing-application/customizing-deployment/adding-a-wait-stage/) | Beta |
+| [Deployment manual approval stage](../user-guide/managing-application/customizing-deployment/adding-a-manual-approval/) | Beta |
+| [Notification](../user-guide/managing-piped/configuring-notifications/) to Slack | Beta |
+| [Notification](../user-guide/managing-piped/configuring-notifications/) to external service via webhook | Alpha |
+| [Secrets management](../user-guide/managing-application/secret-management/) - Storing secrets safely in the Git repository | Beta |
+| [Event watcher](../user-guide/event-watcher/) - Updating files in Git automatically for given events | Alpha |
+| [Pipectl](../user-guide/command-line-tool/) - Command-line tool for interacting with Control Plane | Beta |
 | Deployment plugin - Allow executing user-created deployment plugin | Incubating |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) (Automated Deployment Analysis) by Prometheus metrics | Alpha |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by Datadog metrics | Alpha |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by Stackdriver metrics | Incubating |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by Stackdriver log | Incubating |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch metrics | Incubating |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by CloudWatch log | Incubating |
-| [ADA](/docs/user-guide/automated-deployment-analysis/) by HTTP request (smoke test...) | Incubating |
-| [Remote upgrade](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Beta |
-| [Remote config](/docs/operator-manual/piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Beta |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) (Automated Deployment Analysis) by Prometheus metrics | Alpha |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by Datadog metrics | Alpha |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by Stackdriver metrics | Incubating |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by Stackdriver log | Incubating |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by CloudWatch metrics | Incubating |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by CloudWatch log | Incubating |
+| [ADA](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) by HTTP request (smoke test...) | Incubating |
+| [Remote upgrade](../user-guide/managing-piped/remote-upgrade-remote-config/#remote-upgrade) - Ability to upgrade Piped from the web console | Beta |
+| [Remote config](../user-guide/managing-piped/remote-upgrade-remote-config/#remote-config) - Watch and reload configuration from a remote location such as Git | Beta |
 
 ## Control Plane
 
@@ -120,6 +120,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | Support AWS [S3](https://aws.amazon.com/s3/) as file store | Beta |
 | Support [Minio](https://github.com/minio/minio) as file store | Beta |
 | Support using file storage such as GCS, S3, Minio for both data store and file store (It means no database is required to run control plane) | Incubating |
-| [Insights](/docs/user-guide/insights/) - Show the delivery performance of a team or an application | Incubating |
-| [Deployment Chain](/docs/user-guide/deployment-chain/) - Allow rolling out to multiple clusters gradually or promoting across environments | Alpha |
-| [Metrics](/docs/operator-manual/control-plane/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |
+| [Insights](../user-guide/insights/) - Show the delivery performance of a team or an application | Incubating |
+| [Deployment Chain](../user-guide/managing-application/deployment-chain/) - Allow rolling out to multiple clusters gradually or promoting across environments | Alpha |
+| [Metrics](../user-guide/managing-controlplane/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |

--- a/docs/content/en/docs-dev/installation/_index.md
+++ b/docs/content/en/docs-dev/installation/_index.md
@@ -6,7 +6,7 @@ description: >
   Complete guideline for installing and configuring PipeCD on your own.
 ---
 
-Before starting to install PipeCD, let’s have a look at PipeCD’s components, determine your role, and which components you will interact with while installing/using PipeCD. You’re recommended to read about PipeCD’s [Control Plane](https://pipecd.dev/docs/concepts/#control-plane) and [Piped](/docs/concepts/#piped) on the concepts page.
+Before starting to install PipeCD, let’s have a look at PipeCD’s components, determine your role, and which components you will interact with while installing/using PipeCD. You’re recommended to read about PipeCD’s [Control Plane](../concepts/#control-plane) and [Piped](../concepts/#piped) on the concepts page.
 
 ![](/images/architecture-overview-with-roles.png)
 <p style="text-align: center;">

--- a/docs/content/en/docs-dev/installation/install-controlplane.md
+++ b/docs/content/en/docs-dev/installation/install-controlplane.md
@@ -31,7 +31,7 @@ cat /dev/urandom | head -c64 | base64 > encryption-key
 Control Plane Architecture
 </p>
 
-The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](/docs/user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](/docs/user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](/docs/user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
+The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](../../user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](../../user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](../../user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
 
 #### Using Firestore and GCS
 
@@ -60,7 +60,7 @@ spec:
       credentialsFile: /etc/pipecd-secret/gcs-service-account
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-controlplane/configuration-reference/) for the full configuration.
+See [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/) for the full configuration.
 
 After all, install the Control Plane as bellow:
 
@@ -96,7 +96,7 @@ spec:
       autoCreateBucket: true
 ```
 
-You can find required configurations to use other datastores and filestores from [ConfigurationReference](/docs/user-guide/managing-controlplane/configuration-reference/).
+You can find required configurations to use other datastores and filestores from [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/).
 
 __Caution__: In case of using `MySQL` as Control Plane's datastore, please note that the implementation of PipeCD requires some features that only available on [MySQL v8](https://dev.mysql.com/doc/refman/8.0/en/), make sure your MySQL service is satisfied the requirement.
 
@@ -127,7 +127,7 @@ On that page, you will see the list of registered projects and a link to registe
 
 Once a new project has been registered, a static admin (username, password) will be automatically generated for the project admin, you can use that to login via the login form in the above section.
 
-For more about adding a new project in detail, please read the following [docs](/docs/user-guide/managing-controlplane/adding-a-project/).
+For more about adding a new project in detail, please read the following [docs](../../user-guide/managing-controlplane/adding-a-project/).
 
 ## Production Hardening
 

--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
@@ -10,7 +10,7 @@ description: >
 
 ##### Having piped's ID and Key strings
 - Ensure that the `piped` has been registered and you are having its PIPED_ID and PIPED_KEY strings.
-- If you are not having them, this [page](/docs/user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
+- If you are not having them, this [page](../../../user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
 
 ##### Preparing SSH key
 - If your Git repositories are private, `piped` requires a private SSH key to access those repositories.

--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-fargate.md
@@ -10,7 +10,7 @@ description: >
 
 ##### Having piped's ID and Key strings
 - Ensure that the `piped` has been registered and you are having its PIPED_ID and PIPED_KEY strings.
-- If you are not having them, this [page](/docs/user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
+- If you are not having them, this [page](../../../user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
 
 ##### Preparing SSH key
 - If your Git repositories are private, `piped` requires a private SSH key to access those repositories.

--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-google-cloud-vm.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-google-cloud-vm.md
@@ -10,7 +10,7 @@ description: >
 
 ##### Having piped's ID and Key strings
 - Ensure that the `piped` has been registered and you are having its `PIPED_ID` and `PIPED_KEY` strings.
-- If you are not having them, this [page](/docs/user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
+- If you are not having them, this [page](../../../user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
 
 ##### Preparing SSH key
 - If your Git repositories are private, `piped` requires a private SSH key to access those repositories.

--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-kubernetes.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-kubernetes.md
@@ -10,7 +10,7 @@ description: >
 
 ##### Having piped's ID and Key strings
 - Ensure that the `piped` has been registered and you are having its PIPED_ID and PIPED_KEY strings.
-- If you are not having them, this [page](/docs/user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
+- If you are not having them, this [page](../../../user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
 
 ##### Preparing SSH key
 - If your Git repositories are private, `piped` requires a private SSH key to access those repositories.

--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-single-machine.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-single-machine.md
@@ -10,7 +10,7 @@ description: >
 
 ##### Having piped's ID and Key strings
 - Ensure that the `piped` has been registered and you are having its PIPED_ID and PIPED_KEY strings.
-- If you are not having them, this [page](/docs/user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
+- If you are not having them, this [page](../../../user-guide/managing-controlplane/registering-a-piped/) guides you how to register a new one.
 
 ##### Preparing SSH key
 - If your Git repositories are private, `piped` requires a private SSH key to access those repositories.

--- a/docs/content/en/docs-dev/overview/_index.md
+++ b/docs/content/en/docs-dev/overview/_index.md
@@ -50,16 +50,16 @@ PipeCD provides a unified continuous delivery solution for multiple application 
 
 ## Where should I go next?
 
-For a good understanding of the PipeCD's components, see the [Concepts](/docs/concepts) page.
+For a good understanding of the PipeCD's components, see the [Concepts](../concepts) page.
 
 If you are an **operator** wanting to install and configure PipeCD for other developers.
-- [Quickstart](/docs/quickstart/)
-- [Operating Control Plane](/docs/operator-manual/control-plane/)
-- [Operating Piped](/docs/operator-manual/piped/)
+- [Quickstart](../quickstart/)
+- [Managing Control Plane](../user-guide/managing-controlplane/)
+- [Managing Piped](../user-guide/managing-piped/)
 
 If you are a **user** using PipeCD to deploy your application/infrastructure:
-- [User Guide](/docs/user-guide/)
-- [Examples](/docs/user-guide/examples)
+- [User Guide](../user-guide/)
+- [Examples](../user-guide/examples)
 
 If you want to be a **contributor**:
-- [Contributor Guide](/docs/contribution-guidelines/)
+- [Contributor Guide](../contribution-guidelines/)

--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -114,4 +114,4 @@ pipectl quickstart --uninstall
 
 ### What's next?
 
-To prepare your PipeCD for a production environment, please visit the [Installation](/docs/installation/) guideline. For guidelines to use PipeCD to deploy your application in daily usage, please visit the [User guide](/docs/user-guide/) docs.
+To prepare your PipeCD for a production environment, please visit the [Installation](../installation/) guideline. For guidelines to use PipeCD to deploy your application in daily usage, please visit the [User guide](../user-guide/) docs.

--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -232,7 +232,7 @@ pipectl event register \
 
 Encrypt the plaintext entered either in stdin or via the `--input-file` flag.
 
-You can encrypt it the same way you do [from the web](/docs/user-guide/managing-application/secret-management/#encrypting-secret-data).
+You can encrypt it the same way you do [from the web](../managing-application/secret-management/#encrypting-secret-data).
 
 - From stdin:
 

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -438,7 +438,7 @@ One of `yamlField` or `regex` is required.
 | primary | ECSTargetGroupObject | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
 | canary | ECSTargetGroupObject | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
 
-Note: You can get examples for those object from [here](/docs/examples/#ecs-applications).
+Note: You can get examples for those object from [here](../../examples/#ecs-applications).
 
 ## ECSQuickSync
 
@@ -451,7 +451,7 @@ Note: You can get examples for those object from [here](/docs/examples/#ecs-appl
 |-|-|-|-|
 | provider | string | The unique name of provider defined in the Piped Configuration. | Yes |
 | strategy | string | The strategy name. One of `THRESHOLD` or `PREVIOUS` or `CANARY_BASELINE` or `CANARY_PRIMARY` is available. Defaults to `THRESHOLD`. | No |
-| query | string | A query performed against the [Analysis Provider](/docs/concepts/#analysis-provider). The stage will be skipped if no data points were returned. | Yes |
+| query | string | A query performed against the [Analysis Provider](../../concepts/#analysis-provider). The stage will be skipped if no data points were returned. | Yes |
 | expected | [AnalysisExpected](#analysisexpected) | The statically defined expected query result. This field is ignored if there was no data point as a result of the query. | Yes if the strategy is `THRESHOLD` |
 | interval | duration | Run a query at specified intervals. | Yes |
 | failureLimit | int | Acceptable number of failures. e.g. If 1 is set, the `ANALYSIS` stage will end with failure after two queries results failed. Defaults to 1. | No |

--- a/docs/content/en/docs-dev/user-guide/event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/event-watcher.md
@@ -18,7 +18,7 @@ While it empowers you to build pretty versatile workflows, the canonical use cas
 This guide walks you through configuring Event watcher and how to push an Event.
 
 ## Prerequisites
-Before we get into configuring EventWatcher, be sure to configure Piped. See [here](/docs/user-guide/managing-piped/configuring-event-watcher/) for more details.
+Before we get into configuring EventWatcher, be sure to configure Piped. See [here](../managing-piped/configuring-event-watcher/) for more details.
 
 ## Usage
 File updating can be done by registering the latest value corresponding to the Event in the Control Plane and comparing it with the current value.
@@ -47,7 +47,7 @@ spec:
           yamlField: $.spec.template.spec.containers[0].image
 ```
 
-The full list of configurable `EventWatcher` fields are [here](/docs/user-guide/configuration-reference/#event-watcher-configuration-deprecated).
+The full list of configurable `EventWatcher` fields are [here](../configuration-reference/#event-watcher-configuration-deprecated).
 
 #### Use the application configuration
 
@@ -73,7 +73,7 @@ spec:
               yamlField: $.spec.template.spec.containers[0].image
 ```
 
-The full list of configurable `eventWatcher` fields are [here](/docs/user-guide/configuration-reference/#eventwatcher).
+The full list of configurable `eventWatcher` fields are [here](../configuration-reference/#eventwatcher).
 
 ### 2. Pushing an Event with `pipectl`
 To register a new value corresponding to Event such as the above in the Control Plane, you need to perform `pipectl`.
@@ -81,8 +81,8 @@ And we highly recommend integrating a step for that into your CI workflow.
 
 You first need to set-up the `pipectl`:
 
-- Install it on your CI system or where you want to run according to [this guide](/docs/user-guide/command-line-tool/#installation).
-- Grab the API key to which the `READ_WRITE` role is attached according to [this guide](/docs/user-guide/command-line-tool/#authentication).
+- Install it on your CI system or where you want to run according to [this guide](../command-line-tool/#installation).
+- Grab the API key to which the `READ_WRITE` role is attached according to [this guide](../command-line-tool/#authentication).
 
 Once you're all set up, pushing a new Event to the Control Plane by the following command:
 
@@ -109,7 +109,7 @@ After a while, Piped will create a commit as shown below:
 +        image: gcr.io/pipecd/helloworld:v0.2.0
 ```
 
-NOTE: Keep in mind that it may take a little while because Piped periodically fetches the new events from the Control Plane. You can change its interval according to [here](/docs/user-guide/managing-piped/configuration-reference/#eventwatcher).
+NOTE: Keep in mind that it may take a little while because Piped periodically fetches the new events from the Control Plane. You can change its interval according to [here](../managing-piped/configuration-reference/#eventwatcher).
 
 ### [optional] Using labels
 Event watcher is a project-wide feature, hence an event name is unique inside a project. That is, you can update multiple repositories at the same time if you use the same event name for different events.

--- a/docs/content/en/docs-dev/user-guide/examples/_index.md
+++ b/docs/content/en/docs-dev/user-guide/examples/_index.md
@@ -8,4 +8,4 @@ description: >
 
 One of the best ways to see what PipeCD can do, and learn how to deploy your applications with it, is to see some real examples.
 
-We have prepared some examples for each kind of application, please visit the [PipeCD examples](/docs/examples/) page for details.
+We have prepared some examples for each kind of application, please visit the [PipeCD examples](../../examples/) page for details.

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
@@ -6,7 +6,7 @@ description: >
   How to enable blue-green deployment for Kubernetes application with Istio.
 ---
 
-Similar to [canary deployment](/docs/user-guide/examples/k8s-app-canary-with-istio/), PipeCD allows you to enable and automate the blue-green deployment strategy for your application based on Istio's weighted routing feature.
+Similar to [canary deployment](../k8s-app-canary-with-istio/), PipeCD allows you to enable and automate the blue-green deployment strategy for your application based on Istio's weighted routing feature.
 
 In both canary and blue-green strategies, the old version and the new version of the application get deployed at the same time.
 But while the canary strategy slowly routes the traffic to the new version, the blue-green strategy quickly routes all traffic to one of the versions.
@@ -17,7 +17,7 @@ Complete source code for this example is hosted in [pipe-cd/examples](https://gi
 
 ## Before you begin
 
-- Add a new Kubernetes application by following the instructions in [this guide](/docs/user-guide/adding-an-application/)
+- Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
 - Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 
@@ -107,7 +107,7 @@ The number of workloads (e.g. pod) for canary variant is configured to be 100% o
 ![](/images/example-bluegreen-kubernetes-istio-stage-1.png)
 
 - Stage 2: `K8S_TRAFFIC_ROUTING` ensures that all traffic should be routed to canary variant. Because the `trafficRouting` is configured to use Istio, PipeCD will find Istio's VirtualService resource of this application to control the traffic percentage.
-(You can add an [ANALYSIS](/docs/user-guide/automated-deployment-analysis/) stage after this to validate the new version. When any negative impacts are detected, an auto-rollback stage will be executed to switch all traffic back to the primary variant.)
+(You can add an [ANALYSIS](../../managing-application/customizing-deployment/automated-deployment-analysis/) stage after this to validate the new version. When any negative impacts are detected, an auto-rollback stage will be executed to switch all traffic back to the primary variant.)
 
 ![](/images/example-bluegreen-kubernetes-istio-stage-2.png)
 

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
@@ -9,7 +9,7 @@ description: >
 > Canary release is a technique to reduce the risk of introducing a new software version in production by slowly rolling out the change to a small subset of users before rolling it out to the entire infrastructure and making it available to everybody.
 > -- <cite>[martinfowler.com/canaryrelease](https://martinfowler.com/bliki/CanaryRelease.html)</cite>
 
-With Istio, we can accomplish this goal by configuring a sequence of rules that route a percentage of traffic to each [variant](/docs/user-guide/configuring-deployment/kubernetes/#sync-with-the-specified-pipeline) of the application.
+With Istio, we can accomplish this goal by configuring a sequence of rules that route a percentage of traffic to each [variant](../../managing-application/defining-app-configuration/kubernetes/#sync-with-the-specified-pipeline) of the application.
 And with PipeCD, you can enable and automate the canary strategy for your Kubernetes application even easier.
 
 In this guide, we will show you how to configure the application configuration file to send 10% of traffic to the new version and keep 90% to the primary variant. Then after waiting for manual approval, you will complete the migration by sending 100% of traffic to the new version.
@@ -18,7 +18,7 @@ Complete source code for this example is hosted in [pipe-cd/examples](https://gi
 
 ## Before you begin
 
-- Add a new Kubernetes application by following the instructions in [this guide](/docs/user-guide/adding-an-application/)
+- Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
 - Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
@@ -6,7 +6,7 @@ description: >
   How to enable canary deployment for Kubernetes application with PodSelector.
 ---
 
-Using service mesh like [Istio](/docs/user-guide/examples/k8s-app-canary-with-istio/) helps you doing canary deployment easier with many powerful features, but not all teams are ready to use service mesh in their environment. This page will walk you through using PipeCD to enable canary deployment for Kubernetes application running in a non-mesh environment.
+Using service mesh like [Istio](../k8s-app-canary-with-istio/) helps you doing canary deployment easier with many powerful features, but not all teams are ready to use service mesh in their environment. This page will walk you through using PipeCD to enable canary deployment for Kubernetes application running in a non-mesh environment.
 
 Basically, the idea behind is described as this [Kubernetes document](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#canary-deployments); the Service resource uses the common label set to route the traffic to both canary and primary workloads, and percentage of traffic for each variant is based on their replicas number.
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/_index.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/_index.md
@@ -6,4 +6,4 @@ description: >
   This guide is for developers who have PipeCD installed for them and are using PipeCD to deploy their applications.
 ---
 
-> Note: You must have at least one activated/running Piped to enable using any of the following features of PipeCD. Please refer to [Piped installation docs](/docs/user-guide/installation/install-piped/) if you do not have any Piped in your pocket.
+> Note: You must have at least one activated/running Piped to enable using any of the following features of PipeCD. Please refer to [Piped installation docs](../../installation/install-piped/) if you do not have any Piped in your pocket.

--- a/docs/content/en/docs-dev/user-guide/managing-application/adding-an-application.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/adding-an-application.md
@@ -19,7 +19,7 @@ Through the web console, you can register a new application in one of the follow
 - Picking from a list of unused apps suggested by Pipeds while scanning Git repositories (Recommended)
 - Manually configuring application information
 
-(If you prefer to use [`pipectl`](/docs/user-guide/command-line-tool/#adding-a-new-application) command-line tool, see its usage for the details.)
+(If you prefer to use [`pipectl`](../../command-line-tool/#adding-a-new-application) command-line tool, see its usage for the details.)
 
 ## Picking from a list of unused apps suggested by Pipeds
 
@@ -85,7 +85,7 @@ spec:
 {{< /tab >}}
 {{< /tabpane >}}
 
-To define your application deployment pipeline which contains the guideline to show Piped how to deploy your application, please visit [Defining app configuration](/docs/user-guide/managing-application/defining-app-configuration/).
+To define your application deployment pipeline which contains the guideline to show Piped how to deploy your application, please visit [Defining app configuration](../defining-app-configuration/).
 
 Go to the PipeCD web console on application list page, click the `+ADD` button at the top left corner of the application list page and then go to the `ADD FROM GIT` tab.
 
@@ -121,9 +121,9 @@ Here are the list of fields in the register form:
 
 > Note: Labels couldn't be set via this form. If you want, try the way to register via the application configuration defined in the Git repository.
 
-After submitting the form, one more step left is adding the application configuration file for that application into the application directory in Git repository same as we prepared in [the above method](/docs-dev/user-guide/managing-application/adding-an-application/#picking-from-a-list-of-unused-apps-suggested-by-pipeds).
+After submitting the form, one more step left is adding the application configuration file for that application into the application directory in Git repository same as we prepared in [the above method](../adding-an-application/#picking-from-a-list-of-unused-apps-suggested-by-pipeds).
 
-Please refer [Define your app's configuration](/docs/user-guide/managing-application/defining-app-configuration/) or [pipecd/examples](/docs/user-guide/examples/) for the examples of being supported application kind.
+Please refer [Define your app's configuration](../defining-app-configuration/) or [pipecd/examples](../../examples/) for the examples of being supported application kind.
 
 ## Updating an application
 Regardless of which method you used to register the application, the web console can only be used to disable/enable/delete the application, besides the adding operation. All updates on application information must be done via the application configuration file stored in Git as a single source of truth.
@@ -137,4 +137,4 @@ spec:
     team: new-team
 ```
 
-Refer to [configuration reference](/docs/user-guide/configuration-reference/) to see the full list of configurable fields.
+Refer to [configuration reference](../../configuration-reference/) to see the full list of configurable fields.

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -52,4 +52,4 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-You can change the checking interval as well as [configure the notification](/docs/user-guide/managing-piped/configuring-notifications/) for these events in `piped` configuration.
+You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/adding-a-manual-approval.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/adding-a-manual-approval.md
@@ -27,7 +27,7 @@ spec:
 
 As above example, the deployment requires an approval from `user-abc` before `K8S_PRIMARY_ROLLOUT` stage can be executed.
 
-The value of user ID in the `approvers` list depends on your [SSO configuration](/docs/user-guide/managing-controlplane/auth/), it must be GitHub's user ID if your SSO was configured to use GitHub provider, it must be Gmail account if your SSO was configured to use Google provider.
+The value of user ID in the `approvers` list depends on your [SSO configuration](../../../managing-controlplane/auth/), it must be GitHub's user ID if your SSO was configured to use GitHub provider, it must be Gmail account if your SSO was configured to use Google provider.
 
 In case the `approvers` field was not configured, anyone in the project who has `Editor` or `Admin` role can approve the deployment pipeline.
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
@@ -13,7 +13,7 @@ The analysis of the newly deployed application is often carried out in a manual,
 ADA automates that and helps to build a robust deployment process.
 ADA is available as a stage in the pipeline specified in the application configuration file.
 
-ADA does the analysis by periodically performing queries against the [Analysis Provider](/docs/concepts/#analysis-provider) and evaluating the results to know the impact of the deployment. Then based on these evaluating results, the deployment can be rolled back immediately to minimize any negative impacts.
+ADA does the analysis by periodically performing queries against the [Analysis Provider](../../../../concepts/#analysis-provider) and evaluating the results to know the impact of the deployment. Then based on these evaluating results, the deployment can be rolled back immediately to minimize any negative impacts.
 
 The canonical use case for this stage is to determine if your canary deployment should proceed.
 
@@ -23,7 +23,7 @@ Automatic rollback based on the analysis result
 </p>
 
 ## Prerequisites
-Before enabling ADA inside the pipeline, all required Analysis Providers must be configured in the Piped Configuration according to [this guide](/docs/user-guide/managing-piped/adding-an-analysis-provider/).
+Before enabling ADA inside the pipeline, all required Analysis Providers must be configured in the Piped Configuration according to [this guide](../../../managing-piped/adding-an-analysis-provider/).
 
 ## Analysis by metrics
 ### Strategies
@@ -233,7 +233,7 @@ spec:
       - name: K8S_BASELINE_CLEAN
 ```
 
-The full list of configurable `ANALYSIS` stage fields are [here](/docs/user-guide/configuration-reference/#analysisstageoptions).
+The full list of configurable `ANALYSIS` stage fields are [here](../../../configuration-reference/#analysisstageoptions).
 
 See more the [example](https://github.com/pipe-cd/examples/blob/master/kubernetes/analysis-by-metrics/app.pipecd.yaml).
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/cloudrun.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/cloudrun.md
@@ -34,12 +34,12 @@ spec:
 
 ## Quick sync
 
-By default, when the [pipeline](/docs/user-guide/configuration-reference/#cloudrun-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
+By default, when the [pipeline](../../../configuration-reference/#cloud-run-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
 Quick sync for a Cloud Run deployment will roll out the new version and switch all traffic to it.
 
 ## Sync with the specified pipeline
 
-The [pipeline](/docs/user-guide/configuration-reference/#cloudrun-application) field in the application configuration is used to customize the way to do the deployment.
+The [pipeline](../../../configuration-reference/#cloud-run-application) field in the application configuration is used to customize the way to do the deployment.
 You can add a manual approval before routing traffic to the new version or add an analysis stage the do some smoke tests against the new version before allowing them to receive the real traffic.
 
 These are the provided stages for Cloud Run application you can use to build your pipeline:
@@ -52,7 +52,7 @@ and other common stages:
 - `WAIT_APPROVAL`
 - `ANALYSIS`
 
-See the description of each stage at [Customize application deployment](/docs/user-guide/managing-application/customizing-deployment/).
+See the description of each stage at [Customize application deployment](../../customizing-deployment/).
 
 Here is an example that rolls out the new version gradually:
 
@@ -84,4 +84,4 @@ spec:
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#cloudrun-application) for the full configuration.
+See [Configuration Reference](../../../configuration-reference/#cloud-run-application) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -8,16 +8,16 @@ description: >
 
 Deploying an Amazon ECS application requires `TaskDefinition` and `Service` configuration files placing inside the application directory. Those files contain all configuration for [ECS TaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) object and [ECS Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) object, and will be used by Piped agent while deploy your application/service to ECS cluster.
 
-If you're not familiar with ECS, you can get examples for those files from [here](/docs/examples/#ecs-applications).
+If you're not familiar with ECS, you can get examples for those files from [here](../../../../examples/#ecs-applications).
 
 ## Quick sync
 
-By default, when the [pipeline](/docs/user-guide/configuration-reference/#ecs-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
+By default, when the [pipeline](../../../configuration-reference/#ecs-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
 Quick sync for an ECS deployment will roll out the new version and switch all traffic to it immediately.
 
 ## Sync with the specified pipeline
 
-The [pipeline](/docs/user-guide/configuration-reference/#ecs-application) field in the application configuration is used to customize the way to do the deployment.
+The [pipeline](../../../configuration-reference/#ecs-application) field in the application configuration is used to customize the way to do the deployment.
 You can add a manual approval before routing traffic to the new version or add an analysis stage the do some smoke tests against the new version before allowing them to receive the real traffic.
 
 These are the provided stages for ECS application you can use to build your pipeline:
@@ -36,7 +36,7 @@ and other common stages:
 - `WAIT_APPROVAL`
 - `ANALYSIS`
 
-See the description of each stage at [Customize application deployment](/docs/user-guide/managing-application/customizing-deployment/).
+See the description of each stage at [Customize application deployment](../../customizing-deployment/).
 
 Here is an example that rolls out the new version gradually:
 
@@ -91,4 +91,4 @@ spec:
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#ecs-application) for the full configuration.
+See [Configuration Reference](../../../configuration-reference/#ecs-application) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
@@ -13,7 +13,7 @@ Based on the application configuration and the pull request changes, PipeCD plan
 Quick sync is a fast way to sync application to the state specified in the target Git commit without any progressive strategy. It just applies all the defined manifiests to sync the application.
 The quick sync will be planned in one of the following cases:
 - no pipeline was specified in the application configuration file
-- [pipeline](/docs/user-guide/configuration-reference/#pipeline) was specified but the PR did not make any changes on workload (e.g. Deployment's pod template) or config (e.g. ConfigMap, Secret)
+- [pipeline](../../../configuration-reference/#pipeline) was specified but the PR did not make any changes on workload (e.g. Deployment's pod template) or config (e.g. ConfigMap, Secret)
 
 For example, the application configuration as below is missing the pipeline field. This means any pull request touches the application will trigger a quick sync deployment.
 
@@ -61,7 +61,7 @@ and other common stages:
 - `WAIT_APPROVAL`
 - `ANALYSIS`
 
-See the description of each stage at [Customize application deployment](/docs/user-guide/managing-application/customizing-deployment/).
+See the description of each stage at [Customize application deployment](../../customizing-deployment/).
 
 ## Manifest Templating
 
@@ -109,8 +109,8 @@ A kustomize base can be loaded from:
 - the same git repository with the application directory, we call as a `local base`
 - a different git repository, we call as a `remote base`
 
-See [Examples](/docs/user-guide/examples/#kubernetes-applications) for more specific.
+See [Examples](../../../examples/#kubernetes-applications) for more specific.
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#kubernetes-application) for the full configuration.
+See [Configuration Reference](../../../configuration-reference/#kubernetes-application) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/lambda.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/lambda.md
@@ -100,12 +100,12 @@ All other fields setting are remained as in the case of using [.zip archives as 
 
 ## Quick sync
 
-By default, when the [pipeline](/docs/user-guide/configuration-reference/#lambda-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
+By default, when the [pipeline](../../../configuration-reference/#lambda-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
 Quick sync for a Lambda deployment will roll out the new version and switch all traffic to it.
 
 ## Sync with the specified pipeline
 
-The [pipeline](/docs/user-guide/configuration-reference/#lambda-application) field in the application configuration is used to customize the way to do the deployment.
+The [pipeline](../../../configuration-reference/#lambda-application) field in the application configuration is used to customize the way to do the deployment.
 You can add a manual approval before routing traffic to the new version or add an analysis stage the do some smoke tests against the new version before allowing them to receive the real traffic.
 
 These are the provided stages for Lambda application you can use to build your pipeline:
@@ -120,7 +120,7 @@ and other common stages:
 - `WAIT_APPROVAL`
 - `ANALYSIS`
 
-See the description of each stage at [Customize application deployment](/docs/user-guide/managing-application/customizing-deployment/).
+See the description of each stage at [Customize application deployment](../../customizing-deployment/).
 
 Here is an example that rolls out the new version gradually:
 
@@ -155,4 +155,4 @@ spec:
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#lambda-application) for the full configuration.
+See [Configuration Reference](../../../configuration-reference/#lambda-application) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/terraform.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/terraform.md
@@ -8,12 +8,12 @@ description: >
 
 ## Quick Sync
 
-By default, when the [pipeline](/docs/user-guide/configuration-reference/#terraform-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
+By default, when the [pipeline](../../../configuration-reference/#terraform-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.
 Quick sync for a Terraform deployment does `terraform plan` and if there are any changes detected it applies those changes automatically.
 
 ## Sync with the specified pipeline
 
-The [pipeline](/docs/user-guide/configuration-reference/#terraform-application) field in the application configuration is used to customize the way to do the deployment.
+The [pipeline](../../../configuration-reference/#terraform-application) field in the application configuration is used to customize the way to do the deployment.
 You can add a manual approval before doing `terraform apply` or add an analysis stage after applying the changes to determine the impact of those changes.
 
 These are the provided stages for Terraform application you can use to build your pipeline:
@@ -28,7 +28,7 @@ and other common stages:
 - `WAIT_APPROVAL`
 - `ANALYSIS`
 
-See the description of each stage at [Customize application deployment](/docs/user-guide/managing-application/customizing-deployment/).
+See the description of each stage at [Customize application deployment](../../customizing-deployment/).
 
 ## Module location
 
@@ -39,4 +39,4 @@ Terraform module can be loaded from:
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#terraform-application) for the full configuration.
+See [Configuration Reference](../../../configuration-reference/#terraform-application) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/deployment-chain.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/deployment-chain.md
@@ -41,10 +41,10 @@ In the context of the deployment chain in PipeCD, a chain is made up of many `bl
 
 __Tip__:
 
-1. If you followed all the configuration references and built your deployment chain configuration, but some deployments in your defined chain are not triggered as you want, please re-check those deployments [`trigger configuration`](/docs/user-guide/managing-application/triggering-a-deployment/#trigger-configuration). The `onChain` trigger is __disabled by default__; you need to enable that configuration to enable your deployment to be triggered as a node in the deployment chain.
+1. If you followed all the configuration references and built your deployment chain configuration, but some deployments in your defined chain are not triggered as you want, please re-check those deployments [`trigger configuration`](../triggering-a-deployment/#trigger-configuration). The `onChain` trigger is __disabled by default__; you need to enable that configuration to enable your deployment to be triggered as a node in the deployment chain.
 2. Values configured under `postSync.chain.applications` - we call it __Application matcher__'s values are merged using `AND` operator. Currently, only `name` and `kind` are supported, but `labels` will also be supported soon.
 
-See [Examples](/docs/examples/#deployment-chain) for more specific.
+See [Examples](../../examples/#deployment-chain) for more specific.
 
 ## Deployment chain characteristic
 
@@ -61,4 +61,4 @@ The UI for this deployment chain feature currently is under deployment, we can o
 
 ## Reference
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#postsync) for the full configuration.
+See [Configuration Reference](../../configuration-reference/#postsync) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
@@ -24,7 +24,7 @@ openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out private-key
 openssl pkey -in private-key -pubout -out public-key
 ```
 
-Then specify them while [installing](/docs/operator-manual/piped/installation/installing-on-kubernetes) the `Piped` with these options:
+Then specify them while [installing](../../../installation/install-piped/installing-on-kubernetes) the `Piped` with these options:
 
 ``` console
 --set-file secret.data.secret-public-key=PATH_TO_PUBLIC_KEY_FILE \

--- a/docs/content/en/docs-dev/user-guide/managing-application/triggering-a-deployment.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/triggering-a-deployment.md
@@ -20,7 +20,7 @@ Configuration for the trigger used to determine whether we trigger a new deploym
 - `onOutOfSync`: Controls triggering new deployment when application is at `OUT_OF_SYNC` state.
 - `onChain`: Controls triggering new deployment when the application is counted as a node of some chains.
 
-See [Configuration Reference](/docs/user-guide/configuration-reference/#deploymenttrigger) for the full configuration.
+See [Configuration Reference](../../configuration-reference/#deploymenttrigger) for the full configuration.
 
 After a new deployment was triggered, it will be queued to handle by the appropriate `piped`. And at this time the deployment pipeline was not decided yet.
 `piped` schedules all deployments of applications to ensure that for each application only one deployment will be executed at the same time.
@@ -31,7 +31,7 @@ For example:
 - when the merged pull request updated a Deployment's container image or updated a mounting ConfigMap or Secret, `piped` planner will decide that the deployment should use the specified pipeline to do a progressive deployment.
 - when the merged pull request just updated the `replicas` number, `piped` planner will decide to use a quick sync to scale the resources.
 
-You can force `piped` planner to decide to use the [QuickSync](/docs/concepts/#quick-sync) or the specified pipeline based on the commit message by configuring [CommitMatcher](/docs/user-guide/configuration-reference/#commitmatcher) in the application configuration.
+You can force `piped` planner to decide to use the [QuickSync](../../../concepts/#sync-strategy) or the specified pipeline based on the commit message by configuring [CommitMatcher](../../configuration-reference/#commitmatcher) in the application configuration.
 
 After being planned, the deployment will be executed as the decided pipeline. The deployment execution including the state of each stage as well as their logs can be viewed in realtime at the deployment details page.
 

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
@@ -10,7 +10,7 @@ description: >
 
 ### Static Admin
 
-When the PipeCD owner [adds a new project](/docs/user-guide/managing-controlplane/adding-a-project/), an admin account will be automatically generated for the project. After that, PipeCD owner sends that static admin information including username, password strings to the project admin, who can use that information to log in to PipeCD web with the admin role.
+When the PipeCD owner [adds a new project](../adding-a-project/), an admin account will be automatically generated for the project. After that, PipeCD owner sends that static admin information including username, password strings to the project admin, who can use that information to log in to PipeCD web with the admin role.
 
 After logging, the project admin should change the provided username and password. Or disable the static admin account after configuring the single sign-on for the project.
 

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/metrics.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/metrics.md
@@ -10,7 +10,7 @@ PipeCD comes with a monitoring system including Prometheus, Alertmanager, and Gr
 This page walks you through how to set up and use them.
 
 ## Enable monitoring system
-To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](/docs/user-guide/installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --set monitoring.enabled=true
@@ -63,7 +63,7 @@ prometheus:
             - channel: '#your-channel'
 ```
 
-And give it to the `helm install` command when [installing](/docs/user-guide/installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+And give it to the `helm install` command when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --values=values.yaml

--- a/docs/content/en/docs-dev/user-guide/managing-piped/_index.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/_index.md
@@ -6,6 +6,6 @@ description: >
   This guide is for administrators and operators wanting to install and configure piped for other developers.
 ---
 
-In order to use Piped you need to register through PipeCD control plane, so please refer [register a Piped docs](/docs/user-guide/managing-controlplane/registering-a-piped/) if you do not have already. After registering successfully, you can monitor your Piped live state via the PipeCD console on the settings page.
+In order to use Piped you need to register through PipeCD control plane, so please refer [register a Piped docs](../managing-controlplane/registering-a-piped/) if you do not have already. After registering successfully, you can monitor your Piped live state via the PipeCD console on the settings page.
 
 ![piped-list-page](/images/piped-list-page.png)

--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-cloud-provider.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-cloud-provider.md
@@ -13,16 +13,16 @@ Cloud provider defines which cloud and where the application should be deployed 
 So while registering a new application, the name of a configured cloud provider is required.
 
 Currently, PipeCD is supporting these five kinds of cloud providers: `KUBERNETES`, `ECS`, `TERRAFORM`, `CLOUDRUN`, `LAMBDA`.
-A new cloud provider can be enabled by adding a [CloudProvider](/docs/user-guide/managing-piped/configuration-reference/#cloudprovider) struct to the piped configuration file.
+A new cloud provider can be enabled by adding a [CloudProvider](../configuration-reference/#cloudprovider) struct to the piped configuration file.
 A piped can have one or multiple cloud provider instances from the same or different cloud provider kind.
 
 The next sections show the specific configuration for each kind of cloud provider.
 
 ### Configuring Kubernetes cloud provider
 
-By default, piped deploys Kubernetes application to the cluster where the piped is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in the [configuration](/docs/user-guide/managing-piped/configuration-reference/#cloudproviderkubernetesconfig).
+By default, piped deploys Kubernetes application to the cluster where the piped is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in the [configuration](../configuration-reference/#cloudproviderkubernetesconfig).
 
-And, the default resources (defined at [here](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/cloudprovider/kubernetes/resourcekey.go#L24-L74)) from all namespaces of the Kubernetes cluster will be watched for rendering the application state in realtime and detecting the configuration drift. In case you want to restrict piped to watch only a single namespace, let specify the namespace in the [KubernetesAppStateInformer](/docs/user-guide/managing-piped/configuration-reference/#kubernetesappstateinformer) field. You can also add other resources or exclude resources to/from the watching targets by that field.
+And, the default resources (defined at [here](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/kubernetes/resourcekey.go#L24-L74)) from all namespaces of the Kubernetes cluster will be watched for rendering the application state in realtime and detecting the configuration drift. In case you want to restrict piped to watch only a single namespace, let specify the namespace in the [KubernetesAppStateInformer](../configuration-reference/#kubernetesappstateinformer) field. You can also add other resources or exclude resources to/from the watching targets by that field.
 
 Below configuration snippet just specifies a name and type of cloud provider. It means the cloud provider `kubernetes-dev` will connect to the Kubernetes cluster where the piped is running in, and this cloud provider watches all of the predefined resources from all namespaces inside that cluster.
 
@@ -36,7 +36,7 @@ spec:
       type: KUBERNETES
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#cloudproviderkubernetesconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#cloudproviderkubernetesconfig) for the full configuration.
 
 ### Configuring Terraform cloud provider
 
@@ -55,7 +55,7 @@ spec:
           - "project=pipecd"
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#cloudproviderterraformconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#cloudproviderterraformconfig) for the full configuration.
 
 ### Configuring Cloud Run cloud provider
 
@@ -75,7 +75,7 @@ spec:
         credentialsFile: {PATH_TO_THE_SERVICE_ACCOUNT_FILE}
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#cloudprovidercloudrunconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#cloudprovidercloudrunconfig) for the full configuration.
 
 ### Configuring Lambda cloud provider
 
@@ -104,7 +104,7 @@ It attempts to retrieve credentials in the following order:
 
 Therefore, you don't have to set credentialsFile if you use the environment variables or the EC2 Instance Role. Keep in mind the IAM role/user that you use with your Piped must possess the IAM policy permission for at least `Lambda.Function` and `Lambda.Alias` resources controll (list/read/write).
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#cloudproviderlambdaconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#cloudproviderlambdaconfig) for the full configuration.
 
 ### Configuring ECS cloud provider
 
@@ -131,4 +131,4 @@ It attempts to retrieve credentials in the following order:
 3. From the pod running in EKS cluster via STS (SecurityTokenService).
 4. From the EC2 Instance Role.
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#cloudproviderecsconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#cloudproviderecsconfig) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-git-repository.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-git-repository.md
@@ -7,12 +7,12 @@ description: >
 ---
 
 In the `piped` configuration file, we specify the list of Git repositories should be handled by the `piped`.
-A Git repository contains one or more deployable applications where each application is put inside a directory called as [application directory](/docs/concepts/#application-configuration-directory).
+A Git repository contains one or more deployable applications where each application is put inside a directory called as [application directory](../../../concepts/#application-directory).
 That directory contains an application configuration file as well as application manifests.
 The `piped` periodically checks the new commits and fetches the needed manifests from those repositories for executing the deployment.
 
 A single `piped` can be configured to handle one or more Git repositories.
-In order to enable a new Git repository, let's add a new [GitRepository](/docs/user-guide/managing-piped/configuration-reference/#gitrepository) block to the `repositories` field in the `piped` configuration file.
+In order to enable a new Git repository, let's add a new [GitRepository](../configuration-reference/#gitrepository) block to the `repositories` field in the `piped` configuration file.
 
 For example, with the following snippet, `piped` will take the `master` branch of [pipe-cd/examples](https://github.com/pipe-cd/examples) repository as a target Git repository for doing deployments.
 
@@ -27,7 +27,7 @@ spec:
       branch: master
 ```
 
-In most of the cases, we want to deal with private Git repositories. For accessing those private repositories, `piped` needs a private SSH key, which can be configured while [installing](/docs/user-guide/installation/install-piped/installing-on-kubernetes/) with `secret.sshKey` in the Helm chart.
+In most of the cases, we want to deal with private Git repositories. For accessing those private repositories, `piped` needs a private SSH key, which can be configured while [installing](../../../installation/install-piped/installing-on-kubernetes/) with `secret.sshKey` in the Helm chart.
 
 ``` console
 helm install dev-piped pipecd/piped --version={VERSION} \
@@ -36,6 +36,6 @@ helm install dev-piped pipecd/piped --version={VERSION} \
   --set-file secret.data.ssh-key={PATH_TO_PRIVATE_SSH_KEY_FILE}
 ```
 
-You can see this [configuration reference](/docs/user-guide/managing-piped/configuration-reference/#git) for more configurable fields about Git commands.
+You can see this [configuration reference](../configuration-reference/#git) for more configurable fields about Git commands.
 
 Currently, `piped` allows configuring only one private SSH key for all specified Git repositories. So you can configure the same SSH key for all of those private repositories, or break them into separate `piped`s. In the near future, we also want to update `piped` to support loading multiple SSH keys.

--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-platform-provider.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-a-platform-provider.md
@@ -11,16 +11,16 @@ Platform provider defines which platform and where the application should be dep
 So while registering a new application, the name of a configured platform provider is required.
 
 Currently, PipeCD is supporting these five kinds of platform providers: `KUBERNETES`, `ECS`, `TERRAFORM`, `CLOUDRUN`, `LAMBDA`.
-A new platform provider can be enabled by adding a [PlatformProvider](/docs/user-guide/managing-piped/configuration-reference/#platformprovider) struct to the piped configuration file.
+A new platform provider can be enabled by adding a [PlatformProvider](../configuration-reference/#platformprovider) struct to the piped configuration file.
 A piped can have one or multiple platform provider instances from the same or different platform provider kind.
 
 The next sections show the specific configuration for each kind of platform provider.
 
 ### Configuring Kubernetes platform provider
 
-By default, piped deploys Kubernetes application to the cluster where the piped is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in the [configuration](/docs/user-guide/managing-piped/configuration-reference/#platformproviderkubernetesconfig).
+By default, piped deploys Kubernetes application to the cluster where the piped is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in the [configuration](../configuration-reference/#platformproviderkubernetesconfig).
 
-And, the default resources (defined at [here](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/kubernetes/resourcekey.go#L24-L74)) from all namespaces of the Kubernetes cluster will be watched for rendering the application state in realtime and detecting the configuration drift. In case you want to restrict piped to watch only a single namespace, let specify the namespace in the [KubernetesAppStateInformer](/docs/user-guide/managing-piped/configuration-reference/#kubernetesappstateinformer) field. You can also add other resources or exclude resources to/from the watching targets by that field.
+And, the default resources (defined at [here](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/kubernetes/resourcekey.go#L24-L74)) from all namespaces of the Kubernetes cluster will be watched for rendering the application state in realtime and detecting the configuration drift. In case you want to restrict piped to watch only a single namespace, let specify the namespace in the [KubernetesAppStateInformer](../configuration-reference/#kubernetesappstateinformer) field. You can also add other resources or exclude resources to/from the watching targets by that field.
 
 Below configuration snippet just specifies a name and type of platform provider. It means the platform provider `kubernetes-dev` will connect to the Kubernetes cluster where the piped is running in, and this platform provider watches all of the predefined resources from all namespaces inside that cluster.
 
@@ -34,7 +34,7 @@ spec:
       type: KUBERNETES
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#platformproviderkubernetesconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#platformproviderkubernetesconfig) for the full configuration.
 
 ### Configuring Terraform platform provider
 
@@ -53,7 +53,7 @@ spec:
           - "project=pipecd"
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#platformproviderterraformconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#platformproviderterraformconfig) for the full configuration.
 
 ### Configuring Cloud Run platform provider
 
@@ -73,7 +73,7 @@ spec:
         credentialsFile: {PATH_TO_THE_SERVICE_ACCOUNT_FILE}
 ```
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#platformprovidercloudrunconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#platformprovidercloudrunconfig) for the full configuration.
 
 ### Configuring Lambda platform provider
 
@@ -102,7 +102,7 @@ It attempts to retrieve credentials in the following order:
 
 Therefore, you don't have to set credentialsFile if you use the environment variables or the EC2 Instance Role. Keep in mind the IAM role/user that you use with your Piped must possess the IAM policy permission for at least `Lambda.Function` and `Lambda.Alias` resources controll (list/read/write).
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#platformproviderlambdaconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#platformproviderlambdaconfig) for the full configuration.
 
 ### Configuring ECS platform provider
 
@@ -129,4 +129,4 @@ It attempts to retrieve credentials in the following order:
 3. From the pod running in EKS cluster via STS (SecurityTokenService).
 4. From the EC2 Instance Role.
 
-See [ConfigurationReference](/docs/user-guide/managing-piped/configuration-reference/#platformproviderecsconfig) for the full configuration.
+See [ConfigurationReference](../configuration-reference/#platformproviderecsconfig) for the full configuration.

--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -6,7 +6,7 @@ description: >
   This page describes how to add an analysis provider for doing deployment analysis.
 ---
 
-To enable [Automated deployment analysis](/docs/user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) feature, you have to set the needed information for Piped to connect to the [Analysis Provider](/docs/concepts/#analysis-provider).
+To enable [Automated deployment analysis](../../managing-application/customizing-deployment/automated-deployment-analysis/) feature, you have to set the needed information for Piped to connect to the [Analysis Provider](../../../concepts/#analysis-provider).
 
 Currently, PipeCD supports the following providers:
 - [Prometheus](https://prometheus.io/)
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](/docs/user-guide/managing-piped/configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,9 +45,9 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](/docs/user-guide/managing-piped/configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
 
-If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](/docs/user-guide/installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
+If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 
 ```console
 --set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \

--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-helm-chart-repository-or-registry.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-helm-chart-repository-or-registry.md
@@ -10,7 +10,7 @@ PipeCD supports Kubernetes applications that are using Helm for templating and p
 
 ### Adding Helm chart repository
 
-A Helm [chart repository](https://helm.sh/docs/topics/chart_repository/) is a location backed by an HTTP server where packaged charts can be stored and shared. Before an application can be configured to use a chart from a Helm chart repository, that chart repository must be enabled in the related `piped` by adding the [ChartRepository](/docs/user-guide/managing-piped/configuration-reference/#chartrepository) struct to the piped configuration file.
+A Helm [chart repository](https://helm.sh/docs/topics/chart_repository/) is a location backed by an HTTP server where packaged charts can be stored and shared. Before an application can be configured to use a chart from a Helm chart repository, that chart repository must be enabled in the related `piped` by adding the [ChartRepository](../configuration-reference/#chartrepository) struct to the piped configuration file.
 
 ``` yaml
 # piped configuration file
@@ -38,13 +38,13 @@ spec:
       version: v0.5.0
 ```
 
-In case the chart repository is backed by HTTP basic authentication, the username and password strings are required in [configuration](/docs/user-guide/managing-piped/configuration-reference/#chartrepository).
+In case the chart repository is backed by HTTP basic authentication, the username and password strings are required in [configuration](../configuration-reference/#chartrepository).
 
 ### Adding Helm chart registry
 
 A Helm chart [registry](https://helm.sh/docs/topics/registries/) is a mechanism enabled by default in Helm 3.8.0 and later that allows the OCI registry to be used for storage and distribution of Helm charts.
 
-Before an application can be configured to use a chart from a registry, that registry must be enabled in the related `piped` by adding the [ChartRegistry](/docs/user-guide/managing-piped/configuration-reference/#chartregistry) struct to the piped configuration file if authentication is enabled at the registry.
+Before an application can be configured to use a chart from a registry, that registry must be enabled in the related `piped` by adding the [ChartRegistry](../configuration-reference/#chartregistry) struct to the piped configuration file if authentication is enabled at the registry.
 
 ``` yaml
 # piped configuration file

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-event-watcher.md
@@ -6,10 +6,10 @@ description: >
   This page describes how to configure piped to enable event watcher.
 ---
 
-To enable [EventWatcher](/docs/user-guide/event-watcher/), you have to configure your piped at first.
+To enable [EventWatcher](../../event-watcher/), you have to configure your piped at first.
 
 ### Grant write permission
-The [SSH key used by Piped](/docs/user-guide/managing-piped/configuration-reference/#git) must be a key with write-access because piped needs to commit and push to your git repository when any incoming event matches.
+The [SSH key used by Piped](../configuration-reference/#git) must be a key with write-access because piped needs to commit and push to your git repository when any incoming event matches.
 
 ### Specify Git repositories to be observed
 Piped watches events only for the Git repositories specified in the `gitRepos` list.
@@ -27,7 +27,7 @@ spec:
 ```
 
 ### [optional] Specify Eventwatcher files Piped will use
->NOTE: This way is valid only for defining events using [.pipe/](/docs/user-guide/event-watcher/#use-the-pipe-directory).
+>NOTE: This way is valid only for defining events using [.pipe/](../../event-watcher/#use-the-pipe-directory).
 
 If multiple Pipeds handle a single repository, you can prevent conflicts by splitting into the multiple EventWatcher files and setting `includes/excludes` to specify the files that should be monitored by this Piped.
 
@@ -47,10 +47,10 @@ spec:
 
 `excludes` is prioritized if both `includes` and `excludes` are given.
 
-The full list of configurable fields are [here](/docs/user-guide/managing-piped/configuration-reference/#eventwatcher).
+The full list of configurable fields are [here](../configuration-reference/#eventwatcher).
 
 ### [optional] Settings for git user
-By default, every git commit uses `piped` as a username and `pipecd.dev@gmail.com` as an email. You can change it with the [git](/docs/user-guide/managing-piped/configuration-reference/#git) field.
+By default, every git commit uses `piped` as a username and `pipecd.dev@gmail.com` as an email. You can change it with the [git](../configuration-reference/#git) field.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](/docs/user-guide/managing-piped/configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported |
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](/docs/user-guide/managing-piped/configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](/docs/user-guide/managing-piped/configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-dev/user-guide/managing-piped/remote-upgrade-remote-config.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/remote-upgrade-remote-config.md
@@ -14,7 +14,7 @@ All Pipeds that are running by the provided Piped container image can be enabled
 It means Pipeds running on a Kubernetes cluster, a virtual machine, a serverless service can be upgraded remotely from the web console.
 
 Basically, in order to use this feature you must run Piped with `/launcher` command instead of `/piped` command as usual.
-Please check the [installation](/docs/user-guide/installation/install-piped/) guide on each environment to see the details.
+Please check the [installation](../../../installation/install-piped/) guide on each environment to see the details.
 
 After starting Piped with the remote-upgrade feature, you can go to the Settings page then click on `UPGRADE` button on the top-right corner.
 A dialog will be shown for selecting which Pipeds you want to upgrade and what version they should run.
@@ -30,7 +30,7 @@ Although the remote-upgrade allows you remotely restart your Pipeds to run any n
 
 Remote-config is the ability to load Piped config data from a remote location such as a Git repository. Not only that, but it also watches the config periodically to detect any changes on that config and restarts Piped to reflect the new configuration automatically.
 
-This feature requires the remote-upgrade feature to be enabled simultaneously. Currently, we only support remote config from a Git repository, but other remote locations could be supported in the future. Please check the [installation](/docs/user-guide/installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
+This feature requires the remote-upgrade feature to be enabled simultaneously. Currently, we only support remote config from a Git repository, but other remote locations could be supported in the future. Please check the [installation](../../../installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
 
 
 ## Summary

--- a/docs/content/en/docs-v0.36.x/concepts/_index.md
+++ b/docs/content/en/docs-v0.36.x/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.

--- a/docs/content/en/docs-v0.37.x/concepts/_index.md
+++ b/docs/content/en/docs-v0.37.x/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.

--- a/docs/content/en/docs-v0.38.x/concepts/_index.md
+++ b/docs/content/en/docs-v0.38.x/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.

--- a/docs/content/en/docs-v0.39.x/concepts/_index.md
+++ b/docs/content/en/docs-v0.39.x/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.

--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -72,4 +72,4 @@ Currently, PipeCD is supporting these five platform providers: `KUBERNETES`, `EC
 
 ### Analysis Provider
 An external product that provides metrics/logs to evaluate deployments, such as `Prometheus`, `Datadog`, `Stackdriver`, `CloudWatch` and so on.
-It is mainly used in the [Automated deployment analysis](/docs/user-guide/automated-deployment-analysis/) context.
+It is mainly used in the [Automated deployment analysis](../user-guide/managing-application/customizing-deployment/automated-deployment-analysis/) context.


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a suggestion to fix the links for the dev docs.
Currently, we just copy the `docs/` when creating the docs for a new release hence jumping to `/docs` although see other docs like `/dev`. By doing this, we're able to adapt it by each version even if the architecture of the docs can be changed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
