### PR TITLE
Add ability to set apiKey and applicationKey for AnalysisProviderDatadogConfig directly instead of reading files

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -180,8 +180,8 @@ Must be one of the following structs:
 | address | string | The address of Datadog API server. Only "datadoghq.com", "us3.datadoghq.com", "datadoghq.eu", "ddog-gov.com" are available. Defaults to "datadoghq.com" | No |
 | apiKeyFile | string | The path to the api key file. | Yes |
 | applicationKeyFile | string | The path to the application key file. | Yes |
-| apiKey | string | Optional: API Key for Datadog API server. | No |
-| applicationKey | string | Optional: Application Key for Datadog API server | No |
+| apiKeyData | string | Base64 API Key for Datadog API server. Either apiKeyData or apiKeyFile must be set | No |
+| applicationKeyData | string | Base64 Application Key for Datadog API server. Either applicationKeyFile or applicationKeyData must be set | No |
 
 ## EventWatcher
 

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -179,6 +179,8 @@ Must be one of the following structs:
 | address | string | The address of Datadog API server. Only "datadoghq.com", "us3.datadoghq.com", "datadoghq.eu", "ddog-gov.com" are available. Defaults to "datadoghq.com" | No |
 | apiKeyFile | string | The path to the api key file. | Yes |
 | applicationKeyFile | string | The path to the application key file. | Yes |
+| apiKey | string | Optional: API Key for Datadog API server. | No |
+| applicationKey | string | Optional: Application Key for Datadog API server | No |
 
 ## EventWatcher
 

--- a/pkg/app/piped/analysisprovider/metrics/factory/factory.go
+++ b/pkg/app/piped/analysisprovider/metrics/factory/factory.go
@@ -66,6 +66,12 @@ func NewProvider(analysisTempCfg *config.TemplatableAnalysisMetrics, providerCfg
 			}
 			applicationKey = strings.TrimSpace(string(a))
 		}
+		if cfg.APIKey != "" {
+			apiKey = strings.TrimSpace(cfg.APIKey)
+		}
+		if cfg.ApplicationKey != "" {
+			applicationKey = strings.TrimSpace(cfg.ApplicationKey)
+		}
 		options := []datadog.Option{
 			datadog.WithLogger(logger),
 			datadog.WithTimeout(analysisTempCfg.Timeout.Duration()),

--- a/pkg/app/piped/analysisprovider/metrics/factory/factory.go
+++ b/pkg/app/piped/analysisprovider/metrics/factory/factory.go
@@ -15,6 +15,7 @@
 package factory
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -66,11 +67,19 @@ func NewProvider(analysisTempCfg *config.TemplatableAnalysisMetrics, providerCfg
 			}
 			applicationKey = strings.TrimSpace(string(a))
 		}
