### PR TITLE
Fix part of lint/go errors (deadcode, ineffassign, depguard)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
     - ^.*\.(pb|y)\.go$
   skip-dirs:
     - "vendor$"
+    - "pkg/app/piped/executor/analysis/mannwhitney"
 
 linters:
   disable-all: true

--- a/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
+++ b/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
@@ -28,7 +28,6 @@ import (
 const (
 	outputTTL    = 48 * time.Hour
 	cronSchedule = "0 9 * * *" // Run at 09:00 every day.
-	interval     = 24 * time.Hour
 	prefix       = "command-output/"
 )
 

--- a/pkg/app/piped/livestatestore/cloudrun/store.go
+++ b/pkg/app/piped/livestatestore/cloudrun/store.go
@@ -17,9 +17,9 @@ package cloudrun
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/cloudrun"

--- a/pkg/app/server/grpcapi/grpcapi.go
+++ b/pkg/app/server/grpcapi/grpcapi.go
@@ -184,10 +184,6 @@ func gRPCStoreError(err error, msg string) error {
 	return status.Error(codes.Internal, fmt.Sprintf("Failed to %s", msg))
 }
 
-func makeUnregisteredAppsCacheKey(projectID string) string {
-	return fmt.Sprintf("HASHKEY:UNREGISTERED_APPS:%s", projectID)
-}
-
 func getPipedStatus(cs cache.Cache, id string) (model.Piped_ConnectionStatus, error) {
 	pipedStatus, err := cs.Get(id)
 	if errors.Is(err, cache.ErrNotFound) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix part of errors which `make lint/go` returns (deadcode, ineffassign).

- Delete codes not used.  [bc8f8c0](https://github.com/pipe-cd/pipecd/pull/4624/commits/bc8f8c0bb5902024d1d26e3aea61a0b51e3fecc4)
- Skip `pkg/app/piped/executor/analysis/mannwhitney` from golangci-lint. [2fb53a8](https://github.com/pipe-cd/pipecd/pull/4624/commits/2fb53a837e0e1085c084830d97cfc448e1698296)
- Found still remaining errors by depguard and corrected. https://github.com/pipe-cd/pipecd/pull/4624/commits/4c3ac5cfeee8b37951a5d86438817913e98f1118


<details><summary> List of remaining errors </summary>

- [x] deadcode
- [x] ineffassign
- [ ] errcheck
- [ ] goerr113
- [ ] typecheck
- [ ] gocritic
- [x] ~~misspell, depguard, unconvert~~ https://github.com/pipe-cd/pipecd/pull/4621
- [x] ~~goimports, gosimple, staticcheck~~ https://github.com/pipe-cd/pipecd/pull/4622


```
$ make go/lint | grep -e deadcode -e ineffassign -e misspell -e depguard -e unconvert -e goimports -e gosimple -e staticcheck
-> null
```

</details>

**Which issue(s) this PR fixes**:

part of https://github.com/pipe-cd/pipecd/issues/4566

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:


Sorry for the force pushes for DCO.