### PR TITLE
Modify terraform drift detection's diff detail

### DIFF
--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -280,7 +280,8 @@ func makeSyncState(r provider.PlanResult, commit string) model.ApplicationSyncSt
 	}
 
 	var b strings.Builder
-	b.WriteString("Resource actions are indicated with the following symbols:\n-/+ destroy and then create replacement\n\n")
+	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual live state:\n\n", commit))
+	b.WriteString("+++ Expected (Git)\n--- Actual   (LiveState)\n\n")
 
 	details := r.Render()
 	b.WriteString(details)

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -169,10 +169,10 @@ func (r PlanResult) NoChanges() bool {
 
 func (r PlanResult) Render() string {
 	terraformDiffStart := "Terraform will perform the following actions:"
-	terraformDiffEnd := "─"
+	terraformDiffEnd := fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", r.Adds, r.Changes, r.Destroys)
 
 	startIndex := strings.Index(r.PlanOutput, terraformDiffStart) + len(terraformDiffStart)
-	endIndex := strings.Index(r.PlanOutput, terraformDiffEnd)
+	endIndex := strings.Index(r.PlanOutput, terraformDiffEnd) + len(terraformDiffEnd)
 	out := r.PlanOutput[startIndex:endIndex]
 
 	rendered := ""
@@ -236,8 +236,9 @@ func signMatchBracket(l *[]rune, r rune) rune {
 	if len(list) == 0 {
 		return r
 	}
-	v := list[0]
-	*l = list[1:]
+	n := len(list) - 1
+	v := list[n]
+	*l = list[:n]
 	return v
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fixed implementation of stack was reversed.
- Fixed terraformDiffEnd outputting error depending on environment.
- Changed diff detail header.
![image](https://user-images.githubusercontent.com/60760935/217753051-e21f0935-e62e-4253-adb3-09afc3393b64.png)

**Which issue(s) this PR fixes**:

Fixes #4167

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
