### PR TITLE
Fix docs Piped Cloud Run service manifest

### DIFF
--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
@@ -86,14 +86,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
@@ -128,14 +129,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1.

--- a/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-cloudrun.md
@@ -86,14 +86,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
@@ -128,14 +129,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1.

--- a/docs/content/en/docs/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs/installation/install-piped/installing-on-cloudrun.md
@@ -86,14 +86,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
@@ -128,14 +129,15 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: piped
+  annotaions:
+    run.googleapis.com/ingress: internal
+    run.googleapis.com/ingress-status: internal
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'           # This must be 1.
         autoscaling.knative.dev/minScale: '1'           # This must be 1.
-        run.googleapis.com/ingress: internal
-        run.googleapis.com/ingress-status: internal
         run.googleapis.com/cpu-throttling: "false"      # This is required.
     spec:
       containerConcurrency: 1                           # This must be 1.


### PR DESCRIPTION
**What this PR does / why we need it**:

Move `run.googleapis.com/ingress` and `run.googleapis.com/ingress-status` to the correct location.
ref. https://cloud.google.com/run/docs/reference/yaml/v1

`run.googleapis.com/ingress-status` is an output-only annotation.
It may not be necessary.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
