### PR TITLE
Inactive task definition after delete all of its taskset

### DIFF
--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -379,7 +379,7 @@ func clean(ctx context.Context, in *executor.Input, platformProviderName string,
 		return false
 	}
 
-	in.LogPersister.Infof("Successfully clean CANARY task set %s from service %s", *taskSet.TaskSetArn, *taskSet.ServiceArn)
+	in.LogPersister.Infof("Successfully cleaned CANARY task set %s from service %s", *taskSet.TaskSetArn, *taskSet.ServiceArn)
 	return true
 }
 

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	activeServiceKeyName = "active-service-object"
 	// Canary task set metadata keys.
 	canaryTaskSetKeyName = "canary-taskset-object"
 	// Stage metadata keys.
@@ -266,17 +265,6 @@ func sync(ctx context.Context, in *executor.Input, platformProviderName string, 
 		return false
 	}
 
-	// Store ACTIVE service to delete its unused TaskSet later.
-	serviceObjData, err := json.Marshal(service)
-	if err != nil {
-		in.LogPersister.Errorf("Unable to store applied service to metadata store: %v", err)
-		return false
-	}
-	if err := in.MetadataStore.Shared().Put(ctx, activeServiceKeyName, string(serviceObjData)); err != nil {
-		in.LogPersister.Errorf("Unable to store applied service to metadata store: %v", err)
-		return false
-	}
-
 	in.LogPersister.Infof("Start rolling out ECS task set")
 	if err := createPrimaryTaskSet(ctx, client, *service, *td, targetGroup); err != nil {
 		in.LogPersister.Errorf("Failed to rolling out ECS task set for service %s: %v", *serviceDefinition.ServiceName, err)
@@ -311,17 +299,6 @@ func rollout(ctx context.Context, in *executor.Input, platformProviderName strin
 	service, err := applyServiceDefinition(ctx, client, serviceDefinition)
 	if err != nil {
 		in.LogPersister.Errorf("Failed to apply service %s: %v", *serviceDefinition.ServiceName, err)
-		return false
-	}
-
-	// Store ACTIVE service to delete its unused TaskSet later.
-	serviceObjData, err := json.Marshal(service)
-	if err != nil {
-		in.LogPersister.Errorf("Unable to store applied service to metadata store: %v", err)
-		return false
-	}
-	if err := in.MetadataStore.Shared().Put(ctx, activeServiceKeyName, string(serviceObjData)); err != nil {
-		in.LogPersister.Errorf("Unable to store applied service to metadata store: %v", err)
 		return false
 	}
 

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -168,7 +168,7 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 	in.LogPersister.Infof("Start deleting previous ACTIVE taskSets")
 	for _, ts := range prevTaskSets {
 		in.LogPersister.Infof("Deleting previous ACTIVE taskSet %s", *ts.TaskSetArn)
-		if err := client.DeleteTaskSet(ctx, *service, *ts.TaskSetArn); err != nil {
+		if err := client.DeleteTaskSet(ctx, *ts); err != nil {
 			in.LogPersister.Errorf("Failed to remove previous ACTIVE taskSet %s: %v", *ts.TaskSetArn, err)
 			return false
 		}

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -331,14 +331,14 @@ func (c *client) WaitServiceStable(ctx context.Context, service types.Service) e
 	return err
 }
 
-func (c *client) DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error {
+func (c *client) DeleteTaskSet(ctx context.Context, taskSet types.TaskSet) error {
 	input := &ecs.DeleteTaskSetInput{
-		Cluster: service.ClusterArn,
-		Service: service.ServiceArn,
-		TaskSet: aws.String(taskSetArn),
+		Cluster: taskSet.ClusterArn,
+		Service: taskSet.ServiceArn,
+		TaskSet: taskSet.TaskSetArn,
 	}
 	if _, err := c.ecsClient.DeleteTaskSet(ctx, input); err != nil {
-		return fmt.Errorf("failed to delete ECS task set %s: %w", taskSetArn, err)
+		return fmt.Errorf("failed to delete ECS task set %s: %w", *taskSet.TaskSetArn, err)
 	}
 	return nil
 }

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -340,6 +340,14 @@ func (c *client) DeleteTaskSet(ctx context.Context, taskSet types.TaskSet) error
 	if _, err := c.ecsClient.DeleteTaskSet(ctx, input); err != nil {
 		return fmt.Errorf("failed to delete ECS task set %s: %w", *taskSet.TaskSetArn, err)
 	}
+
+	// Inactive deleted taskset's task definition.
+	taskDefInput := &ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: taskSet.TaskDefinition,
+	}
+	if _, err := c.ecsClient.DeregisterTaskDefinition(ctx, taskDefInput); err != nil {
+		return fmt.Errorf("failed to inactive ECS task definition %s: %w", *taskSet.TaskDefinition, err)
+	}
 	return nil
 }
 

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -51,7 +51,7 @@ type ECS interface {
 	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
 	GetServiceTaskSets(ctx context.Context, service types.Service) ([]*types.TaskSet, error)
 	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup *types.LoadBalancer, scale int) (*types.TaskSet, error)
-	DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error
+	DeleteTaskSet(ctx context.Context, taskSet types.TaskSet) error
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 	TagResource(ctx context.Context, resourceArn string, tags []types.Tag) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a limitation on how many ACTIVE task definitions can be stored by AWS ECS provider (around 1000), so it is better to mark unused task definitions as INACTIVE. We will do it after taskset of that task definition be removed/deleted.

**Which issue(s) this PR fixes**:

Fixes #4577

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
