### PR TITLE
[ECS] Modify ELB listener rules other than defaults without adding config

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -472,12 +472,23 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 				}
 			}
 
-			_, err := c.elbClient.ModifyRule(ctx, &elasticloadbalancingv2.ModifyRuleInput{
-				RuleArn: rule.RuleArn,
-				Actions: modifiedActions,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to modify rule %s: %w", *rule.RuleArn, err)
+			// The default rule needs to be modified by ModifyListener API.
+			if rule.IsDefault {
+				_, err := c.elbClient.ModifyListener(ctx, &elasticloadbalancingv2.ModifyListenerInput{
+					ListenerArn:    &listenerArn,
+					DefaultActions: modifiedActions,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to modify default rule %s: %w", *rule.RuleArn, err)
+				}
+			} else {
+				_, err := c.elbClient.ModifyRule(ctx, &elasticloadbalancingv2.ModifyRuleInput{
+					RuleArn: rule.RuleArn,
+					Actions: modifiedActions,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to modify rule %s: %w", *rule.RuleArn, err)
+				}
 			}
 		}
 	}

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -442,7 +442,7 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 			ListenerArn: aws.String(listenerArn),
 		})
 		if err != nil {
-			return fmt.Errorf("error describing rules %s: %w", listenerArn, err)
+			return fmt.Errorf("failed to describe rules %s: %w", listenerArn, err)
 		}
 
 		for _, rule := range describeRulesOutput.Rules {
@@ -477,7 +477,7 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 				Actions: modifiedActions,
 			})
 			if err != nil {
-				return fmt.Errorf("error modifying rule %s: %w", *rule.RuleArn, err)
+				return fmt.Errorf("failed to modify rule %s: %w", *rule.RuleArn, err)
 			}
 		}
 	}

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -442,11 +442,11 @@ func (c *client) ModifyListeners(ctx context.Context, listenerArns []string, rou
 			ListenerArn: aws.String(listenerArn),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to describe rules %s: %w", listenerArn, err)
+			return fmt.Errorf("failed to describe rules of listener %s: %w", listenerArn, err)
 		}
 
 		for _, rule := range describeRulesOutput.Rules {
-			var modifiedActions []elbtypes.Action
+			modifiedActions := make([]elbtypes.Action, 0, len(rule.Actions))
 			for _, action := range rule.Actions {
 				if action.Type == elbtypes.ActionTypeEnumForward && routingTrafficCfg.hasSameTargets(action.ForwardConfig.TargetGroups) {
 					// Modify only the forward action which has the same target groups.

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic.go
@@ -14,9 +14,37 @@
 
 package ecs
 
+import (
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
 type RoutingTrafficConfig []targetGroupWeight
 
 type targetGroupWeight struct {
 	TargetGroupArn string
 	Weight         int
+}
+
+func (c RoutingTrafficConfig) hasSameTargets(forwardActionTargets []types.TargetGroupTuple) bool {
+	if len(c) != len(forwardActionTargets) {
+		return false
+	}
+
+	// Sort to the both slices have the same target groups.
+	sort.Slice(c, func(i, j int) bool {
+		return c[i].TargetGroupArn < c[j].TargetGroupArn
+	})
+	sort.Slice(forwardActionTargets, func(i, j int) bool {
+		return *forwardActionTargets[i].TargetGroupArn < *forwardActionTargets[j].TargetGroupArn
+	})
+
+	for i := range c {
+		if c[i].TargetGroupArn != *forwardActionTargets[i].TargetGroupArn {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic.go
@@ -30,13 +30,13 @@ func (c RoutingTrafficConfig) hasSameTargets(forwardActionTargets []types.Target
 		return false
 	}
 
-	cMap := make(map[string]bool)
+	cMap := make(map[string]struct{})
 	for _, item := range c {
-		cMap[item.TargetGroupArn] = true
+		cMap[item.TargetGroupArn] = struct{}{}
 	}
 
 	for _, target := range forwardActionTargets {
-		if !cMap[*target.TargetGroupArn] {
+		if _, ok := cMap[*target.TargetGroupArn]; !ok {
 			return false
 		}
 	}

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic.go
@@ -32,7 +32,7 @@ func (c RoutingTrafficConfig) hasSameTargets(forwardActionTargets []types.Target
 		return false
 	}
 
-	// Sort to the both slices have the same target groups.
+	// Sort so that the both slices have the same target groups.
 	sort.Slice(c, func(i, j int) bool {
 		return c[i].TargetGroupArn < c[j].TargetGroupArn
 	})

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic.go
@@ -15,8 +15,6 @@
 package ecs
 
 import (
-	"sort"
-
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
@@ -32,16 +30,13 @@ func (c RoutingTrafficConfig) hasSameTargets(forwardActionTargets []types.Target
 		return false
 	}
 
-	// Sort so that the both slices have the same target groups.
-	sort.Slice(c, func(i, j int) bool {
-		return c[i].TargetGroupArn < c[j].TargetGroupArn
-	})
-	sort.Slice(forwardActionTargets, func(i, j int) bool {
-		return *forwardActionTargets[i].TargetGroupArn < *forwardActionTargets[j].TargetGroupArn
-	})
+	cMap := make(map[string]bool)
+	for _, item := range c {
+		cMap[item.TargetGroupArn] = true
+	}
 
-	for i := range c {
-		if c[i].TargetGroupArn != *forwardActionTargets[i].TargetGroupArn {
+	for _, target := range forwardActionTargets {
+		if !cMap[*target.TargetGroupArn] {
 			return false
 		}
 	}

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
@@ -125,7 +125,8 @@ func TestHasSameTargets(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for _, testcase := range testcases {
+		tc := testcase
 		t.Run(tc.name, func(t *testing.T) {
 			hasSame := tc.cfg.hasSameTargets(tc.actionTargets)
 			assert.Equal(t, tc.expected, hasSame)

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
@@ -1,0 +1,134 @@
+// Copyright 2023 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSameTargets(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		cfg           RoutingTrafficConfig
+		actionTargets []types.TargetGroupTuple
+		expected      bool
+	}{
+		{
+			name: "has the same target groups in the same order",
+			cfg: RoutingTrafficConfig{
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1",
+					Weight:         100,
+				},
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2",
+					Weight:         0,
+				},
+			},
+			actionTargets: []types.TargetGroupTuple{
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1"),
+					Weight:         aws.Int32(100),
+				},
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2"),
+					Weight:         aws.Int32(0),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "has the same target groups in the different order",
+			cfg: RoutingTrafficConfig{
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1",
+					Weight:         100,
+				},
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2",
+					Weight:         0,
+				},
+			},
+			actionTargets: []types.TargetGroupTuple{
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2"),
+					Weight:         aws.Int32(0),
+				},
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1"),
+					Weight:         aws.Int32(100),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "the number of target groups are different",
+			cfg: RoutingTrafficConfig{
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1",
+					Weight:         100,
+				},
+			},
+			actionTargets: []types.TargetGroupTuple{
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1"),
+					Weight:         aws.Int32(0),
+				},
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2"),
+					Weight:         aws.Int32(100),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "has a different target group",
+			cfg: RoutingTrafficConfig{
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1",
+					Weight:         100,
+				},
+				{
+					TargetGroupArn: "arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy2",
+					Weight:         0,
+				},
+			},
+			actionTargets: []types.TargetGroupTuple{
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy1"),
+					Weight:         aws.Int32(0),
+				},
+				{
+					TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:<region>:<account-id>:targetgroup/xxx/yyy3"),
+					Weight:         aws.Int32(100),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			hasSame := tc.cfg.hasSameTargets(tc.actionTargets)
+			assert.Equal(t, tc.expected, hasSame)
+		})
+	}
+}

--- a/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
+++ b/pkg/app/piped/platformprovider/ecs/routing_traffic_test.go
@@ -125,8 +125,8 @@ func TestHasSameTargets(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
-		tc := testcase
+	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			hasSame := tc.cfg.hasSameTargets(tc.actionTargets)
 			assert.Equal(t, tc.expected, hasSame)


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifying listener rules which is not the default rule without specifying in app.pipecd.config, unlike #4726. 

**Which issue(s) this PR fixes**:

Fixes #4725 

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no


** A short explanation ** 

If the ELB and app.pipecd.yaml are as below, the rules that will be modified are `rule-A1`,`rule-B1` and `rule-B2` 
since they have the same target groups as app.pipecd.yaml.

```
ELB-X
|-- Listener-A
|    |-- rule-A1 (default)
|        |-- targetGroup-p
|        |-- targetGroup-c
|-- Listener-B
    |-- rule-B1 (default)
    |    |-- targetGroup-p
    |    |-- targetGroup-c
    |-- rule-B2   [path-pattern: /xxx/*]
    |    |-- targetGroup-p
    |    |-- targetGroup-c
    |-- rule-B3   [path-pattern: /yyy/*]
        |-- targetGroup-x
        |-- targetGroup-y
```

app.pipecd.yaml: 

```yaml
apiVersion: pipecd.dev/v1beta1
kind: ECSApp
spec:
  input:
    targetGroups:
      primary:
        targetGroupArn: arn:aws:elasticloadbalancing:ap-northeast-1:<account-id>:targetgroup/xxx/yyy1 # targetGroup-p
      canary:
        targetGroupArn: arn:aws:elasticloadbalancing:ap-northeast-1:<account-id>:targetgroup/xxx/yyy2 # targetGroup-c
```