### PR TITLE
Enable to specific image tag for container images in Helm template

### DIFF
--- a/manifests/helloworld/templates/deployment.yaml
+++ b/manifests/helloworld/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           args:
             - server

--- a/manifests/helloworld/templates/deployment.yaml
+++ b/manifests/helloworld/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           args:
             - server

--- a/manifests/helloworld/values.yaml
+++ b/manifests/helloworld/values.yaml
@@ -23,6 +23,8 @@ service:
 
 image:
   repository: ghcr.io/pipe-cd/helloworld
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
 {{- end }}
 {{- end }}
         - name: server
-          image: "{{ .Values.server.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           args:
           - server
@@ -284,7 +284,7 @@ spec:
               readOnly: true
 {{- end }}
         - name: ops
-          image: "{{ .Values.ops.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.ops.image.repository }}:{{ .Values.ops.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           args:
           - ops
@@ -371,6 +371,7 @@ spec:
 {{- end }}
 
 ---
+# MinIO File Store
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -30,8 +30,8 @@ gateway:
 server:
   image:
     repository: ghcr.io/pipe-cd/pipecd
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   replicasCount: 1
   args:
     cacheAddress: ""
@@ -53,8 +53,8 @@ cache:
 ops:
   image:
     repository: ghcr.io/pipe-cd/pipecd
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   args:
     cacheAddress: ""
     # One of "humanize", "json", or "console" is available.

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -30,6 +30,8 @@ gateway:
 server:
   image:
     repository: ghcr.io/pipe-cd/pipecd
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   replicasCount: 1
   args:
     cacheAddress: ""
@@ -51,6 +53,8 @@ cache:
 ops:
   image:
     repository: ghcr.io/pipe-cd/pipecd
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   args:
     cacheAddress: ""
     # One of "humanize", "json", or "console" is available.

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -29,11 +29,11 @@ spec:
         - name: piped
           imagePullPolicy: IfNotPresent
           {{- if .Values.launcher.enabled }}
-          image: "{{ .Values.launcher.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.launcher.image.repository }}:{{ .Values.launcher.image.tag | default .Chart.AppVersion }}"
           args:
             {{- include "piped.launcherArgs" . | nindent 12 }}
           {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             {{- include "piped.pipedArgs" . | nindent 12 }}
           {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -1,5 +1,7 @@
 image:
   repository: ghcr.io/pipe-cd/piped
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 args:
   metrics: true
@@ -19,6 +21,8 @@ launcher:
   enabled: false
   image:
     repository: ghcr.io/pipe-cd/launcher
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   configFromGitRepo:
     # Whether to load Piped config that is being stored in a git repository.
     enabled: false

--- a/manifests/site/templates/deployment.yaml
+++ b/manifests/site/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: site
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/manifests/site/values.yaml
+++ b/manifests/site/values.yaml
@@ -18,6 +18,8 @@ ingress:
 
 image:
   repository: ghcr.io/pipe-cd/site
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
I would like we have a way to specific an image tag whenever I or somebody else want to test with new OCI image from local environment or difference registry

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4506

**Does this PR introduce a user-facing change?**: N/A

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
