### PR TITLE
Add deployment ID to the deployment details page

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -12,6 +12,7 @@ import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import dayjs from "dayjs";
 import { FC, memo } from "react";
 import { Link as RouterLink } from "react-router-dom";
+import { CopyIconButton } from "~/components/copy-icon-button";
 import { DeploymentStatusIcon } from "~/components/deployment-status-icon";
 import { DetailTableRow } from "~/components/detail-table-row";
 import { SplitButton } from "~/components/split-button";
@@ -154,6 +155,19 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
             <div className={classes.content}>
               <table>
                 <tbody>
+                  <DetailTableRow
+                    label="Deployment ID"
+                    value={
+                      <>
+                        {deploymentId}
+                        <CopyIconButton
+                          name="Deployment ID"
+                          value={deploymentId}
+                          size="small"
+                        />
+                      </>
+                    }
+                  />
                   <DetailTableRow
                     label="Application"
                     value={


### PR DESCRIPTION
**What this PR does / why we need it**: It adds the deployment ID to the deployment details page.

**Which issue(s) this PR fixes**:

Fixes #4811

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**: They can now see the deployment ID on the deployment details page.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
