### PR TITLE
Don't overtrim whitespace in template that leading 3 dash or multiple manifest

### DIFF
--- a/manifests/piped/templates/rbac.yaml
+++ b/manifests/piped/templates/rbac.yaml
@@ -12,8 +12,8 @@ metadata:
 {{- end }}
 
 ---
-{{- if .Values.rbac.create -}}
-{{- if eq .Values.rbac.scope "cluster" -}}
+{{ if .Values.rbac.create -}}
+{{ if eq .Values.rbac.scope "cluster" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
I realized `helm lint .` has been failed on manifest/piped, however I believed `helm install` and `helm template` still ok :man-shrugging:

```
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/rbac.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: rbac.authorization.k8s.io/v1

Error: 1 chart(s) linted, 1 chart(s) failed
```
did some search and found this
https://github.com/helm/helm/issues/10149#issuecomment-929205040
so this PR will fix the lint, 
for viz, below is my result when does `helm template values.yaml .`

```
---
# Source: piped/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: release-name-piped
  labels:
    helm.sh/chart: piped-0.0.0
    app.kubernetes.io/name: piped
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.0"
    app.kubernetes.io/managed-by: Helm
rules:
  
  - apiGroups:
    - '*'
    resources:
    - '*'
    verbs:
    - '*'
  - nonResourceURLs:
    - '*'
    verbs:
    - '*'
---
# Source: piped/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-piped
  labels:
    helm.sh/chart: piped-0.0.0
    app.kubernetes.io/name: piped
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.0"
    app.kubernetes.io/managed-by: Helm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: release-name-piped
subjects:
- kind: ServiceAccount
  name: release-name-piped
  namespace: default
```
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
