### PR TITLE
Add a param to run/piped in Makefile for setting --log-encoding to run the piped with specific log format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,12 @@ stop/pipecd:
 run/piped: CONFIG_FILE ?=
 run/piped: INSECURE ?= false
 run/piped: LAUNCHER ?= false
+run/piped: LOG_ENCODING ?= humanize
 run/piped:
 ifeq ($(LAUNCHER),true)
-	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
+	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE) --log-encoding=$(LOG_ENCODING)
 else
-	go run cmd/piped/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE)
+	go run cmd/piped/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE) --log-encoding=$(LOG_ENCODING)
 endif
 
 .PHONY: run/web


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a param to run/piped in Makefile for setting --log-encoding to run the piped with a specific log format.
We can choose 3 formats 

- https://github.com/pipe-cd/pipecd/blob/7b26b02d856f819a0670beba49190fa09e4380a4/pkg/cli/app.go#L94C1-L99C3
```golang
	a.rootCmd.PersistentFlags().StringVar(
		&a.telemetryFlags.LogEncoding,
		"log-encoding",
		a.telemetryFlags.LogEncoding,
		"The encoding type for logger [json|console|humanize].",
	)
```


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
