### PR TITLE
Fix part of lint/go errors (gocritic)

### DIFF
--- a/pkg/app/ops/handler/handler.go
+++ b/pkg/app/ops/handler/handler.go
@@ -238,7 +238,7 @@ func groupApplicationCounts(counts []model.InsightApplicationCount) (total int, 
 	for _, c := range counts {
 		total += int(c.Count)
 		kind := c.Labels[model.InsightApplicationCountLabelKey_KIND.String()]
-		groups[kind] = groups[kind] + int(c.Count)
+		groups[kind] += int(c.Count)
 	}
 	return
 }

--- a/pkg/app/server/httpapi/httpapimetrics/delegator.go
+++ b/pkg/app/server/httpapi/httpapimetrics/delegator.go
@@ -100,7 +100,7 @@ type pusherDelegator struct{ *responseWriterDelegator }
 
 func (d closeNotifierDelegator) CloseNotify() <-chan bool {
 	//lint:ignore SA1019 http.CloseNotifier is deprecated but we don't want to
-	//remove support from client_golang yet.
+	// remove support from client_golang yet.
 	return d.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }
 func (d flusherDelegator) Flush() {
@@ -278,7 +278,7 @@ func init() {
 			http.Flusher
 		}{d, pusherDelegator{d}, hijackerDelegator{d}, flusherDelegator{d}}
 	}
-	pickDelegator[pusher+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { //23
+	pickDelegator[pusher+hijacker+flusher+closeNotifier] = func(d *responseWriterDelegator) delegator { // 23
 		return struct {
 			*responseWriterDelegator
 			http.Pusher
@@ -365,7 +365,7 @@ func newDelegator(w http.ResponseWriter, observeWriteHeaderFunc func(int)) deleg
 
 	id := 0
 	//lint:ignore SA1019 http.CloseNotifier is deprecated but we don't want to
-	//remove support from client_golang yet.
+	// remove support from client_golang yet.
 	if _, ok := w.(http.CloseNotifier); ok {
 		id += closeNotifier
 	}

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -192,5 +192,5 @@ func (t Input) CustomMetricsHandlerFor(reg prometheus.Gatherer, mb MetricsBuilde
 }
 
 func extractServiceName(cmd *cobra.Command) string {
-	return strings.Replace(cmd.CommandPath(), " ", ".", -1)
+	return strings.ReplaceAll(cmd.CommandPath(), " ", ".")
 }

--- a/pkg/config/control_plane.go
+++ b/pkg/config/control_plane.go
@@ -281,7 +281,7 @@ func (f *ControlPlaneFileStore) UnmarshalJSON(data []byte) error {
 		}
 	default:
 		// Left comment out for mock response.
-		//err = fmt.Errorf("unsupported filestore type: %s", f.Type)
+		// err = fmt.Errorf("unsupported filestore type: %s", f.Type)
 		err = nil
 	}
 	return err

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -92,7 +92,7 @@ func buildWhereClause(filters []datastore.ListFilter) (string, error) {
 			conds[i] = fmt.Sprintf("%s %s ?", filter.Field, op)
 		}
 	}
-	return fmt.Sprintf("WHERE %s", strings.Join(conds[:], " AND ")), nil
+	return fmt.Sprintf("WHERE %s", strings.Join(conds, " AND ")), nil
 }
 
 func buildPaginationCondition(opts datastore.ListOptions) string {
@@ -165,7 +165,7 @@ func buildOrderByClause(orders []datastore.Order) (string, error) {
 		return "", fmt.Errorf("id field is required as ordering field")
 	}
 
-	return fmt.Sprintf("ORDER BY %s", strings.Join(conds[:], ", ")), nil
+	return fmt.Sprintf("ORDER BY %s", strings.Join(conds, ", ")), nil
 }
 
 func buildLimitClause(limit int) string {

--- a/pkg/filematcher/filematcher.go
+++ b/pkg/filematcher/filematcher.go
@@ -184,7 +184,8 @@ func (p *Pattern) regexpString() string {
 	for scan.Peek() != scanner.EOF {
 		ch := scan.Next()
 
-		if ch == '*' {
+		switch ch {
+		case '*':
 			if scan.Peek() == '*' {
 				// Is some flavor of "**".
 				scan.Next()
@@ -207,14 +208,14 @@ func (p *Pattern) regexpString() string {
 				// Is "*" so map it to anything but "/".
 				regStr += "[^" + escSL + "]*"
 			}
-		} else if ch == '?' {
+		case '?':
 			// "?" is any char except "/".
 			regStr += "[^" + escSL + "]"
-		} else if ch == '.' || ch == '$' {
+		case '.', '$':
 			// Escape some regexp special chars that have no meaning
 			// in golang's filepath.Match.
 			regStr += `\` + string(ch)
-		} else if ch == '\\' {
+		case '\\':
 			// Escape next char. Note that a trailing \ in the pattern
 			// will be left alone (but need to escape it).
 			if sl == `\` {
@@ -229,7 +230,7 @@ func (p *Pattern) regexpString() string {
 			} else {
 				regStr += `\`
 			}
-		} else {
+		default:
 			regStr += string(ch)
 		}
 	}

--- a/pkg/insight/insightmetrics/metrics.go
+++ b/pkg/insight/insightmetrics/metrics.go
@@ -100,7 +100,7 @@ func groupApplicationCounts(counts []model.InsightApplicationCount) map[string]i
 	groups := make(map[string]int, len(counts))
 	for _, c := range counts {
 		kind := c.Labels[model.InsightApplicationCountLabelKey_KIND.String()]
-		groups[kind] = groups[kind] + int(c.Count)
+		groups[kind] += int(c.Count)
 	}
 	return groups
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix part of errors which `make lint/go` returns (gocritic).

<details><summary>gocritic lint errors</summary>

```
$ make lint/go | grep -e "(gocritic)"
pkg/app/ops/handler/handler.go:241:3: assignOp: replace `groups[kind] = groups[kind] + int(c.Count)` with `groups[kind] += int(c.Count)` (gocritic)
pkg/app/server/httpapi/httpapimetrics/delegator.go:103:2: commentFormatting: put a space between `//` and comment text (gocritic)
pkg/app/server/httpapi/httpapimetrics/delegator.go:281:102: commentFormatting: put a space between `//` and comment text (gocritic)
pkg/cli/cmd.go:195:9: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(cmd.CommandPath(), " ", ".", -1)` (gocritic)
pkg/config/control_plane.go:284:3: commentFormatting: put a space between `//` and comment text (gocritic)
pkg/datastore/mysql/query.go:95:46: unslice: could simplify conds[:] to conds (gocritic)
pkg/datastore/mysql/query.go:168:49: unslice: could simplify conds[:] to conds (gocritic)
pkg/filematcher/filematcher.go:187:3: ifElseChain: rewrite if-else to switch statement (gocritic)
pkg/insight/insightmetrics/metrics.go:103:3: assignOp: replace `groups[kind] = groups[kind] + int(c.Count)` with `groups[kind] += int(c.Count)` (gocritic)
```

</details>


<details><summary> List of remaining errors </summary>

- [x] gocritic
- [ ] errcheck
- [ ] goerr113
- [ ] typecheck
- [ ] stylecheck
- [ ] gosec
- [x] ~~deadcode, ineffassign~~ https://github.com/pipe-cd/pipecd/pull/4624
- [x] ~~misspell, depguard, unconvert~~ https://github.com/pipe-cd/pipecd/pull/4621
- [x] ~~goimports, gosimple, staticcheck~~ https://github.com/pipe-cd/pipecd/pull/4622

</details>


**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4566


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
