### PR TITLE
Update site footer

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -78,8 +78,6 @@ style = "tango"
 
 [params]
 copyright = "The PipeCD Authors"
-copyright_since = "2020"
-privacy_policy = "https://github.com/pipe-cd/pipecd/blob/master/LICENSE"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
@@ -126,11 +124,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-	name = "User mailing list"
-	url = "mailto:pipecd.dev@gmail.com"
-	icon = "fa fa-envelope"
-        desc = "Discussion and help from your fellow users"
-[[params.links.user]]
 	name ="Twitter"
 	url = "https://twitter.com/pipecd_dev"
 	icon = "fab fa-twitter"
@@ -140,6 +133,11 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
 	url = "https://stackoverflow.com/questions/tagged/pipecd"
 	icon = "fab fa-stack-overflow"
         desc = "Practical questions and curated answers"
+[[params.links.user]]
+	name = "User mailing list"
+	url = "mailto:pipecd.dev@gmail.com"
+	icon = "fa fa-envelope"
+        desc = "Discussion and help from your fellow users"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -5,10 +5,10 @@
       <div class="col-8 text-white py-3 order-sm-2">
         <a href="https://www.cncf.io/projects/pipecd/" target="_blank">
           <img src="https://www.cncf.io/wp-content/uploads/2022/05/CNCF_logo_white.svg" alt="cncf logo" width="250">
-          <div class="text-white py-2">PipeCD is a Cloud Native Computing Foundation sandbox project</div>
+          <div class="text-white py-2">PipeCD is a Cloud Native Computing Foundation sandbox project.</div>
         </a>
       </div>
-      <div class="col-4 text-right order-sm-3 d-flex align-items-center justify-content-center">
+      <div class="col-4 order-sm-3 d-flex align-items-center justify-content-center">
         {{ with $links }}
         {{ with index . "developer"}}
         {{ template "footer-links-block"  . }}

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -1,32 +1,32 @@
-{{/* TODO: Remove this file after Docsy allows configuring years in copyright. https://github.com/google/docsy/issues/436 */}}
 {{ $links := .Site.Params.links }}
-<footer class="bg-dark py-5 row d-print-none">
-  <div class="container-fluid mx-sm-5">
+<div class="bg-dark row d-print-none">
+  <div class="container-fluid py-3 mx-sm-5">
     <div class="row">
-      <div class="col-6 col-sm-4 text-xs-center order-sm-2">
+      <div class="col-8 text-white py-3 order-sm-2">
+        <a href="https://www.cncf.io/projects/pipecd/" target="_blank">
+          <img src="https://www.cncf.io/wp-content/uploads/2022/05/CNCF_logo_white.svg" alt="cncf logo" width="250">
+          <div class="text-white py-2">PipeCD is a Cloud Native Computing Foundation sandbox project</div>
+        </a>
+      </div>
+      <div class="col-4 text-right order-sm-3 d-flex align-items-center justify-content-center">
         {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
         {{ with index . "user"}}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
-        {{ with $links }}
-        {{ with index . "developer"}}
-        {{ template "footer-links-block"  . }}
-        {{ end }}
-        {{ end }}
-      </div>
-      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-        <small class="text-white">&copy; {{ .Site.Params.copyright_since }}-{{ now.Year }} {{ .Site.Params.copyright }} {{ T "footer_all_rights_reserved" }}</small>
-        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noreferrer">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
-	{{ if not .Site.Params.ui.footer_about_disable }}
-		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
-	{{ end }}
-      </div>
+    </div>
+    <div class="border-top text-center text-white py-3">
+      <small>Copyright {{ .Site.Params.copyright }}.</small>
+      <br>
+      <small>The Linux Foundation® (TLF) has registered trademarks and uses trademarks.For a list of TLF trademarks,
+        see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a>.</small>
     </div>
   </div>
-</footer>
+</div>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The new footer will be as below

<img width="1440" alt="Screen Shot 2023-06-11 at 21 09 01" src="https://github.com/pipe-cd/pipecd/assets/32532742/251706b2-8372-4b78-a8cf-e97f51314414">

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
