### PR TITLE
fix dockefile path

### DIFF
--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -35,14 +35,19 @@ jobs:
           - pipectl
         include:
           - image: helloworld
+            dockerfile: cmd/helloworld/Dockerfile
           - image: launcher
+            dockerfile: cmd/launcher/Dockerfile
           - image: launcher-okd
-            okd: -okd
+            dockerfile: cmd/launcher/Dockerfile-okd
           - image: pipecd
+            dockerfile: cmd/pipecd/Dockerfile
           - image: piped
+            dockerfile: cmd/piped/Dockerfile
           - image: piped-okd
-            okd: -okd
+            dockerfile: cmd/piped/Dockerfile-okd
           - image: pipectl
+            dockerfile: cmd/pipectl/Dockerfile
         exclude:
           - image: launcher-okd
             container_registry: gcr.io/pipecd
@@ -114,7 +119,7 @@ jobs:
         with:
           push: true
           context: .
-          file: cmd/${{ matrix.image }}/Dockerfile${{ matrix.okd }}
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ matrix.container_registry }}/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
       


### PR DESCRIPTION
**What this PR does / why we need it**: fix the last PR 
https://github.com/pipe-cd/pipecd/pull/4719 
https://github.com/pipe-cd/pipecd/pull/4718
https://github.com/pipe-cd/pipecd/pull/4712

seem like hard to maintain the image because of fragment on base tool image and the 2nd iterator.
even better by multistage build tho?

**Which issue(s) this PR fixes**: 

Fixes #

**Does this PR introduce a user-facing change?**: n/a

- **How are users affected by this change**: n/a
- **Is this breaking change**: n/a
- **How to migrate (if breaking change)**: n/a
