### PR TITLE
Add helm 3.8.2 to PipeCD prerequisites

### DIFF
--- a/docs/content/en/docs-dev/contribution-guidelines/development.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-dev/contribution-guidelines/development.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-dev/contribution-guidelines/development.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.36.x/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.37.x/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.38.x/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.39.x/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.40.x/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs/contribution-guidelines/development.md
+++ b/docs/content/en/docs/contribution-guidelines/development.md
@@ -9,7 +9,7 @@ description: >
 ## Prerequisites
 
 - [Go 1.19](https://go.dev/)
-- [Docker Decktop](https://www.docker.com/products/docker-desktop/)
+- [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 

--- a/docs/content/en/docs/contribution-guidelines/development.md
+++ b/docs/content/en/docs/contribution-guidelines/development.md
@@ -11,6 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
+- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/content/en/docs/contribution-guidelines/development.md
+++ b/docs/content/en/docs/contribution-guidelines/development.md
@@ -11,7 +11,7 @@ description: >
 - [Go 1.19](https://go.dev/)
 - [Docker Decktop](https://www.docker.com/products/docker-desktop/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
-- [helm 3.8.2](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
+- [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.


### PR DESCRIPTION
**What this PR does / why we need it**:
Helm 3.8.2 required when running PipeCD in local environment

Helm is used to execute `make run/pipecd`
https://github.com/pipe-cd/pipecd/blob/633f8f143fb2c0042215981e68609344eded6136/Makefile#L108
https://github.com/pipe-cd/pipecd/blob/633f8f143fb2c0042215981e68609344eded6136/Makefile#L109

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
