### PR TITLE
Add restart piped UI

### DIFF
--- a/web/src/api/piped.ts
+++ b/web/src/api/piped.ts
@@ -20,6 +20,8 @@ import {
   UpdatePipedDesiredVersionResponse,
   ListReleasedVersionsResponse,
   ListReleasedVersionsRequest,
+  RestartPipedRequest,
+  RestartPipedResponse,
 } from "pipecd/web/api_client/service_pb";
 
 export const getPipeds = ({
@@ -61,6 +63,14 @@ export const enablePiped = ({
   const req = new EnablePipedRequest();
   req.setPipedId(pipedId);
   return apiRequest(req, apiClient.enablePiped);
+};
+
+export const restartPiped = ({
+  pipedId,
+}: RestartPipedRequest.AsObject): Promise<RestartPipedResponse.AsObject> => {
+  const req = new RestartPipedRequest();
+  req.setPipedId(pipedId);
+  return apiRequest(req, apiClient.restartPiped);
 };
 
 export const recreatePipedKey = ({

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -267,7 +267,11 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
             >
               {UI_TEXT_VIEW_THE_CONFIGURATION}
             </MenuItem>,
-            <MenuItem key="piped-menu-restart" onClick={handleRestart}>
+            <MenuItem
+              key="piped-menu-restart"
+              onClick={handleRestart}
+              disabled={piped.status !== Piped.ConnectionStatus.ONLINE}
+            >
               {UI_TEXT_RESTART}
             </MenuItem>,
             <MenuItem key="piped-menu-disable" onClick={handleDisable}>

--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -33,6 +33,7 @@ import {
   UI_TEXT_DISABLE,
   UI_TEXT_EDIT,
   UI_TEXT_ENABLE,
+  UI_TEXT_RESTART,
 } from "~/constants/ui-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import {
@@ -81,12 +82,13 @@ interface Props {
   onEdit: (id: string) => void;
   onDisable: (id: string) => void;
   onEnable: (id: string) => void;
+  onRestart: (id: string) => void;
 }
 
 const ITEM_HEIGHT = 48;
 const menuStyle = {
   style: {
-    maxHeight: ITEM_HEIGHT * 4.5,
+    maxHeight: ITEM_HEIGHT * 5.5,
     width: "25ch",
   },
 };
@@ -96,6 +98,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
   onEnable,
   onDisable,
   onEdit,
+  onRestart,
 }) {
   const classes = useStyles();
   const piped = useAppSelector(selectPipedById(pipedId));
@@ -162,6 +165,11 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
     setAnchorEl(null);
     onDisable(pipedId);
   }, [pipedId, onDisable]);
+
+  const handleRestart = useCallback(() => {
+    setAnchorEl(null);
+    onRestart(pipedId);
+  }, [pipedId, onRestart]);
 
   if (!piped) {
     return null;
@@ -258,6 +266,9 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
               disabled={piped.config.length === 0}
             >
               {UI_TEXT_VIEW_THE_CONFIGURATION}
+            </MenuItem>,
+            <MenuItem key="piped-menu-restart" onClick={handleRestart}>
+              {UI_TEXT_RESTART}
             </MenuItem>,
             <MenuItem key="piped-menu-disable" onClick={handleDisable}>
               {UI_TEXT_DISABLE}

--- a/web/src/components/settings-page/piped/index.tsx
+++ b/web/src/components/settings-page/piped/index.tsx
@@ -32,18 +32,21 @@ import {
   UI_TEXT_HIDE_FILTER,
   UI_TEXT_UPGRADE,
 } from "~/constants/ui-text";
+import { REQUEST_PIPED_RESTART_SUCCESS } from "~/constants/toast-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import { useInterval } from "~/hooks/use-interval";
 import {
   clearRegisteredPipedInfo,
   disablePiped,
   enablePiped,
+  restartPiped,
   fetchPipeds,
   fetchReleasedVersions,
   Piped,
   RegisteredPiped,
   selectAllPipeds,
 } from "~/modules/pipeds";
+import { addToast } from "~/modules/toasts";
 import { AppState } from "~/store";
 import { useSettingsStyles } from "../styles";
 import { AddPipedDialog } from "./components/add-piped-dialog";
@@ -129,6 +132,19 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
     },
     [dispatch]
   );
+  const handleRestart = useCallback(
+    (id: string) => {
+      dispatch(restartPiped({ pipedId: id })).then(() => {
+        dispatch(
+          addToast({
+            message: REQUEST_PIPED_RESTART_SUCCESS,
+            severity: "success",
+          })
+        );
+      });
+    },
+    [dispatch]
+  );
 
   const handleEdit = useCallback((id: string) => {
     setEditPipedId(id);
@@ -208,6 +224,7 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
                   onEdit={handleEdit}
                   onDisable={handleDisable}
                   onEnable={handleEnable}
+                  onRestart={handleRestart}
                 />
               ))}
             </TableBody>

--- a/web/src/constants/toast-text.ts
+++ b/web/src/constants/toast-text.ts
@@ -10,6 +10,8 @@ export const DISABLE_API_KEY_SUCCESS = "Successfully disabled API Key.";
 // Piped
 export const ADD_PIPED_SUCCESS = "Successfully added Piped.";
 export const UPDATE_PIPED_SUCCESS = "Successfully updated Piped.";
+export const REQUEST_PIPED_RESTART_SUCCESS =
+  "Successfully sent Piped restart request.";
 export const DELETE_OLD_PIPED_KEY_SUCCESS =
   "Successfully deleted old Piped key.";
 export const UPGRADE_PIPEDS_SUCCESS =

--- a/web/src/constants/ui-text.ts
+++ b/web/src/constants/ui-text.ts
@@ -4,6 +4,7 @@ export const UI_TEXT_ADD = "Add";
 export const UI_TEXT_EDIT = "Edit";
 export const UI_TEXT_DISCARD = "Discard";
 export const UI_TEXT_DISABLE = "Disable";
+export const UI_TEXT_RESTART = "Restart";
 export const UI_TEXT_ENABLE = "Enable";
 export const UI_TEXT_REFRESH = "REFRESH";
 export const UI_TEXT_MORE = "MORE";

--- a/web/src/modules/pipeds/index.ts
+++ b/web/src/modules/pipeds/index.ts
@@ -71,6 +71,13 @@ export const enablePiped = createAsyncThunk<void, { pipedId: string }>(
   }
 );
 
+export const restartPiped = createAsyncThunk<void, { pipedId: string }>(
+  `${MODULE_NAME}/restart`,
+  async ({ pipedId }) => {
+    await pipedsApi.restartPiped({ pipedId });
+  }
+);
+
 export const addNewPipedKey = createAsyncThunk<string, { pipedId: string }>(
   `${MODULE_NAME}/addNewKey`,
   async ({ pipedId }) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable to request piped restart command from web console

<img width="272" alt="Screen Shot 2022-11-18 at 12 47 48" src="https://user-images.githubusercontent.com/32532742/202629992-06e18be0-0c38-4300-8552-72f5cbd0ccd7.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
