### PR TITLE
[ECS] Refactored from json.RawMessage to ECSTargetGroup struct

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/target_groups.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups.go
@@ -31,17 +31,19 @@ func loadTargetGroups(targetGroups config.ECSTargetGroups) (*types.LoadBalancer,
 	}
 
 	primary := &types.LoadBalancer{
-		TargetGroupArn: aws.String(targetGroups.Primary.TargetGroupArn),
-		ContainerName:  aws.String(targetGroups.Primary.ContainerName),
-		ContainerPort:  aws.Int32(int32(targetGroups.Primary.ContainerPort)),
+		TargetGroupArn:   aws.String(targetGroups.Primary.TargetGroupArn),
+		ContainerName:    aws.String(targetGroups.Primary.ContainerName),
+		ContainerPort:    aws.Int32(int32(targetGroups.Primary.ContainerPort)),
+		LoadBalancerName: aws.String(targetGroups.Primary.LoadBalancerName),
 	}
 
 	var canary *types.LoadBalancer
 	if targetGroups.Canary != nil {
 		canary = &types.LoadBalancer{
-			TargetGroupArn: aws.String(targetGroups.Canary.TargetGroupArn),
-			ContainerName:  aws.String(targetGroups.Canary.ContainerName),
-			ContainerPort:  aws.Int32(int32(targetGroups.Canary.ContainerPort)),
+			TargetGroupArn:   aws.String(targetGroups.Canary.TargetGroupArn),
+			ContainerName:    aws.String(targetGroups.Canary.ContainerName),
+			ContainerPort:    aws.Int32(int32(targetGroups.Canary.ContainerPort)),
+			LoadBalancerName: aws.String(targetGroups.Canary.LoadBalancerName),
 		}
 	}
 

