### PR TITLE
Add last used time cron updater

### DIFF
--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pipe-cd/pipecd/pkg/admin"
+	"github.com/pipe-cd/pipecd/pkg/app/ops/apikeylastusedtimeupdater"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/deploymentchaincontroller"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/firestoreindexensurer"
 	"github.com/pipe-cd/pipecd/pkg/app/ops/handler"
@@ -178,6 +179,14 @@ func (s *ops) run(ctx context.Context, input cli.Input) error {
 		cleaner := planpreviewoutputcleaner.NewCleaner(fs, input.Logger)
 		group.Go(func() error {
 			return cleaner.Run(ctx)
+		})
+	}
+
+	// Start runnning apiKeyLastUsedTime updater.
+	{
+		updater := apikeylastusedtimeupdater.NewAPIKeyLastUsedTimeUpdater(ds, rd, input.Logger)
+		group.Go(func() error {
+			return updater.Run(ctx)
 		})
 	}
 

--- a/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
+++ b/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
@@ -1,0 +1,108 @@
+// Copyright 2023 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apikeylastusedtimeupdater
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/cache/rediscache"
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+	"github.com/pipe-cd/pipecd/pkg/redis"
+)
+
+var (
+	commandTimeOut = 24 * time.Hour
+	interval       = 1 * time.Minute
+)
+
+type apiKeyStore interface {
+	UpdateLastUsedAt(ctx context.Context, id string, time int64) error
+}
+
+type apiKeyLastUsedTimeCache interface {
+	GetAll() (map[string]interface{}, error)
+}
+
+type APIKeyLastUsedTimeUpdater struct {
+	apiKeyStore             apiKeyStore
+	apiKeyLastUsedTimeCache apiKeyLastUsedTimeCache
+	logger                  *zap.Logger
+}
+
+const apiKeyLastUsedCacheHashKey = "HASHKEY:PIPED:API_KEYS" //nolint:gosec
+
+func NewAPIKeyLastUsedTimeUpdater(
+	ds datastore.DataStore,
+	rd redis.Redis,
+	logger *zap.Logger,
+) *APIKeyLastUsedTimeUpdater {
+	return &APIKeyLastUsedTimeUpdater{
+		apiKeyStore:             datastore.NewAPIKeyStore(ds, datastore.OpsCommander),
+		apiKeyLastUsedTimeCache: rediscache.NewHashCache(rd, apiKeyLastUsedCacheHashKey),
+		logger:                  logger.Named("api-key-last-used-time-updater"),
+	}
+}
+
+func (c *APIKeyLastUsedTimeUpdater) Run(ctx context.Context) error {
+	c.logger.Info("start running APIKeyLastUsedTimeUpdater")
+
+	t := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("APIKeyLastUsedTimeUpdater has been stopped")
+			return nil
+
+		case <-t.C:
+			start := time.Now()
+			if err := c.updateOrphanCommandsStatus(ctx); err == nil {
+				c.logger.Info("successfully update api key last used time", zap.Duration("duration", time.Since(start)))
+			}
+		}
+	}
+}
+
+func (c *APIKeyLastUsedTimeUpdater) updateOrphanCommandsStatus(ctx context.Context) error {
+	keys, err := c.apiKeyLastUsedTimeCache.GetAll()
+	if err != nil {
+		c.logger.Info("there are no cache of api key last used time on redis")
+	}
+
+	for id, time := range keys {
+		lastUsedTime := bytes2int64(time.([]byte))
+		if err := c.apiKeyStore.UpdateLastUsedAt(ctx, id, lastUsedTime); err != nil {
+			c.logger.Error("failed to update last used time",
+				zap.String("id", id),
+				zap.Error(err),
+			)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func bytes2int64(bytes []byte) int64 {
+	var numString string
+	for i := range bytes {
+		numString += string(bytes[i])
+	}
+	num, _ := strconv.ParseInt(numString, 10, 64)
+	return num
+}

--- a/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
+++ b/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
@@ -27,8 +27,7 @@ import (
 )
 
 var (
-	commandTimeOut = 24 * time.Hour
-	interval       = 1 * time.Minute
+	interval = 1 * time.Minute
 )
 
 type apiKeyStore interface {

--- a/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
+++ b/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
@@ -132,9 +132,5 @@ func (c *APIKeyLastUsedTimeUpdater) updateAPIKeyLastUsedTime(ctx context.Context
 
 func bytes2int64(bytes []byte) (int64, error) {
 	numString := string(bytes)
-	num, err := strconv.ParseInt(numString, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return num, nil
+	return strconv.ParseInt(numString, 10, 64)
 }

--- a/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
+++ b/pkg/app/ops/apikeylastusedtimeupdater/apikeylastusedtimeupdater.go
@@ -71,14 +71,14 @@ func (c *APIKeyLastUsedTimeUpdater) Run(ctx context.Context) error {
 
 		case <-t.C:
 			start := time.Now()
-			if err := c.updateOrphanCommandsStatus(ctx); err == nil {
+			if err := c.updateAPIKeyLastUsedTime(ctx); err == nil {
 				c.logger.Info("successfully update api key last used time", zap.Duration("duration", time.Since(start)))
 			}
 		}
 	}
 }
 
-func (c *APIKeyLastUsedTimeUpdater) updateOrphanCommandsStatus(ctx context.Context) error {
+func (c *APIKeyLastUsedTimeUpdater) updateAPIKeyLastUsedTime(ctx context.Context) error {
 	keys, err := c.apiKeyLastUsedTimeCache.GetAll()
 	if err != nil {
 		c.logger.Info("there are no cache of api key last used time on redis")

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -1529,10 +1529,15 @@ func (a *WebAPI) ListAPIKeys(ctx context.Context, req *webservice.ListAPIKeysReq
 
 	for i := range apiKeys {
 		// Get LastUsedTIme from Redis
-		if lastUsedAt, error := a.apiKeyLastUsedStore.Get(apiKeys[i].Id); error == nil {
-			apiKeys[i].LastUsedAt = bytes2int64(lastUsedAt.([]byte))
+		var lastUsedAtFromRedis int64
+		if lastUsedAtFromRedisByte, error := a.apiKeyLastUsedStore.Get(apiKeys[i].Id); error == nil {
+			lastUsedAtFromRedis = bytes2int64(lastUsedAtFromRedisByte.([]byte))
 		} else {
-			apiKeys[i].LastUsedAt = 0
+			lastUsedAtFromRedis = 0
+		}
+
+		if lastUsedAtFromRedis > apiKeys[i].LastUsedAt {
+			apiKeys[i].LastUsedAt = lastUsedAtFromRedis
 		}
 		// Redact all sensitive data inside API key before sending to the client.
 		apiKeys[i].RedactSensitiveData()

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -1529,15 +1529,13 @@ func (a *WebAPI) ListAPIKeys(ctx context.Context, req *webservice.ListAPIKeysReq
 
 	for i := range apiKeys {
 		// Get LastUsedTIme from Redis
-		var lastUsedAtFromRedis int64
-		if lastUsedAtFromRedisByte, error := a.apiKeyLastUsedStore.Get(apiKeys[i].Id); error == nil {
-			lastUsedAtFromRedis = bytes2int64(lastUsedAtFromRedisByte.([]byte))
-		} else {
-			lastUsedAtFromRedis = 0
+		var lastUsedAtFromCache int64 = 0
+		if lastUsedAtFromCacheByte, error := a.apiKeyLastUsedStore.Get(apiKeys[i].Id); error == nil {
+			lastUsedAtFromCache = bytes2int64(lastUsedAtFromCacheByte.([]byte))
 		}
 
-		if lastUsedAtFromRedis > apiKeys[i].LastUsedAt {
-			apiKeys[i].LastUsedAt = lastUsedAtFromRedis
+		if lastUsedAtFromCache > apiKeys[i].LastUsedAt {
+			apiKeys[i].LastUsedAt = lastUsedAtFromCache
 		}
 		// Redact all sensitive data inside API key before sending to the client.
 		apiKeys[i].RedactSensitiveData()

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -153,6 +153,10 @@ func (s *apiKeyStore) Disable(ctx context.Context, id, projectID string) error {
 func (s *apiKeyStore) UpdateLastUsedAt(ctx context.Context, id string, time int64) error {
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		k := e.(*model.APIKey)
+		if time < k.LastUsedAt {
+			return fmt.Errorf("unable to update last used at time earlier than current last used at time")
+		}
+
 		k.LastUsedAt = time
 		return k.Validate()
 	})

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -153,7 +153,9 @@ func (s *apiKeyStore) Disable(ctx context.Context, id, projectID string) error {
 func (s *apiKeyStore) UpdateLastUsedAt(ctx context.Context, id string, time int64) error {
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		k := e.(*model.APIKey)
-		k.LastUsedAt = time
+		if !k.Disabled {
+			k.LastUsedAt = time
+		}
 		return k.Validate()
 	})
 }

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -74,6 +74,7 @@ type APIKeyStore interface {
 	Get(ctx context.Context, id string) (*model.APIKey, error)
 	List(ctx context.Context, opts ListOptions) ([]*model.APIKey, error)
 	Disable(ctx context.Context, id, projectID string) error
+	UpdateLastUsedAt(ctx context.Context, id string, time int64) error
 }
 
 type apiKeyStore struct {
@@ -145,6 +146,14 @@ func (s *apiKeyStore) Disable(ctx context.Context, id, projectID string) error {
 
 		k.Disabled = true
 		k.UpdatedAt = now
+		return k.Validate()
+	})
+}
+
+func (s *apiKeyStore) UpdateLastUsedAt(ctx context.Context, id string, time int64) error {
+	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
+		k := e.(*model.APIKey)
+		k.LastUsedAt = time
 		return k.Validate()
 	})
 }

--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -153,9 +153,7 @@ func (s *apiKeyStore) Disable(ctx context.Context, id, projectID string) error {
 func (s *apiKeyStore) UpdateLastUsedAt(ctx context.Context, id string, time int64) error {
 	return s.ds.Update(ctx, s.col, id, func(e interface{}) error {
 		k := e.(*model.APIKey)
-		if !k.Disabled {
-			k.LastUsedAt = time
-		}
+		k.LastUsedAt = time
 		return k.Validate()
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/pipe-cd/pipecd/pull/4124 enables us to know when api keys are created and used at last time, but it store the time only Redis.
This PR implemented cron updater that gets last used time from Redis and update the time on datastore.

**Which issue(s) this PR fixes**:

Fixes #4118 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
