### PR TITLE
Support recreate for ECS tasks

### DIFF
--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -102,8 +102,8 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	singleton := e.appCfg.QuickSync.Singleton
-	if !sync(ctx, &e.Input, e.platformProviderName, e.platformProviderCfg, singleton, taskDefinition, servicedefinition, primary) {
+	recreate := e.appCfg.QuickSync.Recreate
+	if !sync(ctx, &e.Input, e.platformProviderName, e.platformProviderCfg, recreate, taskDefinition, servicedefinition, primary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -102,7 +102,8 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !sync(ctx, &e.Input, e.platformProviderName, e.platformProviderCfg, taskDefinition, servicedefinition, primary) {
+	singleton := e.appCfg.QuickSync.Singleton
+	if !sync(ctx, &e.Input, e.platformProviderName, e.platformProviderCfg, singleton, taskDefinition, servicedefinition, primary) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -244,7 +244,7 @@ func createPrimaryTaskSet(ctx context.Context, client provider.Client, service t
 	return nil
 }
 
-func sync(ctx context.Context, in *executor.Input, platformProviderName string, platformProviderCfg *config.PlatformProviderECSConfig, singleton bool, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup *types.LoadBalancer) bool {
+func sync(ctx context.Context, in *executor.Input, platformProviderName string, platformProviderCfg *config.PlatformProviderECSConfig, recreate bool, taskDefinition types.TaskDefinition, serviceDefinition types.Service, targetGroup *types.LoadBalancer) bool {
 	client, err := provider.DefaultRegistry().Client(platformProviderName, platformProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", platformProviderName, err)
@@ -265,7 +265,7 @@ func sync(ctx context.Context, in *executor.Input, platformProviderName string, 
 		return false
 	}
 
-	if singleton {
+	if recreate {
 		cnt := service.DesiredCount
 		// Scale down the service tasks by set it to 0
 		in.LogPersister.Infof("Scale down ECS desired tasks count to 0")

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -76,7 +76,7 @@ type ECSSyncStageOptions struct {
 	// Whether to delete old tasksets before creating new ones or not.
 	// If this is set, the application may be unavailable for a short of time during the deployment.
 	// Default is false.
-	Singleton bool `json:"singleton"`
+	Recreate bool `json:"recreate"`
 }
 
 // ECSCanaryRolloutStageOptions contains all configurable values for a ECS_CANARY_ROLLOUT stage.

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -73,6 +73,10 @@ type ECSTargetGroups struct {
 
 // ECSSyncStageOptions contains all configurable values for a ECS_SYNC stage.
 type ECSSyncStageOptions struct {
+	// Whether to delete old tasksets before creating new ones or not.
+	// If this is set, the application may be unavailable for a short of time during the deployment.
+	// Default is false.
+	Singleton bool `json:"singleton"`
 }
 
 // ECSCanaryRolloutStageOptions contains all configurable values for a ECS_CANARY_ROLLOUT stage.


### PR DESCRIPTION
**What this PR does / why we need it**:

Support recreate ECS task while deploying. In such case, we need to configure the application config file like this

```yaml
apiVersion: pipecd.dev/v1beta1
kind: ECSApp
spec:
  quickSync:
    singleton: true
```

**Which issue(s) this PR fixes**:

Part of #4609

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Add option to keep the ECS task singleton while deploying
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
