### PR TITLE
Refactor config package to remove unnecessary default values setter

### DIFF
--- a/pkg/config/analysis.go
+++ b/pkg/config/analysis.go
@@ -57,7 +57,7 @@ type AnalysisMetrics struct {
 	SkipOnNoData bool `json:"skipOnNoData"`
 	// How long after which the query times out.
 	// Default is 30s.
-	Timeout Duration `json:"timeout"`
+	Timeout Duration `json:"timeout" default:"30s"`
 
 	// The stage fails on deviation in the specified direction. One of LOW or HIGH or EITHER is available.
 	// This can be used only for PREVIOUS, CANARY_BASELINE or CANARY_PRIMARY. Defaults to EITHER.

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -19,16 +19,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
-const (
-	defaultWaitApprovalTimeout  = Duration(6 * time.Hour)
-	defaultAnalysisQueryTimeout = Duration(30 * time.Second)
-	allEventsSymbol             = "*"
-)
+const allEventsSymbol = "*"
 
 type GenericApplicationSpec struct {
 	// The application name.
@@ -265,18 +260,10 @@ func (s *PipelineStage) UnmarshalJSON(data []byte) error {
 		if len(gs.With) > 0 {
 			err = json.Unmarshal(gs.With, s.WaitApprovalStageOptions)
 		}
-		if s.WaitApprovalStageOptions.Timeout <= 0 {
-			s.WaitApprovalStageOptions.Timeout = defaultWaitApprovalTimeout
-		}
 	case model.StageAnalysis:
 		s.AnalysisStageOptions = &AnalysisStageOptions{}
 		if len(gs.With) > 0 {
 			err = json.Unmarshal(gs.With, s.AnalysisStageOptions)
-		}
-		for i := 0; i < len(s.AnalysisStageOptions.Metrics); i++ {
-			if s.AnalysisStageOptions.Metrics[i].Timeout <= 0 {
-				s.AnalysisStageOptions.Metrics[i].Timeout = defaultAnalysisQueryTimeout
-			}
 		}
 	case model.StageK8sPrimaryRollout:
 		s.K8sPrimaryRolloutStageOptions = &K8sPrimaryRolloutStageOptions{}
@@ -393,7 +380,7 @@ type WaitStageOptions struct {
 type WaitApprovalStageOptions struct {
 	// The maximum length of time to wait before giving up.
 	// Defaults to 6h.
-	Timeout        Duration `json:"timeout"`
+	Timeout        Duration `json:"timeout" default:"6h"`
 	Approvers      []string `json:"approvers"`
 	MinApproverNum int      `json:"minApproverNum" default:"1"`
 }

--- a/pkg/config/application_terraform_test.go
+++ b/pkg/config/application_terraform_test.go
@@ -142,9 +142,8 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 							{
 								Name: model.StageWaitApproval,
 								WaitApprovalStageOptions: &WaitApprovalStageOptions{
-									Approvers: []string{"foo", "bar"},
-									// Use defaultWaitApprovalTimeout on unset timeout value for WaitApprovalStage.
-									Timeout:        defaultWaitApprovalTimeout,
+									Approvers:      []string{"foo", "bar"},
+									Timeout:        Duration(6 * time.Hour),
 									MinApproverNum: 1,
 								},
 							},
@@ -196,7 +195,7 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 								Name: model.StageWaitApproval,
 								WaitApprovalStageOptions: &WaitApprovalStageOptions{
 									Approvers:      []string{"foo", "bar"},
-									Timeout:        defaultWaitApprovalTimeout,
+									Timeout:        Duration(6 * time.Hour),
 									MinApproverNum: 1,
 								},
 							},

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -516,3 +516,123 @@ func TestGenericPostSyncConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestGenericAnalysisConfiguration(t *testing.T) {
+	testcases := []struct {
+		fileName           string
+		expectedKind       Kind
+		expectedAPIVersion string
+		expectedSpec       interface{}
+		expectedError      error
+	}{
+		{
+			fileName:           "testdata/application/generic-analysis.yaml",
+			expectedKind:       KindKubernetesApp,
+			expectedAPIVersion: "pipecd.dev/v1beta1",
+			expectedSpec: &KubernetesApplicationSpec{
+				GenericApplicationSpec: GenericApplicationSpec{
+					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnOutOfSync: OnOutOfSync{
+							Disabled:  newBoolPointer(true),
+							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
+					},
+					Pipeline: &DeploymentPipeline{
+						Stages: []PipelineStage{
+							{
+								Name: model.StageAnalysis,
+								AnalysisStageOptions: &AnalysisStageOptions{
+									Duration: Duration(10 * time.Minute),
+									Metrics: []TemplatableAnalysisMetrics{
+										{
+											AnalysisMetrics: AnalysisMetrics{
+												Strategy:     AnalysisStrategyThreshold,
+												Provider:     "prometheus-dev",
+												Query:        "grpc_error_percentage",
+												Expected:     AnalysisExpected{Max: floatPointer(0.1)},
+												Interval:     Duration(1 * time.Minute),
+												Timeout:      Duration(30 * time.Second),
+												FailureLimit: 1,
+												Deviation:    AnalysisDeviationEither,
+											},
+										},
+										{
+											AnalysisMetrics: AnalysisMetrics{
+												Strategy:     AnalysisStrategyThreshold,
+												Provider:     "prometheus-dev",
+												Query:        "grpc_succeed_percentage",
+												Expected:     AnalysisExpected{Min: floatPointer(0.9)},
+												Interval:     Duration(1 * time.Minute),
+												Timeout:      Duration(30 * time.Second),
+												FailureLimit: 1,
+												Deviation:    AnalysisDeviationEither,
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: model.StageAnalysis,
+								AnalysisStageOptions: &AnalysisStageOptions{
+									Duration: Duration(10 * time.Minute),
+									Logs: []TemplatableAnalysisLog{
+										{
+											AnalysisLog: AnalysisLog{
+												Provider:     "stackdriver-dev",
+												Query:        "resource.labels.pod_id=\"pod1\"\n",
+												Interval:     Duration(1 * time.Minute),
+												FailureLimit: 3,
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: model.StageAnalysis,
+								AnalysisStageOptions: &AnalysisStageOptions{
+									Duration: Duration(10 * time.Minute),
+									Https: []TemplatableAnalysisHTTP{
+										{
+											AnalysisHTTP: AnalysisHTTP{
+												URL:          "https://canary-endpoint.dev",
+												Method:       "GET",
+												ExpectedCode: 200,
+												FailureLimit: 1,
+												Interval:     Duration(1 * time.Minute),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Input: KubernetesDeploymentInput{
+					AutoRollback: newBoolPointer(true),
+				},
+				VariantLabel: KubernetesVariantLabel{
+					Key:           "pipecd.dev/variant",
+					PrimaryValue:  "primary",
+					BaselineValue: "baseline",
+					CanaryValue:   "canary",
+				},
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.fileName, func(t *testing.T) {
+			cfg, err := LoadFromYAML(tc.fileName)
+			require.Equal(t, tc.expectedError, err)
+			if err == nil {
+				assert.Equal(t, tc.expectedKind, cfg.Kind)
+				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
+				assert.Equal(t, tc.expectedSpec, cfg.spec)
+			}
+		})
+	}
+}

--- a/pkg/config/testdata/application/generic-analysis.yaml
+++ b/pkg/config/testdata/application/generic-analysis.yaml
@@ -1,0 +1,39 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  pipeline:
+    stages:
+      - name: ANALYSIS
+        with:
+          duration: 10m
+          metrics:
+            - query: grpc_error_percentage
+              expected:
+                max: 0.1
+              interval: 1m
+              failureLimit: 1
+              provider: prometheus-dev
+            - query: grpc_succeed_percentage
+              expected:
+                min: 0.9
+              interval: 1m
+              failureLimit: 1
+              provider: prometheus-dev
+      - name: ANALYSIS
+        with:
+          duration: 10m
+          logs:
+            - query: |
+                resource.labels.pod_id="pod1"
+              interval: 1m
+              failureLimit: 3
+              provider: stackdriver-dev
+      - name: ANALYSIS
+        with:
+          duration: 10m
+          https:
+            - url: https://canary-endpoint.dev
+              method: GET
+              expectedCode: 200
+              failureLimit: 1
+              interval: 1m


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unnecessary default value setters from `GenericApplicationSpec` struct and use the `creasty/defaults` package to set the defaults instead.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
