### PR TITLE
fix: update function configuration

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -272,15 +272,17 @@ func (c *client) updateFunctionConfiguration(ctx context.Context, fm FunctionMan
 			Environment: &types.Environment{
 				Variables: fm.Spec.Environments,
 			},
-			VpcConfig: &types.VpcConfig{
-				SecurityGroupIds: fm.Spec.VPCConfig.SecurityGroupIDs,
-				SubnetIds:        fm.Spec.VPCConfig.SubnetIDs,
-			},
 		}
 		// For zip packing Lambda function code, allow update the function handler
 		// on update the function's manifest.
 		if fm.Spec.Handler != "" {
 			configInput.Handler = aws.String(fm.Spec.Handler)
+		}
+		if fm.Spec.VPCConfig != nil {
+			configInput.VpcConfig = &types.VpcConfig{
+				SecurityGroupIds: fm.Spec.VPCConfig.SecurityGroupIDs,
+				SubnetIds:        fm.Spec.VPCConfig.SubnetIDs,
+			}
 		}
 		_, err = c.client.UpdateFunctionConfiguration(ctx, configInput)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

@khanhtc1202 
I'm so sorry, update function configuration has been already defined and called. So I deleted my changes.
And I fixed order to call UpdateFunctionCode and UpdateFunctionConfiguration. Because UpdateFunctionConfiguration is failed, if Lambda state is pending. 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
