### PR TITLE
Fix the filter_mode of reviewdow/action-golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,8 @@ jobs:
         with:
           go_version: ${{ env.GO_VERSION }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
+          filter_mode: nofilter
+          fail_on_error: true
 
   web:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     # - misspell
     # - errcheck
     # - gosimple
-    - staticcheck
+    # - staticcheck
     # - gosec
     # - gocritic
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,22 +8,22 @@ run:
 linters:
   disable-all: true
   enable:
-    - prealloc
-    - ineffassign
-    - goerr113
-    - misspell
-    - errcheck
-    - gosimple
+    # - prealloc
+    # - ineffassign
+    # - goerr113
+    # - misspell
+    # - errcheck
+    # - gosimple
     - staticcheck
-    - gosec
-    - gocritic
+    # - gosec
+    # - gocritic
     - unparam
-    - deadcode
-    - unconvert
+    # - deadcode
+    # - unconvert
     - typecheck
-    - stylecheck
+    # - stylecheck
     - exportloopref
-    - depguard
+    # - depguard
     - goimports
 
 issues:


### PR DESCRIPTION
**What this PR does / why we need it**:
The errors were not noticed although there were a lot of errors due to this `filter_mode`.
https://github.com/pipe-cd/pipecd/runs/10154286748

Hence, fix it to notify all lint errors through reviewdog, and let me fix those errors one by one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
