### PR TITLE
Update golangci-lint and ensure the code passes `make lint/go`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,23 +9,23 @@ run:
 linters:
   disable-all: true
   enable:
-    - prealloc
-    - ineffassign
-    - goerr113
-    - misspell
-    - errcheck
-    - gosimple
-    - staticcheck
-    - gosec
-    - gocritic
-    - unparam
-    - deadcode
-    - unconvert
-    - typecheck
-    - stylecheck
-    - exportloopref
     - depguard
+    - exportloopref
+    - gocritic
     - goimports
+    - gosimple
+    - ineffassign
+    - misspell
+    - prealloc
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    # TODO: Enable these linters
+    # - errcheck
+    # - goerr113
+    # - gosec
 
 issues:
   exclude-rules:
@@ -38,10 +38,15 @@ output:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-message:
-      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
-      - io/ioutil: "Use corresponding 'os' or 'io' functions instead."
+    rules:
+      main:
+        deny:
+          - pkg: "sync/atomic"
+            desc: "Use go.uber.org/atomic instead of sync/atomic."
+          - pkg: "io/ioutil"
+            desc: "Use corresponding 'os' or 'io' functions instead."
+  gocritic:
+    disabled-checks:
+      - appendAssign
   goimports:
     local-prefixes: github.com/pipe-cd/pipecd

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ run/site:
 
 .PHONY: lint/go
 lint/go: FIX ?= false
-lint/go: VERSION ?= sha256:78d1bbd01a9886a395dc8374218a6c0b7b67694e725dd76f0c8ac1de411b85e8 #v1.46.2
+lint/go: VERSION ?= sha256:fb70c9b2e6d0763141f057abcafde7f88d5e4bb3b5882d6b14bc79382f04481c #v1.55.2
 lint/go: FLAGS ?= --rm --platform linux/amd64 -e GOCACHE=/repo/.cache/go-build -e GOLANGCI_LINT_CACHE=/repo/.cache/golangci-lint -v ${PWD}:/repo -w /repo -it
 lint/go:
 ifeq ($(FIX),true)

--- a/pkg/app/ops/deploymentchaincontroller/controller.go
+++ b/pkg/app/ops/deploymentchaincontroller/controller.go
@@ -88,9 +88,7 @@ func (d *DeploymentChainController) Run(ctx context.Context) error {
 				d.logger.Error("failed while sync controller updaters", zap.Error(err))
 			}
 		case <-syncDeploymentChainsTicker.C:
-			if err := d.syncDeploymentChains(ctx); err != nil {
-				d.logger.Error("failed while sync deployment chains", zap.Error(err))
-			}
+			d.syncDeploymentChains(ctx)
 		}
 	}
 }
@@ -130,7 +128,7 @@ func (d *DeploymentChainController) syncUpdaters(ctx context.Context) error {
 	return nil
 }
 
