### PR TITLE
Display namespace of the resources on stage logs

### DIFF
--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -243,24 +243,24 @@ func applyManifests(ctx context.Context, ag applierGetter, manifests []provider.
 		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
 		if annotation != provider.UseReplaceEnabled {
 			if err := applier.ApplyManifest(ctx, m); err != nil {
-				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableLogString(), err)
+				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableString(), err)
 				return err
 			}
-			lp.Successf("- applied manifest: %s", m.Key.ReadableLogString())
+			lp.Successf("- applied manifest: %s", m.Key.ReadableString())
 			continue
 		}
 		// Always try to replace first and create if it fails due to resource not found error.
 		// This is because we cannot know whether resource already exists before executing command.
 		err = applier.ReplaceManifest(ctx, m)
 		if errors.Is(err, provider.ErrNotFound) {
-			lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableLogString(), err)
+			lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableString(), err)
 			err = applier.CreateManifest(ctx, m)
 		}
 		if err != nil {
-			lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableLogString(), err)
+			lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableString(), err)
 			return err
 		}
-		lp.Successf("- replaced or created manifest: %s", m.Key.ReadableLogString())
+		lp.Successf("- replaced or created manifest: %s", m.Key.ReadableString())
 
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))
@@ -286,16 +286,16 @@ func deleteResources(ctx context.Context, ag applierGetter, resources []provider
 
 		err = applier.Delete(ctx, k)
 		if err == nil {
-			lp.Successf("- deleted resource: %s", k.ReadableLogString())
+			lp.Successf("- deleted resource: %s", k.ReadableString())
 			deletedCount++
 			continue
 		}
 		if errors.Is(err, provider.ErrNotFound) {
-			lp.Infof("- no resource %s to delete", k.ReadableLogString())
+			lp.Infof("- no resource %s to delete", k.ReadableString())
 			deletedCount++
 			continue
 		}
-		lp.Errorf("- unable to delete resource: %s (%v)", k.ReadableLogString(), err)
+		lp.Errorf("- unable to delete resource: %s (%v)", k.ReadableString(), err)
 	}
 
 	if deletedCount < resourcesLen {

--- a/pkg/app/piped/executor/kubernetes/primary.go
+++ b/pkg/app/piped/executor/kubernetes/primary.go
@@ -99,7 +99,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 		for _, m := range workloads {
 			if err := checkVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
 				invalid = true
-				e.LogPersister.Errorf("Missing %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableLogString(), err)
+				e.LogPersister.Errorf("Missing %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
 			}
 		}
 		if invalid {
@@ -163,7 +163,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 	}
 	e.LogPersister.Successf("Successfully loaded %d live resources", len(runningManifests))
 	for _, m := range runningManifests {
-		e.LogPersister.Successf("- loaded live resource: %s", m.Key.ReadableLogString())
+		e.LogPersister.Successf("- loaded live resource: %s", m.Key.ReadableString())
 	}
 
 	removeKeys := findRemoveManifests(runningManifests, manifests, e.appCfg.Input.Namespace)
@@ -219,7 +219,7 @@ func (e *deployExecutor) generatePrimaryManifests(manifests []provider.Manifest,
 		workloads := findWorkloadManifests(manifests, e.appCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, variantLabel, variant); err != nil {
-				return nil, fmt.Errorf("unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+variant, m.Key.ReadableLogString(), err)
+				return nil, fmt.Errorf("unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+variant, m.Key.ReadableString(), err)
 			}
 		}
 	}

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -113,7 +113,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		workloads := findWorkloadManifests(manifests, appCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
-				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableLogString(), err)
+				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
 				return model.StageStatus_STAGE_FAILURE
 			}
 		}

--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -53,7 +53,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		workloads := findWorkloadManifests(manifests, e.appCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
-				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableLogString(), err)
+				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
 				return model.StageStatus_STAGE_FAILURE
 			}
 		}
@@ -105,7 +105,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	}
 	e.LogPersister.Successf("Successfully loaded %d live resources", len(liveResources))
 	for _, m := range liveResources {
-		e.LogPersister.Successf("- loaded live resource: %s", m.Key.ReadableLogString())
+		e.LogPersister.Successf("- loaded live resource: %s", m.Key.ReadableString())
 	}
 
 	removeKeys := findRemoveResources(manifests, liveResources)

--- a/pkg/app/piped/executor/kubernetes/traffic.go
+++ b/pkg/app/piped/executor/kubernetes/traffic.go
@@ -91,7 +91,7 @@ func (e *deployExecutor) ensureTrafficRouting(ctx context.Context) model.StageSt
 		e.LogPersister.Infof(
 			"Detected %d traffic routing manifests but only the first one (%s) will be used",
 			len(trafficRoutingManifests),
-			trafficRoutingManifests[0].Key.ReadableLogString(),
+			trafficRoutingManifests[0].Key.ReadableString(),
 		)
 	}
 	trafficRoutingManifest := trafficRoutingManifests[0]
@@ -101,7 +101,7 @@ func (e *deployExecutor) ensureTrafficRouting(ctx context.Context) model.StageSt
 		if err := checkVariantSelectorInService(trafficRoutingManifest, variantLabel, primaryVariant); err != nil {
 			e.LogPersister.Errorf("Traffic routing by PodSelector requires %q inside the selector of Service manifest but it was unable to check that field in manifest %s (%v)",
 				variantLabel+": "+primaryVariant,
-				trafficRoutingManifest.Key.ReadableLogString(),
+				trafficRoutingManifest.Key.ReadableString(),
 				err,
 			)
 			return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
@@ -104,11 +104,6 @@ func (k ResourceKey) ReadableString() string {
 	return fmt.Sprintf("name=%q, kind=%q, namespace=%q, apiVersion=%q", k.Name, k.Kind, k.Namespace, k.APIVersion)
 }
 
-// TODO: Ensure the ResourceKey's Namespace used for Kubernetes diff detection works with the current ResourceKey Namespace loading model
-func (k ResourceKey) ReadableLogString() string {
-	return fmt.Sprintf("name=%q, kind=%q, apiVersion=%q", k.Name, k.Kind, k.APIVersion)
-}
-
 func (k ResourceKey) IsZero() bool {
 	return k.APIVersion == "" &&
 		k.Kind == "" &&


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable display the namespace value for k8s resource in stage logs

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
