### PR TITLE
Fix import block cause failure of parsing regex

### DIFF
--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -314,7 +314,7 @@ func (t *Terraform) makeCommonCommandArgs() (args []string) {
 
 var (
 	// Import block was introduced from Terraform v1.5.0.
-	// TODO: Show import in output.
+	// TODO: Show import in output and add it to diff calculation.
 	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan:(?: \d+ to import,)?? (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
 	planNoChangesRegex = regexp.MustCompile(`(?m)^No changes. Infrastructure is up-to-date.$`)
 )

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -313,7 +313,9 @@ func (t *Terraform) makeCommonCommandArgs() (args []string) {
 }
 
 var (
-	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan: (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
+	// Import block was introduced from Terraform v1.5.0.
+	// TODO: Show import in output.
+	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan:(?: \d+ to import,)?? (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
 	planNoChangesRegex = regexp.MustCompile(`(?m)^No changes. Infrastructure is up-to-date.$`)
 )
 

--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -16,13 +16,13 @@ func TestPlanHasChangeRegex(t *testing.T) {
 	}{
 		{
 			name:     "older than v1.5.0",
-			input:    "Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.",
-			expected: []string{"Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+			input:    "Plan: 1 to add, 2 to change, 3 to destroy.",
+			expected: []string{"Plan: 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
 		},
 		{
 			name:     "later than v1.5.0",
-			input:    "Plan: 1 to add, 2 to change, 3 to destroy.",
-			expected: []string{"Plan: 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+			input:    "Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.",
+			expected: []string{"Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
 		},
 	}
 

--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package terraform
 
 import (

--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -1,0 +1,36 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlanHasChangeRegex(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "older than v1.5.0",
+			input:    "Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.",
+			expected: []string{"Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+		},
+		{
+			name:     "later than v1.5.0",
+			input:    "Plan: 1 to add, 2 to change, 3 to destroy.",
+			expected: []string{"Plan: 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, planHasChangeRegex.FindStringSubmatch(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes [#](https://github.com/pipe-cd/pipecd/issues/4349)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
