### PR TITLE
Fix INVALID_CONFIG status

### DIFF
--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -235,8 +235,9 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			req := &pipedservice.ReportApplicationSyncStateRequest{
 				ApplicationId: app.Id,
 				State: &model.ApplicationSyncState{
-					Status: model.ApplicationSyncStatus_INVALID_CONFIG,
-					Reason: err.Error(),
+					Status:    model.ApplicationSyncStatus_INVALID_CONFIG,
+					Reason:    err.Error(),
+					Timestamp: time.Now().Unix(),
 				},
 			}
 			_, err := t.apiClient.ReportApplicationSyncState(ctx, req)


### PR DESCRIPTION
**What this PR does / why we need it**:
Error
```
failed to report application sync state ae68191f-c448-454e-8980-686cdcf5e0b7: rpc error: code = InvalidArgument desc = invalid request: invalid ReportApplicationSyncStateRequest.State: embedded message failed validation | caused by: invalid ApplicationSyncState.Timestamp: value must be greater than 0   {"error": "rpc error: code = InvalidArgument desc = invalid request: invalid ReportApplicationSyncStateRequest.State: embedded message failed validation | caused by: invalid ApplicationSyncState.Timestamp: value must be greater than 0"}
github.com/pipe-cd/pipecd/pkg/app/piped/trigger.(*Trigger).checkRepoCandidates
        /home/runner/work/pipecd/pipecd/pkg/app/piped/trigger/trigger.go:245
github.com/pipe-cd/pipecd/pkg/app/piped/trigger.(*Trigger).checkCandidates
        /home/runner/work/pipecd/pipecd/pkg/app/piped/trigger/trigger.go:191
github.com/pipe-cd/pipecd/pkg/app/piped/trigger.(*Trigger).Run
        /home/runner/work/pipecd/pipecd/pkg/app/piped/trigger/trigger.go:158
github.com/pipe-cd/pipecd/pkg/app/piped/cmd/piped.(*piped).run.func15
        /home/runner/work/pipecd/pipecd/pkg/app/piped/cmd/piped/piped.go:431
golang.org/x/sync/errgroup.(*Group).Go.func1
        /home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/errgroup/errgroup.go:75
```
ApplicationSyncState.Timestamp was missing and failed.
So here's the PR for that fix.

**Which issue(s) this PR fixes**:

Follows #4206

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
