### PR TITLE
Fix pod config for envoy upstreaming termination error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: BUILD_VERSION = "$(shell git describe --tags --always --abbrev=7)-$(shell date +%s)"
+run/pipecd: BUILD_VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test/integration:
 # Run commands
 
 .PHONY: run/pipecd
-run/pipecd: BUILD_VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
+run/pipecd: BUILD_VERSION = "$(shell git describe --tags --always --abbrev=7)-$(shell date +%s)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -166,6 +166,10 @@ spec:
             - name: pipecd-config
               mountPath: /etc/pipecd-config
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "sleep 5" ]
 {{- if .Values.server.resources }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: [ "/bin/sh", "-c", "sleep 5" ]
+                command: [ "/bin/sh", "-c", "sleep 30" ]
 {{- if .Values.server.resources }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add preStop to api-server's manifest to enable envoy to know server is terminating

**Which issue(s) this PR fixes**:

Fixes #1349 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
