### PR TITLE
Update example in drift detection docs

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -87,7 +87,6 @@ Add the following statements to `app.pipecd.yaml` to ignore diff on those fields
 
 ```yaml
 spec:
-  name: simple
   ...
   driftDetection:
     ignoreFields:

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
@@ -87,7 +87,6 @@ Add the following statements to `app.pipecd.yaml` to ignore diff on those fields
 
 ```yaml
 spec:
-  name: simple
   ...
   driftDetection:
     ignoreFields:

--- a/docs/content/en/docs/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs/user-guide/managing-application/configuration-drift-detection.md
@@ -87,7 +87,6 @@ Add the following statements to `app.pipecd.yaml` to ignore diff on those fields
 
 ```yaml
 spec:
-  name: simple
   ...
   driftDetection:
     ignoreFields:


### PR DESCRIPTION
**What this PR does / why we need it**:

Users get confused easily with this unneeded note, so we should remove it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
