### PR TITLE
Fix pipectl plugin installation command by asdf

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -45,7 +45,7 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 
 1. Add pipectl plugin to asdf. (If you have not yet `asdf add plugin add pipectl`.)
     ```console
-    asdf add plugin pipectl
+    asdf plugin add pipectl
     ```
 
 2. Install pipectl. Available versions are [here](https://github.com/pipe-cd/pipecd/releases).


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request includes a minor change to the `command-line-tool.md` documentation file. The change corrects the command for adding the `pipectl` plugin to `asdf`. The previous command was incorrect, and the correct command is now provided.

**Which issue(s) this PR fixes**:
https://github.com/pipe-cd/pipecd/issues/4755

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
