### PR TITLE
Fix bug on parsing empty kubernetes manifest

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/platformprovider/kubernetes/manifest.go
@@ -234,6 +234,9 @@ func ParseManifests(data string) ([]Manifest, error) {
 		if err := yaml.Unmarshal([]byte(part), &obj); err != nil {
 			return nil, err
 		}
+		if len(obj.Object) == 0 {
+			continue
+		}
 		manifests = append(manifests, Manifest{
 			Key: MakeResourceKey(&obj),
 			u:   &obj,

--- a/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
@@ -1,0 +1,121 @@
+// Copyright 2022 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestParseManifests(t *testing.T) {
+	maker := func(name, kind string, metadata map[string]interface{}) Manifest {
+		return Manifest{
+			Key: ResourceKey{
+				APIVersion: "v1",
+				Kind:       kind,
+				Name:       name,
+				Namespace:  "default",
+			},
+			u: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       kind,
+					"metadata":   metadata,
+				},
+			},
+		}
+	}
+
+	testcases := []struct {
+		name      string
+		manifests string
+		want      []Manifest
+	}{
+		{
+			name: "empty1",
+		},
+		{
+			name:      "empty2",
+			manifests: "",
+		},
+		{
+			name:      "empty3",
+			manifests: "---",
+		},
+		{
+			name:      "empty4",
+			manifests: "\n---",
+		},
+		{
+			name:      "empty5",
+			manifests: "\n---\n",
+		},
+		{
+			name:      "multiple empty manifests",
+			manifests: "---\n---\n---\n---\n---\n",
+		},
+		{
+			name: "one manifest",
+			manifests: `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-config
+  creationTimestamp: "2022-12-09T01:23:45Z"
+`,
+			want: []Manifest{
+				maker("envoy-config", "ConfigMap", map[string]interface{}{
+					"name":              "envoy-config",
+					"creationTimestamp": "2022-12-09T01:23:45Z",
+				}),
+			},
+		},
+		{
+			name: "multiple manifests",
+			manifests: `
+apiVersion: v1
+kind: Kind1
+metadata:
+  name: config1
+---
+apiVersion: v1
+kind: Kind2
+metadata:
+  name: config2
+---
+apiVersion: v1
+kind: Kind3
+metadata:
+  name: config3
+			`,
+			want: []Manifest{
+				maker("config1", "Kind1", map[string]interface{}{"name": "config1"}),
+				maker("config2", "Kind2", map[string]interface{}{"name": "config2"}),
+				maker("config3", "Kind3", map[string]interface{}{"name": "config3"}),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := ParseManifests(tc.manifests)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, m, tc.want)
+		})
+	}
+}

--- a/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
@@ -51,18 +51,14 @@ func TestParseManifests(t *testing.T) {
 		},
 		{
 			name:      "empty2",
-			manifests: "",
-		},
-		{
-			name:      "empty3",
 			manifests: "---",
 		},
 		{
-			name:      "empty4",
+			name:      "empty3",
 			manifests: "\n---",
 		},
 		{
-			name:      "empty5",
+			name:      "empty4",
 			manifests: "\n---\n",
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the bug on parsing leading document separator.

For example:
```
---
apiVersion: v1
kind: ConfigMap
```
```
---
---
---
apiVersion: v1
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bug on parsing empty kubernetes manifest
```