--- a/pkg/app/piped/platformprovider/ecs/target_groups_test.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups_test.go
@@ -42,7 +42,11 @@ func TestLoadTargetGroup(t *testing.T) {
 		{
 			name: "primary target group only",
 			cfg: config.ECSTargetGroups{
-				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn", "containerName": "primary-container-name", "containerPort": 80}`),
+				Primary: &config.ECSTargetGroup{
+					TargetGroupArn: "primary-target-group-arn",
+					ContainerName:  "primary-container-name",
+					ContainerPort:  80,
+				},
 			},
 			expected: []*types.LoadBalancer{
 				{
@@ -57,8 +61,16 @@ func TestLoadTargetGroup(t *testing.T) {
 		{
 			name: "primary and canary target group",
 			cfg: config.ECSTargetGroups{
-				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn", "containerName": "primary-container-name", "containerPort": 80}`),
-				Canary:  []byte(`{"targetGroupArn": "canary-target-group-arn", "containerName": "canary-container-name", "containerPort": 80}`),
+				Primary: &config.ECSTargetGroup{
+					TargetGroupArn: "primary-target-group-arn",
+					ContainerName:  "primary-container-name",
+					ContainerPort:  80,
+				},
+				Canary: &config.ECSTargetGroup{
+					TargetGroupArn: "canary-target-group-arn",
+					ContainerName:  "canary-container-name",
+					ContainerPort:  80,
+				},
 			},
 			expected: []*types.LoadBalancer{
 				{
@@ -73,23 +85,6 @@ func TestLoadTargetGroup(t *testing.T) {
 				},
 			},
 			expectedErr: false,
-		},
-		{
-			name: "invalid primary target group",
-			cfg: config.ECSTargetGroups{
-				Primary: []byte(`{"invalidField": "primary-target-group-arn"}`),
-			},
-			expected:    []*types.LoadBalancer{nil, nil},
-			expectedErr: true,
-		},
-		{
-			name: "invalid canary target group",
-			cfg: config.ECSTargetGroups{
-				Primary: []byte(`{"targetGroupArn": "primary-target-group-arn"`),
-				Canary:  []byte(`{"invalidField": "canary-target-group-arn"}`),
-			},
-			expected:    []*types.LoadBalancer{nil, nil},
-			expectedErr: true,
 		},
 	}
 

--- a/pkg/app/piped/platformprovider/ecs/target_groups_test.go
+++ b/pkg/app/piped/platformprovider/ecs/target_groups_test.go
@@ -50,9 +50,10 @@ func TestLoadTargetGroup(t *testing.T) {
 			},
 			expected: []*types.LoadBalancer{
 				{
-					TargetGroupArn: aws.String("primary-target-group-arn"),
-					ContainerName:  aws.String("primary-container-name"),
-					ContainerPort:  aws.Int32(80),
+					TargetGroupArn:   aws.String("primary-target-group-arn"),
+					ContainerName:    aws.String("primary-container-name"),
+					ContainerPort:    aws.Int32(80),
+					LoadBalancerName: aws.String(""),
 				},
 				nil,
 			},
@@ -74,14 +75,16 @@ func TestLoadTargetGroup(t *testing.T) {
 			},
 			expected: []*types.LoadBalancer{
 				{
-					TargetGroupArn: aws.String("primary-target-group-arn"),
-					ContainerName:  aws.String("primary-container-name"),
-					ContainerPort:  aws.Int32(80),
+					TargetGroupArn:   aws.String("primary-target-group-arn"),
+					ContainerName:    aws.String("primary-container-name"),
+					ContainerPort:    aws.Int32(80),
+					LoadBalancerName: aws.String(""),
 				},
 				{
-					TargetGroupArn: aws.String("canary-target-group-arn"),
-					ContainerName:  aws.String("canary-container-name"),
-					ContainerPort:  aws.Int32(80),
+					TargetGroupArn:   aws.String("canary-target-group-arn"),
+					ContainerName:    aws.String("canary-container-name"),
+					ContainerPort:    aws.Int32(80),
+					LoadBalancerName: aws.String(""),
 				},
 			},
 			expectedErr: false,

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -95,9 +95,10 @@ type ECSTargetGroups struct {
 }
 
 type ECSTargetGroup struct {
-	TargetGroupArn string `json:"targetGroupArn"`
-	ContainerName  string `json:"containerName"`
-	ContainerPort  int    `json:"containerPort"`
+	TargetGroupArn   string `json:"targetGroupArn"`
+	ContainerName    string `json:"containerName"`
+	ContainerPort    int    `json:"containerPort"`
+	LoadBalancerName string `json:"loadBalancerName"`
 }
 
 // ECSSyncStageOptions contains all configurable values for a ECS_SYNC stage.

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -91,8 +90,14 @@ type ECSVpcConfiguration struct {
 }
 
 type ECSTargetGroups struct {
-	Primary json.RawMessage `json:"primary"`
-	Canary  json.RawMessage `json:"canary"`
+	Primary *ECSTargetGroup `json:"primary"`
+	Canary  *ECSTargetGroup `json:"canary"`
+}
+
+type ECSTargetGroup struct {
+	TargetGroupArn string `json:"targetGroupArn"`
+	ContainerName  string `json:"containerName"`
+	ContainerPort  int    `json:"containerPort"`
 }
 
 // ECSSyncStageOptions contains all configurable values for a ECS_SYNC stage.

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -60,7 +59,11 @@ func TestECSApplicationConfig(t *testing.T) {
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",
 					TaskDefinitionFile:    "/path/to/taskdef.yaml",
 					TargetGroups: ECSTargetGroups{
-						Primary: json.RawMessage(`{"containerName":"web","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:xyz"}`),
+						Primary: &ECSTargetGroup{
+							TargetGroupArn: "arn:aws:elasticloadbalancing:xyz",
+							ContainerName:  "web",
+							ContainerPort:  80,
+						},
 					},
 					LaunchType:        "FARGATE",
 					AutoRollback:      newBoolPointer(true),


### PR DESCRIPTION
**What this PR does / why we need it**:

Internal refactoring.

For `pipectl init` command and ECS redesigning, it's more convenient to have struct than json.RawMessage.

**Which issue(s) this PR fixes**:

no

**Does this PR introduce a user-facing change?**:  no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