-		if cfg.APIKey != "" {
-			apiKey = strings.TrimSpace(cfg.APIKey)
+		if cfg.APIKeyData != "" {
+			a, err := base64.StdEncoding.DecodeString(cfg.APIKeyData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode the api-key data: %w", err)
+			}
+			apiKey = string(a)
 		}
-		if cfg.ApplicationKey != "" {
-			applicationKey = strings.TrimSpace(cfg.ApplicationKey)
+		if cfg.ApplicationKeyData != "" {
+			a, err := base64.StdEncoding.DecodeString(cfg.ApplicationKeyData)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode the application-key data: %w", err)
+			}
+			applicationKey = string(a)
 		}
 		options := []datadog.Option{
 			datadog.WithLogger(logger),

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -853,11 +853,11 @@ type AnalysisProviderDatadogConfig struct {
 }
 
 func (a *AnalysisProviderDatadogConfig) Validate() error {
-	if a.APIKeyFile == "" {
-		return fmt.Errorf("datadog analysis provider requires the api key file")
+	if a.APIKeyFile == "" && a.APIKey == "" {
+		return fmt.Errorf("datadog analysis provider requires the api key or file")
 	}
-	if a.ApplicationKeyFile == "" {
-		return fmt.Errorf("datadog analysis provider requires the application key file")
+	if a.ApplicationKeyFile == "" && a.ApplicationKey == "" {
+		return fmt.Errorf("datadog analysis provider requires the application key or file")
 	}
 	return nil
 }

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -642,7 +642,7 @@ type PlatformProviderTerraformConfig struct {
 	// 'image_id_list=["ami-abc123","ami-def456"]'
 	// 'image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
 	Vars []string `json:"vars,omitempty"`
-	// Enable drift detection. 
+	// Enable drift detection.
 	// TODO: This is a temporary option because Terraform drift detection is buggy and has performace issues. This will be possibly removed in the future release.
 	DriftDetectionEnabled *bool `json:"driftDetectionEnabled" default:"true"`
 }
@@ -849,18 +849,24 @@ type AnalysisProviderDatadogConfig struct {
 	APIKeyFile string `json:"apiKeyFile"`
 	// Required: The path to the application key file.
 	ApplicationKeyFile string `json:"applicationKeyFile"`
-	// Optional: API Key for Datadog API server.
-	APIKey string `json:"apiKey,omitempty"`
-	// Optional: Application Key for Datadog API server.
-	ApplicationKey string `json:"applicationKey,omitempty"`
+	// Base64 API Key for Datadog API server.
+	APIKeyData string `json:"apiKeyData,omitempty"`
+	// Base64 Application Key for Datadog API server.
+	ApplicationKeyData string `json:"applicationKeyData,omitempty"`
 }
 
 func (a *AnalysisProviderDatadogConfig) Validate() error {
-	if a.APIKeyFile == "" && a.APIKey == "" {
-		return fmt.Errorf("datadog analysis provider requires the api key or file")
+	if a.APIKeyFile == "" && a.APIKeyData == "" {
+		return fmt.Errorf("either datadog APIKeyFile or APIKeyData must be set")
 	}
-	if a.ApplicationKeyFile == "" && a.ApplicationKey == "" {
-		return fmt.Errorf("datadog analysis provider requires the application key or file")
+	if a.ApplicationKeyFile == "" && a.ApplicationKeyData == "" {
+		return fmt.Errorf("either datadog ApplicationKeyFile or ApplicationKeyData must be set")
+	}
+	if a.APIKeyData != "" && a.APIKeyFile != "" {
+		return fmt.Errorf("only datadog APIKeyFile or APIKeyData can be set")
+	}
+	if a.ApplicationKeyData != "" && a.ApplicationKeyFile != "" {
+		return fmt.Errorf("only datadog ApplicationKeyFile or ApplicationKeyData can be set")
 	}
 	return nil
 }
@@ -872,13 +878,15 @@ func (a *AnalysisProviderDatadogConfig) Mask() {
 	if len(a.ApplicationKeyFile) != 0 {
 		a.ApplicationKeyFile = maskString
 	}
-	if len(a.APIKey) != 0 {
-		a.APIKey = maskString
+	if len(a.APIKeyData) != 0 {
+		a.APIKeyData = maskString
 	}
-	if len(a.ApplicationKey) != 0 {
-		a.ApplicationKey = maskString
+	if len(a.ApplicationKeyData) != 0 {
+		a.ApplicationKeyData = maskString
 	}
 }
+
+// func(a *AnalysisProviderDatadogConfig)
 
 type AnalysisProviderStackdriverConfig struct {
 	// The path to the service account file.

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -846,6 +846,10 @@ type AnalysisProviderDatadogConfig struct {
 	APIKeyFile string `json:"apiKeyFile"`
 	// Required: The path to the application key file.
 	ApplicationKeyFile string `json:"applicationKeyFile"`
+	// Optional: API Key for Datadog API server.
+	APIKey string `json:"apiKey,omitempty"`
+	// Optional: Application Key for Datadog API server.
+	ApplicationKey string `json:"applicationKey,omitempty"`
 }
 
 func (a *AnalysisProviderDatadogConfig) Validate() error {
@@ -864,6 +868,12 @@ func (a *AnalysisProviderDatadogConfig) Mask() {
 	}
 	if len(a.ApplicationKeyFile) != 0 {
 		a.ApplicationKeyFile = maskString
+	}
+	if len(a.APIKey) != 0 {
+		a.APIKey = maskString
+	}
+	if len(a.ApplicationKey) != 0 {
+		a.ApplicationKey = maskString
 	}
 }
 

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -164,8 +164,6 @@ func TestPipedConfig(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
-							APIKey:             "datadog-api-key",
-							ApplicationKey:     "datadog-application-key",
 						},
 					},
 					{
@@ -544,8 +542,8 @@ func TestPipedConfigMask(t *testing.T) {
 							Address:            "foo",
 							APIKeyFile:         "foo",
 							ApplicationKeyFile: "foo",
-							APIKey:             "foo",
-							ApplicationKey:     "foo",
+							APIKeyData:         "foo",
+							ApplicationKeyData: "foo",
 						},
 						StackdriverConfig: &AnalysisProviderStackdriverConfig{
 							ServiceAccountFile: "foo",
@@ -704,8 +702,8 @@ func TestPipedConfigMask(t *testing.T) {
 							Address:            "foo",
 							APIKeyFile:         maskString,
 							ApplicationKeyFile: maskString,
-							APIKey:             maskString,
-							ApplicationKey:     maskString,
+							APIKeyData:         maskString,
+							ApplicationKeyData: maskString,
 						},
 						StackdriverConfig: &AnalysisProviderStackdriverConfig{
 							ServiceAccountFile: maskString,
@@ -913,8 +911,8 @@ func TestPipedSpecClone(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
-							APIKey:             "datadog-api-key",
-							ApplicationKey:     "datadog-application-key",
+							APIKeyData:         "datadog-api-key",
+							ApplicationKeyData: "datadog-application-key",
 						},
 					},
 					{
@@ -1110,8 +1108,8 @@ func TestPipedSpecClone(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
-							APIKey:             "datadog-api-key",
-							ApplicationKey:     "datadog-application-key",
+							APIKeyData:         "datadog-api-key",
+							ApplicationKeyData: "datadog-application-key",
 						},
 					},
 					{

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -163,6 +163,8 @@ func TestPipedConfig(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
+							APIKey:             "datadog-api-key",
+							ApplicationKey:     "datadog-application-key",
 						},
 					},
 					{
@@ -541,6 +543,8 @@ func TestPipedConfigMask(t *testing.T) {
 							Address:            "foo",
 							APIKeyFile:         "foo",
 							ApplicationKeyFile: "foo",
+							APIKey:             "foo",
+							ApplicationKey:     "foo",
 						},
 						StackdriverConfig: &AnalysisProviderStackdriverConfig{
 							ServiceAccountFile: "foo",
@@ -699,6 +703,8 @@ func TestPipedConfigMask(t *testing.T) {
 							Address:            "foo",
 							APIKeyFile:         maskString,
 							ApplicationKeyFile: maskString,
+							APIKey:             maskString,
+							ApplicationKey:     maskString,
 						},
 						StackdriverConfig: &AnalysisProviderStackdriverConfig{
 							ServiceAccountFile: maskString,
@@ -906,6 +912,8 @@ func TestPipedSpecClone(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
+							APIKey:             "datadog-api-key",
+							ApplicationKey:     "datadog-application-key",
 						},
 					},
 					{
@@ -1101,6 +1109,8 @@ func TestPipedSpecClone(t *testing.T) {
 							Address:            "https://your-datadog.dev",
 							APIKeyFile:         "/etc/piped-secret/datadog-api-key",
 							ApplicationKeyFile: "/etc/piped-secret/datadog-application-key",
+							APIKey:             "datadog-api-key",
+							ApplicationKey:     "datadog-application-key",
 						},
 					},
 					{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -88,6 +88,8 @@ spec:
         address: https://your-datadog.dev
         apiKeyFile: /etc/piped-secret/datadog-api-key
         applicationKeyFile: /etc/piped-secret/datadog-application-key
+        apiKey: datadog-api-key
+        applicationKey: datadog-application-key
     - name: stackdriver-dev
       type: STACKDRIVER
       config:

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -89,8 +89,6 @@ spec:
         address: https://your-datadog.dev
         apiKeyFile: /etc/piped-secret/datadog-api-key
         applicationKeyFile: /etc/piped-secret/datadog-application-key
-        apiKey: datadog-api-key
-        applicationKey: datadog-application-key
     - name: stackdriver-dev
       type: STACKDRIVER
       config:


### PR DESCRIPTION
**What this PR does / why we need it**:

add an option to set apiKey + applicationKey AnalysisProviderDatadogConfig directly in yaml file

**Which issue(s) this PR fixes**:

Fixes #4492

**Does this PR introduce a user-facing change?**: N/A

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
