### PR TITLE
fix: matrix build recorrect and use docker build and push action on v5.0.0

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -22,18 +22,6 @@ jobs:
           - piped-base
           - piped-base-okd
           - firestore-emulator
-        include:
-          - image: actions-gh-release
-            context: tool/actions-gh-release
-          - image: actions-plan-preview
-            context: tool/actions-plan-preview
-          - image: codegen
-            context: tool/codegen
-          - image: piped-base
-            context: tool/piped-base
-          - image: piped-base-okd
-            context: tool/piped-base-okd
-          - image: firestore-emulator
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,5 +32,5 @@ jobs:
       - name: Build ${{ matrix.image }} image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
-          context: ${{ matrix.context }}
+          context: tool/${{ matrix.image }}
           tags: ${{ env.REGISTRY }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -22,6 +22,9 @@ jobs:
       packages: write
     strategy:
       matrix:
+        container_registry:
+          - ghcr.io
+          - gcr.io
         image:
           - helloworld
           - launcher
@@ -30,26 +33,30 @@ jobs:
           - piped
           - piped-okd
           - pipectl
-        container_registry:
-          - ghcr.io
         include:
           - image: helloworld
             dockerfile: cmd/helloworld/Dockerfile
-            container_registry: gcr.io
           - image: launcher
             dockerfile: cmd/launcher/Dockerfile
-            container_registry: gcr.io
           - image: launcher-okd
             dockerfile: cmd/launcher/Dockerfile-okd
           - image: pipecd
             dockerfile: cmd/pipecd/Dockerfile
-            container_registry: gcr.io
           - image: piped
             dockerfile: cmd/piped/Dockerfile
           - image: piped-okd
             dockerfile: cmd/piped/Dockerfile-okd
           - image: pipectl
             dockerfile: cmd/pipectl/Dockerfile
+        exclude:
+          - image: launcher-okd
+            container_registry: gcr.io
+          - image: piped
+            container_registry: gcr.io
+          - image: piped-okd
+            container_registry: gcr.io
+          - image: pipectl
+            container_registry: gcr.io
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -49,7 +49,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push site image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
           push: true
           context: docs

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -15,6 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    strategy:
+      matrix:
+        image:
+          - actions-gh-release
+          - actions-plan-preview
+          - codegen
+          - piped-base
+          - piped-base-okd
+          - firestore-emulator
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,44 +40,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Building and pushing container images.
-      - name: Build and push actions-gh-release image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      - name: Build and push ${{ matrix.image }} image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
-          context: tool/actions-gh-release
-          tags: ${{ env.GHCR }}/pipe-cd/actions-gh-release:${{ env.PIPECD_VERSION }}
-          push: true
-
-      - name: Build and push actions-plan-preview image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/actions-plan-preview
-          tags: ${{ env.GHCR }}/pipe-cd/actions-plan-preview:${{ env.PIPECD_VERSION }}
-          push: true
-
-      - name: Build and push codegen image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/codegen
-          tags: ${{ env.GHCR }}/pipe-cd/codegen:${{ env.PIPECD_VERSION }}
-          push: true
-
-      - name: Build and push piped-base image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/piped-base
-          tags: ${{ env.GHCR }}/pipe-cd/piped-base:${{ env.PIPECD_VERSION }}
-          push: true
-
-      - name: Build and push piped-base-okd image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/piped-base-okd
-          tags: ${{ env.GHCR }}/pipe-cd/piped-base-okd:${{ env.PIPECD_VERSION }}
-          push: true
-
-      - name: Build and push firestore-emulator image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: tool/firestore-emulator
-          tags: ${{ env.GHCR }}/pipe-cd/firestore-emulator:${{ env.PIPECD_VERSION }}
+          context: tool/${{ matrix.image }}
+          tags: ${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
           push: true


### PR DESCRIPTION
**What this PR does / why we need it**: fix last PR #https://github.com/pipe-cd/pipecd/pull/4712
apologized for my last PR did not deep check test
This PR will introduce `exclude`  and update docker build and push action to v5.0.0 on all flows

![image](https://github.com/pipe-cd/pipecd/assets/26101787/f48d0fec-5436-4a7d-8995-87416eeafdab)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: n/a

- **How are users affected by this change**: n/a
- **Is this breaking change**: n/a
- **How to migrate (if breaking change)**: n/a
