### PR TITLE
Update gen release docs command

### DIFF
--- a/hack/gen-release-docs.sh
+++ b/hack/gen-release-docs.sh
@@ -64,14 +64,14 @@ then
 fi
 
 # Update docs/config.toml
-tail -r docs/config.toml | tail -n +5 | tail -r >> docs/config.toml.tmp
+LINE_NUM=$(($(grep -Fn "# Append the release versions here." docs/config.toml | cut -f1 -d ':')+5))
+head -n $LINE_NUM docs/config.toml >> docs/config.toml.tmp
 cat <<EOT >> docs/config.toml.tmp
-
 [[params.versions]]
   version = "$VERSION"
   url = "/docs-$VERSION/"
 EOT
-tail -4 docs/config.toml >> docs/config.toml.tmp
+tail -n +$LINE_NUM docs/config.toml >> docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
 echo "Version docs has been prepared successfully at $CONTENT_DIR/docs-$VERSION/"


### PR DESCRIPTION
**What this PR does / why we need it**:

Change logic to update `docs/config.yaml` so that we can reduce manual steps while generating release docs.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
