### PR TITLE
feat: github action matrix for images build

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -1,4 +1,4 @@
-name: build
+name: build_tool
 
 on:
   pull_request:
@@ -13,6 +13,27 @@ env:
 jobs:
   tool:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: 
+          - actions-gh-release
+          - actions-plan-preview
+          - codegen
+          - piped-base
+          - piped-base-okd
+          - firestore-emulator
+        include:
+          - image: actions-gh-release
+            context: tool/actions-gh-release
+          - image: actions-plan-preview
+            context: tool/actions-plan-preview
+          - image: codegen
+            context: tool/codegen
+          - image: piped-base
+            context: tool/piped-base
+          - image: piped-base-okd
+            context: tool/piped-base-okd
+          - image: firestore-emulator
     steps:
       - uses: actions/checkout@v3
         with:
@@ -20,38 +41,8 @@ jobs:
       - name: Determine version
         run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
 
-      - name: Build actions-gh-release image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      - name: Build ${{ matrix.image }} image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
-          context: tool/actions-gh-release
-          tags: ${{ env.REGISTRY }}/pipe-cd/actions-gh-release:${{ env.PIPECD_VERSION }}
-
-      - name: Build actions-plan-preview image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/actions-plan-preview
-          tags: ${{ env.REGISTRY }}/pipe-cd/actions-plan-preview:${{ env.PIPECD_VERSION }}
-
-      - name: Build codegen image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/codegen
-          tags: ${{ env.REGISTRY }}/pipe-cd/codegen:${{ env.PIPECD_VERSION }}
-
-      - name: Build piped-base image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/piped-base
-          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base:${{ env.PIPECD_VERSION }}
-
-      - name: Build piped-base-okd image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/piped-base-okd
-          tags: ${{ env.REGISTRY }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}
-
-      - name: Build firestore-emulator image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/firestore-emulator
-          tags: ${{ env.REGISTRY }}/pipe-cd/firestore-emulator:${{ env.PIPECD_VERSION }}
+          context: ${{ matrix.context }}
+          tags: ${{ env.REGISTRY }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -114,7 +114,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
+          tags: ${{ matrix.container_registry }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
       
       # Building and pushing Helm charts.
       - name: Install helm

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -1,4 +1,4 @@
-name: publish
+name: publish_image_chart
 
 on:
   push:
@@ -103,7 +103,7 @@ jobs:
 
       # Building and pushing container images.
       - name: Build and push ${{ matrix.image }} image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
           push: true
           context: .

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -30,15 +30,20 @@ jobs:
           - piped
           - piped-okd
           - pipectl
+        container_registry:
+          - ghcr.io
         include:
           - image: helloworld
             dockerfile: cmd/helloworld/Dockerfile
+            container_registry: gcr.io
           - image: launcher
             dockerfile: cmd/launcher/Dockerfile
+            container_registry: gcr.io
           - image: launcher-okd
             dockerfile: cmd/launcher/Dockerfile-okd
           - image: pipecd
             dockerfile: cmd/pipecd/Dockerfile
+            container_registry: gcr.io
           - image: piped
             dockerfile: cmd/piped/Dockerfile
           - image: piped-okd

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -20,6 +20,32 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        image:
+          - helloworld
+          - launcher
+          - launcher-okd
+          - pipecd
+          - piped
+          - piped-okd
+          - pipectl
+        include:
+          - image: helloworld
+            dockerfile: cmd/helloworld/Dockerfile
+          - image: launcher
+            dockerfile: cmd/launcher/Dockerfile
+          - image: launcher-okd
+            dockerfile: cmd/launcher/Dockerfile-okd
+          - image: pipecd
+            dockerfile: cmd/pipecd/Dockerfile
+          - image: piped
+            dockerfile: cmd/piped/Dockerfile
+          - image: piped-okd
+            dockerfile: cmd/piped/Dockerfile-okd
+          - image: pipectl
+            dockerfile: cmd/pipectl/Dockerfile
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,69 +102,15 @@ jobs:
           password: ${{ secrets.GCR_SA }}
 
       # Building and pushing container images.
-      - name: Build and push pipecd image
+      - name: Build and push ${{ matrix.image }} image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           push: true
           context: .
-          file: cmd/pipecd/Dockerfile
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.GHCR }}/pipe-cd/pipecd:${{ env.PIPECD_VERSION }}
-      - name: Build and push piped image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/piped/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.GHCR }}/pipe-cd/piped:${{ env.PIPECD_VERSION }}
-            ${{ env.GCR }}/pipecd/piped:${{ env.PIPECD_VERSION }}
-      - name: Build and push piped-okd image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/piped/Dockerfile-okd
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.GHCR }}/pipe-cd/piped-okd:${{ env.PIPECD_VERSION }}
-      - name: Build and push launcher image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/launcher/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.GHCR }}/pipe-cd/launcher:${{ env.PIPECD_VERSION }}
-            ${{ env.GCR }}/pipecd/launcher:${{ env.PIPECD_VERSION }}
-      - name: Build and push launcher-okd image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/launcher/Dockerfile-okd
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.GHCR }}/pipe-cd/launcher-okd:${{ env.PIPECD_VERSION }}
-      - name: Build and push pipectl image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/pipectl/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.GHCR }}/pipe-cd/pipectl:${{ env.PIPECD_VERSION }}
-      - name: Build and push helloworld image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          push: true
-          context: .
-          file: cmd/helloworld/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.GHCR }}/pipe-cd/helloworld:${{ env.PIPECD_VERSION }}
-            ${{ env.GCR }}/pipecd/helloworld:${{ env.PIPECD_VERSION }}
-
+          tags: ${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
+      
       # Building and pushing Helm charts.
       - name: Install helm
         uses: Azure/setup-helm@v1

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -1,4 +1,4 @@
-name: publish
+name: publish_site
 
 on:
   push:

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -1,4 +1,4 @@
-name: publish
+name: publish_tool
 
 on:
   push:

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -1,4 +1,4 @@
-name: test
+name: test_tool
 
 on:
   push:


### PR DESCRIPTION
**What this PR does / why we need it**: better DRY on images build CI
this also prepare for upgrade image base, will have flexible option to put image TAG as ARG
https://github.com/pipe-cd/pipecd/discussions/4702#discussioncomment-7810428

another point, though that this could be better view
<img width="335" alt="image" src="https://github.com/pipe-cd/pipecd/assets/26101787/0c592b8c-aacb-4353-b3b2-6aa024b10aca">

**Which issue(s) this PR fixes**:

Part of #4713 
- [x] add matrix image build

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
