### PR TITLE
[ECS] Delete old tasksets before QuickSync except PRIMARY

### DIFF
--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -258,7 +258,7 @@ func deleteOldTaskSets(ctx context.Context, client provider.Client, service type
 
 	// Remove old taskSets except PRIMARY if exist.
 	for _, prevTaskSet := range prevTaskSets {
-		if *prevTaskSet.Status != "PRIMARY" {
+		if *prevTaskSet.Status != "PRIMARY" && provider.IsPipeCDManagedTaskSet(prevTaskSet) {
 			if err = client.DeleteTaskSet(ctx, *prevTaskSet); err != nil {
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

If old deployments remain, the new deployment will sometimes fail.
So this PR removes old deployments before the new deployment.

**Which issue(s) this PR fixes**:

Workaround for #4692


**Does this PR introduce a user-facing change?**:  

- **How are users affected by this change**:  
- **Is this breaking change**:  
- **How to migrate (if breaking change)**:   
