### PR TITLE
Improve: add deployment timestamp in webhook

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -99,6 +99,7 @@ func buildDeployment(
 		Status:                    model.DeploymentStatus_DEPLOYMENT_PENDING,
 		StatusReason:              "The deployment is waiting to be planned",
 		Metadata:                  metadata,
+		CompletedAt:               app.MostRecentlySuccessfulDeployment.CompletedAt,
 		CreatedAt:                 now.Unix(),
 		UpdatedAt:                 now.Unix(),
 		DeploymentChainId:         deploymentChainID,


### PR DESCRIPTION
**What this PR does / why we need it**:

Including in PipeCD webhook the timestamp when an existing resource was changed by piped.

---
PipeCD gets the deployment status by [reportDeploymentCompleted](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/controller/scheduler.go#L597-L667). At this time, a timestamp ([CompletedAt](CompletedAt)) of when the status was obtained is included in PipeCD webhook.

We can know precisely the timing of the deployment by obtaining the timestamp when receiving the apply result of the manifests.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4584

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
