### PR TITLE
Fix docs wrong params name

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -482,7 +482,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs-v0.37.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.37.x/user-guide/configuration-reference.md
@@ -486,7 +486,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs-v0.38.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.38.x/user-guide/configuration-reference.md
@@ -486,7 +486,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs-v0.39.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/configuration-reference.md
@@ -486,7 +486,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs-v0.40.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/configuration-reference.md
@@ -481,7 +481,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs-v0.41.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/configuration-reference.md
@@ -482,7 +482,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 

--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -482,7 +482,7 @@ Note: You can get examples for those object from [here](../../examples/#ecs-appl
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The template name to refer. | Yes |
-| args | map[string]string | The arguments for custom-args. | No |
+| appArgs | map[string]string | The arguments for custom-args. | No |
 
 ## StageOptions
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on this place, it should be `appArgs` instead of `args`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
