### PR TITLE
Add deployment metrics

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/piped/appconfigreporter"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/chartrepo"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/controller"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/controller/controllermetrics"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/livestatereporter"
@@ -817,6 +818,7 @@ func registerMetrics(pipedID, projectID, launcherVersion string) *prometheus.Reg
 	k8scloudprovidermetrics.Register(wrapped)
 	k8slivestatestoremetrics.Register(wrapped)
 	planpreviewmetrics.Register(wrapped)
+	controllermetrics.Register(wrapped)
 
 	return r
 }

--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/pipe-cd/pipecd/pkg/app/piped/controller/controllermetrics"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/logpersister"
 	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/kubernetes"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
@@ -341,6 +342,9 @@ func (c *controller) syncPlanners(ctx context.Context) error {
 			)
 			continue
 		}
+
+		controllermetrics.UpdateDeploymentStatus(d.Id, d.Status, d.Kind, d.PlatformProvider)
+
 		// For each application, only one deployment can be planned at the same time.
 		if p, ok := c.planners[appID]; ok {
 			c.logger.Info("temporarily skip planning because another deployment is planning",

--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -342,9 +342,6 @@ func (c *controller) syncPlanners(ctx context.Context) error {
 			)
 			continue
 		}
-
-		controllermetrics.UpdateDeploymentStatus(d.Id, d.Status, d.Kind, d.PlatformProvider)
-
 		// For each application, only one deployment can be planned at the same time.
 		if p, ok := c.planners[appID]; ok {
 			c.logger.Info("temporarily skip planning because another deployment is planning",
@@ -367,6 +364,7 @@ func (c *controller) syncPlanners(ctx context.Context) error {
 		if pre, ok := pendingByApp[appID]; ok && !d.TriggerBefore(pre) {
 			continue
 		}
+		controllermetrics.UpdateDeploymentStatus(d.Id, d.Status, d.Kind, d.PlatformProvider)
 		pendingByApp[appID] = d
 	}
 

--- a/pkg/app/piped/controller/controllermetrics/metrics.go
+++ b/pkg/app/piped/controller/controllermetrics/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllermetrics
+
+import (
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	deploymentIDKey     = "deployment"
+	applicationKindKey  = "application_kind"
+	platformProviderKey = "platform_provider"
+	deploymentStatusKey = "status"
+)
+
+var (
+	deploymentStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "deployment_status",
+			Help: "The current status of deployment. 1 for current status, 0 for others.",
+		},
+		[]string{deploymentIDKey, applicationKindKey, platformProviderKey, deploymentStatusKey},
+	)
+)
+
+func UpdateDeploymentStatus(id string, status model.DeploymentStatus, applicationKind model.ApplicationKind, platformProvider string) {
+	for name, value := range model.DeploymentStatus_value {
+		if model.DeploymentStatus(value) == status {
+			deploymentStatus.WithLabelValues(id, applicationKind.String(), platformProvider, name).Set(1)
+		} else {
+			deploymentStatus.WithLabelValues(id, applicationKind.String(), platformProvider, name).Set(0)
+		}
+	}
+}
+
+func Register(r prometheus.Registerer) {
+	r.MustRegister(
+		deploymentStatus,
+	)
+}

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/pipe-cd/pipecd/pkg/app/piped/controller/controllermetrics"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/deploysource"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/executor/registry"
@@ -192,6 +193,7 @@ func (s *scheduler) Run(ctx context.Context) error {
 	defer func() {
 		s.doneTimestamp = s.nowFunc()
 		s.doneDeploymentStatus = deploymentStatus
+		controllermetrics.UpdateDeploymentStatus(s.deployment.Id, deploymentStatus, s.deployment.Kind, s.deployment.PlatformProvider)
 		s.done.Store(true)
 	}()
 
@@ -207,6 +209,7 @@ func (s *scheduler) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		controllermetrics.UpdateDeploymentStatus(s.deployment.Id, model.DeploymentStatus_DEPLOYMENT_RUNNING, s.deployment.Kind, s.deployment.PlatformProvider)
 	}
 
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds deployment metrics.

**Which issue(s) this PR fixes**:

Fixes #4337

For Prometheus, the following PromQL queries can be executed.
```
// How many deployments
count(count by (deployment) (deployment_status))

// How many deployments are running
count(count by (deployment) (deployment_status{status="DEPLOYMENT_RUNNING"}))

// How to detect long-running deployments
sum_over_time(deployment_status{status="DEPLOYMENT_RUNNING"}[1h:1m]) >= 60 and deployment_status{status="DEPLOYMENT_RUNNING"} == 1
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
