### PR TITLE
Fix a crash bug of piped when generate diff from empty manifest on Cloud Run

### DIFF
--- a/pkg/app/piped/platformprovider/cloudrun/diff.go
+++ b/pkg/app/piped/platformprovider/cloudrun/diff.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/pipe-cd/pipecd/pkg/diff"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -39,7 +40,19 @@ func (d *DiffResult) NoChange() bool {
 }
 
 func Diff(old, new ServiceManifest, opts ...diff.Option) (*DiffResult, error) {
-	d, err := diff.DiffUnstructureds(*old.u, *new.u, opts...)
+	var oldu, newu unstructured.Unstructured
+	if old.u == nil {
+		oldu = unstructured.Unstructured{}
+	} else {
+		oldu = *old.u
+	}
+	if new.u == nil {
+		newu = unstructured.Unstructured{}
+	} else {
+		newu = *new.u
+	}
+
+	d, err := diff.DiffUnstructureds(oldu, newu, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/app/piped/platformprovider/cloudrun/diff_test.go
+++ b/pkg/app/piped/platformprovider/cloudrun/diff_test.go
@@ -32,15 +32,37 @@ func TestDiff(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, new)
 
+	empty := ServiceManifest{
+		Name: "empty-manifest",
+	}
+
 	// Have diff.
 	got, err := Diff(old, new)
 	require.NoError(t, err)
 	require.NotEmpty(t, got)
+	require.NotEmpty(t, got.Old.u)
+	require.NotEmpty(t, got.New.u)
+
+	// Have diff(old is empty).
+	got, err = Diff(empty, new)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.Empty(t, got.Old.u)
+	require.NotEmpty(t, got.New.u)
 
 	// Don't have diff.
 	got, err = Diff(old, old)
 	require.NoError(t, err)
 	require.NotEmpty(t, got)
+	require.Empty(t, got.Old)
+	require.Empty(t, got.New)
+
+	// Don't have diff(manifests are empty).
+	got, err = Diff(empty, empty)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.Empty(t, got.Old.u)
+	require.Empty(t, got.New.u)
 }
 
 func TestDiffResult_NoChange(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix crashes when generate plan preview from empty service manifest on Cloud Run.

Stack Trace:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13a953b]
goroutine 207 [running]:
github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/cloudrun.Diff({{0x0?, 0x0?}, 0x0?}, {{0xc000b49500?, 0x0?}, 0xc00011c2f8?}, {0xc0009f3740?, 0xc00063f600?, 0xb?})
    /home/runner/work/pipecd/pipecd/pkg/app/piped/platformprovider/cloudrun/diff.go:42 +0x5b
github.com/pipe-cd/pipecd/pkg/app/piped/planpreview.(*builder).cloudrundiff(0xc0007b2180, {0x26e1080, 0xc0000b9c80}, 0xc00077e2d0, {0x26d3140?, 0xc0007dc620?}, {0x0, 0x0}, 0xc00063f640?)
    /home/runner/work/pipecd/pipecd/pkg/app/piped/planpreview/cloudrundiff.go:61 +0x4f7
github.com/pipe-cd/pipecd/pkg/app/piped/planpreview.(*builder).buildApp(0xc0007b2180, {0x26e1080, 0xc0000b9c80}, 0x1?, {0xc000a50f30?, 0xc00052eec8?}, 0xc00077e2d0, {0x26eaea8?, 0xc000768780}, {0xc000ae3578, ...})
    /home/runner/work/pipecd/pipecd/pkg/app/piped/planpreview/builder.go:254 +0xabd
github.com/pipe-cd/pipecd/pkg/app/piped/planpreview.(*builder).build.func1(0x1)
    /home/runner/work/pipecd/pipecd/pkg/app/piped/planpreview/builder.go:185 +0x205
created by github.com/pipe-cd/pipecd/pkg/app/piped/planpreview.(*builder).build
    /home/runner/work/pipecd/pipecd/pkg/app/piped/planpreview/builder.go:182 +0xc55"
timestamp: "2023-01-01T05:48:57.613492Z
```

<img width="982" alt="image" src="https://user-images.githubusercontent.com/591247/210163071-d3a41582-9ed4-4dd5-a1c7-963d89f8b500.png">

**Does this PR introduce a user-facing change?**:

```release-note
Fix a crash bug of piped when generate diff from empty manifest on Cloud Run.
```
