### PR TITLE
Fix to unable to plan deployment if failed to load manifest files

### DIFF
--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -82,11 +82,12 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	if !ok {
 		// When the manifests were not in the cache we have to load them.
 		loader := provider.NewLoader(in.ApplicationName, ds.AppDir, ds.RepoDir, in.GitPath.ConfigFilename, cfg.Input, in.GitClient, in.Logger)
-		newManifests, err = loader.LoadManifests(ctx)
-		if err != nil {
-			return
+		newManifests, e := loader.LoadManifests(ctx)
+		if e != nil {
+			in.Logger.Error("unable to load manifests", zap.Error(e))
+		} else {
+			manifestCache.Put(in.Trigger.Commit.Hash, newManifests)
 		}
-		manifestCache.Put(in.Trigger.Commit.Hash, newManifests)
 	}
 
 	// Determine application version from the manifests.

--- a/pkg/app/piped/planner/terraform/terraform.go
+++ b/pkg/app/piped/planner/terraform/terraform.go
@@ -76,9 +76,9 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	now := time.Now()
 	out.Version = "N/A"
 
-	files, err := provider.LoadTerraformFiles(ds.AppDir)
-	if err != nil {
-		return
+	files, e := provider.LoadTerraformFiles(ds.AppDir)
+	if e != nil {
+		in.Logger.Warn("unable to load terraform files", zap.Error(e))
 	}
 
 	if versions, e := provider.FindArtifactVersions(files); e != nil || len(versions) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/pipe-cd/pipecd/pull/4234 fixed to enable  to plan deployment if determineVersion fails, but terraform and kubernetes even fails if loadManifest fails.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
