### PR TITLE
Disable gc.autoDetach by default

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -107,7 +107,7 @@ func NewClient(opts ...Option) (Client, error) {
 	c := &client{
 		username:      defaultUsername,
 		email:         defaultEmail,
-		gcAutoDetach:  true, // Enable this by default. See issue #4760, discussion #4758.
+		gcAutoDetach:  false, // Disable this by default. See issue #4760, discussion #4758.
 		gitPath:       gitPath,
 		cacheDir:      cacheDir,
 		repoLocks:     make(map[string]*sync.Mutex),


### PR DESCRIPTION
**What this PR does / why we need it**:

Set gc.autoDetach to false by default.
I mistook the default value, not true but false on PR https://github.com/pipe-cd/pipecd/pull/4761

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/4760

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
