### PR TITLE
Document to ignore drift detection

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -60,6 +60,12 @@ You can change the checking interval as well as [configure the notification](../
 
 You can also ignore drift detection for specified fields in your application manifests. In other words, even if the selected fields have different values between live state and Git, the application status will not be set to `Out of Sync`.
 
+##### Input format
+```yaml
+driftDetection:
+  ignoreFields:
+    - apiVersion:kind:namespace:name#path
+```
 
 For example, suppose you have the application's manifest as below 
 ```yaml
@@ -86,11 +92,12 @@ If you want to ignore the drift detection for the two sceans
 Add the following statements to `app.pipecd.yaml` to ignore diff on those fields.
 ```yaml
 spec:
+  name: simple
   ...
   driftDetection:
     ignoreFields:
-      - spec.replicas
-      - spec.template.spec.containers.0.args
+      - apps/v1:Deployment:default:simple#spec.replicas
+      - apps/v1:Deployment:default:simple#spec.template.spec.containers.0.args
 ```
 For more information, see the [configuration reference](../../configuration-reference/#driftdetection).
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -60,13 +60,6 @@ You can change the checking interval as well as [configure the notification](../
 
 You can also ignore drift detection for specified fields in your application manifests. In other words, even if the selected fields have different values between live state and Git, the application status will not be set to `Out of Sync`.
 
-##### Input format
-```yaml
-driftDetection:
-  ignoreFields:
-    - apiVersion:kind:namespace:name#path
-```
-
 For example, suppose you have the application's manifest as below 
 ```yaml
 apiVersion: apps/v1
@@ -101,3 +94,4 @@ spec:
 ```
 For more information, see the [configuration reference](../../configuration-reference/#driftdetection).
 
+The `ignoreFields` is in format `apiVersion:kind:namespace:name#yamlFieldPath`

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -61,6 +61,7 @@ You can change the checking interval as well as [configure the notification](../
 You can also ignore drift detection for specified fields in your application manifests. In other words, even if the selected fields have different values between live state and Git, the application status will not be set to `Out of Sync`.
 
 For example, suppose you have the application's manifest as below 
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -83,6 +84,7 @@ If you want to ignore the drift detection for the two sceans
 - `helloworld` container's args
 
 Add the following statements to `app.pipecd.yaml` to ignore diff on those fields.
+
 ```yaml
 spec:
   name: simple
@@ -92,6 +94,7 @@ spec:
       - apps/v1:Deployment:default:simple#spec.replicas
       - apps/v1:Deployment:default:simple#spec.template.spec.containers.0.args
 ```
-For more information, see the [configuration reference](../../configuration-reference/#driftdetection).
 
-The `ignoreFields` is in format `apiVersion:kind:namespace:name#yamlFieldPath`
+Note: The `ignoreFields` is in format `apiVersion:kind:namespace:name#yamlFieldPath`
+
+For more information, see the [configuration reference](../../configuration-reference/#driftdetection).


### PR DESCRIPTION
**What this PR does / why we need it**:
The specification which ignore drift detection is changed by #4192   So, I change the document for the feature which ignore drift detection.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
