### PR TITLE
Add imports to terraform plan result

### DIFF
--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -287,8 +287,8 @@ func makeSyncState(r provider.PlanResult, commit string) model.ApplicationSyncSt
 		}
 	}
 
-	total := r.Adds + r.Destroys + r.Changes
-	shortReason := fmt.Sprintf("There are %d manifests not synced (%d adds, %d deletes, %d changes)", total, r.Adds, r.Destroys, r.Changes)
+	total := r.Imports + r.Adds + r.Destroys + r.Changes
+	shortReason := fmt.Sprintf("There are %d manifests not synced (%d imports, %d adds, %d deletes, %d changes)", total, r.Imports, r.Adds, r.Destroys, r.Changes)
 	if len(commit) >= 7 {
 		commit = commit[:7]
 	}

--- a/pkg/app/piped/executor/terraform/deploy.go
+++ b/pkg/app/piped/executor/terraform/deploy.go
@@ -126,7 +126,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_SUCCESS
 	}
 
-	e.LogPersister.Infof("Detected %d add, %d change, %d destroy. Those changes will be applied automatically.", planResult.Adds, planResult.Changes, planResult.Destroys)
+	e.LogPersister.Infof("Detected %d import, %d add, %d change, %d destroy. Those changes will be applied automatically.", planResult.Imports, planResult.Adds, planResult.Changes, planResult.Destroys)
 
 	if err := cmd.Apply(ctx, e.LogPersister); err != nil {
 		e.LogPersister.Errorf("Failed to apply changes (%v)", err)
@@ -178,7 +178,7 @@ func (e *deployExecutor) ensurePlan(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_SUCCESS
 	}
 
-	e.LogPersister.Successf("Detected %d add, %d change, %d destroy.", planResult.Adds, planResult.Changes, planResult.Destroys)
+	e.LogPersister.Successf("Detected %d import, %d add, %d change, %d destroy.", planResult.Imports, planResult.Adds, planResult.Changes, planResult.Destroys)
 	return model.StageStatus_STAGE_SUCCESS
 }
 

--- a/pkg/app/piped/planpreview/terraformdiff.go
+++ b/pkg/app/piped/planpreview/terraformdiff.go
@@ -111,7 +111,7 @@ func (b *builder) terraformDiff(
 		}, nil
 	}
 
