### PR TITLE
Update go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
   NODE_VERSION: 16.13.0
   HELM_VERSION: 3.8.2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
   NODE_VERSION: 16.13.0
   GOLANGCI_LINT_VERSION: v1.46.2
 

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
 
 jobs:
   gh_release:

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -11,7 +11,7 @@ env:
   GHCR: ghcr.io
   GCR: gcr.io
   HELM_VERSION: 3.8.2
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -13,7 +13,7 @@ on:
       - tool/**
 
 env:
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.20.5
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/docs/content/en/docs-dev/contribution-guidelines/development.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/development.md
@@ -8,7 +8,7 @@ description: >
 
 ## Prerequisites
 
-- [Go 1.19](https://go.dev/)
+- [Go 1.20](https://go.dev/)
 - [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/common v0.26.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/slack-go/slack v0.12.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
@@ -158,7 +159,6 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/slack-go/slack v0.12.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/goccy/go-yaml v1.9.8 h1:5gMyLUeU1/6zl+WFfR1hN7D2kf+1/eRGa7DFtToiBvQ=
 github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=

--- a/tool/actions-gh-release/Dockerfile
+++ b/tool/actions-gh-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.15
+FROM golang:1.20.5-alpine3.18
 
 RUN apk update && apk add git
 

--- a/tool/actions-plan-preview/Dockerfile
+++ b/tool/actions-plan-preview/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.19.3-alpine3.15 as builder
+FROM golang:1.20.5-alpine3.18 as builder
 WORKDIR /app
 COPY go.mod go.sum  ./
 RUN go mod download
 COPY . ./
 RUN go build -o /plan-preview .
 
-FROM gcr.io/pipecd/pipectl:v0.26.0
+FROM ghcr.io/pipe-cd/pipectl:v0.43.1
 COPY --from=builder /plan-preview /
 ENV PATH $PATH:/app/cmd/pipectl
 RUN chmod +x /plan-preview

--- a/tool/codegen/Dockerfile
+++ b/tool/codegen/Dockerfile
@@ -15,7 +15,7 @@ ENV PROTOC_GEN_GRPC_WEB_VER=1.3.1
 ENV PROTOC_GEN_GO_GRPC_VER=1.2.0
 ENV PROTOC_GEN_VALIDATE_VER=0.6.6
 ENV GOMOCK_VER=1.6.0
-ENV GLIBC_VERSION=2.33-r0
+ENV GLIBC_VERSION=2.35-r1
 
 RUN apk --no-cache add wget bash \
     && wget -q https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -O /etc/apk/keys/sgerrand.rsa.pub \

--- a/tool/codegen/Dockerfile
+++ b/tool/codegen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image to build go program.
-FROM golang:1.19.3-alpine3.15 as BUILDER
+FROM golang:1.20.5-alpine3.18 as BUILDER
 
 COPY protoc-gen-auth /protoc-gen-auth
 RUN cd /protoc-gen-auth \
@@ -7,7 +7,7 @@ RUN cd /protoc-gen-auth \
   && chmod +x /usr/local/bin/protoc-gen-auth
 
 # Codegen image which is actually being used.
-FROM golang:1.19.3-alpine3.15
+FROM golang:1.20.5-alpine3.18
 
 ENV PROTOC_VER=3.19.4
 ENV PROTOC_GEN_GO_VER=1.27.1


### PR DESCRIPTION
**What this PR does / why we need it**:

go mod shows that go version 1.20 is in used, but we have not yet updated the go version for tooling-based images. This PR fix that misses, and also update go version 1.20.3 to the latest 1.20.5.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
