### PR TITLE
Fix part of lint/go errors (stylecheck) 

### DIFF
--- a/docs/main.go
+++ b/docs/main.go
@@ -45,7 +45,7 @@ func main() {
 	// Redirect /docs/ to /docs-{latest-version}/
 	mux.HandleFunc("/docs/", func(w http.ResponseWriter, r *http.Request) {
 		latestPattern := strings.Replace(r.URL.Path, "/docs/", latestPath, 1)
-		http.Redirect(w, r, latestPattern, 307)
+		http.Redirect(w, r, latestPattern, http.StatusTemporaryRedirect)
 	})
 
 	defer func() {

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -160,8 +160,8 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 		})
 	}
 	// Run analyses with http providers.
-	for i := range options.Https {
-		analyzer, err := e.newAnalyzerForHTTP(i, &options.Https[i], templateCfg)
+	for i := range options.HTTPS {
+		analyzer, err := e.newAnalyzerForHTTP(i, &options.HTTPS[i], templateCfg)
 		if err != nil {
 			e.LogPersister.Errorf("Failed to spawn analyzer for HTTP: %v", err)
 			return model.StageStatus_STAGE_FAILURE
@@ -312,7 +312,7 @@ func (e *Executor) getHTTPConfig(templatableCfg *config.TemplatableAnalysisHTTP,
 		return &templatableCfg.AnalysisHTTP, nil
 	}
 
-	cfg, ok := templateCfg.HTTPs[name]
+	cfg, ok := templateCfg.HTTPS[name]
 	if !ok {
 		return nil, fmt.Errorf("analysis template %s not found despite template specified", name)
 	}

--- a/pkg/app/piped/planner/cloudrun/pipeline.go
+++ b/pkg/app/piped/planner/cloudrun/pipeline.go
@@ -32,7 +32,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	)
 
 	for i, s := range stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -58,7 +58,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,
@@ -79,7 +79,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	)
 
 	for i, s := range pp.Stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -105,7 +105,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,

--- a/pkg/app/piped/planner/ecs/pipeline.go
+++ b/pkg/app/piped/planner/ecs/pipeline.go
@@ -32,7 +32,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	)
 
 	for i, s := range stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -58,7 +58,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,
@@ -79,7 +79,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	)
 
 	for i, s := range pp.Stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -105,7 +105,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,

--- a/pkg/app/piped/planner/kubernetes/pipeline.go
+++ b/pkg/app/piped/planner/kubernetes/pipeline.go
@@ -32,7 +32,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	)
 
 	for i, s := range stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -58,7 +58,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,
@@ -79,7 +79,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	)
 
 	for i, s := range pp.Stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -105,7 +105,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,

--- a/pkg/app/piped/planner/lambda/pipeline.go
+++ b/pkg/app/piped/planner/lambda/pipeline.go
@@ -32,7 +32,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	)
 
 	for i, s := range stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -58,7 +58,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,