-	summary := fmt.Sprintf("%d to add, %d to change, %d to destroy", result.Adds, result.Changes, result.Destroys)
+	summary := fmt.Sprintf("%d to import, %d to add, %d to change, %d to destroy", result.Imports, result.Adds, result.Changes, result.Destroys)
 	fmt.Fprintln(buf, summary)
 	return &diffResult{
 		summary: summary,

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -159,17 +159,18 @@ type PlanResult struct {
 	Adds     int
 	Changes  int
 	Destroys int
+	Imports  int
 
 	PlanOutput string
 }
 
 func (r PlanResult) NoChanges() bool {
-	return r.Adds == 0 && r.Changes == 0 && r.Destroys == 0
+	return r.Adds == 0 && r.Changes == 0 && r.Destroys == 0 && r.Imports == 0
 }
 
 func (r PlanResult) Render() string {
 	terraformDiffStart := "Terraform will perform the following actions:"
-	terraformDiffEnd := fmt.Sprintf("Plan: %d to add, %d to change, %d to destroy.", r.Adds, r.Changes, r.Destroys)
+	terraformDiffEnd := fmt.Sprintf("Plan: %d to import, %d to add, %d to change, %d to destroy.", r.Imports, r.Adds, r.Changes, r.Destroys)
 
 	startIndex := strings.Index(r.PlanOutput, terraformDiffStart) + len(terraformDiffStart)
 	endIndex := strings.Index(r.PlanOutput, terraformDiffEnd) + len(terraformDiffEnd)
@@ -314,7 +315,7 @@ func (t *Terraform) makeCommonCommandArgs() (args []string) {
 
 var (
 	// Import block was introduced from Terraform v1.5.0.
-	// TODO: Show import in output and add it to diff calculation.
+	// Keep this regex for backward compatibility.
 	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan:(?: \d+ to import,)?? (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
 	planNoChangesRegex = regexp.MustCompile(`(?m)^No changes. Infrastructure is up-to-date.$`)
 )
@@ -329,7 +330,33 @@ func stripAnsiCodes(str string) string {
 }
 
 func parsePlanResult(out string, ansiIncluded bool) (PlanResult, error) {
-	parseNums := func(add, change, destroy string) (adds int, changes int, destroys int, err error) {
+	parseNums := func(vals ...string) (imports, adds, changes, destroys int, err error) {
+		if len(vals) < 3 || len(vals) > 4 {
+			err = fmt.Errorf("invalid plan result: %v", vals)
+			return
+		}
+
+		var impt, add, change, destroy string
+		if len(vals) == 3 {
+			add = vals[0]
+			change = vals[1]
+			destroy = vals[2]
+		}
+
+		if len(vals) == 4 {
+			impt = vals[0]
+			add = vals[1]
+			change = vals[2]
+			destroy = vals[3]
+		}
+
+		if impt != "" {
+			imports, err = strconv.Atoi(impt)
+			if err != nil {
+				return
+			}
+		}
+
 		adds, err = strconv.Atoi(add)
 		if err != nil {
 			return
@@ -349,13 +376,14 @@ func parsePlanResult(out string, ansiIncluded bool) (PlanResult, error) {
 		out = stripAnsiCodes(out)
 	}
 
-	if s := planHasChangeRegex.FindStringSubmatch(out); len(s) == 4 {
-		adds, changes, destroys, err := parseNums(s[1], s[2], s[3])
+	if s := planHasChangeRegex.FindStringSubmatch(out); len(s) > 0 {
+		imports, adds, changes, destroys, err := parseNums(s[1:]...)
 		if err == nil {
 			return PlanResult{
 				Adds:       adds,
 				Changes:    changes,
 				Destroys:   destroys,
+				Imports:    imports,
 				PlanOutput: out,
 			}, nil
 		}

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -316,7 +316,7 @@ func (t *Terraform) makeCommonCommandArgs() (args []string) {
 var (
 	// Import block was introduced from Terraform v1.5.0.
 	// Keep this regex for backward compatibility.
-	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan:(?: \d+ to import,)?? (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
+	planHasChangeRegex = regexp.MustCompile(`(?m)^Plan:(?: (\d+) to import,)?? (\d+) to add, (\d+) to change, (\d+) to destroy.$`)
 	planNoChangesRegex = regexp.MustCompile(`(?m)^No changes. Infrastructure is up-to-date.$`)
 )
 
@@ -331,24 +331,10 @@ func stripAnsiCodes(str string) string {
 
 func parsePlanResult(out string, ansiIncluded bool) (PlanResult, error) {
 	parseNums := func(vals ...string) (imports, adds, changes, destroys int, err error) {
-		if len(vals) < 3 || len(vals) > 4 {
-			err = fmt.Errorf("invalid plan result: %v", vals)
-			return
-		}
-
-		var impt, add, change, destroy string
-		if len(vals) == 3 {
-			add = vals[0]
-			change = vals[1]
-			destroy = vals[2]
-		}
-
-		if len(vals) == 4 {
-			impt = vals[0]
-			add = vals[1]
-			change = vals[2]
-			destroy = vals[3]
-		}
+		impt := vals[0]
+		add := vals[1]
+		change := vals[2]
+		destroy := vals[3]
 
 		if impt != "" {
 			imports, err = strconv.Atoi(impt)
@@ -376,7 +362,7 @@ func parsePlanResult(out string, ansiIncluded bool) (PlanResult, error) {
 		out = stripAnsiCodes(out)
 	}
 
-	if s := planHasChangeRegex.FindStringSubmatch(out); len(s) > 0 {
+	if s := planHasChangeRegex.FindStringSubmatch(out); len(s) == 5 {
 		imports, adds, changes, destroys, err := parseNums(s[1:]...)
 		if err == nil {
 			return PlanResult{

--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -31,12 +31,12 @@ func TestPlanHasChangeRegex(t *testing.T) {
 		{
 			name:     "older than v1.5.0",
 			input:    "Plan: 1 to add, 2 to change, 3 to destroy.",
-			expected: []string{"Plan: 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+			expected: []string{"Plan: 1 to add, 2 to change, 3 to destroy.", "", "1", "2", "3"},
 		},
 		{
 			name:     "later than v1.5.0",
 			input:    "Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.",
-			expected: []string{"Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.", "1", "2", "3"},
+			expected: []string{"Plan: 0 to import, 1 to add, 2 to change, 3 to destroy.", "0", "1", "2", "3"},
 		},
 	}
 
@@ -93,9 +93,7 @@ func TestParsePlanResult(t *testing.T) {
 			t.Parallel()
 			result, err := parsePlanResult(tc.input, false)
 			assert.Equal(t, tc.expectedErr, err != nil)
-			if err != nil {
-				assert.Equal(t, tc.expected, result)
-			}
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -48,3 +48,54 @@ func TestPlanHasChangeRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePlanResult(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name        string
+		input       string
+		expected    PlanResult
+		expectedErr bool
+	}{
+		{
+			name:        "older than v1.5.0",
+			input:       `Plan: 1 to add, 2 to change, 3 to destroy.`,
+			expected:    PlanResult{Adds: 1, Changes: 2, Destroys: 3, PlanOutput: "Plan: 1 to add, 2 to change, 3 to destroy."},
+			expectedErr: false,
+		},
+		{
+			name:        "later than v1.5.0",
+			input:       `Plan: 1 to import, 1 to add, 2 to change, 3 to destroy.`,
+			expected:    PlanResult{Imports: 1, Adds: 1, Changes: 2, Destroys: 3, PlanOutput: "Plan: 1 to import, 1 to add, 2 to change, 3 to destroy."},
+			expectedErr: false,
+		},
+		{
+			name:        "Invalid number of changes",
+			input:       `Plan: a to add, 2 to change, 3 to destroy.`,
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid plan result output",
+			input:       `Plan: 1 to add, 2 to change.`,
+			expectedErr: true,
+		},
+		{
+			name:        "No changes",
+			input:       `No changes. Infrastructure is up-to-date.`,
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parsePlanResult(tc.input, false)
+			assert.Equal(t, tc.expectedErr, err != nil)
+			if err != nil {
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4401

**Does this PR introduce a user-facing change?**:

```release-note
Support Terraform v1.5.0 and later which introduces import feature
```
