### PR TITLE
Fix error handling in to parse ignoreFields

### DIFF
--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -199,7 +199,8 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 			// ignoreField is 'apiVersion:kind:namespace:name#fieldPath'
 			splited := strings.Split(ignoreField, "#")
 			if len(splited) != 2 {
-				return fmt.Errorf("It should be entered in the form of 'apiVersion:kind:namespace:name#fieldPath'")
+				d.logger.Error("It should be entered in the form of 'apiVersion:kind:namespace:name#fieldPath'")
+				continue
 			}
 			key, ignoredPath := splited[0], splited[1]
 			ignoreConfig[key] = append(ignoreConfig[key], ignoredPath)

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -198,10 +198,6 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		for _, ignoreField := range ddCfg.IgnoreFields {
 			// ignoreField is 'apiVersion:kind:namespace:name#fieldPath'
 			splited := strings.Split(ignoreField, "#")
-			if len(splited) != 2 {
-				d.logger.Error("It should be entered in the form of 'apiVersion:kind:namespace:name#fieldPath'")
-				continue
-			}
 			key, ignoredPath := splited[0], splited[1]
 			ignoreConfig[key] = append(ignoreConfig[key], ignoredPath)
 		}

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -647,6 +648,16 @@ func (c *DeploymentChainTriggerCondition) Validate() error {
 type DriftDetection struct {
 	// IgnoreFields are a list of 'apiVersion:kind:namespace:name#fieldPath'
 	IgnoreFields []string `json:"ignoreFields"`
+}
+
+func (d *DriftDetection) Validate() error {
+	for _, ignoreField := range d.IgnoreFields {
+		splited := strings.Split(ignoreField, "#")
+		if len(splited) != 2 {
+			return fmt.Errorf("It should be entered in the form of 'apiVersion:kind:namespace:name#fieldPath'")
+		}
+	}
+	return nil
 }
 
 func LoadApplication(repoPath, configRelPath string, appKind model.ApplicationKind) (*GenericApplicationSpec, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since it is returning when the input is not in key#path, it seems that drift detection is only working when the input is correct.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
