### PR TITLE
fix: ECS WaitService finish before task running

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -252,7 +252,8 @@ func (c *client) WaitServiceStable(ctx context.Context, service types.Service) e
 		Cluster:  service.ClusterArn,
 		Services: []string{*service.ServiceArn},
 	}
-
+	// TODO: Wait until a new task is started instead of sleeping.
+	time.Sleep(30 * time.Second)
 	retry := backoff.NewRetry(retryServiceStable, backoff.NewConstant(retryServiceStableInterval))
 	_, err := retry.Do(ctx, func() (interface{}, error) {
 		output, err := c.ecsClient.DescribeServices(ctx, input)

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -252,6 +252,9 @@ func (c *client) WaitServiceStable(ctx context.Context, service types.Service) e
 		Cluster:  service.ClusterArn,
 		Services: []string{*service.ServiceArn},
 	}
+	// Wait before first checking the service state due to the logic checking service
+	// stable currently is based on `pendingCount`, which could always be `0` when
+	// the service deployment has started running.
 	// TODO: Wait until a new task is started instead of sleeping.
 	time.Sleep(30 * time.Second)
 	retry := backoff.NewRetry(retryServiceStable, backoff.NewConstant(retryServiceStableInterval))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed an issue where ECS tasks were marked as successful before they were all started

**Which issue(s) this PR fixes**:

Follow PR #4548

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
