### PR TITLE
modify sso login description from GitHub Enterprise to GitHub Enterprise Server

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -112,7 +112,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | Triggering a deployment manually from console | Beta |
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
-| GitHub & GitHub Enterprise SSO | Beta |
+| GitHub & GitHub Enterprise Server SSO | Beta |
 | Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,7 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.43.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.43.x/feature-status/_index.md
@@ -112,7 +112,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | Triggering a deployment manually from console | Beta |
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
-| GitHub & GitHub Enterprise SSO | Beta |
+| GitHub & GitHub Enterprise Server SSO | Beta |
 | Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,7 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs/feature-status/_index.md
+++ b/docs/content/en/docs/feature-status/_index.md
@@ -112,7 +112,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | Triggering a deployment manually from console | Beta |
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
-| GitHub & GitHub Enterprise SSO | Beta |
+| GitHub & GitHub Enterprise Server SSO | Beta |
 | Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |

--- a/docs/content/en/docs/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,7 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/web/src/constants/text.ts
+++ b/web/src/constants/text.ts
@@ -1,3 +1,3 @@
 export const STATIC_ADMIN_DESCRIPTION = `An admin account that was automatically generated while initializing the project. This admin account can be logged in by using the provided or configured username and password.`;
-export const SSO_DESCRIPTION = `Single sign-on (SSO) allows to user to log in to PipeCD by relying on a trusted third party service such as GitHub, GitHub Enterprise, Google Gmail, BitBucket...`;
+export const SSO_DESCRIPTION = `Single sign-on (SSO) allows to user to log in to PipeCD by relying on a trusted third party service such as GitHub, GitHub Enterprise Server, Google Gmail, BitBucket...`;
 export const RBAC_DESCRIPTION = `Role-based access control (RBAC) allows restricting the access on PipeCD web based on the roles of user groups within the project. Before using this feature, the SSO must be configured.`;


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify SSO Login message from `GitHub Enterprise` to `GitHub Enterprise Server`.
Because GitHub has `GitHub Enterprise Server` and `GitHub Enterprise Cloud` for enterprise customers.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:

```release-note
Improve SSO login description
```
