### PR TITLE
Support AWS Secrets Manager as a source of piped-config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.26 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.14.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.18.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
+github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.7 h1:CLSjnhJSTSogvqUGhIC6LqFKATMRexcxLZ0i/Nzk9Eg=
 github.com/aws/aws-sdk-go-v2 v1.17.7/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
@@ -123,8 +124,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.13.18 h1:EQMdtHwz0ILTW1hoP+EwuWhwCG1
 github.com/aws/aws-sdk-go-v2/credentials v1.13.18/go.mod h1:vnwlwjIe+3XJPBYKu1et30ZPABG3VaXJYr8ryohpIyM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1 h1:gt57MN3liKiyGopcqgNzJb2+d9MJaKT/q1OksHNXVE4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1/go.mod h1:lfUx8puBRdM5lVVMQlwt2v+ofiG/X6Ms+dy0UkG/kXw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27/go.mod h1:a1/UpzeyBBerajpnP5nGZa9mGzsBn5cOKxm6NWQsvoI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.31 h1:sJLYcS+eZn5EeNINGHSCRAwUJMFVqklwkH36Vbyai7M=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.31/go.mod h1:QT0BqUvX1Bh2ABdTGnjqEjvjzrCfIniM9Sc8zn9Yndo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21/go.mod h1:+Gxn8jYn5k9ebfHEqlhrMirFjSW0v0C9fI+KN5vk2kE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.25 h1:1mnRASEKnkqsntcxHaysxwgVoUUp5dkiB+l3llKnqyg=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.25/go.mod h1:zBHOPwhBc3FlQjQJE/D3IfPWiWaQmT06Vq9aNukDo0k=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32 h1:p5luUImdIqywn6JpQsW3tq5GNOxKmOnEpybzPx+d1lk=
@@ -147,6 +150,8 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.30.2 h1:JEUEgBM8HZ27ahhZsIlgfj7xP
 github.com/aws/aws-sdk-go-v2/service/lambda v1.30.2/go.mod h1:PmNd6f36wPbp2+B3ZSuvHqqSwggfagEdI18tIb8s91o=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.31.0 h1:B1G2pSPvbAtQjilPq+Y7jLIzCOwKzuVEl+aBBaNG0AQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.31.0/go.mod h1:ncltU6n4Nof5uJttDtcNQ537uNuwYqsZZQcpkd2/GUQ=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.18.0 h1:UQDiRZyaHQGPXIuCYqKsz/wIVZknCiZdRmPW8buD/xc=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.18.0/go.mod h1:jAeo/PdIJZuDSwsvxJS94G4d6h8tStj7WXVuKwLHWU8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.6 h1:5V7DWLBd7wTELVz5bPpwzYy/sikk0gsgZfj40X+l5OI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.6/go.mod h1:Y1VOmit/Fn6Tz1uFAeCO6Q7M2fmfXSCLeL5INVYsLuY=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.6 h1:B8cauxOH1W1v7rd8RdI/MWnoR4Ze0wIHWrb90qczxj4=

--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -107,7 +107,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&l.gcpSecretID, "gcp-secret-id", l.gcpSecretID, "The resource ID of secret that contains Piped config in GCP SecretManager service.")
 
 	cmd.Flags().BoolVar(&l.configFromAWSSecret, "config-from-aws-secret", l.configFromAWSSecret, "Whether to load Piped config that is being stored in AWS Secrets Manager service.")
-	cmd.Flags().StringVar(&l.awsSecretID, "aws-secret-id", l.awsSecretID, "The resource ID of secret that contains Piped config in AWS Secrets Manager service.")
+	cmd.Flags().StringVar(&l.awsSecretID, "aws-secret-id", l.awsSecretID, "The ARN of secret that contains Piped config in AWS Secrets Manager service.")
 
 	cmd.Flags().BoolVar(&l.configFromGitRepo, "config-from-git-repo", l.configFromGitRepo, "Whether to load Piped config that is being stored in a git repository.")
 	cmd.Flags().StringVar(&l.gitRepoURL, "git-repo-url", l.gitRepoURL, "The remote URL of git repository to fetch Piped config.")
