### PR TITLE
Add an example of local control plane by docker-compose

### DIFF
--- a/examples/control-plane/local-by-docker-compose/README.md
+++ b/examples/control-plane/local-by-docker-compose/README.md
@@ -1,0 +1,21 @@
+# docker-compose
+
+This example shows how to install a Control Plane on local by docker-compose.
+
+1. Install
+```sh
+docker-compose up
+```
+
+2. Clean up
+```sh
+docker-compose down
+```
+
+NOTE: By following commands instead of above `down`, you can keep data such as Piped or applications on the Control Plane even after restarting/updating the server component.
+
+```sh
+# Restart only the server component.
+docker-compose rm -fsv pipecd-server
+docker-compose up pipecd-server
+```

--- a/examples/control-plane/local-by-docker-compose/docker-compose.yaml
+++ b/examples/control-plane/local-by-docker-compose/docker-compose.yaml
@@ -1,0 +1,64 @@
+version: '3'
+
+services:
+  # Proxy for connecting between the browser and the Control Plane via gRPC.
+  pipecd-gateway:
+    image: envoyproxy/envoy-alpine:v1.18.3
+    command:
+      - -c /etc/envoy/envoy-config.yaml
+    ports:
+      - 9095:9095
+      - 8080:9090
+    volumes:
+      - ./volume/envoy:/etc/envoy
+      - ./volume/pipecd-secret:/etc/pipecd-secret
+
+  # Main component of the Control Plane.
+  pipecd-server:
+    image: ghcr.io/pipe-cd/pipecd:v0.46.0
+    ports:
+      - 9080:9080
+    entrypoint: >
+      /bin/sh -c "
+      until (nc -z pipecd-minio 9000 && nc -z pipecd-mysql 3306) do sleep 2; done;
+      pipecd server --insecure-cookie=true --cache-address=pipecd-cache:6379 --config-file=/etc/pipecd-config/control-plane-config.yaml --enable-grpc-reflection=false --encryption-key-file=/etc/pipecd-secret/encryption-key --log-encoding=humanize --metrics=true;
+      "
+    volumes:
+      - ./volume/pipecd-config:/etc/pipecd-config
+      - ./volume/pipecd-secret:/etc/pipecd-secret
+
+  # For cache.
+  pipecd-cache:
+    image: redis:5.0.5-alpine3.9
+
+  # For administration.
+  pipecd-ops:
+    image: ghcr.io/pipe-cd/pipecd:v0.46.0
+    entrypoint: >
+      /bin/sh -c "
+      until (nc -z pipecd-minio 9000 && nc -z pipecd-mysql 3306) do sleep 2; done;
+      pipecd ops --cache-address=pipecd-cache:6379 --config-file=/etc/pipecd-config/control-plane-config.yaml --log-encoding=humanize --metrics=true;
+      "
+    volumes:
+      - ./volume/pipecd-config:/etc/pipecd-config
+      - ./volume/pipecd-secret:/etc/pipecd-secret
+    ports:
+      - 9185:9085
+
+  # Datastore for storing application data.
+  pipecd-mysql:
+    image: mysql:8.0.23
+    platform: linux/x86_64
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: control-plane-local
+
+  # Filestore for logs and so on.
+  pipecd-minio:
+    image: minio/minio:RELEASE.2020-08-26T00-00-49Z
+    command: server /data
+    environment:
+      MINIO_ACCESS_KEY: control-plane-local-access-key
+      MINIO_SECRET_KEY: control-plane-local-secret-key
+    ports:
+      - 9000:9000

