### PR TITLE
fix  the link of terraform applications autorollback in docs

### DIFF
--- a/docs/content/en/docs-dev/examples/_index.md
+++ b/docs/content/en/docs-dev/examples/_index.md
@@ -47,7 +47,7 @@ https://github.com/pipe-cd/examples
 | [local-module](https://github.com/pipe-cd/examples/tree/master/terraform/local-module) | Deploy application that using local terraform modules from the same Git repository. |
 | [remote-module](https://github.com/pipe-cd/examples/tree/master/terraform/remote-module) | Deploy application that using remote terraform modules from other Git repositories. |
 | [wait-approval](https://github.com/pipe-cd/examples/tree/master/terraform/wait-approval) | Deployment pipeline that contains a manual approval stage. |
-| [autorollback](https://github.com/pipe-cd/examples/tree/master/terraform/auto-rollback) |  Automatically rollback the changes when deployment was failed.  |
+| [autorollback](https://github.com/pipe-cd/examples/tree/master/terraform/autorollback) |  Automatically rollback the changes when deployment was failed.  |
 | [secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management) | Demonstrate how to manage sensitive data by using [Secret Management](../user-guide/managing-application/secret-management/) feature. |
 
 ### Cloud Run Applications


### PR DESCRIPTION
**What this PR does / why we need it**:
 The link of terraform applications autorollback is wrong.
