### PR TITLE
Update community section to color primary

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -73,7 +73,7 @@ linkTitle = "PipeCD"
     </div>
 </div>
 
-{{< blocks/section color="dark" >}}
+{{< blocks/section color="primary" >}}
 
 {{% blocks/feature icon="fab fa-slack" title="Join the conversation!" url="https://slack.cncf.io" %}}
 Have a question?

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -22,7 +22,7 @@
     <div class="border-top text-center text-white py-3">
       <small>Copyright {{ .Site.Params.copyright }}.</small>
       <br>
-      <small>The Linux Foundation® (TLF) has registered trademarks and uses trademarks.For a list of TLF trademarks,
+      <small>The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks,
         see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a>.</small>
     </div>
   </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Before
<img width="1440" alt="Screen Shot 2023-06-12 at 9 57 40" src="https://github.com/pipe-cd/pipecd/assets/32532742/304a709b-1eff-4e8a-90eb-bdc0fc479d46">

After
<img width="1440" alt="Screen Shot 2023-06-12 at 9 57 31" src="https://github.com/pipe-cd/pipecd/assets/32532742/d820966d-43a0-4840-83b0-4042f675a77b">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
