### PR TITLE
Fix part of lint/go errors (goimport, staticcheck, gosimple)

### DIFF
--- a/pkg/app/piped/controller/controllermetrics/metrics.go
+++ b/pkg/app/piped/controller/controllermetrics/metrics.go
@@ -15,8 +15,9 @@
 package controllermetrics
 
 import (
-	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 const (

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -315,7 +315,7 @@ func makeSyncState(r *provider.DiffResult, commit string) model.ApplicationSyncS
 		}
 	}
 
-	shortReason := fmt.Sprintf("The service manifest doesn't be synced")
+	shortReason := "The service manifest doesn't be synced"
 	if len(commit) >= 7 {
 		commit = commit[:7]
 	}

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -120,9 +120,7 @@ func (t *Terraform) Init(ctx context.Context, w io.Writer) error {
 		"init",
 	}
 	args = append(args, t.makeCommonCommandArgs()...)
-	for _, f := range t.options.initFlags {
-		args = append(args, f)
-	}
+	args = append(args, t.options.initFlags...)
 
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir
@@ -278,9 +276,7 @@ func (t *Terraform) Plan(ctx context.Context, w io.Writer) (PlanResult, error) {
 		"-detailed-exitcode",
 	}
 	args = append(args, t.makeCommonCommandArgs()...)
-	for _, f := range t.options.planFlags {
-		args = append(args, f)
-	}
+	args = append(args, t.options.planFlags...)
 
 	var buf bytes.Buffer
 	stdout := io.MultiWriter(w, &buf)
@@ -316,9 +312,7 @@ func (t *Terraform) makeCommonCommandArgs() (args []string) {
 	for _, f := range t.options.varFiles {
 		args = append(args, fmt.Sprintf("-var-file=%s", f))
 	}
-	for _, f := range t.options.sharedFlags {
-		args = append(args, f)
-	}
+	args = append(args, t.options.sharedFlags...)
 	return
 }
 
@@ -398,9 +392,7 @@ func (t *Terraform) Apply(ctx context.Context, w io.Writer) error {
 		"-input=false",
 	}
 	args = append(args, t.makeCommonCommandArgs()...)
-	for _, f := range t.options.applyFlags {
-		args = append(args, f)
-	}
+	args = append(args, t.options.applyFlags...)
 
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir

--- a/pkg/app/server/grpcapi/grpcapi_test.go
+++ b/pkg/app/server/grpcapi/grpcapi_test.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pipe-cd/pipecd/pkg/datastore"
-	"github.com/pipe-cd/pipecd/pkg/filestore"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+	"github.com/pipe-cd/pipecd/pkg/filestore"
 )
 
 func TestGRPCStoreError(t *testing.T) {

--- a/pkg/model/application_live_state.go
+++ b/pkg/model/application_live_state.go
@@ -68,7 +68,6 @@ func (s *ApplicationLiveStateSnapshot) DetermineAppHealthStatus() {
 	case ApplicationKind_CLOUDRUN:
 		s.determineCloudRunAppHealthStatus()
 	}
-	return
 }
 
 func (s *ApplicationLiveStateSnapshot) determineKubernetesAppHealthStatus() {

--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -209,11 +209,10 @@ func (p *ProjectStaticUser) Auth(username, password string) error {
 
 // RedactSensitiveData redacts sensitive data.
 func (p *ProjectSSOConfig) RedactSensitiveData() {
-	if p.Github != nil {
-		p.Github.RedactSensitiveData()
+	if p.Github == nil {
+		return
 	}
-	if p.Google != nil {
-	}
+	p.Github.RedactSensitiveData()
 }
 
 // Update updates ProjectSSOConfig with given data.
@@ -234,24 +233,22 @@ func (p *ProjectSSOConfig) Update(sso *ProjectSSOConfig) error {
 
 // Encrypt encrypts sensitive data in ProjectSSOConfig.
 func (p *ProjectSSOConfig) Encrypt(encrypter encrypter) error {
-	if p.Github != nil {
-		if err := p.Github.Encrypt(encrypter); err != nil {
-			return err
-		}
+	if p.Github == nil {
+		return nil
 	}
-	if p.Google != nil {
+	if err := p.Github.Encrypt(encrypter); err != nil {
+		return err
 	}
 	return nil
 }
 
 // Decrypt decrypts encrypted data in ProjectSSOConfig.
 func (p *ProjectSSOConfig) Decrypt(decrypter decrypter) error {
-	if p.Github != nil {
-		if err := p.Github.Decrypt(decrypter); err != nil {
-			return err
-		}
+	if p.Github == nil {
+		return nil
 	}
-	if p.Google != nil {
+	if err := p.Github.Decrypt(decrypter); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix part of errors which make lint/go returns(goimport, staticcheck, gosimple).

<details><summary> List of remaining errors </summary>

- [x] goimports
- [x] gosimple
- [x] staticcheck
- [ ] deadcode
- [ ] errcheck
- [ ] gocritic
- [ ] goerr113
- [ ] gosec
- [ ] stylecheck
- [ ] typecheck
- [ ] ineffassign
- [x] ~~misspell, depguard, unconvert~~ https://github.com/pipe-cd/pipecd/pull/4621

</details>

**Which issue(s) this PR fixes**:

part of https://github.com/pipe-cd/pipecd/issues/4566

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
