### PR TITLE
tool: Replace set-output with GITHUB_OUTPUT

### DIFF
--- a/tool/actions-gh-release/main.go
+++ b/tool/actions-gh-release/main.go
@@ -134,7 +134,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to marshal releases: %v\n", err)
 	}
-	fmt.Printf("::set-output name=releases::%s\n", string(releasesJSON))
+	os.Setenv("GITHUB_OUTPUT", fmt.Sprintf("releases=%s", string(releasesJSON)))
 	if args.OutputReleasesFilePath != "" {
 		if err := os.WriteFile(args.OutputReleasesFilePath, releasesJSON, 0644); err != nil {
 			log.Fatalf("Failed to write releases JSON to %s: %v\n", args.OutputReleasesFilePath, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

I am getting the following warning in pipe-cd/actions-gh-release@v2.4.0.
Therefore, we have changed to use GITHUB_OUTPUT environment variable instead of set-output.

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
