### PR TITLE
[doc] Add authentication to GitHub Container Registry to the Prerequisites section in QuickStart Page

### DIFF
--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.39.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.39.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.40.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.40.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.41.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.41.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.42.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.42.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.43.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.43.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.44.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.44.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 

--- a/docs/content/en/docs-v0.45.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.45.x/quickstart/_index.md
@@ -13,6 +13,7 @@ Note: It's not required to install the PipeCD control plane to the cluster where
 ### Prerequisites
 - Having a Kubernetes cluster and connect to it via [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Forked the [Examples](https://github.com/pipe-cd/examples) repository
+- Prepare for authentication to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### 1. Installing PipeCD in quickstart mode
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add authentication to GitHub Container Registry to the Prerequisites section in QuickStart Page.

I followed the procedure in QuickStart according to the document, but without GitHub Container Registry authentication, I got the following error, so I added it to the Prerequisites section.

```
Installing the controlplane in quickstart mode...
Failed to install PipeCD control plane!!
github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/quickstart.(*command).run
        /home/runner/work/pipecd/pipecd/pkg/app/pipectl/cmd/quickstart/quickstart.go:114
github.com/pipe-cd/pipecd/pkg/cli.runWithContext
        /home/runner/work/pipecd/pipecd/pkg/cli/cmd.go:95
github.com/pipe-cd/pipecd/pkg/cli.WithContext.func1
        /home/runner/work/pipecd/pipecd/pkg/cli/cmd.go:51
github.com/spf13/cobra.(*Command).execute
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842
github.com/spf13/cobra.(*Command).ExecuteC
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950
github.com/spf13/cobra.(*Command).Execute
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/pipe-cd/pipecd/pkg/cli.(*App).Run
        /home/runner/work/pipecd/pipecd/pkg/cli/app.go:69
main.main
        /home/runner/work/pipecd/pipecd/cmd/pipectl/main.go:46
runtime.main
        /opt/hostedtoolcache/go/1.20.5/x64/src/runtime/proc.go:250
2024/02/04 21:55:59 exit status 1: Error: failed to download "oci://ghcr.io/pipe-cd/chart/pipecd" at version "v0.45.4
```


**Which issue(s) this PR fixes**: no

Fixes #

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
