### PR TITLE
Enable to ignore manifests' fields from kubernetes' drift detection

### DIFF
--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -188,6 +188,10 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 	liveManifests = filterIgnoringManifests(liveManifests)
 	d.logger.Debug(fmt.Sprintf("application %s has %d live manifests", app.Id, len(liveManifests)))
 
+	ddCfg, err := d.getDriftDetectionConfig(repo.GetPath(), app)
+	if err != nil {
+		return err
+	}
 	result, err := provider.DiffList(
 		headManifests,
 		liveManifests,
@@ -195,6 +199,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		diff.WithEquateEmpty(),
 		diff.WithIgnoreAddingMapKeys(),
 		diff.WithCompareNumberAndNumericString(),
+		diff.WithIgnoredPaths(ddCfg.IgnoreFields),
 	)
 	if err != nil {
 		return err
@@ -369,4 +374,17 @@ func makeSyncState(r *provider.DiffListResult, commit string) model.ApplicationS
 		Reason:      b.String(),
 		Timestamp:   time.Now().Unix(),
 	}
+}
+
+func (d *detector) getDriftDetectionConfig(repoDir string, app *model.Application) (*config.DriftDetection, error) {
+	cfg, err := d.loadApplicationConfiguration(repoDir, app)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load application configuration: %w", err)
+	}
+	gds, ok := cfg.GetGenericApplication()
+	if !ok {
+		return nil, fmt.Errorf("unsupport application kind %s", cfg.Kind)
+	}
+
+	return gds.DriftDetection, nil
 }

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -193,7 +193,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		return err
 	}
 
-	ignoreFields := []string{}
+	ignoreFields := make([]string, 0)
 	if ddCfg != nil {
 		ignoreFields = ddCfg.IgnoreFields
 	}

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -192,6 +192,12 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 	if err != nil {
 		return err
 	}
