### PR TITLE
Minimize latest plan preview comment before comment error message

### DIFF
--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -142,60 +142,20 @@ func main() {
 			return
 		}
 
-		// Find comments we sent before
-		comment, err := findLatestPlanPreviewComment(ctx, ghGraphQLClient, event.Owner, event.Repo, event.PRNumber)
-		if err != nil {
-			log.Printf("Unable to find the previous comment to minimize (%v)\n", err)
-		}
+		minimizePreviousComment(ctx, ghGraphQLClient, event)
 
 		body := makeCommentBody(event, result)
 		doComment(body)
-
-		if comment == nil {
-			log.Println("plan-preview result has error")
-			os.Exit(1)
-			return
-		}
-
-		if bool(comment.IsMinimized) {
-			log.Printf("Previous plan-preview comment has already minimized. So don't minimize anything\n")
-			return
-		}
-
-		if err := minimizeComment(ctx, ghGraphQLClient, comment.ID, "OUTDATED"); err != nil {
-			log.Printf("warning: cannot minimize comment: %s\n", err.Error())
-			return
-		}
 
 		log.Printf("Successfully minimized last plan-preview result on pull request\n")
 		log.Println("plan-preview result has error")
 		os.Exit(1)
 	}
 
-	// Find comments we sent before
-	comment, err := findLatestPlanPreviewComment(ctx, ghGraphQLClient, event.Owner, event.Repo, event.PRNumber)
-	if err != nil {
-		log.Printf("Unable to find the previous comment to minimize (%v)\n", err)
-	}
+	minimizePreviousComment(ctx, ghGraphQLClient, event)
 
 	body := makeCommentBody(event, result)
 	doComment(body)
-
-	if comment == nil {
-		return
-	}
-
-	if bool(comment.IsMinimized) {
-		log.Printf("Previous plan-preview comment has already minimized. So don't minimize anything\n")
-		return
-	}
-
-	if err := minimizeComment(ctx, ghGraphQLClient, comment.ID, "OUTDATED"); err != nil {
-		log.Printf("warning: cannot minimize comment: %s\n", err.Error())
-		return
-	}
-
-	log.Printf("Successfully minimized last plan-preview result on pull request\n")
 }
 
 type arguments struct {

--- a/tool/actions-plan-preview/main.go
+++ b/tool/actions-plan-preview/main.go
@@ -147,7 +147,7 @@ func main() {
 		body := makeCommentBody(event, result)
 		doComment(body)
 
-		log.Printf("Successfully minimized last plan-preview result on pull request\n")
+		log.Println("Successfully minimized last plan-preview result on pull request")
 		log.Println("plan-preview result has error")
 		os.Exit(1)
 	}

--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -345,7 +345,7 @@ func minimizePreviousComment(ctx context.Context, ghGraphQLClient *githubv4.Clie
 	}
 
 	if bool(comment.IsMinimized) {
-		log.Printf("Previous plan-preview comment has already minimized. So don't minimize anything\n")
+		log.Println("Previous plan-preview comment has already minimized. So don't minimize anything")
 		return
 	}
 
@@ -354,5 +354,5 @@ func minimizePreviousComment(ctx context.Context, ghGraphQLClient *githubv4.Clie
 		return
 	}
 
-	log.Printf("Successfully minimized last plan-preview result on pull request\n")
+	log.Println("Successfully minimized last plan-preview result on pull request")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

1. The status badge appear twice

![Screenshot 2023-11-22 at 14 52 14](https://github.com/pipe-cd/pipecd/assets/39955827/05d824b7-bd11-4545-ba38-7cce4b9aa5c0)


2. Minimize previous comment when plan-preview result has error

![screencapture-github-CyberAgentAI-aoc-daifuku-app-config-pull-1323-2023-11-22-14_56_14](https://github.com/pipe-cd/pipecd/assets/39955827/c37e3f89-4871-44e7-934c-4c7c9a73a6ff)



**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
