### PR TITLE
Fix unable to delete resource that removed from git for k8s apps

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/loader.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader.go
@@ -173,8 +173,8 @@ func setNamespace(manifests []Manifest, namespace string) {
 	if namespace == "" {
 		return
 	}
-	for _, m := range manifests {
-		m.Key.Namespace = namespace
+	for i := range manifests {
+		manifests[i].Key.Namespace = namespace
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously due to this wrong iteration make changed via `setNamespace` does not returned after loader.LoadManifests run, thus annotation and logic which based on manifest.ResourceKey.Namespace go wrong way

From
```
ResourceKey: apps/v1:Deployment:default:simple
```
To
```
ResourceKey: apps/v1:Deployment:test:simple
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
Fix unable to delete k8s resources which those manifests removed from Git
```
