### PR TITLE
Fix omissions in PipedName output in #4250

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -788,7 +788,7 @@ func (a *API) GetPlanPreviewResults(ctx context.Context, req *apiservice.GetPlan
 			return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("Command %s is not a plan preview command", commandID))
 		}
 
-		if _, isThere := pipedNameMap[cmd.PipedId]; !isThere {
+		if _, ok := pipedNameMap[cmd.PipedId]; !ok {
 			piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
 			if err != nil {
 				return nil, err

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -803,17 +803,7 @@ func (a *API) GetPlanPreviewResults(ctx context.Context, req *apiservice.GetPlan
 				pipedStatus = model.Piped_UNKNOWN
 			}
 
-			piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
-			if err != nil {
-				return nil, err
-			}
-
 			if pipedStatus != model.Piped_ONLINE {
-				piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
-				if err != nil {
-					return nil, err
-				}
-
 				results = append(results, &model.PlanPreviewCommandResult{
 					CommandId: cmd.Id,
 					PipedId:   cmd.PipedId,
@@ -825,11 +815,6 @@ func (a *API) GetPlanPreviewResults(ctx context.Context, req *apiservice.GetPlan
 
 			if time.Since(time.Unix(cmd.CreatedAt, 0)) <= commandHandleTimeout {
 				return nil, status.Error(codes.NotFound, fmt.Sprintf("Waiting for result of command %s from piped %s", commandID, cmd.PipedId))
-			}
-
-			piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
-			if err != nil {
-				return nil, err
 			}
 
 			results = append(results, &model.PlanPreviewCommandResult{

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -800,6 +800,11 @@ func (a *API) GetPlanPreviewResults(ctx context.Context, req *apiservice.GetPlan
 			}
 
 			if pipedStatus != model.Piped_ONLINE {
+				piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
+				if err != nil {
+					return nil, err
+				}
+
 				results = append(results, &model.PlanPreviewCommandResult{
 					CommandId: cmd.Id,
 					PipedId:   cmd.PipedId,
@@ -811,6 +816,11 @@ func (a *API) GetPlanPreviewResults(ctx context.Context, req *apiservice.GetPlan
 
 			if time.Since(time.Unix(cmd.CreatedAt, 0)) <= commandHandleTimeout {
 				return nil, status.Error(codes.NotFound, fmt.Sprintf("Waiting for result of command %s from piped %s", commandID, cmd.PipedId))
+			}
+
+			piped, err := getPiped(ctx, a.pipedStore, cmd.PipedId, a.logger)
+			if err != nil {
+				return nil, err
 			}
 
 			results = append(results, &model.PlanPreviewCommandResult{


### PR DESCRIPTION
**What this PR does / why we need it**:
In the previous implementation, PipedName was output only if ```!cmd.IsHandled()```, but has been modified to include PipedName in the result in any case.

**Which issue(s) this PR fixes**:

Fixes #4250

**Does this PR introduce a user-facing change?**:
The bug in #4250
```bash
❯ bash pipectl/plan-preview.sh --env local
Requested plan-preview, waiting for its results (commands: [a5cb784e-31b3-4253-a898-ce75e9a80438])
Waiting for result of command a5cb784e-31b3-4253-a898-ce75e9a80438 from piped 9c59cdce-a3e9-4b5f-9eb3-9d93e0fe09ca
waiting...

NOTE: An error occurred while building plan-preview for applications of the following Piped:

1. piped:  (9c59cdce-a3e9-4b5f-9eb3-9d93e0fe09ca)
  reason: detected conflicts between commit aaaaa at test branch and the base branch main (err: exit status 1, out: merge: aaaaa - not something we can merge
)
```
This PR's fix
```bash
❯ bash pipectl/plan-preview.sh --env local
Requested plan-preview, waiting for its results (commands: [5bde6951-9c86-4e68-aed7-a83ea39ec68c])
Waiting for result of command 5bde6951-9c86-4e68-aed7-a83ea39ec68c from piped 9c59cdce-a3e9-4b5f-9eb3-9d93e0fe09ca
waiting...

NOTE: An error occurred while building plan-preview for applications of the following Piped:

1. piped: local (9c59cdce-a3e9-4b5f-9eb3-9d93e0fe09ca)
  reason: detected conflicts between commit aaaaa at test branch and the base branch main (err: exit status 1, out: merge: aaaaa - not something we can merge
)
```
```release-note
NONE
```
