### PR TITLE
Support setting kubectlVersion via piped config

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -281,7 +281,7 @@ One of `yamlField` or `regex` is required.
 | Field | Type | Description | Required |
 |-|-|-|-|
 | manifests | []string | List of manifest files in the application directory used to deploy. Empty means all manifest files in the directory will be used. | No |
-| kubectlVersion | string | Version of kubectl will be used. Empty means the [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kubectl.sh#L24) will be used. | No |
+| kubectlVersion | string | Version of kubectl will be used. Empty means the version set on [piped config](../managing-piped/configuration-reference/#platformproviderkubernetesconfig) or [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kubectl.sh#L24) will be used. | No |
 | kustomizeVersion | string | Version of kustomize will be used. Empty means the [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kustomize.sh#L24) will be used. | No |
 | kustomizeOptions | map[string]string | List of options that should be used by Kustomize commands. | No |
 | helmVersion | string | Version of helm will be used. Empty means the [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-helm.sh#L24) will be used. | No |

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -151,6 +151,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | masterURL | string | The master URL of the kubernetes cluster. Empty means in-cluster. | No |
+| kubectlVersion | string | Version of kubectl which will be used to connect to your cluster. Empty means the version set on [piped config](../user-guide/managing-piped/configuration-reference/#platformproviderkubernetesconfig) or [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kubectl.sh#L24) will be used. | No |
 | kubeConfigPath | string | The path to the kubeconfig file. Empty means in-cluster. | No |
 | appStateInformer | [KubernetesAppStateInformer](#kubernetesappstateinformer) | Configuration for application resource informer. | No |
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -606,6 +606,8 @@ type PlatformProviderKubernetesConfig struct {
 	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 	// Configuration for application resource informer.
 	AppStateInformer KubernetesAppStateInformer `json:"appStateInformer"`
+	// Version of kubectl will be used.
+	KubectlVersion string `json:"kubectlVersion"`
 }
 
 type KubernetesAppStateInformer struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

The priority to determine kubectl version would be:
- Version setting via application config
- Version setting via piped config
- Default version

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
Enable to specify default kubectl version via piped config
```
