### PR TITLE
Make log view auto scroll to the end on log line added

### DIFF
--- a/web/src/components/deployments-detail-page/index.test.tsx
+++ b/web/src/components/deployments-detail-page/index.test.tsx
@@ -5,6 +5,8 @@ import { dummyPiped } from "~/__fixtures__/dummy-piped";
 import { createReduxStore, render, waitFor } from "~~/test-utils";
 import { DeploymentDetailPage } from ".";
 
+Element.prototype.scrollIntoView = jest.fn();
+
 beforeAll(() => {
   server.listen();
 });

--- a/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
@@ -5,6 +5,8 @@ import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
 import { createStore, render, screen } from "~~/test-utils";
 import { LogViewer } from ".";
 
+Element.prototype.scrollIntoView = jest.fn();
+
 const activeStageId = createActiveStageKey({
   deploymentId: dummyDeployment.id,
   stageId: dummyDeployment.stagesList[0].id,

--- a/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
@@ -1,4 +1,4 @@
-import { FC, memo } from "react";
+import { FC, memo, useEffect, useRef } from "react";
 import { makeStyles, CircularProgress, Box } from "@material-ui/core";
 import { LogLine } from "../log-line";
 import { DEFAULT_BACKGROUND_COLOR } from "~/constants/term-colors";
@@ -25,6 +25,12 @@ export interface LogProps {
 
 export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
   const classes = useStyles();
+  const bottomRef = useRef<null | HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logs]);
+
   return (
     <div className={classes.container}>
       {logs.map((log, i) => (
@@ -41,7 +47,7 @@ export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
           <CircularProgress color="secondary" />
         </Box>
       )}
-      <div className={classes.space} />
+      <div className={classes.space} ref={bottomRef} />
     </div>
   );
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

The log view will always show the last line of the logs on the log lines added event, while users can scroll back when needed.

https://user-images.githubusercontent.com/32532742/218305836-1381be69-0d2c-4918-86e6-2e3ebc0f6db5.mp4


**Which issue(s) this PR fixes**:

Fixes #4133

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
