### PR TITLE
Support QuickSync for ECS without ELB or target groups

### DIFF
--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -99,7 +99,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	}
 
 	var primary *types.LoadBalancer
-	// When the service is accessed via ELB, the target group is not used.
+	// When the service is not accessed via ELB, the target group is not used.
 	if ecsInput.IsAccessedViaELB() {
 		primary, _, ok = loadTargetGroups(&e.Input, e.appCfg, e.deploySource)
 		if !ok {

--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+
 	"github.com/pipe-cd/pipecd/pkg/app/piped/deploysource"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipecd/pkg/config"

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -58,6 +58,9 @@ type ECSDeploymentInput struct {
 	// Default is true.
 	RunStandaloneTask *bool `json:"runStandaloneTask" default:"true"`
 	// How the ECS service is accessed.
+	// Possible values are:
+	//  - ELB -  The service is accessed via ELB and target groups.
+	//  - SERVICE_DISCOVERY -  The service is accessed via ECS Service Discovery.
 	// Default is ELB.
 	AccessType string `json:"accessType" default:"ELB"`
 }

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	accessTypeELB              string = "ELB"
-	accessTypeServiveDiscovery string = "SERVICE_DISCOVERY"
+	AccessTypeELB              string = "ELB"
+	AccessTypeServiveDiscovery string = "SERVICE_DISCOVERY"
 )
 
 // ECSApplicationSpec represents an application configuration for ECS application.
@@ -81,7 +81,7 @@ func (in *ECSDeploymentInput) IsStandaloneTask() bool {
 }
 
 func (in *ECSDeploymentInput) IsAccessedViaELB() bool {
-	return in.AccessType == accessTypeELB
+	return in.AccessType == AccessTypeELB
 }
 
 type ECSVpcConfiguration struct {
@@ -145,7 +145,7 @@ func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
 
 func (in *ECSDeploymentInput) validateAccessType() error {
 	switch in.AccessType {
-	case accessTypeELB, accessTypeServiveDiscovery:
+	case AccessTypeELB, AccessTypeServiveDiscovery:
 		return nil
 	default:
 		return fmt.Errorf("invalid accessType: %s", in.AccessType)

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -16,6 +16,12 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+)
+
+const (
+	accessTypeELB              string = "ELB"
+	accessTypeServiveDiscovery string = "SERVICE_DISCOVERY"
 )
 
 // ECSApplicationSpec represents an application configuration for ECS application.
@@ -32,6 +38,11 @@ func (s *ECSApplicationSpec) Validate() error {
 	if err := s.GenericApplicationSpec.Validate(); err != nil {
 		return err
 	}
+
+	if err := s.Input.validateAccessType(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -70,7 +81,7 @@ func (in *ECSDeploymentInput) IsStandaloneTask() bool {
 }
 
 func (in *ECSDeploymentInput) IsAccessedViaELB() bool {
-	return in.AccessType == "ELB"
+	return in.AccessType == accessTypeELB
 }
 
 type ECSVpcConfiguration struct {
@@ -130,4 +141,13 @@ func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
 	primary = 100
 	canary = 0
 	return
+}
+
+func (in *ECSDeploymentInput) validateAccessType() error {
+	switch in.AccessType {
+	case accessTypeELB, accessTypeServiveDiscovery:
+		return nil
+	default:
+		return fmt.Errorf("invalid accessType: %s", in.AccessType)
+	}
 }

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -57,10 +57,17 @@ type ECSDeploymentInput struct {
 	// Run standalone task during deployment.
 	// Default is true.
 	RunStandaloneTask *bool `json:"runStandaloneTask" default:"true"`
+	// How the ECS service is accessed.
+	// Default is ELB.
+	AccessType string `json:"accessType" default:"ELB"`
 }
 
 func (in *ECSDeploymentInput) IsStandaloneTask() bool {
 	return in.ServiceDefinitionFile == ""
+}
+
+func (in *ECSDeploymentInput) IsAccessedViaELB() bool {
+	return in.AccessType == "ELB"
 }
 
 type ECSVpcConfiguration struct {

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	AccessTypeELB              string = "ELB"
-	AccessTypeServiveDiscovery string = "SERVICE_DISCOVERY"
+	AccessTypeServiceDiscovery string = "SERVICE_DISCOVERY"
 )
 
 // ECSApplicationSpec represents an application configuration for ECS application.
@@ -145,7 +145,7 @@ func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
 
 func (in *ECSDeploymentInput) validateAccessType() error {
 	switch in.AccessType {
-	case AccessTypeELB, AccessTypeServiveDiscovery:
+	case AccessTypeELB, AccessTypeServiceDiscovery:
 		return nil
 	default:
 		return fmt.Errorf("invalid accessType: %s", in.AccessType)

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -39,7 +39,7 @@ func (s *ECSApplicationSpec) Validate() error {
 		return err
 	}
 
-	if err := s.Input.validateAccessType(); err != nil {
+	if err := s.Input.validate(); err != nil {
 		return err
 	}
 
@@ -143,11 +143,12 @@ func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
 	return
 }
 
-func (in *ECSDeploymentInput) validateAccessType() error {
+func (in *ECSDeploymentInput) validate() error {
 	switch in.AccessType {
 	case AccessTypeELB, AccessTypeServiceDiscovery:
-		return nil
+		break
 	default:
 		return fmt.Errorf("invalid accessType: %s", in.AccessType)
 	}
+	return nil
 }

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,6 +103,40 @@ func TestECSApplicationConfig(t *testing.T) {
 				},
 			},
 			expectedError: nil,
+		},
+		{
+			fileName:           "testdata/application/ecs-app-invalid-access-type.yaml",
+			expectedKind:       KindECSApp,
+			expectedAPIVersion: "pipecd.dev/v1beta1",
+			expectedSpec: &ECSApplicationSpec{
+				GenericApplicationSpec: GenericApplicationSpec{
+					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommit{
+							Disabled: false,
+						},
+						OnCommand: OnCommand{
+							Disabled: false,
+						},
+						OnOutOfSync: OnOutOfSync{
+							Disabled:  newBoolPointer(true),
+							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
+					},
+				},
+				Input: ECSDeploymentInput{
+					ServiceDefinitionFile: "/path/to/servicedef.yaml",
+					TaskDefinitionFile:    "/path/to/taskdef.yaml",
+					LaunchType:            "FARGATE",
+					AutoRollback:          newBoolPointer(true),
+					RunStandaloneTask:     newBoolPointer(true),
+					AccessType:            "XXX",
+				},
+			},
+			expectedError: fmt.Errorf("invalid accessType: XXX"),
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -69,6 +69,40 @@ func TestECSApplicationConfig(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			fileName:           "testdata/application/ecs-app-service-discovery.yaml",
+			expectedKind:       KindECSApp,
+			expectedAPIVersion: "pipecd.dev/v1beta1",
+			expectedSpec: &ECSApplicationSpec{
+				GenericApplicationSpec: GenericApplicationSpec{
+					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommit{
+							Disabled: false,
+						},
+						OnCommand: OnCommand{
+							Disabled: false,
+						},
+						OnOutOfSync: OnOutOfSync{
+							Disabled:  newBoolPointer(true),
+							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
+					},
+				},
+				Input: ECSDeploymentInput{
+					ServiceDefinitionFile: "/path/to/servicedef.yaml",
+					TaskDefinitionFile:    "/path/to/taskdef.yaml",
+					LaunchType:            "FARGATE",
+					AutoRollback:          newBoolPointer(true),
+					RunStandaloneTask:     newBoolPointer(true),
+					AccessType:            "SERVICE_DISCOVERY",
+				},
+			},
+			expectedError: nil,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -64,6 +64,7 @@ func TestECSApplicationConfig(t *testing.T) {
 					LaunchType:        "FARGATE",
 					AutoRollback:      newBoolPointer(true),
 					RunStandaloneTask: newBoolPointer(true),
+					AccessType:        "ELB",
 				},
 			},
 			expectedError: nil,

--- a/pkg/config/testdata/application/ecs-app-invalid-access-type.yaml
+++ b/pkg/config/testdata/application/ecs-app-invalid-access-type.yaml
@@ -1,0 +1,7 @@
+apiVersion: pipecd.dev/v1beta1
+kind: ECSApp
+spec:
+  input:
+    serviceDefinitionFile: /path/to/servicedef.yaml
+    taskDefinitionFile: /path/to/taskdef.yaml
+    accessType: XXX

--- a/pkg/config/testdata/application/ecs-app-service-discovery.yaml
+++ b/pkg/config/testdata/application/ecs-app-service-discovery.yaml
@@ -1,0 +1,7 @@
+apiVersion: pipecd.dev/v1beta1
+kind: ECSApp
+spec:
+  input:
+    serviceDefinitionFile: /path/to/servicedef.yaml
+    taskDefinitionFile: /path/to/taskdef.yaml
+    accessType: SERVICE_DISCOVERY


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR supports QuickSync for ECS using Service Discovery, not ELB and target groups.
I will support canary and blue/green for Service Discovery later.

**Which issue(s) this PR fixes**: 

Part of #4616 

**Does this PR introduce a user-facing change?**:   

- **How are users affected by this change**: not affected including configs.
- **Is this breaking change**: no
- **How to migrate (if breaking change)**:  no
