### PR TITLE
fix: exclude pipecd image to gcr.io as we won't need

### DIFF
--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -51,7 +51,7 @@ jobs:
         exclude:
           - image: launcher-okd
             container_registry: gcr.io/pipecd
-          - image: piped
+          - image: pipecd
             container_registry: gcr.io/pipecd
           - image: piped-okd
             container_registry: gcr.io/pipecd


### PR DESCRIPTION
**What this PR does / why we need it**:
basis only helloworld, launcher, piped need gcr.io
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:n/a

- **How are users affected by this change**: n/a
- **Is this breaking change**: n/a
- **How to migrate (if breaking change)**: n/a
