### PR TITLE
Update deprecated API secretmanagerpb.AccessSecretVersionRequest

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -29,12 +29,12 @@ import (
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awssecretsmanager "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/credentials"
 	"sigs.k8s.io/yaml"
 

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awssecretsmanager "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/credentials"
 	"sigs.k8s.io/yaml"
 

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awssecretsmanager "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 	"google.golang.org/grpc/credentials"
 	"sigs.k8s.io/yaml"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update from deprecated `google.golang.org/genproto/googleapis/cloud/secretmanager/v1` to `cloud.google.com/go/secretmanager/apiv1/secretmanagerpb` when using `AccessSecretVersionRequest`

**Which issue(s) this PR fixes**:

Fixes #4820 

**Does this PR introduce a user-facing change?**:
No