### PR TITLE
Update quickstart to support arm hardware(ex: M1)

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
       {{- end }}
       containers:
         - name: mysql
-          image: mysql:{{ .Values.mysql.imageTag }}
+          image: {{ .Values.mysql.image }}:{{ .Values.mysql.imageTag }}
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_ROOT_PASSWORD

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -69,7 +69,8 @@ cloudSQLProxy:
   resources: {}
 
 mysql:
-  imageTag: "8.0.23"
+  image: mysql
+  imageTag: 8.0.33
   resources: {}
   port: 3306
 

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -150,7 +150,7 @@ func (c *command) installControlPlane(ctx context.Context, helm string, input cl
 		"--values",
 		fmt.Sprintf(helmQuickstartValueRemotePath, c.version),
 		"--set",
-		fmt.Sprintf("mysql.image=%s", selectImage()),
+		fmt.Sprintf("mysql.image=%s", selectMySqlImage()),
 	}
 
 	var stderr, stdout bytes.Buffer
@@ -200,8 +200,6 @@ func (c *command) installPiped(ctx context.Context, helm string, input cli.Input
 		fmt.Sprintf("secret.data.piped-key=%s", pipedKey),
 		"--set",
 		fmt.Sprintf("quickstart.gitRepoRemote=%s", sourceRepo),
-		"--set",
-		fmt.Sprintf("mysql.image=%s", selectImage()),
 	}
 
 	var stderr, stdout bytes.Buffer

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -149,6 +149,8 @@ func (c *command) installControlPlane(ctx context.Context, helm string, input cl
 		"--create-namespace",
 		"--values",
 		fmt.Sprintf(helmQuickstartValueRemotePath, c.version),
+		"--set",
+		fmt.Sprintf("mysql.image=%s", selectImage()),
 	}
 
 	var stderr, stdout bytes.Buffer
@@ -198,6 +200,8 @@ func (c *command) installPiped(ctx context.Context, helm string, input cli.Input
 		fmt.Sprintf("secret.data.piped-key=%s", pipedKey),
 		"--set",
 		fmt.Sprintf("quickstart.gitRepoRemote=%s", sourceRepo),
+		"--set",
+		fmt.Sprintf("mysql.image=%s", selectImage()),
 	}
 
 	var stderr, stdout bytes.Buffer
@@ -312,6 +316,19 @@ func openbrowser(url string) error {
 	return err
 }
 
+func selectImage() string {
+	var mysqlImage string
+	switch runtime.GOARCH {
+	case "amd64":
+		mysqlImage = "mysql"
+	case "arm64":
+		mysqlImage = "arm64v8/mysql"
+	default:
+		mysqlImage = "mysql"
+	}
+	return mysqlImage
+}
+
 func (c *command) uninstallAll(ctx context.Context, helm string, input cli.Input) error {
 	input.Logger.Info("Uninstalling PipeCD components...")
 
@@ -380,9 +397,9 @@ func (c *command) getKubectl() (string, error) {
 }
 
 // getHelm finds and returns helm executable binary in the following priority:
-//   1. pre-installed in command specified toolsDir (default is $HOME/.pipectl/tools)
-//   2. $PATH
-//   3. install new helm to command specified toolsDir
+//  1. pre-installed in command specified toolsDir (default is $HOME/.pipectl/tools)
+//  2. $PATH
+//  3. install new helm to command specified toolsDir
 func (c *command) getHelm(ctx context.Context) (string, error) {
 	binName := "helm"
 

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -150,7 +150,7 @@ func (c *command) installControlPlane(ctx context.Context, helm string, input cl
 		"--values",
 		fmt.Sprintf(helmQuickstartValueRemotePath, c.version),
 		"--set",
-		fmt.Sprintf("mysql.image=%s", selectMySqlImage()),
+		fmt.Sprintf("mysql.image=%s", selectMySQLImage()),
 	}
 
 	var stderr, stdout bytes.Buffer
@@ -314,7 +314,7 @@ func openbrowser(url string) error {
 	return err
 }
 
-func selectMySqlImage() string {
+func selectMySQLImage() string {
 	var mysqlImage string
 	switch runtime.GOARCH {
 	case "amd64":

--- a/pkg/app/pipectl/cmd/quickstart/quickstart.go
+++ b/pkg/app/pipectl/cmd/quickstart/quickstart.go
@@ -316,7 +316,7 @@ func openbrowser(url string) error {
 	return err
 }
 
-func selectImage() string {
+func selectMySqlImage() string {
 	var mysqlImage string
 	switch runtime.GOARCH {
 	case "amd64":


### PR DESCRIPTION
**What this PR does / why we need it**: Currently quickstart doesn't work on ARM machines unless manual steps are taken.

**Which issue(s) this PR fixes**: #4116

Fixes # Quckstart for arm architecture CPU's (tested on M1 Pro)
Update Helm chart values to support different mysql image.

**Does this PR introduce a user-facing change?**: Yes

- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
- **How are users affected by this change**: Enables arm users to easily use quickstart
