### PR TITLE
Replace deprecated io/ioutil package

### DIFF
--- a/tool/actions-gh-release/github.go
+++ b/tool/actions-gh-release/github.go
@@ -17,9 +17,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
+	"net/http"
 	"regexp"
 
 	"github.com/google/go-github/v39/github"
@@ -123,7 +122,7 @@ func (g *githubClient) parseGitHubEvent(ctx context.Context) (*githubEvent, erro
 	}
 
 	eventPath := os.Getenv("GITHUB_EVENT_PATH")
-	payload, err := ioutil.ReadFile(eventPath)
+	payload, err := os.ReadFile(eventPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read event payload: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
[io/ioutil ](https://pkg.go.dev/io/ioutil) package is deprecated, use corresponding 'os' package instead.

refs: https://pkg.go.dev/io/ioutil#ReadFile

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
