### PR TITLE
Fix unable to plan deployment on failed to determine app version

### DIFF
--- a/pkg/app/piped/planner/cloudrun/cloudrun.go
+++ b/pkg/app/piped/planner/cloudrun/cloudrun.go
@@ -62,8 +62,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		in.Logger.Warn("unable to determine target version", zap.Error(e))
 	}
 
-	out.Versions, err = p.determineVersions(ds.AppDir, cfg.Input.ServiceManifestFile)
-	if err != nil {
+	if versions, e := p.determineVersions(ds.AppDir, cfg.Input.ServiceManifestFile); e != nil || len(versions) == 0 {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))
 		out.Versions = []*model.ArtifactVersion{
 			{
@@ -71,6 +70,8 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 				Version: "unknown",
 			},
 		}
+	} else {
+		out.Versions = versions
 	}
 
 	autoRollback := *cfg.Input.AutoRollback

--- a/pkg/app/piped/planner/cloudrun/cloudrun.go
+++ b/pkg/app/piped/planner/cloudrun/cloudrun.go
@@ -63,7 +63,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	if versions, e := p.determineVersions(ds.AppDir, cfg.Input.ServiceManifestFile); e != nil || len(versions) == 0 {
-		in.Logger.Warn("unable to determine target versions", zap.Error(err))
+		in.Logger.Warn("unable to determine target versions", zap.Error(e))
 		out.Versions = []*model.ArtifactVersion{
 			{
 				Kind:    model.ArtifactVersion_UNKNOWN,

--- a/pkg/app/piped/planner/cloudrun/cloudrun.go
+++ b/pkg/app/piped/planner/cloudrun/cloudrun.go
@@ -55,11 +55,11 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Determine application version from the manifest.
-	if version, e := p.determineVersion(ds.AppDir, cfg.Input.ServiceManifestFile); e == nil {
-		out.Version = version
-	} else {
+	if version, e := p.determineVersion(ds.AppDir, cfg.Input.ServiceManifestFile); e != nil {
 		out.Version = "unknown"
 		in.Logger.Warn("unable to determine target version", zap.Error(e))
+	} else {
+		out.Version = version
 	}
 
 	if versions, e := p.determineVersions(ds.AppDir, cfg.Input.ServiceManifestFile); e != nil || len(versions) == 0 {

--- a/pkg/app/piped/planner/ecs/ecs.go
+++ b/pkg/app/piped/planner/ecs/ecs.go
@@ -55,15 +55,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Determine application version from the task definition
-	if version, err := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); err == nil {
+	if version, e := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); e == nil {
 		out.Version = version
 	} else {
 		out.Version = "unknown"
 		in.Logger.Warn("unable to determine target version", zap.Error(err))
 	}
 
-	out.Versions, err = determineVersions(ds.AppDir, cfg.Input.TaskDefinitionFile)
-	if err != nil {
+	if versions, e := determineVersions(ds.AppDir, cfg.Input.TaskDefinitionFile); e != nil || len(versions) == 0 {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))
 		out.Versions = []*model.ArtifactVersion{
 			{
@@ -71,6 +70,8 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 				Version: "unknown",
 			},
 		}
+	} else {
+		out.Versions = versions
 	}
 
 	autoRollback := *cfg.Input.AutoRollback

--- a/pkg/app/piped/planner/ecs/ecs.go
+++ b/pkg/app/piped/planner/ecs/ecs.go
@@ -57,13 +57,13 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// Determine application version from the task definition
 	if version, e := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); e != nil {
 		out.Version = "unknown"
-		in.Logger.Warn("unable to determine target version", zap.Error(err))
+		in.Logger.Warn("unable to determine target version", zap.Error(e))
 	} else {
 		out.Version = version
 	}
 
 	if versions, e := determineVersions(ds.AppDir, cfg.Input.TaskDefinitionFile); e != nil || len(versions) == 0 {
-		in.Logger.Warn("unable to determine target versions", zap.Error(err))
+		in.Logger.Warn("unable to determine target versions", zap.Error(e))
 		out.Versions = []*model.ArtifactVersion{
 			{
 				Kind:    model.ArtifactVersion_UNKNOWN,

--- a/pkg/app/piped/planner/ecs/ecs.go
+++ b/pkg/app/piped/planner/ecs/ecs.go
@@ -55,11 +55,11 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Determine application version from the task definition
-	if version, e := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); e == nil {
-		out.Version = version
-	} else {
+	if version, e := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); e != nil {
 		out.Version = "unknown"
 		in.Logger.Warn("unable to determine target version", zap.Error(err))
+	} else {
+		out.Version = version
 	}
 
 	if versions, e := determineVersions(ds.AppDir, cfg.Input.TaskDefinitionFile); e != nil || len(versions) == 0 {

--- a/pkg/app/piped/planner/lambda/lambda.go
+++ b/pkg/app/piped/planner/lambda/lambda.go
@@ -55,11 +55,11 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Determine application version from the manifest
-	if version, e := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); e == nil {
-		out.Version = version
-	} else {
+	if version, e := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); e != nil {
 		out.Version = "unknown"
 		in.Logger.Warn("unable to determine target version", zap.Error(err))
+	} else {
+		out.Version = version
 	}
 
 	if versions, e := determineVersions(ds.AppDir, cfg.Input.FunctionManifestFile); e != nil || len(versions) == 0 {

--- a/pkg/app/piped/planner/lambda/lambda.go
+++ b/pkg/app/piped/planner/lambda/lambda.go
@@ -57,13 +57,13 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// Determine application version from the manifest
 	if version, e := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); e != nil {
 		out.Version = "unknown"
-		in.Logger.Warn("unable to determine target version", zap.Error(err))
+		in.Logger.Warn("unable to determine target version", zap.Error(e))
 	} else {
 		out.Version = version
 	}
 
 	if versions, e := determineVersions(ds.AppDir, cfg.Input.FunctionManifestFile); e != nil || len(versions) == 0 {
-		in.Logger.Warn("unable to determine target versions", zap.Error(err))
+		in.Logger.Warn("unable to determine target versions", zap.Error(e))
 		out.Versions = []*model.ArtifactVersion{
 			{
 				Kind:    model.ArtifactVersion_UNKNOWN,

--- a/pkg/app/piped/planner/lambda/lambda.go
+++ b/pkg/app/piped/planner/lambda/lambda.go
@@ -55,15 +55,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Determine application version from the manifest
-	if version, err := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); err == nil {
+	if version, e := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); e == nil {
 		out.Version = version
 	} else {
 		out.Version = "unknown"
 		in.Logger.Warn("unable to determine target version", zap.Error(err))
 	}
 
-	out.Versions, err = determineVersions(ds.AppDir, cfg.Input.FunctionManifestFile)
-	if err != nil {
+	if versions, e := determineVersions(ds.AppDir, cfg.Input.FunctionManifestFile); e != nil || len(versions) == 0 {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))
 		out.Versions = []*model.ArtifactVersion{
 			{
@@ -71,6 +70,8 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 				Version: "unknown",
 			},
 		}
+	} else {
+		out.Versions = versions
 	}
 
 	autoRollback := *cfg.Input.AutoRollback

--- a/pkg/app/piped/planner/terraform/terraform.go
+++ b/pkg/app/piped/planner/terraform/terraform.go
@@ -82,7 +82,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	if versions, e := provider.FindArtifactVersions(files); e != nil || len(versions) == 0 {
-		in.Logger.Warn("unable to determine target versions", zap.Error(err))
+		in.Logger.Warn("unable to determine target versions", zap.Error(e))
 		out.Versions = []*model.ArtifactVersion{
 			{
 				Kind:    model.ArtifactVersion_UNKNOWN,

--- a/pkg/app/piped/planner/terraform/terraform.go
+++ b/pkg/app/piped/planner/terraform/terraform.go
@@ -81,8 +81,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
-	out.Versions, err = provider.FindArtifactVersions(files)
-	if err != nil {
+	if versions, e := provider.FindArtifactVersions(files); e != nil || len(versions) == 0 {
 		in.Logger.Warn("unable to determine target versions", zap.Error(err))
 		out.Versions = []*model.ArtifactVersion{
 			{
@@ -90,6 +89,8 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 				Version: "unknown",
 			},
 		}
+	} else {
+		out.Versions = versions
 	}
 
 	if cfg.Pipeline == nil || len(cfg.Pipeline.Stages) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, these functions re-used `err` variable, which defined in function signature. That make the caller side always return failed in case we can't determine the application version (which only be used in showing stub). The right behaviour should be only show version `unknown` and keep deploying as usual.

ref: https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/controller/planner.go#L211-L214

Thanks @kevin55156 for pointing out this 👍 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
Fix unable to plan deployment if failed to determine application version(s)
```
