### PR TITLE
Fix a problem where the piped id was not displayed in the piped filter field

### DIFF
--- a/web/src/components/applications-page/application-filter/index.tsx
+++ b/web/src/components/applications-page/application-filter/index.tsx
@@ -90,7 +90,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
         <FormControl className={classes.formItem} variant="outlined">
           <InputLabel id="filter-piped">Piped</InputLabel>
           <PipedSelect
-            defaultPipedId={options.pipedId ? options.pipedId : ""}
+            value={options.pipedId ?? null}
             onChange={(value) => handleUpdateFilterValue({ pipedId: value })}
           />
         </FormControl>

--- a/web/src/components/applications-page/application-filter/index.tsx
+++ b/web/src/components/applications-page/application-filter/index.tsx
@@ -90,6 +90,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
         <FormControl className={classes.formItem} variant="outlined">
           <InputLabel id="filter-piped">Piped</InputLabel>
           <PipedSelect
+            pipedId={options.pipedId ? options.pipedId : ""}
             onChange={(value) => handleUpdateFilterValue({ pipedId: value })}
           />
         </FormControl>

--- a/web/src/components/applications-page/application-filter/index.tsx
+++ b/web/src/components/applications-page/application-filter/index.tsx
@@ -90,7 +90,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
         <FormControl className={classes.formItem} variant="outlined">
           <InputLabel id="filter-piped">Piped</InputLabel>
           <PipedSelect
-            pipedId={options.pipedId ? options.pipedId : ""}
+            defaultPipedId={options.pipedId ? options.pipedId : ""}
             onChange={(value) => handleUpdateFilterValue({ pipedId: value })}
           />
         </FormControl>

--- a/web/src/components/applications-page/application-filter/piped-select.tsx
+++ b/web/src/components/applications-page/application-filter/piped-select.tsx
@@ -7,6 +7,7 @@ import { selectAllPipeds } from "~/modules/pipeds";
 import clsx from "clsx";
 
 interface Props {
+  pipedId: string;
   onChange: (value: string) => void;
 }
 
@@ -23,7 +24,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export const PipedSelect: FC<Props> = ({ onChange }) => {
+export const PipedSelect: FC<Props> = ({ pipedId, onChange }) => {
   const classes = useStyles();
 
   const ps = useAppSelector((state) => selectAllPipeds(state));
@@ -40,7 +41,7 @@ export const PipedSelect: FC<Props> = ({ onChange }) => {
       id="filter-piped"
       className={classes.root}
       label="Piped"
-      value={selectedPipedId}
+      value={selectedPipedId ? selectedPipedId : pipedId}
       onChange={(e) => {
         setSelectedPipedId(e.target.value as string);
         onChange(e.target.value as string);

--- a/web/src/components/applications-page/application-filter/piped-select.tsx
+++ b/web/src/components/applications-page/application-filter/piped-select.tsx
@@ -1,13 +1,13 @@
 import { makeStyles } from "@material-ui/styles";
 import { Select, MenuItem, IconButton } from "@material-ui/core";
 import ClearIcon from "@material-ui/icons/Clear";
-import { FC, useState } from "react";
+import { FC } from "react";
 import { useAppSelector } from "~/hooks/redux";
 import { selectAllPipeds } from "~/modules/pipeds";
 import clsx from "clsx";
 
 interface Props {
-  defaultPipedId: string;
+  value: string | null;
   onChange: (value: string) => void;
 }
 
@@ -24,16 +24,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export const PipedSelect: FC<Props> = ({ defaultPipedId, onChange }) => {
+export const PipedSelect: FC<Props> = ({ value, onChange }) => {
   const classes = useStyles();
 
   const ps = useAppSelector((state) => selectAllPipeds(state));
   const pipeds = ps
     .filter((piped) => !piped.disabled)
     .sort((a, b) => sortComp(a.name, b.name));
-  const [selectedPipedId, setSelectedPipedId] = useState(
-    pipeds.length === 1 ? pipeds[0].id : ""
-  );
 
   return (
     <Select
@@ -41,19 +38,17 @@ export const PipedSelect: FC<Props> = ({ defaultPipedId, onChange }) => {
       id="filter-piped"
       className={classes.root}
       label="Piped"
-      value={selectedPipedId ? selectedPipedId : defaultPipedId}
+      value={value}
       onChange={(e) => {
-        setSelectedPipedId(e.target.value as string);
         onChange(e.target.value as string);
       }}
       endAdornment={
         <IconButton
           className={clsx(classes.clearIndicator, {
-            [classes.clearIndicatorDirty]: setSelectedPipedId.length > 0,
+            [classes.clearIndicatorDirty]: value && value.length > 0,
           })}
           size="small"
           onClick={() => {
-            setSelectedPipedId("");
             onChange("");
           }}
         >

--- a/web/src/components/applications-page/application-filter/piped-select.tsx
+++ b/web/src/components/applications-page/application-filter/piped-select.tsx
@@ -7,7 +7,7 @@ import { selectAllPipeds } from "~/modules/pipeds";
 import clsx from "clsx";
 
 interface Props {
-  pipedId: string;
+  defaultPipedId: string;
   onChange: (value: string) => void;
 }
 
@@ -24,7 +24,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export const PipedSelect: FC<Props> = ({ pipedId, onChange }) => {
+export const PipedSelect: FC<Props> = ({ defaultPipedId, onChange }) => {
   const classes = useStyles();
 
   const ps = useAppSelector((state) => selectAllPipeds(state));
@@ -41,7 +41,7 @@ export const PipedSelect: FC<Props> = ({ pipedId, onChange }) => {
       id="filter-piped"
       className={classes.root}
       label="Piped"
-      value={selectedPipedId ? selectedPipedId : pipedId}
+      value={selectedPipedId ? selectedPipedId : defaultPipedId}
       onChange={(e) => {
         setSelectedPipedId(e.target.value as string);
         onChange(e.target.value as string);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed an issue where the piped id was not displayed in the piped filter field after page transitions.

**Which issue(s) this PR fixes**:

Fixes #4244 

**Does this PR introduce a user-facing change?**:
**Before** 

https://user-images.githubusercontent.com/60760935/225868100-2dd2c8a8-bb4a-403e-9f44-bd4131299d0e.mov

**After**

https://user-images.githubusercontent.com/60760935/225868956-7a78cb04-b64a-417e-a5c3-ff3ebc94eaea.mov

```release-note

NONE
```
