### PR TITLE
Support deploying Lambda functions depending on Lambda layers

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -529,6 +529,30 @@ func (c *client) untagFunction(ctx context.Context, functionArn string, tags map
 	return nil
 }
 
+func (c *client) publishLayer(ctx context.Context, in *lambda.PublishLayerVersionInput) error {
+	// in := &lambda.PublishLayerVersionInput{
+	// 	Content: &types.LayerVersionContentInput{
+	// 		S3Bucket:        aws.String(""),
+	// 		S3Key:           aws.String(""),
+	// 		S3ObjectVersion: aws.String(""),
+	// 		ZipFile:         []byte{},
+	// 	},
+	// 	CompatibleRuntimes: []types.Runtime{
+	// 		// "nodejs",
+	// 	},
+	// 	Description: aws.String(""),
+	// 	LicenseInfo: aws.String(""),
+	// 	LayerName:   aws.String(""),
+	// }
+
+	_, err := c.client.PublishLayerVersion(ctx, in)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func makeFlowControlTagsMaps(remoteTags, definedTags map[string]string) (newDefinedTags, updatedTags, removedTags map[string]string) {
 	newDefinedTags = make(map[string]string)
 	updatedTags = make(map[string]string)

--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -529,30 +529,6 @@ func (c *client) untagFunction(ctx context.Context, functionArn string, tags map
 	return nil
 }
 
-func (c *client) publishLayer(ctx context.Context, in *lambda.PublishLayerVersionInput) error {
-	// in := &lambda.PublishLayerVersionInput{
-	// 	Content: &types.LayerVersionContentInput{
-	// 		S3Bucket:        aws.String(""),
-	// 		S3Key:           aws.String(""),
-	// 		S3ObjectVersion: aws.String(""),
-	// 		ZipFile:         []byte{},
-	// 	},
-	// 	CompatibleRuntimes: []types.Runtime{
-	// 		// "nodejs",
-	// 	},
-	// 	Description: aws.String(""),
-	// 	LicenseInfo: aws.String(""),
-	// 	LayerName:   aws.String(""),
-	// }
-
-	_, err := c.client.PublishLayerVersion(ctx, in)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func makeFlowControlTagsMaps(remoteTags, definedTags map[string]string) (newDefinedTags, updatedTags, removedTags map[string]string) {
 	newDefinedTags = make(map[string]string)
 	updatedTags = make(map[string]string)

--- a/pkg/app/piped/platformprovider/lambda/client.go
+++ b/pkg/app/piped/platformprovider/lambda/client.go
@@ -118,6 +118,7 @@ func (c *client) CreateFunction(ctx context.Context, fm FunctionManifest) error 
 		Environment: &types.Environment{
 			Variables: fm.Spec.Environments,
 		},
+		Layers: fm.Spec.Layers,
 	}
 	if len(fm.Spec.Architectures) != 0 {
 		var architectures []types.Architecture
@@ -183,6 +184,7 @@ func (c *client) CreateFunctionFromSource(ctx context.Context, fm FunctionManife
 		Environment: &types.Environment{
 			Variables: fm.Spec.Environments,
 		},
+		Layers: fm.Spec.Layers,
 	}
 	if len(fm.Spec.Architectures) != 0 {
 		architectures := make([]types.Architecture, 0, len(fm.Spec.Architectures))
@@ -294,6 +296,7 @@ func (c *client) updateFunctionConfiguration(ctx context.Context, fm FunctionMan
 			Environment: &types.Environment{
 				Variables: fm.Spec.Environments,
 			},
+			Layers: fm.Spec.Layers,
 		}
 		// For zip packing Lambda function code, allow update the function handler
 		// on update the function's manifest.

--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -74,7 +74,9 @@ type FunctionManifestSpec struct {
 	Tags             map[string]string `json:"tags,omitempty"`
 	Environments     map[string]string `json:"environments,omitempty"`
 	VPCConfig        *VPCConfig        `json:"vpcConfig,omitempty"`
-	Layers           []string          `json:"layers,omitempty"`
+	// A list of function layers used in the function.
+	// Specify each layer by its ARN including the version.
+	Layers []string `json:"layers,omitempty"`
 }
 
 type VPCConfig struct {

--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -76,7 +76,7 @@ type FunctionManifestSpec struct {
 	VPCConfig        *VPCConfig        `json:"vpcConfig,omitempty"`
 	// A list of function layers used in the function.
 	// Specify each layer by its ARN including the version.
-	// You can use layers only with Lambda functions deployed as a .zip file archive, not for a container image.
+	// You can use layers only with Lambda functions deployed as a .zip file archive. Layers are ignored for a container image.
 	// See https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html.
 	Layers []string `json:"layers,omitempty"`
 }

--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -74,6 +74,7 @@ type FunctionManifestSpec struct {
 	Tags             map[string]string `json:"tags,omitempty"`
 	Environments     map[string]string `json:"environments,omitempty"`
 	VPCConfig        *VPCConfig        `json:"vpcConfig,omitempty"`
+	Layers           []string          `json:"layers,omitempty"`
 }
 
 type VPCConfig struct {

--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -76,6 +76,8 @@ type FunctionManifestSpec struct {
 	VPCConfig        *VPCConfig        `json:"vpcConfig,omitempty"`
 	// A list of function layers used in the function.
 	// Specify each layer by its ARN including the version.
+	// You can use layers only with Lambda functions deployed as a .zip file archive, not for a container image.
+	// See https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html.
 	Layers []string `json:"layers,omitempty"`
 }
 

--- a/pkg/app/piped/platformprovider/lambda/function_test.go
+++ b/pkg/app/piped/platformprovider/lambda/function_test.go
@@ -130,6 +130,40 @@ func TestParseFunctionManifest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "correct config for LambdaFunction with specifying layers",
+			data: `{
+  "apiVersion": "pipecd.dev/v1beta1",
+  "kind": "LambdaFunction",
+  "spec": {
+	  "name": "SimpleFunction",
+	  "role": "arn:aws:iam::xxxxx:role/lambda-role",
+	  "memory": 128,
+	  "timeout": 5,
+	  "image": "ecr.region.amazonaws.com/lambda-simple-function:v0.0.1",
+	  "layers": [
+		"arn:aws:lambda:REGION:ACCOUNT:layer:test-layer-1:1",
+		"arn:aws:lambda:REGION:ACCOUNT:layer:test-layer-2:2"
+	  ]
+  }
+}`,
+			wantSpec: FunctionManifest{
+				Kind:       "LambdaFunction",
+				APIVersion: "pipecd.dev/v1beta1",
+				Spec: FunctionManifestSpec{
+					Name:     "SimpleFunction",
+					Role:     "arn:aws:iam::xxxxx:role/lambda-role",
+					Memory:   128,
+					Timeout:  5,
+					ImageURI: "ecr.region.amazonaws.com/lambda-simple-function:v0.0.1",
+					Layers: []string{
+						"arn:aws:lambda:REGION:ACCOUNT:layer:test-layer-1:1",
+						"arn:aws:lambda:REGION:ACCOUNT:layer:test-layer-2:2",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "correct config for LambdaFunction with specifying vpc config",
 			data: `{
   "apiVersion": "pipecd.dev/v1beta1",


### PR DESCRIPTION
**What this PR does / why we need it**:

Enabled to deploy Lambda functions which use layers.

The config is like below:

function.yaml
```yaml
apiVersion: pipecd.dev/v1beta1
kind: LambdaFunction
spec:
  ...
  layers: # NEW ATTRIBUTE.  not necessary.
    - arn:aws:lambda:REGION:ACCOUNT_ID:layer:layer-A:3
    - arn:aws:lambda:REGION:ACCOUNT_ID:layer:layer-B:1
```


**Which issue(s) this PR fixes**:

Fixes #4803 

**Does this PR introduce a user-facing change?**:  yes (addition only)

- **How are users affected by this change**:  add attributes if needed
- **Is this breaking change**: no 
- **How to migrate (if breaking change)**: no
