### PR TITLE
Update the interval for Terraform's drift detection

### DIFF
--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -94,7 +94,7 @@ func NewDetector(
 		stateGetter:       stateGetter,
 		reporter:          reporter,
 		appManifestsCache: appManifestsCache,
-		interval:          time.Minute,
+		interval:          10 * time.Minute,
 		config:            cfg,
 		secretDecrypter:   sd,
 		gitRepos:          make(map[string]git.Repo),


### PR DESCRIPTION
**What this PR does / why we need it**:
For the performance, this changes the interval of Terraform's drift detection.
This param should be mutable through piped config in the end.


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
