### PR TITLE
Update planpreview comment format

### DIFF
--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -176,9 +176,11 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 	}
 
 	b.WriteString(fmt.Sprintf(hasChangeTitleFormat, event.HeadCommit, len(r.Applications)))
-	b.WriteString("\n## Plans\n\n")
 
 	changedApps, pipelineApps, quickSyncApps := groupApplicationResults(r.Applications)
+	if len(changedApps)+len(pipelineApps)+len(quickSyncApps) > 0 {
+		b.WriteString("\n## Plans\n\n")
+	}
 
 	var detailLen int
 	for _, app := range changedApps {

--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -176,13 +176,13 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 	}
 
 	b.WriteString(fmt.Sprintf(hasChangeTitleFormat, event.HeadCommit, len(r.Applications)))
+	b.WriteString("\n## Plans\n\n")
 
 	changedApps, pipelineApps, quickSyncApps := groupApplicationResults(r.Applications)
 
 	var detailLen int
-
 	for _, app := range changedApps {
-		fmt.Fprintf(&b, "\n## %s\n", makeTitleText(&app.ApplicationInfo))
+		fmt.Fprintf(&b, "\n### %s\n", makeTitleText(&app.ApplicationInfo))
 		fmt.Fprintf(&b, "Sync strategy: %s\n", app.SyncStrategy)
 		fmt.Fprintf(&b, "Summary: %s\n\n", app.PlanSummary)
 
@@ -211,7 +211,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 	}
 
 	if len(pipelineApps)+len(quickSyncApps) > 0 {
-		b.WriteString("\n## No resource changes were detected but the following apps will also be triggered\n")
+		b.WriteString("\n### No resource changes were detected but the following apps will also be triggered\n")
 
 		if len(pipelineApps) > 0 {
 			b.WriteString("\n###### `PIPELINE`\n")
@@ -232,13 +232,13 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		return b.String()
 	}
 
-	fmt.Fprintf(&b, "\n---\n\n## NOTE\n\n")
+	fmt.Fprintf(&b, "\n## NOTE\n\n")
 
 	if len(r.FailureApplications) > 0 {
 		fmt.Fprintf(&b, "**An error occurred while building plan-preview for the following applications**\n")
 
 		for _, app := range r.FailureApplications {
-			fmt.Fprintf(&b, "\n## %s\n", makeTitleText(&app.ApplicationInfo))
+			fmt.Fprintf(&b, "\n### %s\n", makeTitleText(&app.ApplicationInfo))
 			fmt.Fprintf(&b, "Reason: %s\n\n", app.Reason)
 
 			var lang = "diff"
@@ -256,7 +256,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		fmt.Fprintf(&b, "**An error occurred while building plan-preview for applications of the following Pipeds**\n")
 
 		for _, piped := range r.FailurePipeds {
-			fmt.Fprintf(&b, "\n## piped: [%s](%s)\n", piped.PipedID, piped.PipedURL)
+			fmt.Fprintf(&b, "\n### piped: [%s](%s)\n", piped.PipedID, piped.PipedURL)
 			fmt.Fprintf(&b, "Reason: %s\n\n", piped.Reason)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
## Before
①
![Screenshot 2023-01-04 at 14 49 54](https://user-images.githubusercontent.com/50069775/210492278-442ebe2d-5925-443c-ba96-1ce0b6758e29.png)

②
![Screenshot 2023-01-04 at 14 50 55](https://user-images.githubusercontent.com/50069775/210492398-046a0c30-2241-4536-9982-51932dd4e3c7.png)


## After
①
![Screenshot 2023-01-04 at 14 49 22](https://user-images.githubusercontent.com/50069775/210492234-afbc0093-0bd3-4f33-a489-1bdf6029b6aa.png)

②
![Screenshot 2023-01-04 at 14 50 19](https://user-images.githubusercontent.com/50069775/210492318-1ffc1f3d-88d6-496f-ba0d-b0e61cd4c668.png)


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
