### PR TITLE
Better time range based on step to request Insights data

### DIFF
--- a/web/src/modules/deployment-change-failure-rate/index.ts
+++ b/web/src/modules/deployment-change-failure-rate/index.ts
@@ -33,7 +33,10 @@ export const fetchDeploymentChangeFailureRate = createAsyncThunk<
     }
   }
 
-  const [rangeFrom, rangeTo] = determineTimeRange(state.insight.range, state.insight.step);
+  const [rangeFrom, rangeTo] = determineTimeRange(
+    state.insight.range,
+    state.insight.step
+  );
 
   const data = await InsightAPI.getInsightData({
     metricsKind: InsightMetricsKind.CHANGE_FAILURE_RATE,

--- a/web/src/modules/deployment-change-failure-rate/index.ts
+++ b/web/src/modules/deployment-change-failure-rate/index.ts
@@ -4,7 +4,7 @@ import { InsightMetricsKind, InsightDataPoint } from "../insight";
 import * as InsightAPI from "~/api/insight";
 import { LoadingStatus } from "~/types/module";
 import { InsightResultType } from "pipecd/web/model/insight_pb";
-import { makeTimeRange } from "~/modules/insight";
+import { determineTimeRange } from "~/modules/insight";
 
 const MODULE_NAME = "deploymentChangeFailureRate";
 
@@ -33,7 +33,7 @@ export const fetchDeploymentChangeFailureRate = createAsyncThunk<
     }
   }
 
-  const [rangeFrom, rangeTo] = makeTimeRange(state.insight.range);
+  const [rangeFrom, rangeTo] = determineTimeRange(state.insight.range, state.insight.step);
 
   const data = await InsightAPI.getInsightData({
     metricsKind: InsightMetricsKind.CHANGE_FAILURE_RATE,

--- a/web/src/modules/deployment-frequency/index.ts
+++ b/web/src/modules/deployment-frequency/index.ts
@@ -4,7 +4,7 @@ import { InsightMetricsKind, InsightDataPoint } from "../insight";
 import * as InsightAPI from "~/api/insight";
 import { LoadingStatus } from "~/types/module";
 import { InsightResultType } from "pipecd/web/model/insight_pb";
-import { makeTimeRange } from "~/modules/insight";
+import { determineTimeRange } from "~/modules/insight";
 
 const MODULE_NAME = "deploymentFrequency";
 
@@ -33,7 +33,7 @@ export const fetchDeploymentFrequency = createAsyncThunk<
     }
   }
 
-  const [rangeFrom, rangeTo] = makeTimeRange(state.insight.range);
+  const [rangeFrom, rangeTo] = determineTimeRange(state.insight.range, state.insight.step);
 
   const data = await InsightAPI.getInsightData({
     metricsKind: InsightMetricsKind.DEPLOYMENT_FREQUENCY,

--- a/web/src/modules/deployment-frequency/index.ts
+++ b/web/src/modules/deployment-frequency/index.ts
@@ -33,7 +33,10 @@ export const fetchDeploymentFrequency = createAsyncThunk<
     }
   }
 
-  const [rangeFrom, rangeTo] = determineTimeRange(state.insight.range, state.insight.step);
+  const [rangeFrom, rangeTo] = determineTimeRange(
+    state.insight.range,
+    state.insight.step
+  );
 
   const data = await InsightAPI.getInsightData({
     metricsKind: InsightMetricsKind.DEPLOYMENT_FREQUENCY,

--- a/web/src/modules/insight/index.ts
+++ b/web/src/modules/insight/index.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { InsightStep } from "pipecd/web/model/insight_pb";
 import dayjs from "dayjs";
-import utc from 'dayjs/plugin/utc';
+import utc from "dayjs/plugin/utc";
 
 const MODULE_NAME = "insight";
 
@@ -87,7 +87,10 @@ export {
   InsightStep,
 } from "pipecd/web/model/insight_pb";
 
-export function determineTimeRange(r: InsightRange, s: InsightStep): [number, number] {
+export function determineTimeRange(
+  r: InsightRange,
+  s: InsightStep
+): [number, number] {
   // Load utc plugin.
   dayjs.extend(utc);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does:
- Using `UTC` instead of `Local` time zone to get the correct value for the server
- Calculating `rangeFrom` and `rangeTo` based on the kind of `Step` to have better graph data

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
