### PR TITLE
Fix app live resource lister wrong attribute

### DIFF
--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -719,13 +719,13 @@ func (c *controller) cancelDeployment(ctx context.Context, d *model.Deployment, 
 }
 
 type appLiveResourceLister struct {
-	lister        liveResourceLister
-	cloudProvider string
-	appID         string
+	lister           liveResourceLister
+	platformProvider string
+	appID            string
 }
 
 func (l appLiveResourceLister) ListKubernetesResources() ([]provider.Manifest, bool) {
-	return l.lister.ListKubernetesAppLiveResources(l.cloudProvider, l.appID)
+	return l.lister.ListKubernetesAppLiveResources(l.platformProvider, l.appID)
 }
 
 func reportApplicationDeployingStatus(ctx context.Context, c apiClient, appID string, deploying bool) error {

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -477,9 +477,9 @@ func (s *scheduler) executeStage(sig executor.StopSignal, ps model.PipelineStage
 		stageID:      ps.Id,
 	}
 	alrLister := appLiveResourceLister{
-		lister:        s.liveResourceLister,
-		cloudProvider: app.CloudProvider,
-		appID:         app.Id,
+		lister:           s.liveResourceLister,
+		platformProvider: app.PlatformProvider,
+		appID:            app.Id,
 	}
 	aStore := appAnalysisResultStore{
 		store:         s.analysisResultStore,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the appLiveResourceLister attribute, previously this bug could not be found because we keep both CloudProvider and PlatformProvider duplicated in the Application model.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
