### PR TITLE
Fix ECS rollback stage does not remove canary created tasks

### DIFF
--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -82,19 +82,19 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	primary, _, ok := loadTargetGroups(&e.Input, appCfg, runningDS)
+	primary, canary, ok := loadTargetGroups(&e.Input, appCfg, runningDS)
 	if !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !rollback(ctx, &e.Input, platformProviderName, platformProviderCfg, taskDefinition, serviceDefinition, primary) {
+	if !rollback(ctx, &e.Input, platformProviderName, platformProviderCfg, taskDefinition, serviceDefinition, primary, canary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func rollback(ctx context.Context, in *executor.Input, platformProviderName string, platformProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup *types.LoadBalancer) bool {
+func rollback(ctx context.Context, in *executor.Input, platformProviderName string, platformProviderCfg *config.PlatformProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service, primaryTargetGroup *types.LoadBalancer, canaryTargetGroup *types.LoadBalancer) bool {
 	in.LogPersister.Infof("Start rollback the ECS service and task family: %s and %s to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
 	client, err := provider.DefaultRegistry().Client(platformProviderName, platformProviderCfg, in.Logger)
 	if err != nil {
@@ -127,9 +127,43 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 	}
 
 	// On rolling back, the scale of desired tasks will be set to 100 (same as the original state).
-	taskSet, err := client.CreateTaskSet(ctx, *service, *td, targetGroup, 100)
+	taskSet, err := client.CreateTaskSet(ctx, *service, *td, primaryTargetGroup, 100)
 	if err != nil {
 		in.LogPersister.Errorf("Failed to create ECS task set %s: %v", *serviceDefinition.ServiceName, err)
+		return false
+	}
+
+	// Reset routing
+	routingTrafficCfg := provider.RoutingTrafficConfig{
+		{
+			TargetGroupArn: *primaryTargetGroup.TargetGroupArn,
+			Weight:         100,
+		},
+		{
+			TargetGroupArn: *canaryTargetGroup.TargetGroupArn,
+			Weight:         0,
+		},
+	}
+
+	currListenerArns, err := client.GetListenerArns(ctx, *primaryTargetGroup)
+	if err != nil {
+		in.LogPersister.Errorf("Failed to get current active listener: %v", err)
+		return false
+	}
+
+	if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
+		in.LogPersister.Errorf("Failed to routing traffic to CANARY variant: %v", err)
+		return false
+	}
+
+	// Delete Canary taskSet
+	canaryTaskSet, ok := in.MetadataStore.Shared().Get(canaryTaskSetARNKeyName)
+	if !ok {
+		in.LogPersister.Errorf("Unable to restore CANARY task set to clean: Not found")
+		return false
+	}
+	if err = client.DeleteTaskSet(ctx, *service, canaryTaskSet); err != nil {
+		in.LogPersister.Errorf("Failed to remove unused previous PRIMARY taskSet %s: %v", canaryTaskSet, err)
 		return false
 	}
 

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -161,12 +161,12 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 
 	currListenerArns, err := client.GetListenerArns(ctx, *primaryTargetGroup)
 	if err != nil {
-		in.LogPersister.Errorf("Failed to get current active listener: %v", err)
+		in.LogPersister.Errorf("Failed to get current active listeners: %v", err)
 		return false
 	}
 
 	if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
-		in.LogPersister.Errorf("Failed to routing traffic to CANARY variant: %v", err)
+		in.LogPersister.Errorf("Failed to routing traffic to PRIMARY variant: %v", err)
 		return false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix `Cancel with rollback` does not remove canary created tasks

**Which issue(s) this PR fixes**:

Fixes #4329

**Does this PR introduce a user-facing change?**:

- **Is this breaking change**:
- **How to migrate (if breaking change)**:
- **How are users affected by this change**: Fix ECS rollback stage does not remove ECS canary created tasks
