### PR TITLE
feat: add spec input.AutoCreateNamespace for creating when doesn't exist

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -304,6 +304,7 @@ One of `yamlField` or `regex` is required.
 | helmOptions | [HelmOptions](#helmoptions) | Configurable parameters for helm commands. | No |
 | namespace | string | The namespace where manifests will be applied. | No |
 | autoRollback | bool | Automatically reverts all deployment changes on failure. Default is `true`. | No |
+| AutoCreateNamespace | bool | Automatically create a new namespace if it does not exist. Default is `false`. | No |
 
 ### HelmChart
 

--- a/pkg/app/piped/platformprovider/kubernetes/applier.go
+++ b/pkg/app/piped/platformprovider/kubernetes/applier.go
@@ -63,6 +63,15 @@ func (a *applier) ApplyManifest(ctx context.Context, manifest Manifest) error {
 	if a.initErr != nil {
 		return a.initErr
 	}
+	if *a.input.AutoCreateNamespace == true {
+		if err := a.kubectl.CreateNamespace(
+			ctx,
+			a.platformProvider.KubeConfigPath,
+			a.getNamespaceToRun(manifest.Key),
+		); err != nil {
+			return err
+		}
+	}
 
 	return a.kubectl.Apply(
 		ctx,
@@ -79,6 +88,15 @@ func (a *applier) CreateManifest(ctx context.Context, manifest Manifest) error {
 	})
 	if a.initErr != nil {
 		return a.initErr
+	}
+	if *a.input.AutoCreateNamespace == true {
+		if err := a.kubectl.CreateNamespace(
+			ctx,
+			a.platformProvider.KubeConfigPath,
+			a.getNamespaceToRun(manifest.Key),
+		); err != nil {
+			return err
+		}
 	}
 
 	return a.kubectl.Create(

--- a/pkg/app/piped/platformprovider/kubernetes/kubectl.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubectl.go
@@ -223,3 +223,22 @@ func (c *Kubectl) Get(ctx context.Context, kubeconfig, namespace string, r Resou
 	}
 	return ms[0], nil
 }
+
+func (c *Kubectl) CreateNamespace(ctx context.Context, kubeconfig, namespace string) (err error) {
+	args := make([]string, 0, 7)
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig", kubeconfig)
+	}
+	args = append(args, "create", "namespace", namespace)
+
+	cmd := exec.CommandContext(ctx, c.execPath, args...)
+	out, err := cmd.CombinedOutput()
+
+	if strings.Contains(string(out), "(AlreadyExists)") {
+		return fmt.Errorf("failed to create namespace: %s, %v", string(out), err)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %s, %v", string(out), err)
+	}
+	return nil
+}

--- a/pkg/config/application_kubernetes.go
+++ b/pkg/config/application_kubernetes.go
@@ -94,6 +94,10 @@ type KubernetesDeploymentInput struct {
 	// Automatically reverts all deployment changes on failure.
 	// Default is true.
 	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
+
+	// Automatically create a new namespace if it does not exist.
+	// Default is false.
+	AutoCreateNamespace *bool `json:"autoCreateNamespace" default:"false"`
 }
 
 type InputHelmChart struct {

--- a/pkg/config/testdata/application/k8s-app-helm.yaml
+++ b/pkg/config/testdata/application/k8s-app-helm.yaml
@@ -22,6 +22,7 @@ spec:
     helmValueFiles:
     - values.yaml
     helmVersion: 3.1.1
+    AutoCreateNamespace: true
 
 ---
 apiVersion: pipecd.dev/v1beta1
@@ -36,3 +37,4 @@ spec:
     helmValueFiles:
     - values.yaml
     helmVersion: 3.1.1
+    AutoCreateNamespace: false


### PR DESCRIPTION
**What this PR does / why we need it**: 
- hey team, I'm new here so really need your help and correct me if I'm wrong on smt
this PR will try to use `kubectl create namespace <ns_name>` when we put flag `AutoCreateNamespace` to avoid error when the ns doesn't exit

- basis I created field `AutoCreateNamespace` under `KubernetesDeploymentInput`  following this comment https://github.com/pipe-cd/pipecd/pull/4150#pullrequestreview-1272107822

**Which issue(s) this PR fixes**: https://github.com/pipe-cd/pipecd/issues/1202

Fixes #

**Does this PR introduce a user-facing change?**: N/A

- **How are users affected by this change**: ? not sure
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
