### PR TITLE
Migrate from legacy loaders to asset module

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "faker": "^5.3.1",
-    "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^6.2.10",
     "html-webpack-plugin": "^5.3.1",
     "jest": "^27.4.7",

--- a/web/webpack.common.js
+++ b/web/webpack.common.js
@@ -29,15 +29,10 @@ module.exports = (env) => {
       rules: [
         {
           test: /\.(png|svg|jpg|gif|ico)$/,
-          loader: "file-loader",
-          options: {
-            name(file) {
-              if (file.includes("/favicon.ico")) {
-                return "[name].[ext]";
-              }
-              return "assets/[name].[hash:8].[ext]";
-            },
-          },
+          type: "asset/resource",
+          generator: {
+            filename: "assets/[name].[hash:8][ext]"
+          }
         },
       ],
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
`file-loader` is already deprecated for webpack v5 hence migrate to asset module.
https://webpack.js.org/guides/asset-modules/#custom-data-uri-generator


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
