### PR TITLE
Refactor fmt.Errorf to log.Fatal

### DIFF
--- a/cmd/pipectl/main.go
+++ b/cmd/pipectl/main.go
@@ -15,8 +15,7 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/application"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/deployment"
@@ -45,7 +44,6 @@ func main() {
 	)
 
 	if err := app.Run(); err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactored because it was notated with fmt.Errorf and os.Exit instead of log.Fatal
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
