### PR TITLE
Change application invalid config detail UI

### DIFF
--- a/web/src/components/application-detail-page/application-detail/sync-state-reason/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/sync-state-reason/index.tsx
@@ -76,7 +76,7 @@ export const InvalidConfigReason: FC<SyncStateReasonProps> = ({ detail }) => {
   const [showReason, setShowReason] = useState(false);
 
   const msgHeader = "Failed to load aplication config: ";
-  const MAX_DISPLAY_LENGTH = 70;
+  const MAX_DISPLAY_LENGTH = 200;
   if (detail.length < MAX_DISPLAY_LENGTH) {
     return (
       <>

--- a/web/src/components/application-detail-page/application-detail/sync-state-reason/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/sync-state-reason/index.tsx
@@ -21,6 +21,11 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
   },
+  showText: {
+    color: theme.palette.grey[500],
+    marginLeft: theme.spacing(0.5),
+    cursor: "pointer",
+  },
 }));
 
 export interface SyncStateReasonProps {
@@ -100,14 +105,12 @@ export const InvalidConfigReason: FC<SyncStateReasonProps> = ({ detail }) => {
           </Typography>
         )}
         {detail && (
-          <Button
-            variant="text"
-            size="small"
-            className={classes.showButton}
+          <span
+            className={classes.showText}
             onClick={() => setShowReason(!showReason)}
           >
-            {showReason ? "HIDE" : "MORE"}
-          </Button>
+            {showReason ? "show less" : "show more"}
+          </span>
         )}
       </div>
     </>


### PR DESCRIPTION
**What this PR does / why we need it**:

Change application invalid config detail UI from using button to using end text

Before

https://user-images.githubusercontent.com/32532742/228563611-0be70d30-f407-4e05-b863-d81ccc807ab4.mp4

After

https://user-images.githubusercontent.com/32532742/228563651-ab0f0f06-72e1-4193-ab1b-ed1f4851c705.mp4


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