@@ -464,6 +464,7 @@ func (l *launcher) loadConfigData(ctx context.Context) ([]byte, error) {
 		"config-file",
 		"config-data",
 		"config-from-gcp-secret",
+		"config-from-aws-secret",
 		"config-from-git-repo",
 	}, ", "))
 }

--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -449,7 +449,11 @@ func (l *launcher) loadConfigData(ctx context.Context) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		return []byte(*result.SecretString), nil
+		decoded, err := base64.StdEncoding.DecodeString(*result.SecretString)
+		if err != nil {
+			return nil, err
+		}
+		return decoded, nil
 	}
 
 	if l.configFromGitRepo {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -829,7 +829,12 @@ func (p *piped) getConfigDataFromAWSSecretsManager(ctx context.Context) ([]byte,
 		return nil, err
 	}
 
-	return []byte(*result.SecretString), nil
+	decoded, err := base64.StdEncoding.DecodeString(*result.SecretString)
+	if err != nil {
+		return nil, err
+	}
+
+	return decoded, nil
 }
 
 func registerMetrics(pipedID, projectID, launcherVersion string) *prometheus.Registry {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -578,7 +578,7 @@ func (p *piped) createAPIClient(ctx context.Context, address, projectID, pipedID
 
 // loadConfig reads the Piped configuration data from the specified source.
 func (p *piped) loadConfig(ctx context.Context) (*config.PipedSpec, error) {
-	// HACK: When the version of cobra is updated to >=v1.8.0, this should be replaced with https://pkg.go.dev/github.com/spf13/cobra#Command.MarkFlagsOneRequired.
+	// HACK: When the version of cobra is updated to >=v1.8.0, this should be replaced with https://pkg.go.dev/github.com/spf13/cobra#Command.MarkFlagsMutuallyExclusive.
 	if err := p.hasTooManyConfigFlags(); err != nil {
 		return nil, err
 	}

--- a/pkg/app/piped/cmd/piped/piped_test.go
+++ b/pkg/app/piped/cmd/piped/piped_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package piped
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasTooManyConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		title     string
+		p         *piped
+		expectErr bool
+	}{
+		{
+			title: "no config",
+			p: &piped{
+				configFile:      "",
+				configGCPSecret: "",
+				configAWSSecret: "",
+			},
+			expectErr: false,
+		},
+		{
+			title: "only one config is set",
+			p: &piped{
+				configFile:      "config.yaml",
+				configGCPSecret: "",
+				configAWSSecret: "",
+			},
+			expectErr: false,
+		},
+		{
+			title: "two configs are set",
+			p: &piped{
+				configFile:      "config.yaml",
+				configGCPSecret: "xxx",
+				configAWSSecret: "",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			err := tc.p.hasTooManyConfigFlags()
+			assert.Equal(t, tc.expectErr, err != nil)
+		})
+	}
+}

--- a/pkg/app/piped/cmd/piped/piped_test.go
+++ b/pkg/app/piped/cmd/piped/piped_test.go
@@ -55,6 +55,15 @@ func TestHasTooManyConfigFlags(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			title: "three configs are set",
+			p: &piped{
+				configFile:      "config.yaml",
+				configGCPSecret: "xxx",
+				configAWSSecret: "yyy",
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enabled to use a secret in AWS Secrets Manager as the piped-config.

usage:  
- `launcher --config-from-aws-secret=true --aws-secret-id=arn:aws:secretsmanager:ap-xxx:xxx:secret:my-piped-config`

- `piped --config-aws-secret=arn:aws:secretsmanager:xxx:xxx:secret:my-piped-config`

This enables uses to run a piped on App Runner, with storing the piped-config securely in AWS Secrets Manager.

**Which issue(s) this PR fixes**:

Related to https://github.com/pipe-cd/pipecd/discussions/4765

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
