### PR TITLE
Remove trigger paths

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -88,7 +88,6 @@ spec:
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
 | quickSync | [CloudRunQuickSync](#cloudrunquicksync) | Configuration for quick sync. | No |
 | pipeline | [Pipeline](#pipeline) | Pipeline for deploying progressively. | No |
-| triggerPaths | []string | List of directories or files where their changes will trigger the deployment. Regular expression can be used. This field is `deprecated`, please use [`spec.trigger.onCommit.paths`](#deploymenttrigger) instead. | No (deprecated) |
 | encryption | [SecretEncryption](#secretencryption) | List of encrypted secrets and targets that should be decrypted before using. | No |
 | timeout | duration | The maximum length of time to execute deployment before giving up. Default is 6h. | No |
 | notification | [DeploymentNotification](#deploymentnotification) | Additional configuration used while sending notification to external services. | No |

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -191,25 +191,7 @@ func (d *OnCommitDeterminer) ShouldTrigger(ctx context.Context, app *model.Appli
 		return false, err
 	}
 
-	// TODO: Remove deprecated `appCfg.TriggerPaths` configuration.
-	checkingPaths := make([]string, 0, len(appCfg.Trigger.OnCommit.Paths)+len(appCfg.TriggerPaths))
-	// Note: appCfg.TriggerPaths or appCfg.Trigger.OnCommit.Paths may contain "" (empty string)
-	// in case users use one of them without the other, that cause unexpected "" path in the checkingPaths list
-	// leads to always trigger deployment since "" path matched all other paths.
-	// The below logic is to remove that "" path from checking path list, will remove after remove the
-	// deprecated appCfg.TriggerPaths.
-	for _, p := range appCfg.Trigger.OnCommit.Paths {
-		if p != "" {
-			checkingPaths = append(checkingPaths, p)
-		}
-	}
-	for _, p := range appCfg.TriggerPaths {
-		if p != "" {
-			checkingPaths = append(checkingPaths, p)
-		}
-	}
-
-	touched, err := isTouchedByChangedFiles(app.GitPath.Path, checkingPaths, changedFiles)
+	touched, err := isTouchedByChangedFiles(app.GitPath.Path, appCfg.Trigger.OnCommit.Paths, changedFiles)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -48,10 +48,6 @@ type GenericApplicationSpec struct {
 	CommitMatcher DeploymentCommitMatcher `json:"commitMatcher"`
 	// Pipeline for deploying progressively.
 	Pipeline *DeploymentPipeline `json:"pipeline"`
-	// List of directories or files where their changes will trigger the deployment.
-	// Regular expression can be used.
-	// Deprecated: use Trigger.Paths instead.
-	TriggerPaths []string `json:"triggerPaths,omitempty"`
 	// The trigger configuration use to determine trigger logic.
 	Trigger Trigger `json:"trigger"`
 	// Configuration to be used once the deployment is triggered successfully.


### PR DESCRIPTION
**What this PR does / why we need it**:

It's been already a year from the time this field is marked as a deprecated field. Would like to remove this to simplify the `onCommit` config before doing other tasks.

**Which issue(s) this PR fixes**:

Fixes #2785

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Remove the deprecated TriggerPaths field from application config
```
