### PR TITLE
Specify gpt-4-1106-preview as the model for code-butler

### DIFF
--- a/.github/workflows/code-butler.yaml
+++ b/.github/workflows/code-butler.yaml
@@ -18,6 +18,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           cmd: review
+          model: gpt-4-1106-preview
   chat:
     if: startsWith(github.event.comment.body, '/chat')
     runs-on: ubuntu-latest
@@ -27,4 +28,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           cmd: chat
+          model: gpt-4-1106-preview
           comment_body: ${{ github.event.comment.body }}


### PR DESCRIPTION
**What this PR does / why we need it**:

- By specifying gpt-4-1106-preview as the model for code-butler, PRs with many differences can be reviewed at once.
- However, since OpenAI's paid plan Token is required, you need to update your Token before Merge this PR.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
