### PR TITLE
Add apis for ecs in aws sdk

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -42,16 +42,21 @@ type Client interface {
 }
 
 type ECS interface {
-	ServiceExists(ctx context.Context, clusterName string, servicesName string) (bool, error)
 	CreateService(ctx context.Context, service types.Service) (*types.Service, error)
-	UpdateService(ctx context.Context, service types.Service) (*types.Service, error)
-	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
-	RunTask(ctx context.Context, taskDefinition types.TaskDefinition, clusterArn string, launchType string, awsVpcConfiguration *config.ECSVpcConfiguration, tags []types.Tag) error
-	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
 	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup *types.LoadBalancer, scale int) (*types.TaskSet, error)
 	DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error
-	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
+	DescribeServices(ctx context.Context, serviceArns []string, clusterArn string) ([]types.Service, error)
+	DescribeTasks(ctx context.Context, taskArns []string, clusterArn string) ([]types.Task, error)
+	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
+	ListClusters(ctx context.Context, clusterInput ListClustersInput) ([]string, *string, error)
+	ListServices(ctx context.Context, serviceInput ListServicesInput) ([]string, *string, error)
+	ListTasks(ctx context.Context, taskInput ListTasksInput) ([]string, *string, error)
+	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
+	RunTask(ctx context.Context, taskDefinition types.TaskDefinition, clusterArn string, launchType string, awsVpcConfiguration *config.ECSVpcConfiguration, tags []types.Tag) error
+	ServiceExists(ctx context.Context, clusterName string, servicesName string) (bool, error)
 	TagResource(ctx context.Context, resourceArn string, tags []types.Tag) error
+	UpdateService(ctx context.Context, service types.Service) (*types.Service, error)
+	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 }
 
 type ELB interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add apis for ecs in [aws-sdk-go-v2 ecs](https://github.com/aws/aws-sdk-go-v2/tree/main/service/ecs)
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
