### PR TITLE
Allow config mysql database via config URL

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/configuration-reference.md
@@ -53,7 +53,7 @@ Must be one of the following objects:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | url | string | The address to MySQL server. Should attach with the database port info as `127.0.0.1:3307` in case you want to use another port than the default value. | Yes |
-| database | string | The name of database. | Yes |
+| database | string | The name of database. | No (If you set it via URL) |
 | usernameFile | string | Path to the file containing the username. | No |
 | passwordFile | string | Path to the file containing the password. | No |
 

--- a/pkg/config/control_plane.go
+++ b/pkg/config/control_plane.go
@@ -228,6 +228,7 @@ type DataStoreMySQLConfig struct {
 	// The url of MySQL. All of credentials can be specified via this field.
 	URL string `json:"url"`
 	// The name of the database.
+	// For those who don't want to include the database in the URL.
 	Database string `json:"database"`
 	// The path to the username file.
 	// For those who don't want to include the username in the URL.

--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
@@ -269,7 +270,10 @@ func BuildDataSourceName(url, database, usernameFile, passwordFile string) (stri
 		return "", fmt.Errorf("url is required field")
 	}
 	if database == "" {
-		return "", fmt.Errorf("database is required field")
+		if !strings.Contains(url, "/") {
+			return "", fmt.Errorf("database is not set")
+		}
+		return url, nil
 	}
 	// In case username and password files are not provided,
 	// those values may be included in the URL already so just return the given URL attached with Database name.

--- a/pkg/datastore/mysql/mysql_test.go
+++ b/pkg/datastore/mysql/mysql_test.go
@@ -41,6 +41,12 @@ func TestBuildDataSourceName(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:           "returns url with configured database",
+			url:            "test:test@tcp(localhost:3306)/test",
+			dataSourceName: "test:test@tcp(localhost:3306)/test",
+			expectErr:      false,
+		},
+		{
 			name:           "returns url/database in usernameFile or passwordFile are not provided",
 			url:            "test:test@tcp(localhost:3306)",
 			database:       "test",


### PR DESCRIPTION
**What this PR does / why we need it**:

Thanks @ono-max for pointing out this :+1:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable to configure MySQL database via DataStoreMySQLConfig.url
```
