### PR TITLE
Add make command to docs to install dependencies

### DIFF
--- a/cmd/pipecd/README.md
+++ b/cmd/pipecd/README.md
@@ -30,7 +30,13 @@ For the full list of available commands, please see the Makefile at the root of 
 
     Once it is no longer used, run `make kind-down` to delete it.
 
-2. Install Control Plane into the local cluster
+2. Install the web dependencies module
+
+    ``` console
+    make update/web-deps
+    ```
+
+3. Install Control Plane into the local cluster
 
     ``` console
     make run/pipecd
@@ -42,7 +48,7 @@ For the full list of available commands, please see the Makefile at the root of 
     kubectl -n pipecd port-forward svc/pipecd 8080
     ```
 
-3. Access to the local Control Plane web console
+4. Access to the local Control Plane web console
 
     Point your web browser to [http://localhost:8080](http://localhost:8080) to login with the configured static admin account: project = `quickstart`, username = `hello-pipecd`, password = `hello-pipecd`.
 

--- a/docs/content/en/docs-v0.43.x/contribution-guidelines/development.md
+++ b/docs/content/en/docs-v0.43.x/contribution-guidelines/development.md
@@ -43,7 +43,13 @@ For the full list of available commands, please see the Makefile at the root of 
 
     Once it is no longer used, run `make kind-down` to delete it.
 
-2. Install Control Plane into the local cluster
+2. Install the web dependencies module
+
+    ``` console
+    make update/web-deps
+    ```
+
+3. Install Control Plane into the local cluster
 
     ``` console
     make run/pipecd
@@ -55,7 +61,7 @@ For the full list of available commands, please see the Makefile at the root of 
     kubectl -n pipecd port-forward svc/pipecd 8080
     ```
 
-3. Access to the local Control Plane web console
+4. Access to the local Control Plane web console
 
     Point your web browser to [http://localhost:8080](http://localhost:8080) to login with the configured static admin account: project = `quickstart`, username = `hello-pipecd`, password = `hello-pipecd`.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the web config dependency install command to the documentation.
Developers run this command before building the Control Plane.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4546

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
