### PR TITLE
Add release command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,9 @@ gen/test-tls:
 		-subj "/CN=localhost" \
 		-config pkg/rpc/testdata/tls.config
 
+.PHONY: release
+release: release/init release/docs
+
 .PHONY: release/init
 release/init:
 	./hack/gen-release.sh $(version)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes release commands reduce to single command

```console
make release version=vX.Y.Z
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
