### PR TITLE
Add reference to the blog that shows how to install control plane on ECS

### DIFF
--- a/docs/content/en/docs-dev/installation/install-control-plane/_index.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Install Control Plane"
+linkTitle: "Install Control Plane"
+weight: 3
+description: >
+  This page describes how to install a control plane.
+---
+
+Since Control Plane is a centralized component managing deployment data and provides gRPC API, it needs some components fo storing data or credential... and so on. We explain how to deploy Control Plane components.

--- a/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-ECS.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-ECS.md
@@ -1,0 +1,12 @@
+---
+title: "Installing Control Plane on ECS"
+linkTitle: "Installing Control Plane on ECS"
+weight: 2
+description: >
+  This page describes how to install control plane on ECS.
+---
+
+Currently, we provide the example of deploying Control Plane to ECS using terraform. 
+
+Please refer to the blog post :)
+[PipeCD best practice 02 - control plane on ECS]({{< ref "/blog/control-plane-on-ecs.md" >}} "PipeCD best practice 02 - control plane on ECS").

--- a/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -1,7 +1,7 @@
 ---
-title: "Install Control Plane"
-linkTitle: "Install Control Plane"
-weight: 2
+title: "Installing Control Plane on Kubernetes"
+linkTitle: "Installing Control Plane on Kubernetes"
+weight: 1
 description: >
   This page describes how to install control plane on a Kubernetes cluster.
 ---
@@ -31,7 +31,7 @@ cat /dev/urandom | head -c64 | base64 > encryption-key
 Control Plane Architecture
 </p>
 
-The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](../../user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](../../user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](../../user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
+The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](../../../user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](../../../user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](../../../user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
 
 #### Using Firestore and GCS
 
@@ -60,7 +60,7 @@ spec:
       credentialsFile: /etc/pipecd-secret/gcs-service-account
 ```
 
-See [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/) for the full configuration.
+See [ConfigurationReference](../../../user-guide/managing-controlplane/configuration-reference/) for the full configuration.
 
 After all, install the Control Plane as bellow:
 
@@ -96,7 +96,7 @@ spec:
       autoCreateBucket: true
 ```
 
-You can find required configurations to use other datastores and filestores from [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/).
+You can find required configurations to use other datastores and filestores from [ConfigurationReference](../../../user-guide/managing-controlplane/configuration-reference/).
 
 __Caution__: In case of using `MySQL` as Control Plane's datastore, please note that the implementation of PipeCD requires some features that only available on [MySQL v8](https://dev.mysql.com/doc/refman/8.0/en/), make sure your MySQL service is satisfied the requirement.
 
@@ -127,7 +127,7 @@ On that page, you will see the list of registered projects and a link to registe
 
 Once a new project has been registered, a static admin (username, password) will be automatically generated for the project admin, you can use that to login via the login form in the above section.
 
-For more about adding a new project in detail, please read the following [docs](../../user-guide/managing-controlplane/adding-a-project/).
+For more about adding a new project in detail, please read the following [docs](../../../user-guide/managing-controlplane/adding-a-project/).
 
 ### 4'. Upgrade Control Plane version
 

--- a/docs/content/en/docs-v0.45.x/installation/install-control-plane/_index.md
+++ b/docs/content/en/docs-v0.45.x/installation/install-control-plane/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Install Control Plane"
+linkTitle: "Install Control Plane"
+weight: 3
+description: >
+  This page describes how to install a control plane.
+---
+
+Since Control Plane is a centralized component managing deployment data and provides gRPC API, it needs some components fo storing data or credential... and so on. We explain how to deploy Control Plane components.

--- a/docs/content/en/docs-v0.45.x/installation/install-control-plane/installing-controlplane-on-ECS.md
+++ b/docs/content/en/docs-v0.45.x/installation/install-control-plane/installing-controlplane-on-ECS.md
@@ -1,0 +1,12 @@
+---
+title: "Installing Control Plane on ECS"
+linkTitle: "Installing Control Plane on ECS"
+weight: 2
+description: >
+  This page describes how to install control plane on ECS.
+---
+
+Currently, we provide the example of deploying Control Plane to ECS using terraform. 
+
+Please refer to the blog post :)
+[PipeCD best practice 02 - control plane on ECS]({{< ref "/blog/control-plane-on-ecs.md" >}} "PipeCD best practice 02 - control plane on ECS").

--- a/docs/content/en/docs-v0.45.x/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-v0.45.x/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -1,7 +1,7 @@
 ---
-title: "Install Control Plane"
-linkTitle: "Install Control Plane"
-weight: 2
+title: "Installing Control Plane on Kubernetes"
+linkTitle: "Installing Control Plane on Kubernetes"
+weight: 1
 description: >
   This page describes how to install control plane on a Kubernetes cluster.
 ---
@@ -31,7 +31,7 @@ cat /dev/urandom | head -c64 | base64 > encryption-key
 Control Plane Architecture
 </p>
 
-The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](../../user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](../../user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](../../user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
+The Control Plane of PipeCD is constructed by several components, as shown in the above graph (for more in detail please read [Control Plane architecture overview docs](../../../user-guide/managing-controlplane/architecture-overview/)). As mentioned in the graph, the PipeCD's data can be stored in one of the provided fully-managed or self-managed services. So you have to decide which kind of [data store](../../../user-guide/managing-controlplane/architecture-overview/#data-store) and [file store](../../../user-guide/managing-controlplane/architecture-overview/#file-store) you want to use and prepare a Control Plane configuration file suitable for that choice.
 
 #### Using Firestore and GCS
 
@@ -60,7 +60,7 @@ spec:
       credentialsFile: /etc/pipecd-secret/gcs-service-account
 ```
 
-See [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/) for the full configuration.
+See [ConfigurationReference](../../../user-guide/managing-controlplane/configuration-reference/) for the full configuration.
 
 After all, install the Control Plane as bellow:
 
@@ -96,7 +96,7 @@ spec:
       autoCreateBucket: true
 ```
 
-You can find required configurations to use other datastores and filestores from [ConfigurationReference](../../user-guide/managing-controlplane/configuration-reference/).
+You can find required configurations to use other datastores and filestores from [ConfigurationReference](../../../user-guide/managing-controlplane/configuration-reference/).
 
 __Caution__: In case of using `MySQL` as Control Plane's datastore, please note that the implementation of PipeCD requires some features that only available on [MySQL v8](https://dev.mysql.com/doc/refman/8.0/en/), make sure your MySQL service is satisfied the requirement.
 
@@ -127,7 +127,7 @@ On that page, you will see the list of registered projects and a link to registe
 
 Once a new project has been registered, a static admin (username, password) will be automatically generated for the project admin, you can use that to login via the login form in the above section.
 
-For more about adding a new project in detail, please read the following [docs](../../user-guide/managing-controlplane/adding-a-project/).
+For more about adding a new project in detail, please read the following [docs](../../../user-guide/managing-controlplane/adding-a-project/).
 
 ### 4'. Upgrade Control Plane version
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added the link for [PipeCD best practice 02 - control plane on ECS](https://pipecd.dev/blog/2023/02/07/pipecd-best-practice-02-control-plane-on-ecs/)

<img width="1251" alt="Cursor_と_Install_Control_Plane___PipeCD" src="https://github.com/pipe-cd/pipecd/assets/40124947/d82d79f3-2134-4817-90c7-ed09e9d55f41">

<img width="1134" alt="Installing_Control_Plane_on_ECS___PipeCD" src="https://github.com/pipe-cd/pipecd/assets/40124947/13215790-e4b4-4a24-8e1b-070d61528032">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
