### PR TITLE
fix: update deprecated apiVersion since gke removed

### DIFF
--- a/manifests/pipecd/templates/managed-certificate.yaml
+++ b/manifests/pipecd/templates/managed-certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedCertificate.enabled -}}
-apiVersion: networking.gke.io/v1beta2
+apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: {{ include "pipecd.fullname" . }}
@@ -12,7 +12,7 @@ spec:
 
 {{ if .Values.monitoring.managedCertificate.enabled -}}
 ---
-apiVersion: networking.gke.io/v1beta2
+apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: {{ include "pipecd.fullname" . }}-grafana

--- a/manifests/site/templates/managed-certificate.yaml
+++ b/manifests/site/templates/managed-certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managedCertificate.enabled -}}
-apiVersion: networking.gke.io/v1beta2
+apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: {{ include "site.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**: 
since gcp removed handling v1beta1/v1beta2 APIs, the v1beta2 is deprecated
this PR will fix it
https://github.com/GoogleCloudPlatform/gke-managed-certs/pull/58

**Which issue(s) this PR fixes**: https://github.com/pipe-cd/pipecd/issues/4415

Fixes #

**Does this PR introduce a user-facing change?**: N/A

- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
- **How are users affected by this change**: N/A
