### PR TITLE
[doc] fix typo of AWS Secrets Manager

### DIFF
--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-fargate.md
@@ -63,10 +63,10 @@ description: >
 
 See [ConfigurationReference](../../../user-guide/managing-piped/configuration-reference/) for the full configuration.
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -79,7 +79,7 @@ See [ConfigurationReference](../../../user-guide/managing-piped/configuration-re
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.39.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.39.x/installation/install-piped/installing-on-fargate.md
@@ -61,10 +61,10 @@ description: >
     #     publicKeyData: {BASE64_ENCODED_PUBLIC_KEY}
   ```
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -77,7 +77,7 @@ description: >
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.40.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.40.x/installation/install-piped/installing-on-fargate.md
@@ -61,10 +61,10 @@ description: >
     #     publicKeyData: {BASE64_ENCODED_PUBLIC_KEY}
   ```
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -77,7 +77,7 @@ description: >
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.41.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.41.x/installation/install-piped/installing-on-fargate.md
@@ -61,10 +61,10 @@ description: >
     #     publicKeyData: {BASE64_ENCODED_PUBLIC_KEY}
   ```
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -77,7 +77,7 @@ description: >
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-fargate.md
@@ -63,10 +63,10 @@ description: >
 
 See [ConfigurationReference](../../../user-guide/managing-piped/configuration-reference/) for the full configuration.
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -79,7 +79,7 @@ See [ConfigurationReference](../../../user-guide/managing-piped/configuration-re
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.43.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.43.x/installation/install-piped/installing-on-fargate.md
@@ -63,10 +63,10 @@ description: >
 
 See [ConfigurationReference](../../../user-guide/managing-piped/configuration-reference/) for the full configuration.
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -79,7 +79,7 @@ See [ConfigurationReference](../../../user-guide/managing-piped/configuration-re
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.44.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.44.x/installation/install-piped/installing-on-fargate.md
@@ -63,10 +63,10 @@ description: >
 
 See [ConfigurationReference](../../../user-guide/managing-piped/configuration-reference/) for the full configuration.
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -79,7 +79,7 @@ See [ConfigurationReference](../../../user-guide/managing-piped/configuration-re
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 

--- a/docs/content/en/docs-v0.45.x/installation/install-piped/installing-on-fargate.md
+++ b/docs/content/en/docs-v0.45.x/installation/install-piped/installing-on-fargate.md
@@ -63,10 +63,10 @@ description: >
 
 See [ConfigurationReference](../../../user-guide/managing-piped/configuration-reference/) for the full configuration.
 
-- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS SecretManager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
+- Store the above configuration data to AWS to enable using it while creating piped task. Both [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) and [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) are available to address this task.
 
   {{< tabpane >}}
-  {{< tab lang="bash" header="Store in AWS SecretManager" >}}
+  {{< tab lang="bash" header="Store in AWS Secrets Manager" >}}
   aws secretsmanager create-secret --name PipedConfig \
     --description "Configuration of piped running as ECS Fargate task" \
     --secret-string `base64 piped-config.yaml`
@@ -79,7 +79,7 @@ See [ConfigurationReference](../../../user-guide/managing-piped/configuration-re
   {{< /tab >}}
   {{< /tabpane >}}
 
-- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS SecretManager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
+- Prepare task definition for your piped task. Basically, you can just define your piped TaskDefinition as normal TaskDefinition, the only thing that needs to be beware is, in case you used [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to store piped configuration, to enable your piped accesses it's configuration we created as a secret on above, you need to add `secretsmanager:GetSecretValue` policy to your piped task `executionRole`. Read more in [Required IAM permissions for Amazon ECS secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html).
 
   A sample TaskDefinition for Piped as follows
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaced `AWS SecretManager` with `AWS Secrets Manager`

**Which issue(s) this PR fixes**: no


**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
