### PR TITLE
Remove cloud-provider term in piped logs

### DIFF
--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -63,7 +63,7 @@ func newAddCommand(root *command) *cobra.Command {
 	cmd.MarkFlagRequired("app-name")
 	cmd.MarkFlagRequired("app-kind")
 	cmd.MarkFlagRequired("piped-id")
-	cmd.MarkFlagRequired("cloud-provider")
+	cmd.MarkFlagRequired("platform-provider")
 	cmd.MarkFlagRequired("repo-id")
 	cmd.MarkFlagRequired("app-dir")
 

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -83,7 +83,7 @@ func NewDetector(
 ) Detector {
 
 	logger = logger.Named("cloudrun-detector").With(
-		zap.String("cloud-provider", cp.Name),
+		zap.String("platform-provider", cp.Name),
 	)
 	return &detector{
 		provider:          cp,

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -84,7 +84,7 @@ func NewDetector(
 ) Detector {
 
 	logger = logger.Named("kubernetes-detector").With(
-		zap.String("cloud-provider", cp.Name),
+		zap.String("platform-provider", cp.Name),
 	)
 	return &detector{
 		provider:          cp,

--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -85,7 +85,7 @@ func NewDetector(
 ) Detector {
 
 	logger = logger.Named("terraform-detector").With(
-		zap.String("cloud-provider", cp.Name),
+		zap.String("platform-provider", cp.Name),
 	)
 	return &detector{
 		provider:          cp,

--- a/pkg/app/piped/livestatereporter/cloudrun/report.go
+++ b/pkg/app/piped/livestatereporter/cloudrun/report.go
@@ -55,7 +55,7 @@ type reporter struct {
 
 func NewReporter(cp config.PipedPlatformProvider, appLister applicationLister, stateGetter cloudrun.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
 	logger = logger.Named("cloudrun-reporter").With(
-		zap.String("cloud-provider", cp.Name),
+		zap.String("platform-provider", cp.Name),
 	)
 	return &reporter{
 		provider:              cp,

--- a/pkg/app/piped/livestatereporter/kubernetes/reporter.go
+++ b/pkg/app/piped/livestatereporter/kubernetes/reporter.go
@@ -61,7 +61,7 @@ type reporter struct {
 
 func NewReporter(cp config.PipedPlatformProvider, appLister applicationLister, stateGetter kubernetes.Getter, apiClient apiClient, logger *zap.Logger) Reporter {
 	logger = logger.Named("kubernetes-reporter").With(
-		zap.String("cloud-provider", cp.Name),
+		zap.String("platform-provider", cp.Name),
 	)
 	return &reporter{
 		provider:              cp,

--- a/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
+++ b/pkg/app/piped/livestatestore/cloudrun/cloudrun.go
@@ -46,7 +46,7 @@ type State struct {
 
 func NewStore(ctx context.Context, cfg *config.PlatformProviderCloudRunConfig, platformProvider string, logger *zap.Logger) (*Store, error) {
 	logger = logger.Named("cloudrun").
-		With(zap.String("cloud-provider", platformProvider))
+		With(zap.String("platform-provider", platformProvider))
 
 	client, err := provider.DefaultRegistry().Client(ctx, platformProvider, cfg, logger)
 	if err != nil {

--- a/pkg/app/piped/livestatestore/ecs/store.go
+++ b/pkg/app/piped/livestatestore/ecs/store.go
@@ -36,7 +36,7 @@ type Getter interface {
 
 func NewStore(cfg *config.PlatformProviderECSConfig, platformProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("ecs").
-		With(zap.String("cloud-provider", platformProvider))
+		With(zap.String("platform-provider", platformProvider))
 
 	return &Store{
 		logger: logger,

--- a/pkg/app/piped/livestatestore/kubernetes/kubernetes.go
+++ b/pkg/app/piped/livestatestore/kubernetes/kubernetes.go
@@ -66,7 +66,7 @@ func (it EventIterator) Next(maxNum int) []model.KubernetesResourceStateEvent {
 
 func NewStore(cfg *config.PlatformProviderKubernetesConfig, pipedConfig *config.PipedSpec, platformProvider string, logger *zap.Logger) *Store {
 	logger = logger.Named("kubernetes").
-		With(zap.String("cloud-provider", platformProvider))
+		With(zap.String("platform-provider", platformProvider))
 
 	return &Store{
 		config:      cfg,

--- a/pkg/app/piped/livestatestore/lambda/store.go
+++ b/pkg/app/piped/livestatestore/lambda/store.go
@@ -36,7 +36,7 @@ type Getter interface {
 
 func NewStore(cfg *config.PlatformProviderLambdaConfig, platformProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("lambda").
-		With(zap.String("cloud-provider", platformProvider))
+		With(zap.String("platform-provider", platformProvider))
 
 	return &Store{
 		logger: logger,

--- a/pkg/app/piped/livestatestore/terraform/store.go
+++ b/pkg/app/piped/livestatestore/terraform/store.go
@@ -36,7 +36,7 @@ type Getter interface {
 
 func NewStore(cfg *config.PlatformProviderTerraformConfig, platformProvider string, appLister applicationLister, logger *zap.Logger) *Store {
 	logger = logger.Named("terraform").
-		With(zap.String("cloud-provider", platformProvider))
+		With(zap.String("platform-provider", platformProvider))
 
 	return &Store{
 		logger: logger,

--- a/pkg/datastore/applicationstore_test.go
+++ b/pkg/datastore/applicationstore_test.go
@@ -54,7 +54,7 @@ func TestAddApplication(t *testing.T) {
 					Repo: &model.ApplicationGitRepository{Id: "id"},
 					Path: "path",
 				},
-				CloudProvider: "cloud-provider",
+				PlatformProvider: "platform-provider",
 
 				CreatedAt: 1,
 				UpdatedAt: 1,

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -337,7 +337,6 @@ func TestAddDeployment(t *testing.T) {
 					Repo: &model.ApplicationGitRepository{Id: "id"},
 					Path: "path",
 				},
-				CloudProvider:    "cloud-provider",
 				PlatformProvider: "platform-provider",
 				Trigger: &model.DeploymentTrigger{
 					Commit: &model.Commit{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
