### PR TITLE
Expose grafana.pspEnabled to pipecd manifest

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -200,7 +200,7 @@ prometheus:
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
   rbac:
-    pspEnabled: true
+    pspEnabled: false
   adminPassword: admin
   ingress:
     enabled: false

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -199,6 +199,8 @@ prometheus:
 # Head to the below link to see all available values.
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
+  rbac:
+    pspEnabled: true
   adminPassword: admin
   ingress:
     enabled: false


### PR DESCRIPTION
Locally tested;

```
kubectl version --short | grep -i server                       
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
WARNING: version difference between client (1.24) and server (1.27) exceeds the supported minor version skew of +/-1
Server Version: v1.27.1

make run/pipecd
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4407

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
