### PR TITLE
[doc] Add links to `pipectl init` from the pages of configuring ECS/K8s App

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -19,6 +19,11 @@ To deploy your application to run continuously or to place it behind a load bala
 
 If you're not familiar with ECS, you can get examples for those files from [here](../../../../examples/#ecs-applications).
 
+## Easier configuration by `pipectl init`
+
+You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
+
+
 ## Quick sync
 
 By default, when the [pipeline](../../../configuration-reference/#ecs-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -19,7 +19,7 @@ To deploy your application to run continuously or to place it behind a load bala
 
 If you're not familiar with ECS, you can get examples for those files from [here](../../../../examples/#ecs-applications).
 
-## Easier configuration by `pipectl init`
+Note:
 
 You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
@@ -8,6 +8,11 @@ description: >
 
 Based on the application configuration and the pull request changes, PipeCD plans how to execute the deployment: doing quick sync or doing progressive sync with the specified pipeline.
 
+## Easier configuration by `pipectl init`
+
+You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
+
+
 ## Quick sync
 
 Quick sync is a fast way to sync application to the state specified in the target Git commit without any progressive strategy. It just applies all the defined manifiests to sync the application.

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/kubernetes.md
@@ -8,7 +8,7 @@ description: >
 
 Based on the application configuration and the pull request changes, PipeCD plans how to execute the deployment: doing quick sync or doing progressive sync with the specified pipeline.
 
-## Easier configuration by `pipectl init`
+Note:
 
 You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -19,6 +19,11 @@ To deploy your application to run continuously or to place it behind a load bala
 
 If you're not familiar with ECS, you can get examples for those files from [here](../../../../examples/#ecs-applications).
 
+## Easier configuration by `pipectl init`
+
+You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
+
+
 ## Quick sync
 
 By default, when the [pipeline](../../../configuration-reference/#ecs-application) was not specified, PipeCD triggers a quick sync deployment for the merged pull request.

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -19,7 +19,7 @@ To deploy your application to run continuously or to place it behind a load bala
 
 If you're not familiar with ECS, you can get examples for those files from [here](../../../../examples/#ecs-applications).
 
-## Easier configuration by `pipectl init`
+Note:
 
 You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/kubernetes.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/kubernetes.md
@@ -8,6 +8,11 @@ description: >
 
 Based on the application configuration and the pull request changes, PipeCD plans how to execute the deployment: doing quick sync or doing progressive sync with the specified pipeline.
 
+## Easier configuration by `pipectl init`
+
+You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
+
+
 ## Quick sync
 
 Quick sync is a fast way to sync application to the state specified in the target Git commit without any progressive strategy. It just applies all the defined manifiests to sync the application.

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/kubernetes.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/kubernetes.md
@@ -8,7 +8,7 @@ description: >
 
 Based on the application configuration and the pull request changes, PipeCD plans how to execute the deployment: doing quick sync or doing progressive sync with the specified pipeline.
 
-## Easier configuration by `pipectl init`
+Note:
 
 You can generate an application config file easily and interactively by [`pipectl init`](../../command-line-tool.md#generating-an-application-config-apppipecdyaml).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To Inform users `pipectl init`.

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
