### PR TITLE
Handle plan preview workflow's error and exit with error status code

### DIFF
--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -139,6 +139,9 @@ func main() {
 			doComment(failureBadgeURL + "\nUnable to run plan-preview for a closed pull request.")
 			return
 		}
+		body := makeCommentBody(event, result)
+		doComment(failureBadgeURL + body)
+		log.Fatal("plan-preview result has error")
 	}
 
 	// Find comments we sent before

--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -140,7 +140,7 @@ func main() {
 			return
 		}
 		body := makeCommentBody(event, result)
-		doComment(failureBadgeURL + body)
+		doComment(failureBadgeURL + "\n" + body)
 		log.Fatal("plan-preview result has error")
 	}
 

--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -141,7 +141,8 @@ func main() {
 		}
 		body := makeCommentBody(event, result)
 		doComment(failureBadgeURL + "\n" + body)
-		log.Fatal("plan-preview result has error")
+		log.Println("plan-preview result has error")
+		os.Exit(1)
 	}
 
 	// Find comments we sent before


### PR DESCRIPTION
**What this PR does / why we need it**:
Plan preview workflow comments error message but CI workflow passed.
It makes us very confused.

![](https://user-images.githubusercontent.com/39955827/281349322-dd035731-493f-4cca-8d23-5ce27a0359e6.png)

**Which issue(s) this PR fixes**:

Fixes #4661 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
  - Plan preview CI workflow will failed when result has error
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
