### PR TITLE
Remove all generated go files before regenerating

### DIFF
--- a/tool/codegen/codegen.sh
+++ b/tool/codegen/codegen.sh
@@ -25,7 +25,7 @@ for dir in ${goProtoDirs[*]}; do
   echo ""
   echo "- ${dir}"
   echo "deleting previously generated Go files..."
-  find ${dir} -name "*.pb.go" -o -name "*.pb.validate.go" -type f -delete
+  find ${dir} -name "*.pb.go" -o -name "*.pb.*.go" -type f -delete
   echo "successfully deleted"
 
   echo "generating new Go files..."


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the regex to remove all generated go files before regenerating

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
