### PR TITLE
Add ECSTargetGroupObject to the configuration reference documentation

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -450,10 +450,19 @@ One of `yamlField` or `regex` is required.
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| primary | ECSTargetGroupObject | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
-| canary | ECSTargetGroupObject | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
+| primary | [ECSTargetGroupObject](#ecstargetgroupobject) | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
+| canary | [ECSTargetGroupObject](#ecstargetgroupobject) | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
 
-Note: You can get examples for those object from [here](../../examples/#ecs-applications).
+#### ECSTargetGroupObject
+
+| Field | Type | Description | Required |
+|-|-|-|-|
+| targetGroupArn | string | The name of the container (as it appears in a container definition) to　associate with the load balancer | Yes |
+| containerName | string | The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group or groups associated with a service or task set. | Yes |
+| containerPort | int | The port on the container to associate with the load balancer. | Yes |
+| LoadBalancerName | string | The name of the load balancer to associate with the Amazon ECS service or task set. | No |
+
+Note: The available values are identical to those found in the aws-sdk-go-v2 Types.LoadBalancer. For more details, please refer to [this link](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs/types#LoadBalancer) .
 
 ## ECSQuickSync
 

--- a/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
@@ -450,10 +450,19 @@ One of `yamlField` or `regex` is required.
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| primary | ECSTargetGroupObject | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
-| canary | ECSTargetGroupObject | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
+| primary | [ECSTargetGroupObject](#ecstargetgroupobject) | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
+| canary | [ECSTargetGroupObject](#ecstargetgroupobject) | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
 
-Note: You can get examples for those object from [here](../../examples/#ecs-applications).
+#### ECSTargetGroupObject
+
+ Field            | Type | Description | Required 
+|-|-|-|-|
+ targetGroupArn   | string | The name of the container (as it appears in a container definition) to　associate with the load balancer | Yes 
+ containerName    | string | The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group or groups associated with a service or task set. | Yes 
+ containerPort    | int | The port on the container to associate with the load balancer. | Yes 
+ LoadBalancerName | string | The name of the load balancer to associate with the Amazon ECS service or task set. | No 
+
+Note: The available values are identical to those found in the aws-sdk-go-v2 Types.LoadBalancer. For more details, please refer to [this link](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs/types#LoadBalancer) .
 
 ## ECSQuickSync
 

--- a/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
@@ -455,12 +455,12 @@ One of `yamlField` or `regex` is required.
 
 #### ECSTargetGroupObject
 
- Field            | Type | Description | Required 
+| Field | Type | Description | Required |
 |-|-|-|-|
- targetGroupArn   | string | The name of the container (as it appears in a container definition) to　associate with the load balancer | Yes 
- containerName    | string | The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group or groups associated with a service or task set. | Yes 
- containerPort    | int | The port on the container to associate with the load balancer. | Yes 
- LoadBalancerName | string | The name of the load balancer to associate with the Amazon ECS service or task set. | No 
+| targetGroupArn | string | The name of the container (as it appears in a container definition) to　associate with the load balancer | Yes |
+| containerName | string | The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group or groups associated with a service or task set. | Yes |
+| containerPort | int | The port on the container to associate with the load balancer. | Yes |
+| LoadBalancerName | string | The name of the load balancer to associate with the Amazon ECS service or task set. | No |
 
 Note: The available values are identical to those found in the aws-sdk-go-v2 Types.LoadBalancer. For more details, please refer to [this link](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs/types#LoadBalancer) .
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I added ECSTargetGroupObject as it was not documented.

I didn't know to what extent I should add the document, so I added it only to the latest version first.
Please let me know if you need to add it to `docs-dev` or any other ver.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
