### PR TITLE
Fix part of lint/go errors (misspell, depguard, unconvert)

### DIFF
--- a/pkg/app/pipectl/client/deployment.go
+++ b/pkg/app/pipectl/client/deployment.go
@@ -89,7 +89,7 @@ func WaitDeploymentStatuses(
 func makeDeploymentStatusesMap(statuses []model.DeploymentStatus) map[model.DeploymentStatus]struct{} {
 	out := make(map[model.DeploymentStatus]struct{}, len(statuses))
 	for _, s := range statuses {
-		out[model.DeploymentStatus(s)] = struct{}{}
+		out[(s)] = struct{}{}
 	}
 	return out
 }

--- a/pkg/app/piped/apistore/applicationstore/store.go
+++ b/pkg/app/piped/apistore/applicationstore/store.go
@@ -16,9 +16,9 @@ package applicationstore
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 

--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -16,9 +16,9 @@ package deploymentstore
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 

--- a/pkg/app/piped/apistore/eventstore/store.go
+++ b/pkg/app/piped/apistore/eventstore/store.go
@@ -17,9 +17,9 @@ package eventstore
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 

--- a/pkg/app/piped/platformprovider/terraform/module.go
+++ b/pkg/app/piped/platformprovider/terraform/module.go
@@ -16,7 +16,7 @@ package terraform
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
@@ -56,7 +56,7 @@ const tfFileExtension = ".tf"
 
 // LoadTerraformFiles loads terraform files from a given dir.
 func LoadTerraformFiles(dir string) ([]File, error) {
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -643,7 +643,7 @@ type PlatformProviderTerraformConfig struct {
 	// 'image_id_map={"us-east-1":"ami-abc123","us-east-2":"ami-def456"}'
 	Vars []string `json:"vars,omitempty"`
 	// Enable drift detection.
-	// TODO: This is a temporary option because Terraform drift detection is buggy and has performace issues. This will be possibly removed in the future release.
+	// TODO: This is a temporary option because Terraform drift detection is buggy and has performance issues. This will be possibly removed in the future release.
 	DriftDetectionEnabled *bool `json:"driftDetectionEnabled" default:"true"`
 }
 

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -484,7 +484,7 @@ func TestMergeMetadata(t *testing.T) {
 			expected: map[string]string{},
 		},
 		{
-			name: "ori map is emtpy",
+			name: "ori map is empty",
 			new: map[string]string{
 				"key-1": "value-1",
 			},
@@ -493,7 +493,7 @@ func TestMergeMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "new map is emtpy",
+			name: "new map is empty",
 			ori: map[string]string{
 				"key-1": "value-1",
 			},

--- a/pkg/datastore/filedb/filter.go
+++ b/pkg/datastore/filedb/filter.go
@@ -70,7 +70,7 @@ func filter(col datastore.Collection, e interface{}, filters []datastore.ListFil
 		}
 
 		val, ok := omap[field]
-		// If the object does not contain given field name in filter, return false immidiately.
+		// If the object does not contain given field name in filter, return false immediately.
 		if !ok {
 			return false, nil
 		}

--- a/pkg/diff/renderer_test.go
+++ b/pkg/diff/renderer_test.go
@@ -66,7 +66,7 @@ func TestRenderNodeValue(t *testing.T) {
 			expected: "hello",
 		},
 		{
-			name: "slice of primative elements",
+			name: "slice of primitive elements",
 			value: func() reflect.Value {
 				v := []int{1, 2, 3}
 				return reflect.ValueOf(v)
@@ -110,7 +110,7 @@ two: two-value`,
 				v := map[string]interface{}{
 					"1-number":           1,
 					"2-string":           "hello",
-					"3-map-of-primative": mapOfPrimative,
+					"3-map-of-primitive": mapOfPrimative,
 					"4-map-of-map":       mapOfMap,
 					"5-map-of-slice":     mapOfSlice,
 					"6-slice":            []string{"a", "b"},
@@ -120,7 +120,7 @@ two: two-value`,
 			}(),
 			expected: `1-number: 1
 2-string: hello
-3-map-of-primative:
+3-map-of-primitive:
   one: 1
   two: 2
 4-map-of-map:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix part of errors which make lint/go returns(misspell, depguard, unconvert).

<details><summary> List of remaining errors </summary>

- [x] misspell
- [x] depguard
- [x] unconvert
- [ ] deadcode
- [ ] errcheck
- [ ] gocritic
- [ ] goerr113
- [ ] gosec
- [ ] stylecheck
- [ ] goimports
- [ ] gosimple
- [ ] typecheck
- [ ] ineffassign

</details>

**Which issue(s) this PR fixes**:

part of https://github.com/pipe-cd/pipecd/issues/4566

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
