### PR TITLE
Function template.parse parses {{}} instead of {}

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -760,7 +760,7 @@ type argsTemplate struct {
 }
 
 // parseCommitMsg parses event watcher's commit message.
-// Currently, only { .Value } and { .EventName } are supported.
+// Currently, only {{ .Value }} and {{ .EventName }} are supported.
 func parseCommitMsg(msg string, args argsTemplate) string {
 	if msg == "" {
 		return fmt.Sprintf(defaultCommitMessageFormat, args.Value, args.EventName)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4120 #1334 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
