### PR TITLE
Fix application store listBy method

### DIFF
--- a/pkg/app/piped/apistore/applicationstore/store.go
+++ b/pkg/app/piped/apistore/applicationstore/store.go
@@ -32,8 +32,8 @@ type Lister interface {
 	// List lists all applications that should be handled by this piped.
 	// All disabled applications will be ignored.
 	List() []*model.Application
-	// ListByCloudProvider lists all applications for a given cloud provider name.
-	ListByCloudProvider(name string) []*model.Application
+	// ListByPlatformProvider lists all applications for a given cloud provider name.
+	ListByPlatformProvider(name string) []*model.Application
 	// Get retrieves a specifiec deployment for the given id.
 	Get(id string) (*model.Application, bool)
 }
@@ -127,8 +127,8 @@ func (s *store) List() []*model.Application {
 	return apps.([]*model.Application)
 }
 
-// ListByCloudProvider lists all applications for a given cloud provider name.
-func (s *store) ListByCloudProvider(name string) []*model.Application {
+// ListByPlatformProvider lists all applications for a given platform provider name.
+func (s *store) ListByPlatformProvider(name string) []*model.Application {
 	list := s.applicationList.Load()
 	if list == nil {
 		return nil
@@ -139,7 +139,7 @@ func (s *store) ListByCloudProvider(name string) []*model.Application {
 		out  = make([]*model.Application, 0, len(apps))
 	)
 	for _, app := range apps {
-		if app.CloudProvider == name {
+		if app.PlatformProvider == name {
 			out = append(out, app)
 		}
 	}

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -35,7 +35,7 @@ import (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type gitClient interface {
@@ -183,7 +183,7 @@ func (d *detector) cloneGitRepository(ctx context.Context, repoID string) (git.R
 // and then groups them by repoID.
 func (d *detector) listGroupedApplication() map[string][]*model.Application {
 	var (
-		apps = d.appLister.ListByCloudProvider(d.provider.Name)
+		apps = d.appLister.ListByPlatformProvider(d.provider.Name)
 		m    = make(map[string][]*model.Application)
 	)
 	for _, app := range apps {

--- a/pkg/app/piped/driftdetector/detector.go
+++ b/pkg/app/piped/driftdetector/detector.go
@@ -38,7 +38,7 @@ import (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type deploymentLister interface {

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -35,7 +35,7 @@ import (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type gitClient interface {
@@ -282,7 +282,7 @@ func (d *detector) loadHeadManifests(ctx context.Context, app *model.Application
 // and then groups them by repoID.
 func (d *detector) listGroupedApplication() map[string][]*model.Application {
 	var (
-		apps = d.appLister.ListByCloudProvider(d.provider.Name)
+		apps = d.appLister.ListByPlatformProvider(d.provider.Name)
 		m    = make(map[string][]*model.Application)
 	)
 	for _, app := range apps {

--- a/pkg/app/piped/livestatereporter/cloudrun/report.go
+++ b/pkg/app/piped/livestatereporter/cloudrun/report.go
@@ -29,7 +29,7 @@ import (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type apiClient interface {
@@ -97,7 +97,7 @@ func (r *reporter) ProviderName() string {
 }
 
 func (r *reporter) flushSnapshots(ctx context.Context) error {
-	apps := r.appLister.ListByCloudProvider(r.provider.Name)
+	apps := r.appLister.ListByPlatformProvider(r.provider.Name)
 	for _, app := range apps {
 		state, ok := r.stateGetter.GetState(app.Id)
 		if !ok {

--- a/pkg/app/piped/livestatereporter/kubernetes/reporter.go
+++ b/pkg/app/piped/livestatereporter/kubernetes/reporter.go
@@ -33,7 +33,7 @@ const (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type apiClient interface {
@@ -112,7 +112,7 @@ func (r *reporter) Run(ctx context.Context) error {
 func (r *reporter) flushSnapshots(ctx context.Context) error {
 	// TODO: In the future, maybe we should apply worker model for this or
 	// send multiple application states in one request.
-	apps := r.appLister.ListByCloudProvider(r.provider.Name)
+	apps := r.appLister.ListByPlatformProvider(r.provider.Name)
 	for _, app := range apps {
 		state, ok := r.stateGetter.GetKubernetesAppLiveState(app.Id)
 		if !ok {

--- a/pkg/app/piped/livestatereporter/reporter.go
+++ b/pkg/app/piped/livestatereporter/reporter.go
@@ -34,7 +34,7 @@ import (
 )
 
 type applicationLister interface {
-	ListByCloudProvider(name string) []*model.Application
+	ListByPlatformProvider(name string) []*model.Application
 }
 
 type apiClient interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as PR #4072  but this time effect driftdetector and livestatereporter. Same as previous PR, this issue could not be found currently causes be store CloudProvider and PlatformProvider duplicated in application model.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
