### PR TITLE
Fix console error on web

### DIFF
--- a/web/src/components/applications-page/application-filter/index.tsx
+++ b/web/src/components/applications-page/application-filter/index.tsx
@@ -90,7 +90,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
         <FormControl className={classes.formItem} variant="outlined">
           <InputLabel id="filter-piped">Piped</InputLabel>
           <PipedSelect
-            value={options.pipedId ?? null}
+            value={options.pipedId ?? ""}
             onChange={(value) => handleUpdateFilterValue({ pipedId: value })}
           />
         </FormControl>

--- a/web/src/components/applications-page/application-filter/piped-select.tsx
+++ b/web/src/components/applications-page/application-filter/piped-select.tsx
@@ -7,7 +7,7 @@ import { selectAllPipeds } from "~/modules/pipeds";
 import clsx from "clsx";
 
 interface Props {
-  value: string | null;
+  value: string;
   onChange: (value: string) => void;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspend this error from web console
```
  ● Console

    console.error
      Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
          at input
          at SelectInput (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/Select/SelectInput.js:59:24)
          at div
          at InputBase (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/InputBase/InputBase.js:219:30)
          at WithStyles (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at OutlinedInput (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/OutlinedInput/OutlinedInput.js:137:23)
          at WithStyles (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at Select (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/Select/Select.js:50:32)
          at WithStyles (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at PipedSelect (/workspace/pipecd/pipecd/web/src/components/applications-page/application-filter/piped-select.tsx:851:3)
          at div
          at FormControl (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/FormControl/FormControl.js:90:24)
          at WithStyles (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at div
          at Paper (/workspace/pipecd/pipecd/web/node_modules/@material-ui/core/Paper/Paper.js:55:23)
          at WithStyles (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
          at FilterView (/workspace/pipecd/pipecd/web/src/components/filter-view/index.tsx:1244:3)
          at ApplicationFilter (/workspace/pipecd/pipecd/web/src/components/applications-page/application-filter/index.tsx:1933:3)
          at ThemeProvider (/workspace/pipecd/pipecd/web/node_modules/@material-ui/styles/ThemeProvider/ThemeProvider.js:48:24)
          at Provider (/workspace/pipecd/pipecd/web/node_modules/react-redux/lib/components/Provider.js:21:20)
          at Wrapper (/workspace/pipecd/pipecd/web/test-utils/index.tsx:1389:5)
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