+
+	ignoreFields := []string{}
+	if ddCfg != nil {
+		ignoreFields = ddCfg.IgnoreFields
+	}
+
 	result, err := provider.DiffList(
 		headManifests,
 		liveManifests,
@@ -199,7 +205,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		diff.WithEquateEmpty(),
 		diff.WithIgnoreAddingMapKeys(),
 		diff.WithCompareNumberAndNumericString(),
-		diff.WithIgnoredPaths(ddCfg.IgnoreFields),
+		diff.WithIgnoredPaths(ignoreFields),
 	)
 	if err != nil {
 		return err

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -58,6 +58,8 @@ type GenericApplicationSpec struct {
 	DeploymentNotification *DeploymentNotification `json:"notification"`
 	// List of the configuration for event watcher.
 	EventWatcher []EventWatcherConfig `json:"eventWatcher"`
+	// Configuration for drift detection
+	DriftDetection *DriftDetection `json:"driftDetection"`
 }
 
 type DeploymentPlanner struct {
@@ -629,6 +631,10 @@ func (c *DeploymentChainTriggerCondition) Validate() error {
 		return fmt.Errorf("missing commitPrefix configration as deployment chain trigger condition")
 	}
 	return nil
+}
+
+type DriftDetection struct {
+	IgnoreFields []string `json:"ignoreFields"`
 }
 
 func LoadApplication(repoPath, configRelPath string, appKind model.ApplicationKind) (*GenericApplicationSpec, error) {

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -26,6 +27,7 @@ type differ struct {
 	ignoreAddingMapKeys           bool
 	equateEmpty                   bool
 	compareNumberAndNumericString bool
+	ignoredPaths                  []string
 
 	result *Result
 }
@@ -56,6 +58,13 @@ func WithCompareNumberAndNumericString() Option {
 	}
 }
 
+// WithIgnoredPaths configures ignored fields.
+func WithIgnoredPaths(paths []string) Option {
+	return func(d *differ) {
+		d.ignoredPaths = paths
+	}
+}
+
 // DiffUnstructureds calculates the diff between two unstructured objects.
 func DiffUnstructureds(x, y unstructured.Unstructured, opts ...Option) (*Result, error) {
 	var (
@@ -82,7 +91,7 @@ func (d *differ) diff(path []PathStep, vx, vy reflect.Value) error {
 			return nil
 		}
 
-		d.result.addNode(path, nil, vy.Type(), vx, vy)
+		d.addNode(path, nil, vy.Type(), vx, vy)
 		return nil
 	}
 
@@ -91,7 +100,7 @@ func (d *differ) diff(path []PathStep, vx, vy reflect.Value) error {
 			return nil
 		}
 
-		d.result.addNode(path, vx.Type(), nil, vx, vy)
+		d.addNode(path, vx.Type(), nil, vx, vy)
 		return nil
 	}
 
@@ -114,7 +123,7 @@ func (d *differ) diff(path []PathStep, vx, vy reflect.Value) error {
 	}
 
 	if vx.Type() != vy.Type() {
-		d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+		d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 		return nil
 	}
 
@@ -141,7 +150,7 @@ func (d *differ) diff(path []PathStep, vx, vy reflect.Value) error {
 
 func (d *differ) diffSlice(path []PathStep, vx, vy reflect.Value) error {
 	if vx.IsNil() || vy.IsNil() {
-		d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+		d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 		return nil
 	}
 
@@ -162,13 +171,13 @@ func (d *differ) diffSlice(path []PathStep, vx, vy reflect.Value) error {
 	for i := minLen; i < vx.Len(); i++ {
 		nextPath := newSlicePath(path, i)
 		nextValueX := vx.Index(i)
-		d.result.addNode(nextPath, nextValueX.Type(), nextValueX.Type(), nextValueX, reflect.Value{})
+		d.addNode(nextPath, nextValueX.Type(), nextValueX.Type(), nextValueX, reflect.Value{})
 	}
 
 	for i := minLen; i < vy.Len(); i++ {
 		nextPath := newSlicePath(path, i)
 		nextValueY := vy.Index(i)
-		d.result.addNode(nextPath, nextValueY.Type(), nextValueY.Type(), reflect.Value{}, nextValueY)
+		d.addNode(nextPath, nextValueY.Type(), nextValueY.Type(), reflect.Value{}, nextValueY)
 	}
 
 	return nil
@@ -176,7 +185,7 @@ func (d *differ) diffSlice(path []PathStep, vx, vy reflect.Value) error {
 
 func (d *differ) diffMap(path []PathStep, vx, vy reflect.Value) error {
 	if vx.IsNil() || vy.IsNil() {
-		d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+		d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 		return nil
 	}
 
@@ -214,7 +223,7 @@ func (d *differ) diffInterface(path []PathStep, vx, vy reflect.Value) error {
 	}
 
 	if vx.IsNil() || vy.IsNil() {
-		d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+		d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 		return nil
 	}
 
@@ -226,7 +235,7 @@ func (d *differ) diffString(path []PathStep, vx, vy reflect.Value) error {
 	if vx.String() == vy.String() {
 		return nil
 	}
-	d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+	d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 	return nil
 }
 
@@ -234,7 +243,7 @@ func (d *differ) diffBool(path []PathStep, vx, vy reflect.Value) error {
 	if vx.Bool() == vy.Bool() {
 		return nil
 	}
-	d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+	d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 	return nil
 }
 
@@ -243,7 +252,7 @@ func (d *differ) diffNumber(path []PathStep, vx, vy reflect.Value) error {
 		return nil
 	}
 
-	d.result.addNode(path, vx.Type(), vy.Type(), vx, vy)
+	d.addNode(path, vx.Type(), vy.Type(), vx, vy)
 	return nil
 }
 
@@ -321,4 +330,91 @@ func newMapPath(path []PathStep, index string) []PathStep {
 		MapIndex: index,
 	})
 	return next
+}
+
+func (d *differ) addNode(path []PathStep, tx, ty reflect.Type, vx, vy reflect.Value) {
+	if len(d.ignoredPaths) > 0 {
+		pathString := makePathString(path)
+		if d.isIgnoredPaths(pathString) {
+			return
+		}
+		nvx := d.ignoredValue(vx, pathString)
+		nvy := d.ignoredValue(vy, pathString)
+
+		d.result.addNode(path, tx, ty, nvx, nvy)
+		return
+	}
+
+	d.result.addNode(path, tx, ty, vx, vy)
+}
+
+func (d *differ) ignoredValue(v reflect.Value, prefix string) reflect.Value {
+	switch v.Kind() {
+	case reflect.Map:
+		nv := reflect.MakeMap(v.Type())
+		keys := v.MapKeys()
+		for _, k := range keys {
+			nprefix := prefix + "." + k.String()
+			if d.isIgnoredPaths(nprefix) {
+				continue
+			}
+
+			sub := v.MapIndex(k)
+			filtered := d.ignoredValue(sub, nprefix)
+			if !filtered.IsValid() {
+				continue
+			}
+			nv.SetMapIndex(k, filtered)
+		}
+		return nv
+
+	case reflect.Slice, reflect.Array:
+		nv := reflect.MakeSlice(v.Type(), 0, 0)
+		for i := 0; i < v.Len(); i++ {
+			nprefix := prefix + "." + strconv.Itoa(i)
+			if d.isIgnoredPaths(nprefix) {
+				continue
+			}
+
+			filtered := d.ignoredValue(v.Index(i), nprefix)
+			if !filtered.IsValid() {
+				continue
+			}
+			nv = reflect.Append(nv, filtered)
+		}
+		return nv
+
+	case reflect.Interface:
+		nprefix := prefix + "." + v.String()
+		if d.isIgnoredPaths(nprefix) {
+			return reflect.New(v.Type())
+		}
+		return d.ignoredValue(v.Elem(), prefix)
+
+	case reflect.String:
+		return v
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v
+
+	case reflect.Float32, reflect.Float64:
+		return v
+
+	default:
+		nprefix := prefix + "." + v.String()
+		if d.isIgnoredPaths(nprefix) {
+			return reflect.New(v.Type())
+		}
+		return v
+	}
+}
+
+func (d *differ) isIgnoredPaths(pathString string) bool {
+	for _, ignoredPath := range d.ignoredPaths {
+		if strings.HasPrefix(pathString, ignoredPath) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -53,6 +53,52 @@ func TestDiff(t *testing.T) {
 			diffNum: 0,
 		},
 		{
+			name:     "diff by ignoring specified field",
+			yamlFile: "testdata/ignore_specified_field.yaml",
+			options: []Option{
+				WithIgnoredPaths([]string{"spec.replicas", "spec.template.spec.containers.0.args.1", "spec.template.spec.strategy.rollingUpdate.maxSurge", "spec.template.spec.containers.3.livenessProbe.initialDelaySeconds"}),
+			},
+			diffNum: 6,
+			diffString: `  spec:
+    template:
+      metadata:
+        labels:
+          #spec.template.metadata.labels.app
+-         app: simple
++         app: simple2
+
+          #spec.template.metadata.labels.component
+-         component: foo
+
+      spec:
+        containers:
+          -
+            #spec.template.spec.containers.1.image
+-           image: gcr.io/pipecd/helloworld:v2.0.0
++           image: gcr.io/pipecd/helloworld:v2.1.0
+
+          -
+            #spec.template.spec.containers.2.image
+-           image: 
+
+          #spec.template.spec.containers.3
++         - image: new-image
++           livenessProbe:
++             exec:
++               command:
++                 - cat
++                 - /tmp/healthy
++           name: foo
+
+        #spec.template.spec.strategy
++       strategy:
++         rollingUpdate:
++           maxUnavailable: 25%
++         type: RollingUpdate
+
+`,
+		},
+		{
 			name:     "has diff",
 			yamlFile: "testdata/has_diff.yaml",
 			diffNum:  8,

--- a/pkg/diff/testdata/ignore_specified_field.yaml
+++ b/pkg/diff/testdata/ignore_specified_field.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Foo
+metadata:
+  name: simple
+  labels:
+    app: simple
+    pipecd.dev/managed-by: piped
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+        component: foo
+    spec:
+      containers:
+      - name: helloworld
+        image: gcr.io/pipecd/helloworld:v1.0.0
+        args:
+          - hi
+          - hello
+        ports:
+        - containerPort: 9085
+      - name: bar
+        image: gcr.io/pipecd/helloworld:v2.0.0
+      - name: helloword2
+        image: ""
+---
+apiVersion: apps/v1
+kind: Foo
+metadata:
+  name: simple
+  labels:
+    pipecd.dev/managed-by: piped
+    app: simple
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple2
+    spec:
+      strategy:
+        rollingUpdate:
+          maxSurge: 25%
+          maxUnavailable: 25%
+        type: RollingUpdate
+      containers:
+      - name: helloworld
+        image: gcr.io/pipecd/helloworld:v1.0.0
+        args:
+          - hi
+        ports:
+        - containerPort: 9085
+      - name: bar
+        image: gcr.io/pipecd/helloworld:v2.1.0
+      - name: helloword2
+      - name: foo
+        image: new-image
+        livenessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
In the previous implementation, panic occurred when ddCfg was nil. So, this problem is solved.

**Which issue(s) this PR fixes**:

Fixes #4202 #4241

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
