### PR TITLE
Fix to escape the user-provided value for ops

### DIFF
--- a/pkg/app/ops/handler/handler.go
+++ b/pkg/app/ops/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"html"
 	"html/template"
 	"net/http"
 	"strconv"
@@ -164,9 +165,9 @@ func (h *Handler) handleAddProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var (
-		id                 = r.FormValue("ID")
-		description        = r.FormValue("Description")
-		sharedSSOName      = r.FormValue("SharedSSO")
+		id                 = html.EscapeString(r.FormValue("ID"))
+		description        = html.EscapeString(r.FormValue("Description"))
+		sharedSSOName      = html.EscapeString(r.FormValue("SharedSSO"))
 		allowStrayAsViewer = r.FormValue("AllowStrayAsViewer") == "on"
 	)
 	if id == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is not necessary but escapes special characters like <, >, &, ' and " to avoid unexpected behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
