### PR TITLE
Change build tag every time when make run/pipecd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: BUILD_VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
+run/pipecd: BUILD_VERSION = "$(shell git describe --tags --always --abbrev=7)-$(shell date +%s)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: $(eval TIMESTAMP ?= $(shell date +%s))
+run/pipecd: $(eval TIMESTAMP = $(shell date +%s))
 run/pipecd: BUILD_VERSION ?= "$(shell git describe --tags --always --abbrev=7)-$(TIMESTAMP)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: BUILD_VERSION = "$(shell git describe --tags --always --abbrev=7)-$(shell date +%s)"
+run/pipecd: $(eval DATE ?= $(shell date +%s))
+run/pipecd: BUILD_VERSION ?= "$(shell git describe --tags --always --abbrev=7)-$(DATE)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: $(eval DATE ?= $(shell date +%s))
-run/pipecd: BUILD_VERSION ?= "$(shell git describe --tags --always --abbrev=7)-$(DATE)"
+run/pipecd: $(eval TIMESTAMP ?= $(shell date +%s))
+run/pipecd: BUILD_VERSION ?= "$(shell git describe --tags --always --abbrev=7)-$(TIMESTAMP)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version


### PR DESCRIPTION
**What this PR does / why we need it**:
We can change image-tag every time when make run/pipecd, so we can see controller's change easily on kubernetes.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
