### PR TITLE
Ensure newly created revision is ready to receive traffic before going to the next stage

### DIFF
--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -128,8 +128,7 @@ func apply(ctx context.Context, client provider.Client, sm provider.ServiceManif
 
 	lp.Infof("Service %s was not found, a new service will be created", sm.Name)
 
-	_, err = client.Create(ctx, sm)
-	if err != nil {
+	if _, err := client.Create(ctx, sm); err != nil {
 		lp.Errorf("Failed to create the service %s (%v)", sm.Name, err)
 		return false
 	}

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -184,7 +184,7 @@ func waitRevisionReady(ctx context.Context, client provider.Client, revisionName
 		if len(unknownConds) > 0 {
 			return true, fmt.Errorf("%s", strings.Join(unknownConds, "\n"))
 		}
-		for k, _ := range mustPassConditions {
+		for k := range mustPassConditions {
 			if _, ok := trueConds[k]; !ok {
 				return true, fmt.Errorf("could not check status field %q", k)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #661
Fixes #1109

**Does this PR introduce a user-facing change?**:

```release-note
The newly created CloudRun revision will be checked to ensure its readiness before going to the next stage
```