--- a/examples/control-plane/local-by-docker-compose/volume/envoy/envoy-config.yaml
+++ b/examples/control-plane/local-by-docker-compose/volume/envoy/envoy-config.yaml
@@ -1,0 +1,140 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9095
+
+static_resources:
+  listeners:
+  - name: ingress
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9090
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.grpc_stats
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              stats_for_all_methods: true
+              enable_upstream_stats: true
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: envoy
+              domains:
+                - '*'
+              routes:
+                - match:
+                    prefix: /grpc.service.pipedservice.PipedService/
+                    grpc:
+                  route:
+                    cluster: grpc-piped-service
+                - match:
+                    prefix: /pipe.api.service.pipedservice.PipedService/
+                    grpc:
+                  route:
+                    cluster: grpc-piped-service
+                    prefix_rewrite: /grpc.service.pipedservice.PipedService/
+                - match:
+                    prefix: /grpc.service.webservice.WebService/
+                    grpc:
+                  route:
+                    cluster: grpc-web-service
+                - match:
+                    prefix: /pipe.api.service.webservice.WebService/
+                    grpc:
+                  route:
+                    cluster: grpc-web-service
+                    prefix_rewrite: /grpc.service.webservice.WebService/
+                - match:
+                    prefix: /grpc.service.apiservice.APIService/
+                    grpc:
+                  route:
+                    cluster: grpc-api-service
+                - match:
+                    prefix: /pipe.api.service.apiservice.APIService/
+                    grpc:
+                  route:
+                    cluster: grpc-api-service
+                    prefix_rewrite: /grpc.service.apiservice.APIService/
+                - match:
+                    prefix: /
+                  route:
+                    cluster: server-http
+  clusters:
+  - name: grpc-piped-service
+    http2_protocol_options: {}
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: grpc-piped-service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: pipecd-server
+                port_value: 9080
+    track_cluster_stats:
+      request_response_sizes: true
+  - name: grpc-web-service
+    http2_protocol_options: {}
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: grpc-web-service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: pipecd-server
+                port_value: 9081
+    track_cluster_stats:
+      request_response_sizes: true
+  - name: grpc-api-service
+    http2_protocol_options: {}
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: grpc-api-service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: pipecd-server
+                port_value: 9083
+    track_cluster_stats:
+      request_response_sizes: true
+  - name: server-http
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: server-http
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: pipecd-server
+                port_value: 9082
+    track_cluster_stats:
+      request_response_sizes: true

--- a/examples/control-plane/local-by-docker-compose/volume/pipecd-config/control-plane-config.yaml
+++ b/examples/control-plane/local-by-docker-compose/volume/pipecd-config/control-plane-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: "pipecd.dev/v1beta1"
+kind: ControlPlane
+spec:
+  datastore:
+    type: MYSQL
+    config:
+      url: root:test@tcp(pipecd-mysql:3306)
+      database: control-plane-local
+  filestore:
+    type: MINIO
+    config:
+      endpoint: http://pipecd-minio:9000
+      bucket: control-plane-local
+      accessKeyFile: /etc/pipecd-secret/minio-access-key
+      secretKeyFile: /etc/pipecd-secret/minio-secret-key
+      autoCreateBucket: true
+  projects:
+    - id: control-plane-local
+      staticAdmin:
+        username: hello-pipecd
+        passwordHash: "$2a$10$ye96mUqUqTnjUqgwQJbJzel/LJibRhUnmzyypACkvrTSnQpVFZ7qK" # bcrypt value of "hello-pipecd"

--- a/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/encryption-key
+++ b/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/encryption-key
@@ -1,0 +1,1 @@
+encryption-key-just-used-for-control-plane-local

--- a/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/minio-access-key
+++ b/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/minio-access-key
@@ -1,0 +1,1 @@
+control-plane-local-access-key

--- a/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/minio-secret-key
+++ b/examples/control-plane/local-by-docker-compose/volume/pipecd-secret/minio-secret-key
@@ -1,0 +1,1 @@
+control-plane-local-secret-key


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an example of building a control plane locally by docker-compose
in order to enable users to experiment control plane / piped easily.

The codes are based on @kevin-namba 's https://github.com/pipe-cd/pipecd/pull/4139