@@ -80,7 +80,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 
 	shouldRollbackCustomSync := false
 	for i, s := range pp.Stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -110,7 +110,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 		if shouldRollbackCustomSync {
 			s, _ := planner.GetPredefinedStage(planner.PredefinedStageCustomSyncRollback)
 			out = append(out, &model.PipelineStage{
-				Id:         s.Id,
+				Id:         s.ID,
 				Name:       s.Name.String(),
 				Desc:       s.Desc,
 				Predefined: true,
@@ -122,7 +122,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 		} else {
 			s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 			out = append(out, &model.PipelineStage{
-				Id:         s.Id,
+				Id:         s.ID,
 				Name:       s.Name.String(),
 				Desc:       s.Desc,
 				Predefined: true,

--- a/pkg/app/piped/planner/predefined_stages.go
+++ b/pkg/app/piped/planner/predefined_stages.go
@@ -31,37 +31,37 @@ const (
 
 var predefinedStages = map[string]config.PipelineStage{
 	PredefinedStageK8sSync: {
-		Id:   PredefinedStageK8sSync,
+		ID:   PredefinedStageK8sSync,
 		Name: model.StageK8sSync,
 		Desc: "Sync by applying all manifests",
 	},
 	PredefinedStageTerraformSync: {
-		Id:   PredefinedStageTerraformSync,
+		ID:   PredefinedStageTerraformSync,
 		Name: model.StageTerraformSync,
 		Desc: "Sync by automatically applying any detected changes",
 	},
 	PredefinedStageCloudRunSync: {
-		Id:   PredefinedStageCloudRunSync,
+		ID:   PredefinedStageCloudRunSync,
 		Name: model.StageCloudRunSync,
 		Desc: "Deploy the new version and configure all traffic to it",
 	},
 	PredefinedStageLambdaSync: {
-		Id:   PredefinedStageLambdaSync,
+		ID:   PredefinedStageLambdaSync,
 		Name: model.StageLambdaSync,
 		Desc: "Deploy the new version and configure all traffic to it",
 	},
 	PredefinedStageECSSync: {
-		Id:   PredefinedStageECSSync,
+		ID:   PredefinedStageECSSync,
 		Name: model.StageECSSync,
 		Desc: "Deploy the new version and configure all traffic to it",
 	},
 	PredefinedStageRollback: {
-		Id:   PredefinedStageRollback,
+		ID:   PredefinedStageRollback,
 		Name: model.StageRollback,
 		Desc: "Rollback the deployment",
 	},
 	PredefinedStageCustomSyncRollback: {
-		Id:   PredefinedStageCustomSyncRollback,
+		ID:   PredefinedStageCustomSyncRollback,
 		Name: model.StageCustomSyncRollback,
 		Desc: "Rollback the custom stages",
 	},

--- a/pkg/app/piped/planner/terraform/pipeline.go
+++ b/pkg/app/piped/planner/terraform/pipeline.go
@@ -30,7 +30,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	)
 
 	// Append SYNC stage.
-	id := s.Id
+	id := s.ID
 	if id == "" {
 		id = "stage-0"
 	}
@@ -52,7 +52,7 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,
@@ -73,7 +73,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	)
 
 	for i, s := range pp.Stages {
-		id := s.Id
+		id := s.ID
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", i)
 		}
@@ -99,7 +99,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 	if autoRollback {
 		s, _ := planner.GetPredefinedStage(planner.PredefinedStageRollback)
 		out = append(out, &model.PipelineStage{
-			Id:         s.Id,
+			Id:         s.ID,
 			Name:       s.Name.String(),
 			Desc:       s.Desc,
 			Predefined: true,

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -177,12 +177,12 @@ func (t *Trigger) checkCandidates(ctx context.Context, cs []candidate) (err erro
 	// Group candidates by repository to reduce the number of Git operations on each repo.
 	csm := make(map[string][]candidate)
 	for _, c := range cs {
-		repoId := c.application.GitPath.Repo.Id
-		if _, ok := csm[repoId]; !ok {
-			csm[repoId] = []candidate{c}
+		repoID := c.application.GitPath.Repo.Id
+		if _, ok := csm[repoID]; !ok {
+			csm[repoID] = []candidate{c}
 			continue
 		}
-		csm[repoId] = append(csm[repoId], c)
+		csm[repoID] = append(csm[repoID], c)
 	}
 
 	// Iterate each repository and check its candidates.

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -42,7 +42,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
 
-type pipedApiApplicationStore interface {
+type pipedAPIApplicationStore interface {
 	Get(ctx context.Context, id string) (*model.Application, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
 	UpdateSyncState(ctx context.Context, id string, state *model.ApplicationSyncState) error
@@ -51,7 +51,7 @@ type pipedApiApplicationStore interface {
 	UpdateMostRecentDeployment(ctx context.Context, id string, status model.DeploymentStatus, d *model.ApplicationDeploymentReference) error
 }
 
-type pipedApiDeploymentStore interface {
+type pipedAPIDeploymentStore interface {
 	Add(ctx context.Context, app *model.Deployment) error
 	Get(ctx context.Context, id string) (*model.Deployment, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error)
@@ -63,17 +63,17 @@ type pipedApiDeploymentStore interface {
 	UpdateStageMetadata(ctx context.Context, deploymentID, stageID string, metadata map[string]string) error
 }
 
-type pipedApiDeploymentChainStore interface {
+type pipedAPIDeploymentChainStore interface {
 	Add(ctx context.Context, d *model.DeploymentChain) error
 	Get(ctx context.Context, id string) (*model.DeploymentChain, error)
 }
 
-type pipedApiPipedStore interface {
+type pipedAPIPipedStore interface {
 	Get(ctx context.Context, id string) (*model.Piped, error)
 	UpdateMetadata(ctx context.Context, id, version, config string, pps []*model.Piped_PlatformProvider, repos []*model.ApplicationGitRepository, se *model.Piped_SecretEncryption, startedAt int64) error
 }
 
-type pipedApiEventStore interface {
+type pipedAPIEventStore interface {
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Event, string, error)
 	UpdateStatus(ctx context.Context, eventID string, status model.EventStatus, statusDescription string) error
 }
@@ -86,11 +86,11 @@ type commandOutputPutter interface {
 type PipedAPI struct {
 	pipedservice.UnimplementedPipedServiceServer
 
-	applicationStore          pipedApiApplicationStore
-	deploymentStore           pipedApiDeploymentStore
-	deploymentChainStore      pipedApiDeploymentChainStore
-	pipedStore                pipedApiPipedStore
-	eventStore                pipedApiEventStore
+	applicationStore          pipedAPIApplicationStore
+	deploymentStore           pipedAPIDeploymentStore
+	deploymentChainStore      pipedAPIDeploymentChainStore
+	pipedStore                pipedAPIPipedStore
+	eventStore                pipedAPIEventStore
 	stageLogStore             stagelogstore.Store
 	applicationLiveStateStore applicationlivestatestore.Store
 	analysisResultStore       analysisresultstore.Store

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -104,7 +104,7 @@ type webAPIAPIKeyStore interface {
 	Disable(ctx context.Context, id, projectID string) error
 }
 
-type webAPIAPIKeyLastUsedStore interface { //nolint:stylecheck
+type webAPIAPIKeyLastUsedStore interface {
 	Get(k string) (interface{}, error)
 }
 

--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -48,7 +48,7 @@ type encrypter interface {
 	Encrypt(text string) (string, error)
 }
 
-type webApiApplicationStore interface {
+type webAPIApplicationStore interface {
 	Add(ctx context.Context, app *model.Application) error
 	Get(ctx context.Context, id string) (*model.Application, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
@@ -58,17 +58,17 @@ type webApiApplicationStore interface {
 	Disable(ctx context.Context, id string) error
 }
 
-type webApiDeploymentChainStore interface {
+type webAPIDeploymentChainStore interface {
 	Get(ctx context.Context, id string) (*model.DeploymentChain, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.DeploymentChain, string, error)
 }
 
-type webApiDeploymentStore interface {
+type webAPIDeploymentStore interface {
 	Get(ctx context.Context, id string) (*model.Deployment, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error)
 }
 
-type webApiPipedStore interface {
+type webAPIPipedStore interface {
 	Add(ctx context.Context, piped *model.Piped) error
 	Get(ctx context.Context, id string) (*model.Piped, error)
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Piped, error)
@@ -80,7 +80,7 @@ type webApiPipedStore interface {
 	UpdateDesiredVersion(ctx context.Context, id, version string) error
 }
 
-type webApiProjectStore interface {
+type webAPIProjectStore interface {
 	Get(ctx context.Context, id string) (*model.Project, error)
 	UpdateProjectStaticAdmin(ctx context.Context, id, username, password string) error
 	EnableStaticAdmin(ctx context.Context, id string) error
@@ -94,18 +94,17 @@ type webApiProjectStore interface {
 	DeleteProjectUserGroup(ctx context.Context, id, sso string) error
 }
 
-type webApiEventStore interface {
+type webAPIEventStore interface {
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.Event, string, error)
 }
 
-type webApiAPIKeyStore interface {
+type webAPIAPIKeyStore interface {
 	Add(ctx context.Context, k *model.APIKey) error
 	List(ctx context.Context, opts datastore.ListOptions) ([]*model.APIKey, error)
 	Disable(ctx context.Context, id, projectID string) error
 }
 
-// TODO: all structs webApi should be webAPI
-type webApiAPIKeyLastUsedStore interface { //nolint:stylecheck
+type webAPIAPIKeyLastUsedStore interface { //nolint:stylecheck
 	Get(k string) (interface{}, error)
 }
 
@@ -113,14 +112,14 @@ type webApiAPIKeyLastUsedStore interface { //nolint:stylecheck
 type WebAPI struct {
 	webservice.UnimplementedWebServiceServer
 
-	applicationStore          webApiApplicationStore
-	deploymentChainStore      webApiDeploymentChainStore
-	deploymentStore           webApiDeploymentStore
-	pipedStore                webApiPipedStore
-	projectStore              webApiProjectStore
-	apiKeyStore               webApiAPIKeyStore
-	apiKeyLastUsedStore       webApiAPIKeyLastUsedStore
-	eventStore                webApiEventStore
+	applicationStore          webAPIApplicationStore
+	deploymentChainStore      webAPIDeploymentChainStore
+	deploymentStore           webAPIDeploymentStore
+	pipedStore                webAPIPipedStore
+	projectStore              webAPIProjectStore
+	apiKeyStore               webAPIAPIKeyStore
+	apiKeyLastUsedStore       webAPIAPIKeyLastUsedStore
+	eventStore                webAPIEventStore
 	stageLogStore             stagelogstore.Store
 	applicationLiveStateStore applicationlivestatestore.Store
 	commandStore              commandstore.Store
@@ -1210,7 +1209,7 @@ func (a *WebAPI) GetProject(ctx context.Context, req *webservice.GetProjectReque
 func (a *WebAPI) getProject(ctx context.Context, projectID string) (*model.Project, error) {
 	if p, ok := a.projectsInConfig[projectID]; ok {
 		p := &model.Project{
-			Id:   p.Id,
+			Id:   p.ID,
 			Desc: p.Desc,
 			StaticAdmin: &model.ProjectStaticUser{
 				Username:     p.StaticAdmin.Username,

--- a/pkg/app/server/pipedverifier/verifier_test.go
+++ b/pkg/app/server/pipedverifier/verifier_test.go
@@ -121,7 +121,7 @@ func TestVerify(t *testing.T) {
 		&config.ControlPlaneSpec{
 			Projects: []config.ControlPlaneProject{
 				{
-					Id: "project-0",
+					ID: "project-0",
 				},
 			},
 		},

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -30,7 +30,7 @@ type App struct {
 	telemetryFlags TelemetryFlags
 }
 
-var FlagParseErr = errors.New("FlagParseErr")
+var ErrFlagParse = errors.New("FlagParseErr")
 
 func NewApp(name, desc string) *App {
 	a := &App{
@@ -45,7 +45,7 @@ func NewApp(name, desc string) *App {
 	a.rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.Println(err)
 		cmd.Println(cmd.UsageString())
-		return FlagParseErr
+		return ErrFlagParse
 	})
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/pkg/config/analysis_template.go
+++ b/pkg/config/analysis_template.go
@@ -23,7 +23,7 @@ import (
 type AnalysisTemplateSpec struct {
 	Metrics map[string]AnalysisMetrics `json:"metrics"`
 	Logs    map[string]AnalysisLog     `json:"logs"`
-	HTTPs   map[string]AnalysisHTTP    `json:"https"`
+	HTTPS   map[string]AnalysisHTTP    `json:"https"`
 }
 
 // LoadAnalysisTemplate finds the config file for the analysis template in the .pipe

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -216,7 +216,7 @@ type DeploymentPipeline struct {
 // PipelineStage represents a single stage of a pipeline.
 // This is used as a generic struct for all stage type.
 type PipelineStage struct {
-	Id      string
+	ID      string
 	Name    model.Stage
 	Desc    string
 	Timeout Duration
@@ -252,7 +252,7 @@ type PipelineStage struct {
 }
 
 type genericPipelineStage struct {
-	Id      string          `json:"id"`
+	ID      string          `json:"id"`
 	Name    model.Stage     `json:"name"`
 	Desc    string          `json:"desc,omitempty"`
 	Timeout Duration        `json:"timeout"`
@@ -265,7 +265,7 @@ func (s *PipelineStage) UnmarshalJSON(data []byte) error {
 	if err = json.Unmarshal(data, &gs); err != nil {
 		return err
 	}
-	s.Id = gs.Id
+	s.ID = gs.ID
 	s.Name = gs.Name
 	s.Desc = gs.Desc
 	s.Timeout = gs.Timeout
@@ -440,7 +440,7 @@ type AnalysisStageOptions struct {
 	RestartThreshold int                          `json:"restartThreshold"`
 	Metrics          []TemplatableAnalysisMetrics `json:"metrics"`
 	Logs             []TemplatableAnalysisLog     `json:"logs"`
-	Https            []TemplatableAnalysisHTTP    `json:"https"`
+	HTTPS            []TemplatableAnalysisHTTP    `json:"https"`
 }
 
 func (a *AnalysisStageOptions) Validate() error {
@@ -471,7 +471,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			return fmt.Errorf("one of log configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}
-	for _, h := range a.Https {
+	for _, h := range a.HTTPS {
 		if h.Template.Name != "" {
 			if err := h.Template.Validate(); err != nil {
 				return fmt.Errorf("one of http configurations of ANALYSIS stage is invalid: %w", err)

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -596,7 +596,7 @@ func TestGenericAnalysisConfiguration(t *testing.T) {
 								Name: model.StageAnalysis,
 								AnalysisStageOptions: &AnalysisStageOptions{
 									Duration: Duration(10 * time.Minute),
-									Https: []TemplatableAnalysisHTTP{
+									HTTPS: []TemplatableAnalysisHTTP{
 										{
 											AnalysisHTTP: AnalysisHTTP{
 												URL:          "https://canary-endpoint.dev",

--- a/pkg/config/control_plane.go
+++ b/pkg/config/control_plane.go
@@ -52,7 +52,7 @@ func (s *ControlPlaneSpec) Validate() error {
 
 type ControlPlaneProject struct {
 	// The unique identifier of the project.
-	Id string `json:"id"`
+	ID string `json:"id"`
 	// The description about the project.
 	Desc string `json:"desc"`
 	// Static admin account of the project.
@@ -108,7 +108,7 @@ func (s *SharedSSOConfig) UnmarshalJSON(data []byte) error {
 // FindProject finds and returns a specific project in the configured list.
 func (s *ControlPlaneSpec) FindProject(id string) (ControlPlaneProject, bool) {
 	for i := range s.Projects {
-		if s.Projects[i].Id != id {
+		if s.Projects[i].ID != id {
 			continue
 		}
 		return s.Projects[i], true
@@ -119,7 +119,7 @@ func (s *ControlPlaneSpec) FindProject(id string) (ControlPlaneProject, bool) {
 func (s *ControlPlaneSpec) ProjectMap() map[string]ControlPlaneProject {
 	m := make(map[string]ControlPlaneProject, len(s.Projects))
 	for i := range s.Projects {
-		m[s.Projects[i].Id] = s.Projects[i]
+		m[s.Projects[i].ID] = s.Projects[i]
 	}
 	return m
 }

--- a/pkg/config/control_plane_test.go
+++ b/pkg/config/control_plane_test.go
@@ -40,7 +40,7 @@ func TestControlPlaneConfig(t *testing.T) {
 			expectedSpec: &ControlPlaneSpec{
 				Projects: []ControlPlaneProject{
 					{
-						Id: "abc",
+						ID: "abc",
 						StaticAdmin: ProjectStaticUser{
 							Username:     "test-user",
 							PasswordHash: "test-password",

--- a/pkg/insight/application.go
+++ b/pkg/insight/application.go
@@ -19,7 +19,7 @@ import (
 )
 
 type ApplicationData struct {
-	Id     string            `json:"id"`
+	ID     string            `json:"id"`
 	Labels map[string]string `json:"labels"`
 	Kind   string            `json:"kind"`
 	Status string            `json:"status"`
@@ -34,7 +34,7 @@ func BuildApplicationData(a *model.Application) ApplicationData {
 	status := determineApplicationStatus(a)
 
 	return ApplicationData{
-		Id:     a.Id,
+		ID:     a.Id,
 		Labels: a.Labels,
 		Kind:   a.Kind.String(),
 		Status: status.String(),

--- a/pkg/insight/deployment.go
+++ b/pkg/insight/deployment.go
@@ -19,7 +19,7 @@ import (
 )
 
 type DeploymentData struct {
-	Id                string            `json:"id"`
+	ID                string            `json:"id"`
 	AppID             string            `json:"app_id"`
 	Labels            map[string]string `json:"labels"`
 	StartedAt         int64             `json:"started_at"`
@@ -35,7 +35,7 @@ func BuildDeploymentData(d *model.Deployment) DeploymentData {
 	}
 
 	return DeploymentData{
-		Id:                d.Id,
+		ID:                d.Id,
 		AppID:             d.ApplicationId,
 		Labels:            d.Labels,
 		StartedAt:         d.CreatedAt,

--- a/pkg/insight/insightstore/deployment_store.go
+++ b/pkg/insight/insightstore/deployment_store.go
@@ -272,11 +272,11 @@ func (s *store) putCompletedDeploymentsToChunk(ctx context.Context, projectID, b
 		duplicates = 0
 	)
 	for _, d := range chunk.Deployments {
-		dsMap[d.Id] = struct{}{}
+		dsMap[d.ID] = struct{}{}
 		mergedList = append(mergedList, d)
 	}
 	for _, d := range ds {
-		if _, ok := dsMap[d.Id]; ok {
+		if _, ok := dsMap[d.ID]; ok {
 			duplicates++
 			continue
 		}

--- a/pkg/insight/insightstore/deployment_store_test.go
+++ b/pkg/insight/insightstore/deployment_store_test.go
@@ -97,10 +97,10 @@ func TestChunkStoring(t *testing.T) {
 			ChunkID: chunkID,
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id: "deployment-1",
+					ID: "deployment-1",
 				},
 				&insight.DeploymentData{
-					Id: "deployment-2",
+					ID: "deployment-2",
 				},
 			},
 		}
@@ -137,10 +137,10 @@ func TestPutCompletedDeploymentsToChunk(t *testing.T) {
 
 	ds := []*insight.DeploymentData{
 		&insight.DeploymentData{
-			Id: "deployment-1",
+			ID: "deployment-1",
 		},
 		&insight.DeploymentData{
-			Id: "deployment-2",
+			ID: "deployment-2",
 		},
 	}
 	err = s.putCompletedDeploymentsToChunk(ctx, projectID, blockID, chunkID, ds)
@@ -150,10 +150,10 @@ func TestPutCompletedDeploymentsToChunk(t *testing.T) {
 		ChunkID: chunkID,
 		Deployments: []*insight.DeploymentData{
 			&insight.DeploymentData{
-				Id: "deployment-1",
+				ID: "deployment-1",
 			},
 			&insight.DeploymentData{
-				Id: "deployment-2",
+				ID: "deployment-2",
 			},
 		},
 	}
@@ -164,13 +164,13 @@ func TestPutCompletedDeploymentsToChunk(t *testing.T) {
 	// Add to an existing chunk.
 	ds = []*insight.DeploymentData{
 		&insight.DeploymentData{
-			Id: "deployment-2",
+			ID: "deployment-2",
 		},
 		&insight.DeploymentData{
-			Id: "deployment-4",
+			ID: "deployment-4",
 		},
 		&insight.DeploymentData{
-			Id: "deployment-5",
+			ID: "deployment-5",
 		},
 	}
 	err = s.putCompletedDeploymentsToChunk(ctx, projectID, blockID, chunkID, ds)
@@ -180,16 +180,16 @@ func TestPutCompletedDeploymentsToChunk(t *testing.T) {
 		ChunkID: chunkID,
 		Deployments: []*insight.DeploymentData{
 			&insight.DeploymentData{
-				Id: "deployment-1",
+				ID: "deployment-1",
 			},
 			&insight.DeploymentData{
-				Id: "deployment-2",
+				ID: "deployment-2",
 			},
 			&insight.DeploymentData{
-				Id: "deployment-4",
+				ID: "deployment-4",
 			},
 			&insight.DeploymentData{
-				Id: "deployment-5",
+				ID: "deployment-5",
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 
 	ds := []*insight.DeploymentData{
 		&insight.DeploymentData{
-			Id:          "deployment-1",
+			ID:          "deployment-1",
 			CompletedAt: 100,
 		},
 	}
@@ -245,7 +245,7 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 			ChunkID: "chunk_0",
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-1",
+					ID:          "deployment-1",
 					CompletedAt: 100,
 				},
 			},
@@ -260,15 +260,15 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 	// Add to require a new chunk because of size limit.
 	ds = []*insight.DeploymentData{
 		&insight.DeploymentData{
-			Id:          "deployment-2",
+			ID:          "deployment-2",
 			CompletedAt: 200,
 		},
 		&insight.DeploymentData{
-			Id:          "deployment-3",
+			ID:          "deployment-3",
 			CompletedAt: 300,
 		},
 		&insight.DeploymentData{
-			Id:          "deployment-4",
+			ID:          "deployment-4",
 			CompletedAt: 400,
 		},
 	}
@@ -305,15 +305,15 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 			ChunkID: "chunk_0",
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-1",
+					ID:          "deployment-1",
 					CompletedAt: 100,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-2",
+					ID:          "deployment-2",
 					CompletedAt: 200,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-3",
+					ID:          "deployment-3",
 					CompletedAt: 300,
 				},
 			},
@@ -322,7 +322,7 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 			ChunkID: "chunk_1",
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-4",
+					ID:          "deployment-4",
 					CompletedAt: 400,
 				},
 			},
@@ -337,11 +337,11 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 	// Add to the limit of chunk to test the edge case.
 	ds = []*insight.DeploymentData{
 		&insight.DeploymentData{
-			Id:          "deployment-5",
+			ID:          "deployment-5",
 			CompletedAt: 500,
 		},
 		&insight.DeploymentData{
-			Id:          "deployment-6",
+			ID:          "deployment-6",
 			CompletedAt: 600,
 		},
 	}
@@ -378,15 +378,15 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 			ChunkID: "chunk_0",
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-1",
+					ID:          "deployment-1",
 					CompletedAt: 100,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-2",
+					ID:          "deployment-2",
 					CompletedAt: 200,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-3",
+					ID:          "deployment-3",
 					CompletedAt: 300,
 				},
 			},
@@ -395,15 +395,15 @@ func TestPutCompletedDeploymentsBlock(t *testing.T) {
 			ChunkID: "chunk_1",
 			Deployments: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-4",
+					ID:          "deployment-4",
 					CompletedAt: 400,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-5",
+					ID:          "deployment-5",
 					CompletedAt: 500,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-6",
+					ID:          "deployment-6",
 					CompletedAt: 600,
 				},
 			},
@@ -439,15 +439,15 @@ func TestGroupCompletedDeploymentsByBlock(t *testing.T) {
 			name: "one block",
 			ds: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-1",
+					ID:          "deployment-1",
 					CompletedAt: date2022.Unix(),
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-3",
+					ID:          "deployment-3",
 					CompletedAt: date2022.Unix() + 200,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-2",
+					ID:          "deployment-2",
 					CompletedAt: date2022.Unix() + 100,
 				},
 			},
@@ -456,15 +456,15 @@ func TestGroupCompletedDeploymentsByBlock(t *testing.T) {
 					BlockID: "block_2022",
 					Deployments: []*insight.DeploymentData{
 						&insight.DeploymentData{
-							Id:          "deployment-1",
+							ID:          "deployment-1",
 							CompletedAt: date2022.Unix(),
 						},
 						&insight.DeploymentData{
-							Id:          "deployment-2",
+							ID:          "deployment-2",
 							CompletedAt: date2022.Unix() + 100,
 						},
 						&insight.DeploymentData{
-							Id:          "deployment-3",
+							ID:          "deployment-3",
 							CompletedAt: date2022.Unix() + 200,
 						},
 					},
@@ -475,19 +475,19 @@ func TestGroupCompletedDeploymentsByBlock(t *testing.T) {
 			name: "multiple blocks",
 			ds: []*insight.DeploymentData{
 				&insight.DeploymentData{
-					Id:          "deployment-1",
+					ID:          "deployment-1",
 					CompletedAt: date2022.Unix(),
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-4",
+					ID:          "deployment-4",
 					CompletedAt: date2023.Unix(),
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-3",
+					ID:          "deployment-3",
 					CompletedAt: date2022.Unix() + 200,
 				},
 				&insight.DeploymentData{
-					Id:          "deployment-2",
+					ID:          "deployment-2",
 					CompletedAt: date2022.Unix() + 100,
 				},
 			},
@@ -496,15 +496,15 @@ func TestGroupCompletedDeploymentsByBlock(t *testing.T) {
 					BlockID: "block_2022",
 					Deployments: []*insight.DeploymentData{
 						&insight.DeploymentData{
-							Id:          "deployment-1",
+							ID:          "deployment-1",
 							CompletedAt: date2022.Unix(),
 						},
 						&insight.DeploymentData{
-							Id:          "deployment-2",
+							ID:          "deployment-2",
 							CompletedAt: date2022.Unix() + 100,
 						},
 						&insight.DeploymentData{
-							Id:          "deployment-3",
+							ID:          "deployment-3",
 							CompletedAt: date2022.Unix() + 200,
 						},
 					},
@@ -513,7 +513,7 @@ func TestGroupCompletedDeploymentsByBlock(t *testing.T) {
 					BlockID: "block_2023",
 					Deployments: []*insight.DeploymentData{
 						&insight.DeploymentData{
-							Id:          "deployment-4",
+							ID:          "deployment-4",
 							CompletedAt: date2023.Unix(),
 						},
 					},

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -89,8 +89,8 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
-func (x *ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
-	switch *x {
+func (k ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
+	switch k {
 	case ApplicationKind_KUBERNETES:
 		return PlatformProviderKubernetes
 	case ApplicationKind_TERRAFORM:

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -89,8 +89,8 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
-func (k *ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
-	switch *k {
+func (x *ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
+	switch *x {
 	case ApplicationKind_KUBERNETES:
 		return PlatformProviderKubernetes
 	case ApplicationKind_TERRAFORM:

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -89,8 +89,8 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
-func (k ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
-	switch k {
+func (ak ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
+	switch ak {
 	case ApplicationKind_KUBERNETES:
 		return PlatformProviderKubernetes
 	case ApplicationKind_TERRAFORM:

--- a/pkg/model/common.go
+++ b/pkg/model/common.go
@@ -23,8 +23,8 @@ func ApplicationKindStrings() []string {
 	return out
 }
 
-func (k ApplicationKind) ToRollbackKind() RollbackKind {
-	switch k {
+func (ak ApplicationKind) ToRollbackKind() RollbackKind {
+	switch ak {
 	case ApplicationKind_KUBERNETES:
 		return RollbackKind_Rollback_KUBERNETES
 	case ApplicationKind_TERRAFORM:

--- a/pkg/model/common.go
+++ b/pkg/model/common.go
@@ -23,8 +23,8 @@ func ApplicationKindStrings() []string {
 	return out
 }
 
-func (x ApplicationKind) ToRollbackKind() RollbackKind {
-	switch x {
+func (k ApplicationKind) ToRollbackKind() RollbackKind {
+	switch k {
 	case ApplicationKind_KUBERNETES:
 		return RollbackKind_Rollback_KUBERNETES
 	case ApplicationKind_TERRAFORM:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix part of errors which `make lint/go` returns (stylecheck).

<details><summary>stylecheck lint errors</summary>

```
$ make lint/go | grep -e "(stylecheck)"
docs/main.go:48:38: ST1013: should use constant http.StatusTemporaryRedirect instead of numeric literal 307 (stylecheck)
pkg/app/piped/trigger/trigger.go:180:3: ST1003: var repoId should be repoID (stylecheck)
pkg/app/server/grpcapi/piped_api.go:45:6: ST1003: type pipedApiApplicationStore should be pipedAPIApplicationStore (stylecheck)
pkg/app/server/grpcapi/piped_api.go:54:6: ST1003: type pipedApiDeploymentStore should be pipedAPIDeploymentStore (stylecheck)
pkg/app/server/grpcapi/piped_api.go:66:6: ST1003: type pipedApiDeploymentChainStore should be pipedAPIDeploymentChainStore (stylecheck)
pkg/app/server/grpcapi/piped_api.go:71:6: ST1003: type pipedApiPipedStore should be pipedAPIPipedStore (stylecheck)
pkg/app/server/grpcapi/piped_api.go:76:6: ST1003: type pipedApiEventStore should be pipedAPIEventStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:51:6: ST1003: type webApiApplicationStore should be webAPIApplicationStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:61:6: ST1003: type webApiDeploymentChainStore should be webAPIDeploymentChainStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:66:6: ST1003: type webApiDeploymentStore should be webAPIDeploymentStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:71:6: ST1003: type webApiPipedStore should be webAPIPipedStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:83:6: ST1003: type webApiProjectStore should be webAPIProjectStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:97:6: ST1003: type webApiEventStore should be webAPIEventStore (stylecheck)
pkg/app/server/grpcapi/web_api.go:101:6: ST1003: type webApiAPIKeyStore should be webAPIAPIKeyStore (stylecheck)
pkg/cli/app.go:33:5: ST1012: error var FlagParseErr should have name of the form ErrFoo (stylecheck)
pkg/config/analysis_template.go:26:2: ST1003: struct field HTTPs should be HTTPS (stylecheck)
pkg/config/application.go:219:2: ST1003: struct field Id should be ID (stylecheck)
pkg/config/application.go:255:2: ST1003: struct field Id should be ID (stylecheck)
pkg/config/application.go:443:2: ST1003: struct field Https should be HTTPS (stylecheck)
pkg/config/control_plane.go:55:2: ST1003: struct field Id should be ID (stylecheck)
pkg/model/application.go:92:27: ST1016: methods on the same type should have the same receiver name (seen 1x "k", 1x "x") (stylecheck)
```

</details>


<details><summary> List of remaining errors </summary>

- [x] stylecheck
- [ ] gocritic
- [ ] errcheck
- [ ] goerr113
- [ ] typecheck
- [ ] gosec
- [x] ~~deadcode, ineffassign~~ https://github.com/pipe-cd/pipecd/pull/4624
- [x] ~~misspell, depguard, unconvert~~ https://github.com/pipe-cd/pipecd/pull/4621
- [x] ~~goimports, gosimple, staticcheck~~ https://github.com/pipe-cd/pipecd/pull/4622

</details>


**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4566


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
