### PR TITLE
avoid nil pointer in ephemeral storage  settings

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -127,7 +127,9 @@ func (c *client) CreateFunction(ctx context.Context, fm FunctionManifest) error 
 		input.Architectures = architectures
 	}
 	if fm.Spec.EphemeralStorage != nil {
-		input.EphemeralStorage.Size = aws.Int32(fm.Spec.EphemeralStorage.Size)
+		input.EphemeralStorage = &types.EphemeralStorage{
+			Size: aws.Int32(fm.Spec.EphemeralStorage.Size),
+		}
 	}
 	if fm.Spec.VPCConfig != nil {
 		input.VpcConfig = &types.VpcConfig{
@@ -183,7 +185,9 @@ func (c *client) CreateFunctionFromSource(ctx context.Context, fm FunctionManife
 		},
 	}
 	if fm.Spec.EphemeralStorage != nil {
-		input.EphemeralStorage.Size = aws.Int32(fm.Spec.EphemeralStorage.Size)
+		input.EphemeralStorage = &types.EphemeralStorage{
+			Size: aws.Int32(fm.Spec.EphemeralStorage.Size),
+		}
 	}
 	_, err = c.client.CreateFunction(ctx, input)
 	if err != nil {
@@ -284,7 +288,9 @@ func (c *client) updateFunctionConfiguration(ctx context.Context, fm FunctionMan
 			configInput.Handler = aws.String(fm.Spec.Handler)
 		}
 		if fm.Spec.EphemeralStorage != nil {
-			configInput.EphemeralStorage.Size = aws.Int32(fm.Spec.EphemeralStorage.Size)
+			configInput.EphemeralStorage = &types.EphemeralStorage{
+				Size: aws.Int32(fm.Spec.EphemeralStorage.Size),
+			}
 		}
 		if fm.Spec.VPCConfig != nil {
 			configInput.VpcConfig = &types.VpcConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
If the size input is accessed, a nil pointer could be triggered, so I have fixed it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
