### PR TITLE
Add the application ID to the application detail page

### DIFF
--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -361,7 +361,11 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                     value={
                       <>
                         {applicationId}
-                        <CopyIconButton name="Application ID" value={applicationId} size="small" />
+                        <CopyIconButton
+                          name="Application ID"
+                          value={applicationId}
+                          size="small"
+                        />
                       </>
                     }
                   />

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -36,6 +36,7 @@ import { selectPipedById } from "~/modules/pipeds";
 import { AppLiveState } from "./app-live-state";
 import { OutOfSyncReason, InvalidConfigReason } from "./sync-state-reason";
 import { ArtifactVersion } from "~~/model/common_pb";
+import { CopyIconButton } from "~/components/copy-icon-button";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -355,6 +356,15 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                       }
                     />
                   )}
+                  <DetailTableRow
+                    label="Application ID"
+                    value={
+                      <>
+                        {applicationId}
+                        <CopyIconButton name="Application ID" value={applicationId} size="small" />
+                      </>
+                    }
+                  />
                 </tbody>
               </table>
             ) : (

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -331,7 +331,7 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
             {app && piped ? (
               <table>
                 <tbody>
-                <DetailTableRow
+                  <DetailTableRow
                     label="Application ID"
                     value={
                       <>

--- a/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.tsx
@@ -331,6 +331,19 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
             {app && piped ? (
               <table>
                 <tbody>
+                <DetailTableRow
+                    label="Application ID"
+                    value={
+                      <>
+                        {applicationId}
+                        <CopyIconButton
+                          name="Application ID"
+                          value={applicationId}
+                          size="small"
+                        />
+                      </>
+                    }
+                  />
                   <DetailTableRow
                     label="Kind"
                     value={APPLICATION_KIND_TEXT[app.kind]}
@@ -356,19 +369,6 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                       }
                     />
                   )}
-                  <DetailTableRow
-                    label="Application ID"
-                    value={
-                      <>
-                        {applicationId}
-                        <CopyIconButton
-                          name="Application ID"
-                          value={applicationId}
-                          size="small"
-                        />
-                      </>
-                    }
-                  />
                 </tbody>
               </table>
             ) : (


### PR DESCRIPTION
**What this PR does / why we need it**: It displays the application ID on the application details page with a handy copy button.

**Which issue(s) this PR fixes**:

Fixes #4810

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**: Additional information in the UI only
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
