### PR TITLE
Skip update AppState when no log updates

### DIFF
--- a/web/src/modules/stage-logs/index.ts
+++ b/web/src/modules/stage-logs/index.ts
@@ -106,7 +106,11 @@ export const stageLogsSlice = createSlice({
       })
       .addCase(fetchStageLog.fulfilled, (state, action) => {
         const id = createActiveStageKey(action.meta.arg);
-        state[id] = action.payload;
+        // Skip update state when no log updates
+        // to avoid unnecessary state update and trigger re-render.
+        if (JSON.stringify(state[id]) !== JSON.stringify(action.payload)) {
+          state[id] = action.payload;
+        }
       });
   },
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip update AppState when no log updates.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4473

**Does this PR introduce a user-facing change?**:
Stop unnecessary scrolling on deployments detail page.

Thanks to helping me! @texdeath