### PR TITLE
Update site footer

### DIFF
--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -1,40 +1,51 @@
 {{ $links := .Site.Params.links }}
-<div class="bg-dark row d-print-none">
+{{ $bg_color := "bg-dark" }}
+{{ if .IsHome }} {{ $bg_color = "bg-white" }} {{ end }}
+{{ $text_color := "text-white" }}
+{{ if .IsHome }} {{ $text_color = "text-dark" }} {{ end }}
+{{ $cncf_logo := "https://www.cncf.io/wp-content/uploads/2022/05/CNCF_logo_white.svg" }}
+{{ if .IsHome }} {{ $cncf_logo = "https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" }} {{ end }}
+<div class="{{ $bg_color }} row d-print-none">
   <div class="container-fluid py-3 mx-sm-5">
     <div class="row">
-      <div class="col-8 text-white py-3 order-sm-2">
+      <div class="col-8 py-3 order-sm-2 {{ $text_color }}">
         <a href="https://www.cncf.io/projects/pipecd/" target="_blank">
-          <img src="https://www.cncf.io/wp-content/uploads/2022/05/CNCF_logo_white.svg" alt="cncf logo" width="250">
-          <div class="text-white py-2">PipeCD is a Cloud Native Computing Foundation sandbox project.</div>
+          <img src="{{ $cncf_logo }}" alt="cncf logo" width="250">
+          <div class="py-2 {{ $text_color }}">PipeCD is a Cloud Native Computing Foundation sandbox project.</div>
         </a>
       </div>
       <div class="col-4 order-sm-3 d-flex align-items-center justify-content-center">
         {{ with $links }}
         {{ with index . "developer"}}
-        {{ template "footer-links-block"  . }}
+        <ul class="list-inline mb-0">
+          {{ range . }}
+          <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+            <a class="text-white" target="_blank" rel="noopener noreferrer" href="{{ .url }}">
+              <i class="{{ .icon }} {{ $text_color }}"></i>
+            </a>
+          </li>
+          {{ end }}
+        </ul>
         {{ end }}
         {{ with index . "user"}}
-        {{ template "footer-links-block"  . }}
+        <ul class="list-inline mb-0">
+          {{ range . }}
+          <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+            <a class="text-white" target="_blank" rel="noopener noreferrer" href="{{ .url }}">
+              <i class="{{ .icon }} {{ $text_color }}"></i>
+            </a>
+          </li>
+          {{ end }}
+        </ul>
         {{ end }}
         {{ end }}
       </div>
     </div>
-    <div class="border-top text-center text-white py-3">
+    <div class="border-top text-center py-3 {{ $text_color }}">
       <small>Copyright {{ .Site.Params.copyright }}.</small>
       <br>
-      <small>The Linux Foundation® (TLF) has registered trademarks and uses trademarks.For a list of TLF trademarks,
+      <small>The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks,
         see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a>.</small>
     </div>
   </div>
 </div>
-{{ define "footer-links-block" }}
-<ul class="list-inline mb-0">
-  {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
-    <a class="text-white" target="_blank" rel="noopener noreferrer" href="{{ .url }}">
-      <i class="{{ .icon }}"></i>
-    </a>
-  </li>
-  {{ end }}
-</ul>
-{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the site footer background change based on the page.

Before
<img width="1440" alt="Screen Shot 2023-06-12 at 12 05 58" src="https://github.com/pipe-cd/pipecd/assets/32532742/26865b16-dbcc-4169-a9c6-3f6f6f75c0c3">

After

Homepage
<img width="1440" alt="Screen Shot 2023-06-12 at 12 05 31" src="https://github.com/pipe-cd/pipecd/assets/32532742/3ae2df73-aa28-4a26-9c1e-53dc2bc93c3b">

Other pages
<img width="1440" alt="Screen Shot 2023-06-12 at 12 05 44" src="https://github.com/pipe-cd/pipecd/assets/32532742/a0294cd5-4259-4ef1-854f-88ea4cf17c84">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
