### PR TITLE
feat(piped): add EnableExecuteCommand field to ECS service

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -82,6 +82,7 @@ func (c *client) CreateService(ctx context.Context, service types.Service) (*typ
 		DeploymentController:          service.DeploymentController,
 		DeploymentConfiguration:       service.DeploymentConfiguration,
 		EnableECSManagedTags:          service.EnableECSManagedTags,
+		EnableExecuteCommand:          service.EnableExecuteCommand,
 		HealthCheckGracePeriodSeconds: service.HealthCheckGracePeriodSeconds,
 		PlacementConstraints:          service.PlacementConstraints,
 		PlacementStrategy:             service.PlacementStrategy,

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -109,10 +109,11 @@ func (c *client) CreateService(ctx context.Context, service types.Service) (*typ
 
 func (c *client) UpdateService(ctx context.Context, service types.Service) (*types.Service, error) {
 	input := &ecs.UpdateServiceInput{
-		Cluster:           service.ClusterArn,
-		Service:           service.ServiceName,
-		DesiredCount:      aws.Int32(service.DesiredCount),
-		PlacementStrategy: service.PlacementStrategy,
+		Cluster:              service.ClusterArn,
+		Service:              service.ServiceName,
+		DesiredCount:         aws.Int32(service.DesiredCount),
+		EnableExecuteCommand: aws.Bool(service.EnableExecuteCommand),
+		PlacementStrategy:    service.PlacementStrategy,
 		// TODO: Support update other properties of service.
 		// PlacementConstraints:    service.PlacementConstraints,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I want to enable ecs exec for service.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
