### PR TITLE
Output usage only when flag parsing fails #4381

### DIFF
--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -29,15 +30,23 @@ type App struct {
 	telemetryFlags TelemetryFlags
 }
 
+var FlagParseErr = errors.New("FlagParseErr")
+
 func NewApp(name, desc string) *App {
 	a := &App{
 		rootCmd: &cobra.Command{
 			Use:           name,
 			Short:         desc,
 			SilenceErrors: true,
+			SilenceUsage:  true,
 		},
 		telemetryFlags: defaultTelemetryFlags,
 	}
+	a.rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		cmd.Println(err)
+		cmd.Println(cmd.UsageString())
+		return FlagParseErr
+	})
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the information of current binary.",


### PR DESCRIPTION
**What this PR does / why we need it**:

Clis (like piped, pipectl...) output usage only when flag parsing fails, not when internal errors occur.

**Which issue(s) this PR fixes**:

Fixes #4381

**Does this PR introduce a user-facing change?**:

- **Is this breaking change**:
- **How to migrate (if breaking change)**:
- **How are users affected by this change**:
