### PR TITLE
Revert SameSite cookie for SSO login

### DIFF
--- a/pkg/app/server/httpapi/auth_handler.go
+++ b/pkg/app/server/httpapi/auth_handler.go
@@ -170,7 +170,7 @@ func makeStateCookie(value string, secure bool) *http.Cookie {
 		Path:     rootPath,
 		Secure:   secure,
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 	}
 }
 
@@ -182,7 +182,7 @@ func makeExpiredStateCookie(secure bool) *http.Cookie {
 		Path:     rootPath,
 		Secure:   secure,
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/pipe-cd/pipecd/pull/4191 has caused an error for SSO login.
Hence this reverts just the SameSite cookie for it used by SSO login.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
