### PR TITLE
Platform provider deployment detail page

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -166,7 +166,11 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                       </Link>
                     }
                   />
-                  <DetailTableRow label="Piped" value={piped.name + " (provider:" + " " + deployment.platformProvider + ")" } />
+                  <DetailTableRow label="Piped" value={piped.name} />
+                  <DetailTableRow
+                    label="Platform Provider"
+                    value={deployment.platformProvider}
+                  />
                   <DetailTableRow label="Summary" value={deployment.summary} />
                 </tbody>
               </table>

--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -166,7 +166,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                       </Link>
                     }
                   />
-                  <DetailTableRow label="Piped" value={piped.name} />
+                  <DetailTableRow label="Piped" value={piped.name + " (provider:" + " " + deployment.platformProvider + ")" } />
                   <DetailTableRow label="Summary" value={deployment.summary} />
                 </tbody>
               </table>
@@ -208,12 +208,6 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                       deployment.trigger?.commander ||
                       deployment.trigger?.commit?.author ||
                       ""
-                    }
-                  />
-                  <DetailTableRow
-                    label="Platform Provider"
-                    value={
-                      deployment.platformProvider
                     }
                   />
                 </tbody>

--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -210,6 +210,12 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                       ""
                     }
                   />
+                  <DetailTableRow
+                    label="Platform Provider"
+                    value={
+                      deployment.platformProvider
+                    }
+                  />
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Display Platform Provider in Deployment detail page

<img width="1440" alt="image" src="https://github.com/pipe-cd/pipecd/assets/40441000/62299ce8-5142-4d8d-a662-b2796ab020a5">

**Which issue(s) this PR fixes**:

Fixes #3418 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
