### PR TITLE
Add vpc and architectures option to the creation of lambda from source

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -184,9 +184,22 @@ func (c *client) CreateFunctionFromSource(ctx context.Context, fm FunctionManife
 			Variables: fm.Spec.Environments,
 		},
 	}
+	if len(fm.Spec.Architectures) != 0 {
+		var architectures []types.Architecture
+		for _, arch := range fm.Spec.Architectures {
+			architectures = append(architectures, types.Architecture(arch.Name))
+		}
+		input.Architectures = architectures
+	}
 	if fm.Spec.EphemeralStorage != nil {
 		input.EphemeralStorage = &types.EphemeralStorage{
 			Size: aws.Int32(fm.Spec.EphemeralStorage.Size),
+		}
+	}
+	if fm.Spec.VPCConfig != nil {
+		input.VpcConfig = &types.VpcConfig{
+			SecurityGroupIds: fm.Spec.VPCConfig.SecurityGroupIDs,
+			SubnetIds:        fm.Spec.VPCConfig.SubnetIDs,
 		}
 	}
 	_, err = c.client.CreateFunction(ctx, input)

--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -185,7 +185,7 @@ func (c *client) CreateFunctionFromSource(ctx context.Context, fm FunctionManife
 		},
 	}
 	if len(fm.Spec.Architectures) != 0 {
-		var architectures []types.Architecture
+		architectures := make([]types.Architecture, 0, len(fm.Spec.Architectures))
 		for _, arch := range fm.Spec.Architectures {
 			architectures = append(architectures, types.Architecture(arch.Name))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
I added vpc and architectures optional configuration to creation of lambda from source code as they did not exist.
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
