### PR TITLE
Set 'gc.autoDetach' to false to be executed 'git gc' in the foreground by some git commands

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -275,7 +275,6 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	gitOptions := []git.Option{
 		git.WithUserName(cfg.Git.Username),
 		git.WithEmail(cfg.Git.Email),
-		git.WithAutoDetach(true),
 		git.WithLogger(input.Logger),
 	}
 	for _, repo := range cfg.GitHelmChartRepositories() {
@@ -457,7 +456,6 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		gc, err := git.NewClient(
 			git.WithUserName(cfg.Git.Username),
 			git.WithEmail(cfg.Git.Email),
-			git.WithAutoDetach(true),
 			git.WithLogger(input.Logger),
 		)
 		if err != nil {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -275,6 +275,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	gitOptions := []git.Option{
 		git.WithUserName(cfg.Git.Username),
 		git.WithEmail(cfg.Git.Email),
+		git.WithAutoDetach(true),
 		git.WithLogger(input.Logger),
 	}
 	for _, repo := range cfg.GitHelmChartRepositories() {
@@ -456,6 +457,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		gc, err := git.NewClient(
 			git.WithUserName(cfg.Git.Username),
 			git.WithEmail(cfg.Git.Email),
+			git.WithAutoDetach(true),
 			git.WithLogger(input.Logger),
 		)
 		if err != nil {

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -212,6 +212,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 		}
 	}
 
+	logger.Info("setting gc.autoDetach", zap.Bool("gc.autoDetach", c.gitGCAutoDetach))
 	if err := r.setAutoDetach(ctx, c.gitGCAutoDetach); err != nil {
 		return nil, fmt.Errorf("failed to set auto detach: %v", err)
 	}

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -212,8 +212,8 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 		}
 	}
 
-	logger.Info("setting gc.autoDetach", zap.Bool("gc.autoDetach", c.gitGCAutoDetach))
-	if err := r.setAutoDetach(ctx, c.gitGCAutoDetach); err != nil {
+	logger.Info("setting gc.autoDetach", zap.Bool("gc.autoDetach", c.gitGCAutoDetach), zap.String("r.dir", r.dir))
+	if err := r.setGCAutoDetach(ctx, c.gitGCAutoDetach); err != nil {
 		return nil, fmt.Errorf("failed to set auto detach: %v", err)
 	}
 

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -288,6 +289,14 @@ func (r *repo) setUser(ctx context.Context, username, email string) error {
 
 func (r *repo) setRemote(ctx context.Context, remote string) error {
 	out, err := r.runGitCommand(ctx, "remote", "set-url", "origin", remote)
+	if err != nil {
+		return formatCommandError(err, out)
+	}
+	return nil
+}
+
+func (r *repo) setAutoDetach(ctx context.Context, autoDetach bool) error {
+	out, err := r.runGitCommand(ctx, "config", "gc.autoDetach", strconv.FormatBool(autoDetach))
 	if err != nil {
 		return formatCommandError(err, out)
 	}

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -295,7 +295,7 @@ func (r *repo) setRemote(ctx context.Context, remote string) error {
 	return nil
 }
 
-func (r *repo) setAutoDetach(ctx context.Context, autoDetach bool) error {
+func (r *repo) setGCAutoDetach(ctx context.Context, autoDetach bool) error {
 	out, err := r.runGitCommand(ctx, "config", "gc.autoDetach", strconv.FormatBool(autoDetach))
 	if err != nil {
 		return formatCommandError(err, out)


### PR DESCRIPTION
**What this PR does / why we need it**:
Set 'gc.autoDetach' to false to be executed 'git gc' in the foreground by some git commands
**Which issue(s) this PR fixes**:

Fixes #4760

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
