### PR TITLE
Increase limit of stale action operations

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          operations-per-run: 1000
           # Issues
           stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. Feel free to reopen if still applicable.'


### PR DESCRIPTION
**What this PR does / why we need it**:

GitHub rate limit is 5,000 requests per hour.([here](https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users) . 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
