### PR TITLE
Fix to override namespace if set for k8s manifest

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/loader.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader.go
@@ -84,6 +84,9 @@ func NewLoader(
 // LoadManifests renders and loads all manifests for application.
 func (l *loader) LoadManifests(ctx context.Context) (manifests []Manifest, err error) {
 	defer func() {
+		// Override namespace if set because ParseManifests does not parse it
+		// if namespace is not explicitly specified in the manifests.
+		setNamespace(manifests, l.input.Namespace)
 		sortManifests(manifests)
 	}()
 	l.initOnce.Do(func() {
@@ -164,6 +167,15 @@ func (l *loader) LoadManifests(ctx context.Context) (manifests []Manifest, err e
 	}
 
 	return
+}
+
+func setNamespace(manifests []Manifest, namespace string) {
+	if namespace == "" {
+		return
+	}
+	for _, m := range manifests {
+		m.Key.Namespace = namespace
+	}
 }
 
 func sortManifests(manifests []Manifest) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, `pipecd.dev/resource-key` annotation is wrong because of this, which means every key will have been `apiVersion:ResourceKind:default:appName` if not having it in the manifest directly although the namespace is set in the `app.config.yaml`.

This will resolve the problem that k8s resources aren't pruned even if running Quick Sync


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix the problem that k8s resources are not pruned even if running Quick Sync
```