-func (d *DeploymentChainController) syncDeploymentChains(ctx context.Context) error {
+func (d *DeploymentChainController) syncDeploymentChains(ctx context.Context) {
 	var (
 		updatersNum = len(d.updaters)
 		updaterCh   = make(chan *updater, updatersNum)
@@ -162,8 +160,6 @@ func (d *DeploymentChainController) syncDeploymentChains(ctx context.Context) er
 
 	d.logger.Info("waiting for all updaters to finish")
 	wg.Wait()
-
-	return nil
 }
 
 func listNotCompletedDeploymentChain(ctx context.Context, dcs deploymentChainStore) ([]*model.DeploymentChain, error) {

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -167,10 +167,7 @@ func (r *Reporter) updateRegisteredApps(ctx context.Context, headCommits map[str
 	outOfSyncRegisteredApps := make([]*model.ApplicationInfo, 0)
 	for repoID, repo := range r.gitRepos {
 		headCommit := headCommits[repoID]
-		rs, err := r.findOutOfSyncRegisteredApps(repo.GetPath(), repoID, headCommit)
-		if err != nil {
-			return err
-		}
+		rs := r.findOutOfSyncRegisteredApps(repo.GetPath(), repoID, headCommit)
 		r.logger.Info(fmt.Sprintf("found out %d valid registered applications that config has been changed in repository %q", len(rs), repoID))
 		outOfSyncRegisteredApps = append(outOfSyncRegisteredApps, rs...)
 	}
@@ -233,7 +230,7 @@ func (r *Reporter) updateUnregisteredApps(ctx context.Context) error {
 }
 
 // findOutOfSyncRegisteredApps finds out registered application info that should be updated in the given git repository.
-func (r *Reporter) findOutOfSyncRegisteredApps(repoPath, repoID, headCommit string) ([]*model.ApplicationInfo, error) {
+func (r *Reporter) findOutOfSyncRegisteredApps(repoPath, repoID, headCommit string) []*model.ApplicationInfo {
 	// Compare the apps registered on Control-plane with the latest config file
 	// and return only the ones that have been changed.
 	apps := make([]*model.ApplicationInfo, 0)
@@ -275,7 +272,7 @@ func (r *Reporter) findOutOfSyncRegisteredApps(repoPath, repoID, headCommit stri
 		appCfg.Id = app.Id
 		apps = append(apps, appCfg)
 	}
-	return apps, nil
+	return apps
 }
 
 func (r *Reporter) isSynced(appInfo *model.ApplicationInfo, app *model.Application) bool {

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -157,8 +157,7 @@ spec:
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.reporter.findOutOfSyncRegisteredApps(tc.args.repoPath, tc.args.repoID, "not-existed-head-commit")
-			assert.Equal(t, tc.wantErr, err != nil)
+			got := tc.reporter.findOutOfSyncRegisteredApps(tc.args.repoPath, tc.args.repoID, "not-existed-head-commit")
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -696,17 +696,14 @@ func (p *piped) sendPipedMeta(ctx context.Context, client pipedservice.Client, c
 	}
 
 	// Configure secret management.
-	if sm := cfg.SecretManagement; sm != nil {
-		switch sm.Type {
-		case model.SecretManagementTypeKeyPair:
-			publicKey, err := sm.KeyPair.LoadPublicKey()
-			if err != nil {
-				return fmt.Errorf("failed to read public key for secret management (%w)", err)
-			}
-			req.SecretEncryption = &model.Piped_SecretEncryption{
-				Type:      sm.Type.String(),
-				PublicKey: string(publicKey),
-			}
+	if sm := cfg.SecretManagement; sm != nil && sm.Type == model.SecretManagementTypeKeyPair {
+		publicKey, err := sm.KeyPair.LoadPublicKey()
+		if err != nil {
+			return fmt.Errorf("failed to read public key for secret management (%w)", err)
+		}
+		req.SecretEncryption = &model.Piped_SecretEncryption{
+			Type:      sm.Type.String(),
+			PublicKey: string(publicKey),
 		}
 	}
 	if req.SecretEncryption == nil {

--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -288,7 +288,7 @@ func (c *controller) checkCommands() {
 }
 
 // syncPlanners adds new planner for newly PENDING deployments.
-func (c *controller) syncPlanners(ctx context.Context) error {
+func (c *controller) syncPlanners(ctx context.Context) {
 	// Remove stale planners from the recently completed list.
 	for id, t := range c.donePlanners {
 		if time.Since(t) >= plannerStaleDuration {
@@ -324,7 +324,7 @@ func (c *controller) syncPlanners(ctx context.Context) error {
 	// Add missing planners.
 	pendings := c.deploymentLister.ListPendings()
 	if len(pendings) == 0 {
-		return nil
+		return
 	}
 
 	c.logger.Info(fmt.Sprintf("there are %d pending deployments for planning", len(pendings)),
@@ -426,8 +426,6 @@ func (c *controller) syncPlanners(ctx context.Context) error {
 			)
 		}
 	}
-
-	return nil
 }
 
 func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (*planner, error) {
@@ -506,7 +504,7 @@ func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (
 
 // syncSchedulers adds new scheduler for newly PLANNED/RUNNING deployments
 // as well as removes the schedulers for the completed deployments.
-func (c *controller) syncSchedulers(ctx context.Context) error {
+func (c *controller) syncSchedulers(ctx context.Context) {
 	// Update the most recent successful commit hashes.
 	for id, s := range c.schedulers {
 		if !s.IsDone() {
@@ -556,7 +554,7 @@ func (c *controller) syncSchedulers(ctx context.Context) error {
 	targets := append(runnings, planneds...)
 
 	if len(targets) == 0 {
-		return nil
+		return
 	}
 
 	c.logger.Info(fmt.Sprintf("there are %d planned/running deployments for scheduling", len(targets)),
@@ -589,8 +587,6 @@ func (c *controller) syncSchedulers(ctx context.Context) error {
 			zap.Int("count", len(c.schedulers)),
 		)
 	}
-
-	return nil
 }
 
 // startNewScheduler creates and starts running a new scheduler

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -122,7 +122,7 @@ func (d *detector) ProviderName() string {
 	return d.provider.Name
 }
 
-func (d *detector) check(ctx context.Context) error {
+func (d *detector) check(ctx context.Context) {
 	appsByRepo := d.listGroupedApplication()
 
 	for repoID, apps := range appsByRepo {
@@ -168,7 +168,6 @@ func (d *detector) check(ctx context.Context) error {
 			}
 		}
 	}
-	return nil
 }
 
 func (d *detector) cloneGitRepository(ctx context.Context, repoID string) (git.Repo, error) {

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -120,7 +120,7 @@ func (d *detector) Run(ctx context.Context) error {
 	}
 }
 
-func (d *detector) check(ctx context.Context) error {
+func (d *detector) check(ctx context.Context) {
 	appsByRepo := d.listGroupedApplication()
 
 	for repoID, apps := range appsByRepo {
@@ -171,8 +171,6 @@ func (d *detector) check(ctx context.Context) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit) error {

--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -121,7 +121,7 @@ func (d *detector) Run(ctx context.Context) error {
 	}
 }
 
-func (d *detector) check(ctx context.Context) error {
+func (d *detector) check(ctx context.Context) {
 	appsByRepo := d.listGroupedApplication()
 
 	for repoID, apps := range appsByRepo {
@@ -167,8 +167,6 @@ func (d *detector) check(ctx context.Context) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit) error {

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -116,7 +116,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 					continue
 				}
 				status = model.StageStatus_STAGE_SKIPPED
-				// Stop the context to cancel all running analysises.
+				// Stop the context to cancel all running analyses.
 				cancel()
 				return
 			case <-doneCh:

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -308,7 +308,7 @@ func deleteResources(ctx context.Context, ag applierGetter, resources []provider
 }
 
 func findManifests(kind, name string, manifests []provider.Manifest) []provider.Manifest {
-	var out []provider.Manifest
+	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {
 		if m.Key.Kind != kind {
 			continue
@@ -322,7 +322,7 @@ func findManifests(kind, name string, manifests []provider.Manifest) []provider.
 }
 
 func findConfigMapManifests(manifests []provider.Manifest) []provider.Manifest {
-	var out []provider.Manifest
+	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {
 		if !m.Key.IsConfigMap() {
 			continue
@@ -333,7 +333,7 @@ func findConfigMapManifests(manifests []provider.Manifest) []provider.Manifest {
 }
 
 func findSecretManifests(manifests []provider.Manifest) []provider.Manifest {
-	var out []provider.Manifest
+	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {
 		if !m.Key.IsSecret() {
 			continue

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -1018,7 +1018,7 @@ func TestPatchManifests(t *testing.T) {
 
 	patcher := func(m provider.Manifest, cfg config.K8sResourcePatch) (*provider.Manifest, error) {
 		out := m
-		out.Key.Namespace = out.Key.Namespace + "+"
+		out.Key.Namespace = fmt.Sprintf("%s+", out.Key.Namespace)
 		return &out, nil
 	}
 

--- a/pkg/app/piped/executor/kubernetes/traffic.go
+++ b/pkg/app/piped/executor/kubernetes/traffic.go
@@ -226,7 +226,7 @@ func findIstioVirtualServiceManifests(manifests []provider.Manifest, ref config.
 		return nil, fmt.Errorf("support only %q kind for VirtualService reference", istioVirtualServiceKind)
 	}
 
-	var out []provider.Manifest
+	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {
 		if !strings.HasPrefix(m.Key.APIVersion, istioNetworkingAPIVersionPrefix) {
 			continue

--- a/pkg/app/piped/livestatereporter/cloudrun/report.go
+++ b/pkg/app/piped/livestatereporter/cloudrun/report.go
@@ -96,7 +96,7 @@ func (r *reporter) ProviderName() string {
 	return r.provider.Name
 }
 
-func (r *reporter) flushSnapshots(ctx context.Context) error {
+func (r *reporter) flushSnapshots(ctx context.Context) {
 	apps := r.appLister.ListByPlatformProvider(r.provider.Name)
 	for _, app := range apps {
 		state, ok := r.stateGetter.GetState(app.Id)
@@ -130,5 +130,4 @@ func (r *reporter) flushSnapshots(ctx context.Context) error {
 		r.snapshotVersions[app.Id] = state.Version
 		r.logger.Info(fmt.Sprintf("successfully reported application live state for application: %s", app.Id))
 	}
-	return nil
 }

--- a/pkg/app/piped/livestatereporter/kubernetes/reporter.go
+++ b/pkg/app/piped/livestatereporter/kubernetes/reporter.go
@@ -109,7 +109,7 @@ func (r *reporter) Run(ctx context.Context) error {
 	}
 }
 
-func (r *reporter) flushSnapshots(ctx context.Context) error {
+func (r *reporter) flushSnapshots(ctx context.Context) {
 	// TODO: In the future, maybe we should apply worker model for this or
 	// send multiple application states in one request.
 	apps := r.appLister.ListByPlatformProvider(r.provider.Name)
@@ -145,7 +145,6 @@ func (r *reporter) flushSnapshots(ctx context.Context) error {
 		r.snapshotVersions[app.Id] = state.Version
 		r.logger.Info(fmt.Sprintf("successfully reported application live state for application: %s", app.Id))
 	}
-	return nil
 }
 
 func (r *reporter) flushEvents(ctx context.Context) error {

--- a/pkg/app/piped/livestatestore/kubernetes/appnodes.go
+++ b/pkg/app/piped/livestatestore/kubernetes/appnodes.go
@@ -84,7 +84,7 @@ func (a *appNodes) addManagingResource(uid string, key provider.ResourceKey, obj
 	}, true
 }
 
-func (a *appNodes) deleteManagingResource(uid string, key provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
+func (a *appNodes) deleteManagingResource(uid string, _ provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
 	a.mu.Lock()
 	n, ok := a.managingNodes[uid]
 	if !ok {
@@ -138,7 +138,7 @@ func (a *appNodes) addDependedResource(uid string, key provider.ResourceKey, obj
 	}, true
 }
 
-func (a *appNodes) deleteDependedResource(uid string, key provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
+func (a *appNodes) deleteDependedResource(uid string, _ provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
 	a.mu.Lock()
 	n, ok := a.dependedNodes[uid]
 	if !ok {

--- a/pkg/app/piped/livestatestore/kubernetes/reflector.go
+++ b/pkg/app/piped/livestatestore/kubernetes/reflector.go
@@ -150,7 +150,7 @@ type reflector struct {
 	logger                *zap.Logger
 }
 
-func (r *reflector) start(ctx context.Context) error {
+func (r *reflector) start(_ context.Context) error {
 	matcher := newResourceMatcher(r.config.AppStateInformer)
 
 	// Use discovery to discover APIs supported by the Kubernetes API server.

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -350,6 +350,7 @@ func makeSlackDate(unix int64) string {
 	return fmt.Sprintf("<!date^%d^{date_num} {time_secs}|date>", unix)
 }
 
+// nolint:unparam
 func truncateText(text string, max int) string {
 	if len(text) <= max {
 		return text

--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -341,7 +341,7 @@ func findWorkloadManifests(manifests []provider.Manifest, refs []config.K8sResou
 }
 
 func findManifests(kind, name string, manifests []provider.Manifest) []provider.Manifest {
-	var out []provider.Manifest
+	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {
 		if m.Key.Kind != kind {
 			continue

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -151,10 +151,7 @@ func (b *builder) build(ctx context.Context, id string, cmd model.Command_BuildP
 	}
 
 	// Find all applications that should be triggered.
-	triggerApps, failedResults, err := b.findTriggerApps(ctx, repo, apps, mergedCommit.Hash)
-	if err != nil {
-		return nil, err
-	}
+	triggerApps, failedResults := b.findTriggerApps(ctx, repo, apps, mergedCommit.Hash)
 	results := failedResults
 
 	if len(triggerApps) == 0 {
@@ -301,7 +298,7 @@ func (b *builder) cloneHeadCommit(ctx context.Context, headBranch, headCommit st
 	return repo, nil
 }
 
-func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult, err error) {
+func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult) {
 	d := trigger.NewOnCommitDeterminer(repo, headCommit, b.commitGetter, b.logger)
 	determine := func(app *model.Application) (bool, error) {
 		appCfg, err := config.LoadApplication(repo.GetPath(), app.GitPath.GetApplicationConfigFilePath(), app.Kind)

--- a/pkg/app/piped/platformprovider/kubernetes/hasher.go
+++ b/pkg/app/piped/platformprovider/kubernetes/hasher.go
@@ -47,19 +47,20 @@ func HashManifests(manifests []Manifest) (string, error) {
 		var encoded string
 		var err error
 
-		if m.Key.IsConfigMap() {
+		switch {
+		case m.Key.IsConfigMap():
 			obj := &v1.ConfigMap{}
 			if err := m.ConvertToStructuredObject(obj); err != nil {
 				return "", err
 			}
 			encoded, err = encodeConfigMap(obj)
-		} else if m.Key.IsSecret() {
+		case m.Key.IsSecret():
 			obj := &v1.Secret{}
 			if err := m.ConvertToStructuredObject(obj); err != nil {
 				return "", err
 			}
 			encoded, err = encodeSecret(obj)
-		} else {
+		default:
 			var encodedBytes []byte
 			encodedBytes, err = m.MarshalJSON()
 			encoded = string(encodedBytes)

--- a/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-var builtInApiVersions = map[string]struct{}{
+var builtInAPIVersions = map[string]struct{}{
 	"admissionregistration.k8s.io/v1":      {},
 	"admissionregistration.k8s.io/v1beta1": {},
 	"apiextensions.k8s.io/v1":              {},
@@ -273,7 +273,7 @@ func DecodeResourceKey(key string) (ResourceKey, error) {
 }
 
 func IsKubernetesBuiltInResource(apiVersion string) bool {
-	_, ok := builtInApiVersions[apiVersion]
+	_, ok := builtInAPIVersions[apiVersion]
 	// TODO: Change the way to detect whether an APIVersion is built-in or not
 	// rather than depending on this fixed list.
 	return ok

--- a/pkg/app/piped/platformprovider/kubernetes/state.go
+++ b/pkg/app/piped/platformprovider/kubernetes/state.go
@@ -424,7 +424,6 @@ func determineIngressHealth(obj *unstructured.Unstructured) (status model.Kubern
 			return
 		}
 		status = model.KubernetesResourceState_HEALTHY
-		return
 	}
 
 	v1Ingress := &networkingv1.Ingress{}

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -474,7 +474,7 @@ func (t *Trigger) GetLastTriggeredCommitGetter() LastTriggeredCommitGetter {
 	return t.commitStore
 }
 
-func (t *Trigger) notifyDeploymentTriggered(ctx context.Context, appCfg *config.GenericApplicationSpec, d *model.Deployment) {
+func (t *Trigger) notifyDeploymentTriggered(_ context.Context, appCfg *config.GenericApplicationSpec, d *model.Deployment) {
 	var mentions []string
 	if n := appCfg.DeploymentNotification; n != nil {
 		mentions = n.FindSlackAccounts(model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED)

--- a/pkg/app/server/apikeyverifier/verifier.go
+++ b/pkg/app/server/apikeyverifier/verifier.go
@@ -86,7 +86,7 @@ func (v *Verifier) Verify(ctx context.Context, key string) (*model.APIKey, error
 	return apiKey, nil
 }
 
-func (v *Verifier) checkAPIKey(ctx context.Context, apiKey *model.APIKey, id, key string) error {
+func (v *Verifier) checkAPIKey(_ context.Context, apiKey *model.APIKey, id, key string) error {
 	if apiKey.Disabled {
 		return fmt.Errorf("the api key %s was already disabled", id)
 	}

--- a/pkg/crypto/hybrid.go
+++ b/pkg/crypto/hybrid.go
@@ -45,7 +45,8 @@ func NewHybridEncrypter(key []byte) (*HybridEncrypter, error) {
 
 // Encrypt performs a regular AES-GCM + RSA-OAEP encryption.
 // The output string is:
-//   RSA ciphertext length || RSA ciphertext || AES ciphertext
+//
+//	RSA ciphertext length || RSA ciphertext || AES ciphertext
 //
 // The implementation of this function was brought from well known Bitnami's SealedSecret library.
 // https://github.com/bitnami-labs/sealed-secrets/blob/master/pkg/crypto/crypto.go#L35

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -268,6 +268,8 @@ func runGitCommand(ctx context.Context, execPath, dir string, envs []string, arg
 }
 
 // retryCommand retries a command a few times with a constant backoff.
+//
+//nolint:unparam
 func retryCommand(retries int, interval time.Duration, logger *zap.Logger, commander func() ([]byte, error)) (out []byte, err error) {
 	for i := 0; i < retries; i++ {
 		out, err = commander()

--- a/pkg/git/client_test.go
+++ b/pkg/git/client_test.go
@@ -116,6 +116,7 @@ func (f *faker) clean() {
 	os.RemoveAll(f.dir)
 }
 
+//nolint:unparam
 func (f *faker) repoDir(org, repo string) string {
 	return filepath.Join(f.dir, org, repo)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update golangci-lint v1.46.2 to v1.55.2 in order to support Go 1.20([v1.51.0](https://golangci-lint.run/product/roadmap/#v1510)~)
- Ensure the code passes golangci-lint 
  - Currently, the `make lint/go` command does not output any errors.
  - Temporarily disabled a few linters(errcheck,goerr113,gosec) that seemed time-consuming to address in order to expedite the implementation of CI. I will handle them in the near future.


<details><summary>Resolved errors from the `make lint/go` command</summary>

```go
pkg/app/ops/deploymentchaincontroller/controller.go:133:79: (*DeploymentChainController).syncDeploymentChains - result 0 (error) is always nil (unparam)
func (d *DeploymentChainController) syncDeploymentChains(ctx context.Context) error {
                                                                              ^
pkg/app/piped/appconfigreporter/appconfigreporter.go:236:112: (*Reporter).findOutOfSyncRegisteredApps - result 1 (error) is always nil (unparam)
func (r *Reporter) findOutOfSyncRegisteredApps(repoPath, repoID, headCommit string) ([]*model.ApplicationInfo, error) {
                                                                                                               ^
pkg/app/piped/cmd/piped/piped.go:700:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
		switch sm.Type {
		^
pkg/app/piped/controller/controller.go:291:56: (*controller).syncPlanners - result 0 (error) is always nil (unparam)
func (c *controller) syncPlanners(ctx context.Context) error {
                                                       ^
pkg/app/piped/controller/controller.go:509:58: (*controller).syncSchedulers - result 0 (error) is always nil (unparam)
func (c *controller) syncSchedulers(ctx context.Context) error {
                                                         ^
pkg/app/piped/controller/controller.go:556:13: appendAssign: append result not assigned to the same slice (gocritic)
	targets := append(runnings, planneds...)
	           ^
pkg/app/piped/driftdetector/cloudrun/detector.go:125:47: (*detector).check - result 0 (error) is always nil (unparam)
func (d *detector) check(ctx context.Context) error {
                                              ^
pkg/app/piped/driftdetector/kubernetes/detector.go:123:47: (*detector).check - result 0 (error) is always nil (unparam)
func (d *detector) check(ctx context.Context) error {
                                              ^
pkg/app/piped/driftdetector/terraform/detector.go:124:47: (*detector).check - result 0 (error) is always nil (unparam)
func (d *detector) check(ctx context.Context) error {
                                              ^
pkg/app/piped/executor/analysis/analysis.go:119:47: `analysises` is a misspelling of `analyses` (misspell)
				// Stop the context to cancel all running analysises.
				                                          ^
pkg/app/piped/executor/kubernetes/kubernetes.go:311:2: Consider pre-allocating `out` (prealloc)
	var out []provider.Manifest
	^
pkg/app/piped/executor/kubernetes/kubernetes.go:325:2: Consider pre-allocating `out` (prealloc)
	var out []provider.Manifest
	^
pkg/app/piped/executor/kubernetes/kubernetes_test.go:1021:3: assignOp: replace `out.Key.Namespace = out.Key.Namespace + "+"` with `out.Key.Namespace += "+"` (gocritic)
		out.Key.Namespace = out.Key.Namespace + "+"
		^
pkg/app/piped/livestatereporter/cloudrun/report.go:99:56: (*reporter).flushSnapshots - result 0 (error) is always nil (unparam)
func (r *reporter) flushSnapshots(ctx context.Context) error {
                                                       ^
pkg/app/piped/livestatereporter/kubernetes/reporter.go:112:56: (*reporter).flushSnapshots - result 0 (error) is always nil (unparam)
func (r *reporter) flushSnapshots(ctx context.Context) error {
                                                       ^
pkg/app/piped/livestatestore/kubernetes/appnodes.go:87:55: `(*appNodes).deleteManagingResource` - `key` is unused (unparam)
func (a *appNodes) deleteManagingResource(uid string, key provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
                                                      ^
pkg/app/piped/livestatestore/kubernetes/appnodes.go:141:55: `(*appNodes).deleteDependedResource` - `key` is unused (unparam)
func (a *appNodes) deleteDependedResource(uid string, key provider.ResourceKey, now time.Time) (model.KubernetesResourceStateEvent, bool) {
                                                      ^
pkg/app/piped/livestatestore/kubernetes/reflector.go:153:27: `(*reflector).start` - `ctx` is unused (unparam)
func (r *reflector) start(ctx context.Context) error {
                          ^
pkg/app/piped/notifier/slack.go:353:32: `truncateText` - `max` always receives `8` (unparam)
func truncateText(text string, max int) string {
                               ^
pkg/app/piped/planner/kubernetes/kubernetes.go:344:2: Consider pre-allocating `out` (prealloc)
	var out []provider.Manifest
	^
pkg/app/piped/planpreview/builder.go:304:205: `(*builder).findTriggerApps` - result `err` is always `nil` (unparam)
func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult, err error) {
                                                                                                                                                                                                            ^
pkg/app/piped/platformprovider/kubernetes/hasher.go:50:3: ifElseChain: rewrite if-else to switch statement (gocritic)
		if m.Key.IsConfigMap() {
		^
pkg/app/piped/platformprovider/kubernetes/resourcekey.go:24:5: ST1003: var builtInApiVersions should be builtInAPIVersions (stylecheck)
var builtInApiVersions = map[string]struct{}{
    ^
pkg/app/piped/platformprovider/kubernetes/state.go:427:3: S1023: redundant `return` statement (gosimple)
		return
		^
pkg/app/piped/trigger/trigger.go:477:45: `(*Trigger).notifyDeploymentTriggered` - `ctx` is unused (unparam)
func (t *Trigger) notifyDeploymentTriggered(ctx context.Context, appCfg *config.GenericApplicationSpec, d *model.Deployment) {
                                            ^
pkg/app/server/apikeyverifier/verifier.go:89:32: `(*Verifier).checkAPIKey` - `ctx` is unused (unparam)
func (v *Verifier) checkAPIKey(ctx context.Context, apiKey *model.APIKey, id, key string) error {
                               ^
pkg/crypto/hybrid.go:48: File is not `goimports`-ed with -local github.com/pipe-cd/pipecd (goimports)
//   RSA ciphertext length || RSA ciphertext || AES ciphertext
pkg/git/client.go:271:19: `retryCommand` - `retries` always receives `3` (unparam)
func retryCommand(retries int, interval time.Duration, logger *zap.Logger, commander func() ([]byte, error)) (out []byte, err error) {
                  ^
pkg/git/client_test.go:119:25: `(*faker).repoDir` - `org` always receives `org` (`"test-repo-org"`) (unparam)
func (f *faker) repoDir(org, repo string) string {
```
</details>

TODO (another PR)
- Integrate golangci-lint into GitHub Actions
- Resolve errcheck,goerr113,gosec errors

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4566

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
