### PR TITLE
Fix ECS not remove taskset on quick sync rollback

### DIFF
--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -36,8 +36,6 @@ const (
 	activeServiceKeyName = "active-service-object"
 	// Canary task set metadata keys.
 	canaryTaskSetARNKeyName = "canary-taskset-arn"
-	// Previous primary task set metadata keys.
-	previousPrimaryTaskSetARNKeyName = "previous-primary-taskset-arn"
 	// Stage metadata keys.
 	trafficRoutePrimaryMetadataKey = "primary-percentage"
 	trafficRouteCanaryMetadataKey  = "canary-percentage"

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -395,11 +395,12 @@ func clean(ctx context.Context, in *executor.Input, platformProviderName string,
 	// Delete canary task set if present.
 	taskSetArn, ok := in.MetadataStore.Shared().Get(canaryTaskSetARNKeyName)
 	if ok {
-		in.LogPersister.Errorf("Cleaning CANARY task set %s from service %s", taskSetArn, *service.ServiceName)
+		in.LogPersister.Infof("Cleaning CANARY task set %s from service %s", taskSetArn, *service.ServiceName)
 		if err := client.DeleteTaskSet(ctx, *service, taskSetArn); err != nil {
 			in.LogPersister.Errorf("Failed to clean CANARY task set %s: %v", taskSetArn, err)
 			return false
 		}
+		return true
 	}
 
 	in.LogPersister.Info("No task set found in metadata store to clean")

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -49,6 +49,7 @@ type ECS interface {
 	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
 	RunTask(ctx context.Context, taskDefinition types.TaskDefinition, clusterArn string, launchType string, awsVpcConfiguration *config.ECSVpcConfiguration, tags []types.Tag) error
 	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
+	GetServiceTaskSets(ctx context.Context, service types.Service) ([]*types.TaskSet, error)
 	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup *types.LoadBalancer, scale int) (*types.TaskSet, error)
 	DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)

--- a/pkg/app/piped/platformprovider/ecs/target_groups.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups.go
@@ -41,10 +41,11 @@ func loadTargetGroups(targetGroups config.ECSTargetGroups) (*types.LoadBalancer,
 		return nil, nil, fmt.Errorf("invalid primary target group definition given: %v", err)
 	}
 
-	canary := &types.LoadBalancer{}
+	var canary *types.LoadBalancer
 	if len(targetGroups.Canary) > 0 {
 		canaryDecoder := json.NewDecoder(bytes.NewReader(targetGroups.Canary))
 		canaryDecoder.DisallowUnknownFields()
+		canary = &types.LoadBalancer{}
 		err := canaryDecoder.Decode(canary)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid canary target group definition given: %v", err)

--- a/pkg/app/piped/platformprovider/ecs/target_groups_test.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups_test.go
@@ -1,0 +1,104 @@
+// Copyright 2023 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
+)
+
+func TestLoadTargetGroup(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name        string
+		cfg         config.ECSTargetGroups
+		expected    []*types.LoadBalancer
+		expectedErr bool
+	}{
+		{
+			name:        "no target group",
+			cfg:         config.ECSTargetGroups{},
+			expected:    []*types.LoadBalancer{nil, nil},
+			expectedErr: true,
+		},
+		{
+			name: "primary target group only",
+			cfg: config.ECSTargetGroups{
+				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn", "containerName": "primary-container-name", "containerPort": 80}`),
+			},
+			expected: []*types.LoadBalancer{
+				{
+					TargetGroupArn: aws.String("primary-target-group-arn"),
+					ContainerName:  aws.String("primary-container-name"),
+					ContainerPort:  aws.Int32(80),
+				},
+				nil,
+			},
+			expectedErr: false,
+		},
+		{
+			name: "primary and canary target group",
+			cfg: config.ECSTargetGroups{
+				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn", "containerName": "primary-container-name", "containerPort": 80}`),
+				Canary:  []byte(`{"targetGroupArn": "canary-target-group-arn", "containerName": "canary-container-name", "containerPort": 80}`),
+			},
+			expected: []*types.LoadBalancer{
+				{
+					TargetGroupArn: aws.String("primary-target-group-arn"),
+					ContainerName:  aws.String("primary-container-name"),
+					ContainerPort:  aws.Int32(80),
+				},
+				{
+					TargetGroupArn: aws.String("canary-target-group-arn"),
+					ContainerName:  aws.String("canary-container-name"),
+					ContainerPort:  aws.Int32(80),
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid primary target group",
+			cfg: config.ECSTargetGroups{
+				Primary: []byte(`{"invalidField": "primary-target-group-arn"}`),
+			},
+			expected:    []*types.LoadBalancer{nil, nil},
+			expectedErr: true,
+		},
+		{
+			name: "invalid canary target group",
+			cfg: config.ECSTargetGroups{
+				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn"`),
+				Canary:  []byte(`{"invalidField": "canary-target-group-arn"}`),
+			},
+			expected:    []*types.LoadBalancer{nil, nil},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			primary, canary, err := loadTargetGroups(tc.cfg)
+			assert.Equal(t, tc.expectedErr, err != nil)
+			assert.Equal(t, tc.expected[0], primary)
+			assert.Equal(t, tc.expected[1], canary)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR I did
- Update rollback traffic routing condition, we only need to revert all traffic to primary target group in case of primary & canary target group config are available (ie. progressive sync)
- Instead of using `clean` function in rollback implementation to remove unused taskset, which can only remove CANARY taskset, for general use of rollback function, I use new defined `GetServiceTaskSets` to get all PRIMARY/ACTIVE tasksets of the current service before rolling back and remove them unused taskset later.
- Other changes are rearrange function code blocks to make the flow more like ECS deployment.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
