### PR TITLE
Delete application_piped_id index

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -29,7 +29,7 @@ CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, U
 ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX application_piped_id_updated_at_desc ON Application (PipedId, UpdatedAt DESC);
 
--- TODO: Should remove that statement after few releases.
+-- TODO: Should remove this statement after few releases.
 DROP INDEX application_piped_id ON Application;
 
 --

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -27,7 +27,8 @@ CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, U
 
 -- index on `PipedId` ASC
 ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
-CREATE INDEX application_piped_id ON Application (PipedId);
+-- TODO: Should remove that statement after few releases.
+DROP INDEX application_piped_id ON Application;
 
 -- index on `PipedId` ASC and `UpdatedAt` DESC
 CREATE INDEX application_piped_id_updated_at_desc ON Application (PipedId, UpdatedAt DESC);

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -25,13 +25,12 @@ CREATE INDEX application_sync_state_updated_at_desc ON Application (SyncState_St
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, UpdatedAt DESC);
 
--- index on `PipedId` ASC
+-- index on `PipedId` ASC and `UpdatedAt` DESC
 ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
+CREATE INDEX application_piped_id_updated_at_desc ON Application (PipedId, UpdatedAt DESC);
+
 -- TODO: Should remove that statement after few releases.
 DROP INDEX application_piped_id ON Application;
-
--- index on `PipedId` ASC and `UpdatedAt` DESC
-CREATE INDEX application_piped_id_updated_at_desc ON Application (PipedId, UpdatedAt DESC);
 
 --
 -- Command table indexes


### PR DESCRIPTION
because application_piped_id_updated_at_desc index covers the index.

**What this PR does / why we need it**:
The application_piped_id_updated_at_desc index covers the index.

Also, `DROP INDEX` statement should be remove after few releases.

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
### Reference
**Before delete application_piped_id index**
```
mysql> EXPLAIN SELECT Data FROM Application WHERE PipedId = "c360ac00-4b59-47b7-803c-f6fa56c8bebf";
+----+-------------+-------------+------------+------+-----------------------------------------------------------+----------------------+---------+-------+------+----------+-------+
| id | select_type | table       | partitions | type | possible_keys                                             | key                  | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------------+------------+------+-----------------------------------------------------------+----------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | Application | NULL       | ref  | application_piped_id,application_piped_id_updated_at_desc | application_piped_id | 146     | const |    1 |   100.00 | NULL  |
+----+-------------+-------------+------------+------+-----------------------------------------------------------+----------------------+---------+-------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)**Which issue(s) this PR fixes**:
```
```mysql> EXPLAIN SELECT Data FROM Application WHERE PipedId = "c360ac00-4b59-47b7-803c-f6fa56c8bebf" ORDER BY UpdatedAt DESC;
+----+-------------+-------------+------------+------+-----------------------------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
| id | select_type | table       | partitions | type | possible_keys                                             | key                                  | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------------+------------+------+-----------------------------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | Application | NULL       | ref  | application_piped_id,application_piped_id_updated_at_desc | application_piped_id_updated_at_desc | 146     | const |    1 |   100.00 | NULL  |
+----+-------------+-------------+------------+------+-----------------------------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
1 row in set, 1 warning (0.00 sec)
```

**After delete application_piped_id index**
```mysql> EXPLAIN SELECT Data FROM Application WHERE PipedId = "c360ac00-4b59-47b7-803c-f6fa56c8bebf";
+----+-------------+-------------+------------+------+--------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
| id | select_type | table       | partitions | type | possible_keys                        | key                                  | key_len | ref   | rows | filtered | Extra |
+----+-------------+-------------+------------+------+--------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
|  1 | SIMPLE      | Application | NULL       | ref  | application_piped_id_updated_at_desc | application_piped_id_updated_at_desc | 146     | const |    1 |   100.00 | NULL  |
+----+-------------+-------------+------------+------+--------------------------------------+--------------------------------------+---------+-------+------+----------+-------+
1 row in set, 1 warning (0.01 sec)
```