### PR TITLE
Select the container registry to use with run/pipecd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version
 run/pipecd: BUILD_OPTS ?= -ldflags "$(BUILD_LDFLAGS_PREFIX).version=$(BUILD_VERSION) $(BUILD_LDFLAGS_PREFIX).gitCommit=$(BUILD_COMMIT) $(BUILD_LDFLAGS_PREFIX).buildDate=$(BUILD_DATE) -w"
 run/pipecd: CONTROL_PLANE_VALUES ?= ./quickstart/control-plane-values.yaml
+run/pipecd: DOCKER_REGISTRY ?= localhost:5001
 run/pipecd:
 	@echo "Building go binary of Control Plane..."
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(BUILD_ENV) go build $(BUILD_OPTS) -o ./.artifacts/pipecd ./cmd/pipecd
@@ -102,15 +103,15 @@ run/pipecd:
 	yarn --cwd web build
 
 	@echo "Building docker image and pushing it to local registry..."
-	docker build -f cmd/pipecd/Dockerfile -t localhost:5001/pipecd:$(BUILD_VERSION) .
-	docker push localhost:5001/pipecd:$(BUILD_VERSION)
+	docker build -f cmd/pipecd/Dockerfile -t $(DOCKER_REGISTRY)/pipecd:$(BUILD_VERSION) .
+	docker push $(DOCKER_REGISTRY)/pipecd:$(BUILD_VERSION)
 
 	@echo "Installing Control Plane in kind..."
 	mkdir -p .artifacts
 	helm package manifests/pipecd --version $(BUILD_VERSION) --app-version $(BUILD_VERSION) --dependency-update --destination .artifacts
 	helm -n pipecd upgrade --install pipecd .artifacts/pipecd-$(BUILD_VERSION).tgz --create-namespace \
-		--set server.image.repository=localhost:5001/pipecd \
-		--set ops.image.repository=localhost:5001/pipecd \
+		--set server.image.repository=$(DOCKER_REGISTRY)/pipecd \
+		--set ops.image.repository=$(DOCKER_REGISTRY)/pipecd \
 		--values $(CONTROL_PLANE_VALUES)
 
 .PHONY: stop/pipecd


### PR DESCRIPTION
Maintain compatibility with previous versions

**What this PR does / why we need it**:
It would be nice to have a free choice of docker registry because fetching from the local registry will be ImagePullBackOff in my environment. I have compatibility with previous versions, so it shouldn't be a problem

**Which issue(s) this PR fixes**:

Fixes #4172

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
