### PR TITLE
Fix description of apiAddress

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs-v0.36.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.36.x/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs-v0.37.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.37.x/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs-v0.38.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.38.x/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |

--- a/docs/content/en/docs/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/managing-piped/configuration-reference.md
@@ -23,7 +23,7 @@ spec:
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
-| apiAddress | string | The address used to connect to the Control Plane's API. | Yes |
+| apiAddress | string | The address used to connect to the Control Plane's API in format `host:port`. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
 | appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |


### PR DESCRIPTION
**What this PR does / why we need it**:
Add supplement to apiAddress description

https://pipecd.dev/docs/user-guide/managing-piped/configuration-reference/#piped-configuration:~:text=Yes-,apiAddress,-string

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
