### PR TITLE
Send error comment before plan preview exit

### DIFF
--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -154,7 +154,7 @@ func main() {
 		return
 	}
 
-	if comment.IsMinimized {
+	if bool(comment.IsMinimized) {
 		log.Printf("Previous plan-preview comment has already minimized. So don't minimize anything\n")
 		return
 	}

--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -101,14 +101,14 @@ func main() {
 	}
 
 	if event.PRClosed {
-		doComment(failureBadgeURL + "Unable to run plan-preview for a closed pull request.")
+		doComment(failureBadgeURL + "\nUnable to run plan-preview for a closed pull request.")
 		return
 	}
 
 	// TODO: When PR opened, `Mergeable` is nil for calculation.
 	// Here it is not considered for now, but needs to be handled.
 	if event.PRMergeable != nil && *event.PRMergeable == false {
-		doComment(failureBadgeURL + "Unable to run plan-preview for an un-mergeable pull request. Please resolve the conficts and try again.")
+		doComment(failureBadgeURL + "\nUnable to run plan-preview for an un-mergeable pull request. Please resolve the conficts and try again.")
 		return
 	}
 
@@ -123,6 +123,7 @@ func main() {
 		args.Timeout,
 	)
 	if err != nil {
+		doComment(failureBadgeURL + "\nUnable to run plan-preview. \ncause: " + err.Error())
 		log.Fatal(err)
 	}
 	log.Println("Successfully retrieved plan-preview result")
@@ -131,10 +132,11 @@ func main() {
 	if result.HasError() {
 		pr, err := getPullRequest(ctx, ghClient.PullRequests, event.Owner, event.Repo, event.PRNumber)
 		if err != nil {
+			doComment(failureBadgeURL + "\nUnable to run plan-preview. \ncause: " + err.Error())
 			log.Fatal(err)
 		}
 		if !pr.GetClosedAt().IsZero() {
-			doComment(failureBadgeURL + "Unable to run plan-preview for a closed pull request.")
+			doComment(failureBadgeURL + "\nUnable to run plan-preview for a closed pull request.")
 			return
 		}
 	}
@@ -152,7 +154,7 @@ func main() {
 		return
 	}
 
-	if bool(comment.IsMinimized) {
+	if comment.IsMinimized {
 		log.Printf("Previous plan-preview comment has already minimized. So don't minimize anything\n")
 		return
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
It's hard to know why plan-preview exited.
Sending error comment before exiting makes us easier to find the problem.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4657

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
  - plan-preview error comment is going to be added a line break
  
<img width="926" alt="Screenshot 2023-11-08 at 15 37 46" src="https://github.com/pipe-cd/pipecd/assets/39955827/e7840ca1-b5ce-4b18-911c-5b30423ac56a">

  - error comment will displayed before plan-preview exiting

- **Is this breaking change**:
- **How to migrate (if breaking change)**:
