### PR TITLE
Remove ModifyRules interface

### DIFF
--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -451,21 +451,6 @@ func routing(ctx context.Context, in *executor.Input, platformProviderName strin
 		return false
 	}
 
-	currListenerRuleArns, err := client.GetListenerRuleArns(ctx, currListenerArns)
-	if err != nil {
-		in.LogPersister.Errorf("Failed to get current active listener rule: %v", err)
-		return false
-	}
-
-	if len(currListenerRuleArns) > 0 {
-		if err := client.ModifyRules(ctx, currListenerRuleArns, routingTrafficCfg); err != nil {
-			in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
-			return false
-		}
-
-		return true
-	}
-
 	if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
 		in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
 		return false

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -158,21 +158,6 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 			return false
 		}
 
-		currListenerRuleArns, err := client.GetListenerRuleArns(ctx, currListenerArns)
-		if err != nil {
-			in.LogPersister.Errorf("Failed to get current active listener rule: %v", err)
-			return false
-		}
-
-		if len(currListenerRuleArns) > 0 {
-			if err := client.ModifyRules(ctx, currListenerRuleArns, routingTrafficCfg); err != nil {
-				in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
-				return false
-			}
-
-			return true
-		}
-
 		if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
 			in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
 			return false

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -418,30 +417,6 @@ func (c *client) GetListenerArns(ctx context.Context, targetGroup types.LoadBala
 	return arns, nil
 }
 
-func (c *client) GetListenerRuleArns(ctx context.Context, listenerArns []string) ([]string, error) {
-	var ruleArns []string
-
-	// Fetch all rules by listeners
-	for _, listenerArn := range listenerArns {
-		input := &elasticloadbalancingv2.DescribeRulesInput{
-			ListenerArn: aws.String(listenerArn),
-		}
-		output, err := c.elbClient.DescribeRules(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		for _, rule := range output.Rules {
-			ruleArns = append(ruleArns, *rule.RuleArn)
-		}
-	}
-
-	if len(ruleArns) == 0 {
-		return nil, platformprovider.ErrNotFound
-	}
-
-	return ruleArns, nil
-}
-
 func (c *client) getLoadBalancerArn(ctx context.Context, targetGroupArn string) (string, error) {
 	input := &elasticloadbalancingv2.DescribeTargetGroupsInput{
 		TargetGroupArns: []string{targetGroupArn},
@@ -475,7 +450,7 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 		var modifiedActions []elbtypes.Action
 		for _, action := range describeListenersOutput.Listeners[0].DefaultActions {
 			if action.Type == elbtypes.ActionTypeEnumForward {
-				// Modify only the forward action (new logic)
+				// Modify only the forward action
 				modifiedAction := elbtypes.Action{
 					Type: elbtypes.ActionTypeEnumForward,
 					ForwardConfig: &elbtypes.ForwardActionConfig{
@@ -493,7 +468,7 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 				}
 				modifiedActions = append(modifiedActions, modifiedAction)
 			} else {
-				// Keep other actions unchanged (new logic)
+				// Keep other actions unchanged
 				modifiedActions = append(modifiedActions, action)
 			}
 		}
@@ -505,59 +480,6 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 		})
 		if err != nil {
 			return fmt.Errorf("error modifying listener %s: %w", listenerArn, err)
-		}
-	}
-	return nil
-}
-
-func (c *client) ModifyRules(ctx context.Context, listenerRuleArns []string, routingTrafficCfg RoutingTrafficConfig) error {
-	if len(routingTrafficCfg) != 2 {
-		return fmt.Errorf("invalid listener configuration: requires 2 target groups")
-	}
-
-	for _, ruleArn := range listenerRuleArns {
-		// Describe the rule to get current actions
-		describeRulesOutput, err := c.elbClient.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
-			RuleArns: []string{ruleArn},
-		})
-		if err != nil {
-			return fmt.Errorf("error describing listener rule %v: %w", strings.Join(listenerRuleArns, ", "), err)
-		}
-
-		// Prepare the actions to be modified
-		var modifiedActions []elbtypes.Action
-		for _, action := range describeRulesOutput.Rules[0].Actions {
-			if action.Type == elbtypes.ActionTypeEnumForward {
-				// Modify only the forward action (new logic)
-				modifiedAction := elbtypes.Action{
-					Type: elbtypes.ActionTypeEnumForward,
-					ForwardConfig: &elbtypes.ForwardActionConfig{
-						TargetGroups: []elbtypes.TargetGroupTuple{
-							{
-								TargetGroupArn: aws.String(routingTrafficCfg[0].TargetGroupArn),
-								Weight:         aws.Int32(int32(routingTrafficCfg[0].Weight)),
-							},
-							{
-								TargetGroupArn: aws.String(routingTrafficCfg[1].TargetGroupArn),
-								Weight:         aws.Int32(int32(routingTrafficCfg[1].Weight)),
-							},
-						},
-					},
-				}
-				modifiedActions = append(modifiedActions, modifiedAction)
-			} else {
-				// Keep other actions unchanged (new logic)
-				modifiedActions = append(modifiedActions, action)
-			}
-		}
-
-		// Modify the rule with the new actions
-		_, err = c.elbClient.ModifyRule(ctx, &elasticloadbalancingv2.ModifyRuleInput{
-			RuleArn: aws.String(ruleArn),
-			Actions: modifiedActions,
-		})
-		if err != nil {
-			return fmt.Errorf("error modifying listener rule %s: %w", ruleArn, err)
 		}
 	}
 	return nil

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -57,9 +57,9 @@ type ECS interface {
 
 type ELB interface {
 	GetListenerArns(ctx context.Context, targetGroup types.LoadBalancer) ([]string, error)
-	GetListenerRuleArns(ctx context.Context, listenerArns []string) ([]string, error)
+	// ModifyListeners modifies the actions of type ActionTypeEnumForward to perform routing traffic
+	// to the given target groups. Other actions won't be modified.
 	ModifyListeners(ctx context.Context, listenerArns []string, routingTrafficCfg RoutingTrafficConfig) error
-	ModifyRules(ctx context.Context, listenerRuleArns []string, routingTrafficCfg RoutingTrafficConfig) error
 }
 
 // Registry holds a pool of aws client wrappers.


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the logic ModifyListeners had been updated to ensure only modifying the actions of kind `ActionTypeEnumForward`, there is no need to separate ModifyRules and ModifyListeners.
Also, no rule exists without associating with listeners in the context of ELB.

**Which issue(s) this PR fixes**:

Follow #4668 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
