### PR TITLE
Use valid semver in run/pipecd command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ test/integration:
 
 .PHONY: run/pipecd
 run/pipecd: $(eval TIMESTAMP = $(shell date +%s))
+# NOTE: previously `git describe --tags` was used to determine the version for running locally
+# However, this does not work on a forked branch, so the decision was made to hardcode at version 0.0.0
+# see: https://github.com/pipe-cd/pipecd/issues/4845
 run/pipecd: BUILD_VERSION ?= "v0.0.0-$(shell git rev-parse --short HEAD)-$(TIMESTAMP)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test/integration:
 
 .PHONY: run/pipecd
 run/pipecd: $(eval TIMESTAMP = $(shell date +%s))
-run/pipecd: BUILD_VERSION ?= "$(shell grep "tag: v" RELEASE | cut -c7-)-build-$(shell git describe --tags --always --abbrev=7)-$(TIMESTAMP)"
+run/pipecd: BUILD_VERSION ?= "v0.0.0-$(shell git rev-parse --short HEAD)-$(TIMESTAMP)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test/integration:
 
 .PHONY: run/pipecd
 run/pipecd: $(eval TIMESTAMP = $(shell date +%s))
-run/pipecd: BUILD_VERSION ?= "$(shell git describe --tags --always --abbrev=7)-$(TIMESTAMP)"
+run/pipecd: BUILD_VERSION ?= "$(shell grep "tag: v" RELEASE | cut -c7-)-build-$(shell git describe --tags --always --abbrev=7)-$(TIMESTAMP)"
 run/pipecd: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 run/pipecd: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version


### PR DESCRIPTION
**What this PR does / why we need it**: It introduces the use of valid semvers so the project can be run on linux using the latest helm.

**Which issue(s) this PR fixes**:

Fixes #4845

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A

**Note to reviewers**: I have not been able to test this on mac, apologies, so I'd appreciate it if someone could confirm the fix is valid there as well. Thank you :) I have created this as a draft as I wanted to get some feedback on the approach of reading the release version from the RELEASE file. 
