### PR TITLE
Fix event name typos on notification docs

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
@@ -52,7 +52,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: prod
           team: pipecd

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -189,7 +189,7 @@ func TestPipedConfig(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_SUCCEEDED"},
 							Receiver: "prod-slack-channel",
 						},
 						{
@@ -1018,7 +1018,7 @@ func TestPipedSpecClone(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_SUCCEEDED"},
 							Receiver: "prod-slack-channel",
 						},
 						{
@@ -1215,7 +1215,7 @@ func TestPipedSpecClone(t *testing.T) {
 							Labels: map[string]string{
 								"env": "dev",
 							},
-							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_COMPLETED"},
+							Events:   []string{"DEPLOYMENT_TRIGGERED", "DEPLOYMENT_SUCCEEDED"},
 							Receiver: "prod-slack-channel",
 						},
 						{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -104,7 +104,7 @@ spec:
       - name: prod-slack
         events:
           - DEPLOYMENT_TRIGGERED
-          - DEPLOYMENT_COMPLETED
+          - DEPLOYMENT_SUCCEEDED
         labels:
           env: dev
         receiver: prod-slack-channel


### PR DESCRIPTION
**What this PR does / why we need it**:
Found a event name typos on notification docs. Fix event name from `DEPLOYMENT_COMPLETED` to `DEPLOYMENT_SUCCEEDED`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
