### PR TITLE
Implement rollback for script run as pre defined stage

### DIFF
--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -436,6 +436,24 @@ func (s *scheduler) executeStage(sig executor.StopSignal, ps model.PipelineStage
 		lp.Complete(time.Minute)
 	}()
 
+	// Check whether to execute the script rollback stage or not.
+	// If the base stage is executed, the script rollback stage will be executed.
+	if ps.Name == model.StageScriptRunRollback.String() {
+		baseStageID := ps.Metadata["baseStageID"]
+		if baseStageID == "" {
+			return
+		}
+
+		baseStageStatus, ok := s.stageStatuses[baseStageID]
+		if !ok {
+			return
+		}
+
+		if baseStageStatus == model.StageStatus_STAGE_NOT_STARTED_YET || baseStageStatus == model.StageStatus_STAGE_SKIPPED {
+			return
+		}
+	}
+
 	// Update stage status to RUNNING if needed.
 	if model.CanUpdateStageStatus(ps.Status, model.StageStatus_STAGE_RUNNING) {
 		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_RUNNING, ps.Requires); err != nil {

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -181,7 +181,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 }
 
 func (e *rollbackExecutor) ensureScriptRunRollback(ctx context.Context) model.StageStatus {
-	e.LogPersister.Infof("Runnnig commands for rollback...")
+	e.LogPersister.Info("Runnnig commands for rollback...")
 
 	onRollback, ok := e.Stage.Metadata["onRollback"]
 	if !ok {

--- a/pkg/app/piped/planner/kubernetes/pipeline.go
+++ b/pkg/app/piped/planner/kubernetes/pipeline.go
@@ -15,6 +15,7 @@
 package kubernetes
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -114,6 +115,31 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 			CreatedAt:  now.Unix(),
 			UpdatedAt:  now.Unix(),
 		})
+
+		// Add a stage for rolling back script run stages.
+		for i, s := range pp.Stages {
+			if s.Name == model.StageScriptRun {
+				// Use metadata as a way to pass parameters to the stage.
+				envStr, _ := json.Marshal(s.ScriptRunStageOptions.Env)
+				metadata := map[string]string{
+					"baseStageID": out[i].Id,
+					"onRollback":  s.ScriptRunStageOptions.OnRollback,
+					"env":         string(envStr),
+				}
+				ss, _ := planner.GetPredefinedStage(planner.PredefinedStageScriptRunRollback)
+				out = append(out, &model.PipelineStage{
+					Id:         ss.ID,
+					Name:       ss.Name.String(),
+					Desc:       ss.Desc,
+					Predefined: true,
+					Visible:    false,
+					Status:     model.StageStatus_STAGE_NOT_STARTED_YET,
+					Metadata:   metadata,
+					CreatedAt:  now.Unix(),
+					UpdatedAt:  now.Unix(),
+				})
+			}
+		}
 	}
 
 	return out

--- a/pkg/app/piped/planner/predefined_stages.go
+++ b/pkg/app/piped/planner/predefined_stages.go
@@ -27,6 +27,7 @@ const (
 	PredefinedStageECSSync            = "ECSSync"
 	PredefinedStageRollback           = "Rollback"
 	PredefinedStageCustomSyncRollback = "CustomSyncRollback"
+	PredefinedStageScriptRunRollback  = "ScriptRunRollback"
 )
 
 var predefinedStages = map[string]config.PipelineStage{
@@ -64,6 +65,11 @@ var predefinedStages = map[string]config.PipelineStage{
 		ID:   PredefinedStageCustomSyncRollback,
 		Name: model.StageCustomSyncRollback,
 		Desc: "Rollback the custom stages",
+	},
+	PredefinedStageScriptRunRollback: {
+		ID:   PredefinedStageScriptRunRollback,
+		Name: model.StageScriptRunRollback,
+		Desc: "Rollback the script run stage",
 	},
 }
 

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -154,6 +154,16 @@ func (d *Deployment) FindRollbackStage() (*PipelineStage, bool) {
 	return nil, false
 }
 
+func (d *Deployment) FindRollbackStages() ([]*PipelineStage, bool) {
+	rollbackStages := make([]*PipelineStage, 0, len(d.Stages))
+	for i, stage := range d.Stages {
+		if d.Stages[i].Name == StageRollback.String() || d.Stages[i].Name == StageScriptRunRollback.String() {
+			rollbackStages = append(rollbackStages, stage)
+		}
+	}
+	return rollbackStages, len(rollbackStages) > 0
+}
+
 // DeploymentStatusesFromStrings converts a list of strings to list of DeploymentStatus.
 func DeploymentStatusesFromStrings(statuses []string) ([]DeploymentStatus, error) {
 	out := make([]DeploymentStatus, 0, len(statuses))

--- a/pkg/model/deployment_test.go
+++ b/pkg/model/deployment_test.go
@@ -587,12 +587,56 @@ func TestFindRollbackStage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := &Deployment{
 				Stages: tt.stages,
 			}
 			stage, found := d.FindRollbackStage()
 			assert.Equal(t, tt.wantStage, stage)
+			assert.Equal(t, tt.wantStageFound, found)
+		})
+	}
+}
+
+func TestFindRollbackStags(t *testing.T) {
+	tests := []struct {
+		name           string
+		stages         []*PipelineStage
+		wantStages     []*PipelineStage
+		wantStageFound bool
+	}{
+		{
+			name: "found",
+			stages: []*PipelineStage{
+				{Name: StageK8sSync.String()},
+				{Name: StageRollback.String()},
+				{Name: StageScriptRunRollback.String()},
+			},
+			wantStages: []*PipelineStage{
+				{Name: StageRollback.String()},
+				{Name: StageScriptRunRollback.String()},
+			},
+			wantStageFound: true,
+		},
+		{
+			name: "not found",
+			stages: []*PipelineStage{
+				{Name: StageK8sSync.String()},
+			},
+			wantStages:     []*PipelineStage{},
+			wantStageFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Deployment{
+				Stages: tt.stages,
+			}
+			stages, found := d.FindRollbackStages()
+			assert.Equal(t, tt.wantStages, stages)
 			assert.Equal(t, tt.wantStageFound, found)
 		})
 	}

--- a/pkg/model/stage.go
+++ b/pkg/model/stage.go
@@ -108,6 +108,10 @@ const (
 	// all changes made by the CUSTOM_SYNC stage will be reverted to
 	// bring back the pre-deploy stage.
 	StageCustomSyncRollback Stage = "CUSTOM_SYNC_ROLLBACK"
+	// StageScriptRunRollback represents a state where
+	// all changes made by the SCRIPT_RUN_ROLLBACK stage will be reverted to
+	// bring back the pre-deploy stage.
+	StageScriptRunRollback Stage = "SCRIPT_RUN_ROLLBACK"
 )
 
 func (s Stage) String() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement rollback for script run as pre defined stage.

**Which issue(s) this PR fixes**:

Part of #4643

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
Users can use `onRollback` feature for `SCRIPT_RUN` stage.
They can execute any command when the deployment failed and the executed `SCRIPT_RUN` stage is included in the pipeline

- **Is this breaking change**: no
