### PR TITLE
Add new line in detailsFormat to fix plan preview format

### DIFF
--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -133,7 +133,7 @@ const (
 
 	noChangeTitleFormat     = "Ran plan-preview against head commit %s of this pull request. PipeCD detected `0` updated application. It means no deployment will be triggered once this pull request got merged.\n"
 	hasChangeTitleFormat    = "Ran plan-preview against head commit %s of this pull request. PipeCD detected `%d` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.\n"
-	detailsFormat           = "<details>\n<summary>Details (Click me)</summary>\n<p>\n\n``` %s\n%s\n```\n</p>\n</details>\n"
+	detailsFormat           = "<details>\n<summary>Details (Click me)</summary>\n<p>\n\n``` %s\n%s\n```\n</p>\n</details>\n\n"
 	detailsOmittedMessage   = "The details are too long to display. Please check the actions log to see full details."
 	appInfoWithEnvFormat    = "app: [%s](%s), env: %s, kind: %s"
 	appInfoWithoutEnvFormat = "app: [%s](%s), kind: %s"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix format when generating multiple plan previews from several apps.
An empty line is required before `### app:`.

<img width="397" alt="image" src="https://user-images.githubusercontent.com/39365493/211890904-eeebc5f3-ef6e-4036-950c-19272c4f201a.png">

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
