### PR TITLE
Update piped-base image

### DIFF
--- a/tool/piped-base/Dockerfile
+++ b/tool/piped-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.1
+FROM alpine:3.13
 
 ARG PIPED_USER=piped
 ARG PIPED_USER_GROUP=piped


### PR DESCRIPTION
**What this PR does / why we need it**:

Using alpine:3.13 as the base image for piped-base image.

The v.3.12.1 is 3 years old and has 3 critical marked vulnerable issues, so better to update it
ref: https://hub.docker.com/_/alpine/tags?page=1&name=3.12.1

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
