### PR TITLE
update: support architectures filed for lambda

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -119,6 +119,13 @@ func (c *client) CreateFunction(ctx context.Context, fm FunctionManifest) error 
 			Variables: fm.Spec.Environments,
 		},
 	}
+	if len(fm.Spec.Architectures) != 0 {
+		var architectures []types.Architecture
+		for _, arch := range fm.Spec.Architectures {
+			architectures = append(architectures, types.Architecture(arch.Name))
+		}
+		input.Architectures = architectures
+	}
 	// Container image packing.
 	if fm.Spec.ImageURI != "" {
 		input.PackageType = types.PackageTypeImage
@@ -189,6 +196,13 @@ func (c *client) UpdateFunction(ctx context.Context, fm FunctionManifest) error 
 		codeInput.S3Key = aws.String(fm.Spec.S3Key)
 		codeInput.S3ObjectVersion = aws.String(fm.Spec.S3ObjectVersion)
 	}
+	if len(fm.Spec.Architectures) != 0 {
+		var architectures []types.Architecture
+		for _, arch := range fm.Spec.Architectures {
+			architectures = append(architectures, types.Architecture(arch.Name))
+		}
+		codeInput.Architectures = architectures
+	}
 	_, err := c.client.UpdateFunctionCode(ctx, codeInput)
 	if err != nil {
 		return fmt.Errorf("failed to update function code for Lambda function %s: %w", fm.Spec.Name, err)
@@ -213,6 +227,13 @@ func (c *client) UpdateFunctionFromSource(ctx context.Context, fm FunctionManife
 	codeInput := &lambda.UpdateFunctionCodeInput{
 		FunctionName: aws.String(fm.Spec.Name),
 		ZipFile:      data,
+	}
+	if len(fm.Spec.Architectures) != 0 {
+		var architectures []types.Architecture
+		for _, arch := range fm.Spec.Architectures {
+			architectures = append(architectures, types.Architecture(arch.Name))
+		}
+		codeInput.Architectures = architectures
 	}
 	_, err = c.client.UpdateFunctionCode(ctx, codeInput)
 	if err != nil {

--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -64,6 +64,7 @@ type FunctionManifestSpec struct {
 	S3ObjectVersion string            `json:"s3ObjectVersion"`
 	SourceCode      SourceCode        `json:"source"`
 	Handler         string            `json:"handler"`
+	Architectures   []Architecture    `json:"architectures,omitempty"`
 	Runtime         string            `json:"runtime"`
 	Memory          int32             `json:"memory"`
 	Timeout         int32             `json:"timeout"`
@@ -86,6 +87,11 @@ func (fmp FunctionManifestSpec) validate() error {
 		}
 		if fmp.Runtime == "" {
 			return fmt.Errorf("runtime is missing")
+		}
+	}
+	for _, arch := range fmp.Architectures {
+		if err := arch.validate(); err != nil {
+			return fmt.Errorf("architecture is invalid: %w", err)
 		}
 	}
 	if fmp.Role == "" {
@@ -112,6 +118,17 @@ func (sc SourceCode) validate() error {
 	}
 	if sc.Ref == "" {
 		return fmt.Errorf("source ref is missing")
+	}
+	return nil
+}
+
+type Architecture struct {
+	Name string `json:"name"`
+}
+
+func (a Architecture) validate() error {
+	if a.Name != "x86_64" && a.Name != "arm64" {
+		return fmt.Errorf("architecture is invalid")
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

lambda supports X86_64 and Arm64. So I update the logic to allow to specify architectures.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
