### PR TITLE
Fix unable to use SecretEncryption and Attachment features at the same time

### DIFF
--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -188,7 +188,7 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 			fmt.Fprintf(lw, "Unable to process the source files (%v)\n", err)
 			return nil, err
 		}
-		fmt.Fprintln(lw, "Successfully process the source files")
+		fmt.Fprintln(lw, "Successfully processed the source files")
 	}
 
 	return &DeploySource{

--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -171,21 +171,24 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 	}
 	fmt.Fprintln(lw, "Successfully loaded the application configuration file")
 
+	var templProcessors []sourceprocesser.SourceTemplateProcessor
 	// Decrypt the sealed secrets if needed.
-	if gac.Encryption != nil && p.secretDecrypter != nil && len(gac.Encryption.DecryptionTargets) > 0 {
-		if err := sourceprocesser.DecryptSecrets(appDir, *gac.Encryption, p.secretDecrypter); err != nil {
-			fmt.Fprintf(lw, "Unable to decrypt the secrets (%v)\n", err)
-			return nil, err
-		}
-		fmt.Fprintf(lw, "Successfully decrypted secrets: %v\n", gac.Encryption.DecryptionTargets)
+	if gac.Encryption != nil && p.secretDecrypter != nil {
+		templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gac.Encryption, p.secretDecrypter))
+	}
+	// Attach the data if needed.
+	if gac.Attachment != nil {
+		templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gac.Attachment))
 	}
 
-	if gac.Attachment != nil && len(gac.Attachment.Targets) > 0 {
-		if err := sourceprocesser.AttachData(appDir, *gac.Attachment); err != nil {
-			fmt.Fprintf(lw, "Unable to attach the data (%v)\n", err)
+	// Process templating source files.
+	if len(templProcessors) > 0 {
+		sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+		if err := sp.Process(); err != nil {
+			fmt.Fprintf(lw, "Unable to process the source files (%v)\n", err)
 			return nil, err
 		}
-		fmt.Fprintf(lw, "Successfully attached data: %v\n", gac.Attachment.Targets)
+		fmt.Fprintln(lw, "Successfully process the source files")
 	}
 
 	return &DeploySource{

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -267,16 +267,19 @@ func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo
 			appDir = filepath.Join(repoDir, app.GitPath.Path)
 		}
 
+		var templProcessors []sourceprocesser.SourceTemplateProcessor
 		// Decrypting secrets to manifests.
 		if encryptionUsed {
-			if err := sourceprocesser.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {
-				return provider.ServiceManifest{}, fmt.Errorf("failed to decrypt secrets (%w)", err)
-			}
+			templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gds.Encryption, d.secretDecrypter))
 		}
 		// Then attaching configurated files to manifests.
 		if attachmentUsed {
-			if err := sourceprocesser.AttachData(appDir, *gds.Attachment); err != nil {
-				return provider.ServiceManifest{}, fmt.Errorf("failed to attach files (%w)", err)
+			templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gds.Attachment))
+		}
+		if len(templProcessors) > 0 {
+			sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+			if err := sp.Process(); err != nil {
+				return provider.ServiceManifest{}, fmt.Errorf("failed to process source files: %w", err)
 			}
 		}
 

--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -210,16 +210,19 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		appDir = filepath.Join(repoDir, app.GitPath.Path)
 	}
 
+	var templProcessors []sourceprocesser.SourceTemplateProcessor
 	// Decrypting secrets to manifests.
 	if encryptionUsed {
-		if err := sourceprocesser.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {
-			return fmt.Errorf("failed to decrypt secrets (%w)", err)
-		}
+		templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gds.Encryption, d.secretDecrypter))
 	}
 	// Then attaching configurated files to manifests.
 	if attachmentUsed {
-		if err := sourceprocesser.AttachData(appDir, *gds.Attachment); err != nil {
-			return fmt.Errorf("failed to attach files (%w)", err)
+		templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gds.Attachment))
+	}
+	if len(templProcessors) > 0 {
+		sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+		if err := sp.Process(); err != nil {
+			return fmt.Errorf("failed to process source files: %w", err)
 		}
 	}
 

--- a/pkg/app/piped/sourceprocesser/sourceprocesser.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser.go
@@ -50,7 +50,7 @@ func NewSourceProcessor(appDir string, templateProcessors ...SourceTemplateProce
 
 func (p *processor) Process() error {
 	if len(p.templateProcessors) == 0 {
-		return nil
+		return fmt.Errorf("no template processor was specified")
 	}
 
 	var targets []string

--- a/pkg/app/piped/sourceprocesser/sourceprocesser.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceprocesser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+type SourceTemplateProcessor interface {
+	// BuildTemplateData returns the data that will be used to template target files
+	BuildTemplateData(appDir string) (map[string]string, error)
+	// TargetFilePaths returns the paths of target files that will be templated
+	TargetFilePaths() []string
+	// TemplateKey returns the key that will be used to store the data in the template
+	TemplateKey() string
+}
+
+type SourceProcessor interface {
+	Process() error
+}
+
+type processor struct {
+	appDir             string
+	templateProcessors []SourceTemplateProcessor
+}
+
+func NewSourceProcessor(appDir string, templateProcessors ...SourceTemplateProcessor) SourceProcessor {
+	return &processor{
+		appDir:             appDir,
+		templateProcessors: templateProcessors,
+	}
+}
+
+func (p *processor) Process() error {
+	if len(p.templateProcessors) == 0 {
+		return nil
+	}
+
+	var targets []string
+	for _, tp := range p.templateProcessors {
+		targets = append(targets, tp.TargetFilePaths()...)
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("no target file path was specified")
+	}
+
+	data := make(map[string](map[string]string))
+	for _, tp := range p.templateProcessors {
+		pdata, err := tp.BuildTemplateData(p.appDir)
+		if err != nil {
+			return err
+		}
+		if len(pdata) == 0 {
+			continue
+		}
+		data[tp.TemplateKey()] = pdata
+	}
+
+	for _, t := range targets {
+		targetPath := filepath.Join(p.appDir, t)
+		fileName := filepath.Base(targetPath)
+		tmpl := template.New(fileName).Funcs(sprig.TxtFuncMap()).Option("missingkey=error")
+		tmpl, err := tmpl.ParseFiles(targetPath)
+		if err != nil {
+			return fmt.Errorf("failed to parse target file %s (%w)", t, err)
+		}
+
+		f, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open target file %s (%w)", t, err)
+		}
+
+		if err := tmpl.Execute(f, data); err != nil {
+			f.Close()
+			return fmt.Errorf("failed to render target file %s (%w)", t, err)
+		}
+
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed to close target file %s (%w)", t, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/app/piped/sourceprocesser/sourceprocesser.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser.go
@@ -21,7 +21,7 @@ import (
 type SourceTemplateProcessor interface {
 	// BuildTemplateData returns the data that will be used to template target files
 	BuildTemplateData(appDir string) (map[string]string, error)
-	// TemplateSource performs the templating prepared data to the source files
+	// TemplateSource performs templating prepared data to the source files
 	TemplateSource(appDir string, data map[string](map[string]string)) error
 	// TemplateKey returns the key that will be used to store the data in the template
 	TemplateKey() string

--- a/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
@@ -1,0 +1,80 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceprocesser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
+)
+
+func TestSourceProcesser(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := os.MkdirTemp("", "test-process-data")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(workspace)
+	})
+	dcr := testSecretDecrypter{
+		prefix: "decrypted-",
+	}
+
+	fileData := map[string]string{
+		"config.yaml":   "config-data",
+		"resource.yaml": "echo {{ .attachment.config }} && echo {{ .encryptedSecrets.secret }}",
+	}
+	attachConfig := config.Attachment{
+		Sources: map[string]string{
+			"config": "config.yaml",
+		},
+		Targets: []string{
+			"resource.yaml",
+		},
+	}
+	secretConfig := config.SecretEncryption{
+		EncryptedSecrets: map[string]string{
+			"secret": "encrypted-secret",
+		},
+		DecryptionTargets: []string{
+			"resource.yaml",
+		},
+	}
+
+	appDir, err := os.MkdirTemp(workspace, "app-dir")
+	require.NoError(t, err)
+
+	for p, c := range fileData {
+		p = filepath.Join(appDir, p)
+		err = os.MkdirAll(filepath.Dir(p), 0700)
+		require.NoError(t, err)
+		err = os.WriteFile(p, []byte(c), 0600)
+		require.NoError(t, err)
+	}
+
+	err = DecryptSecrets(appDir, secretConfig, dcr)
+	require.NoError(t, err)
+	err = AttachData(appDir, attachConfig)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(appDir, "resource.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "echo config-data && echo decrypted-encrypted-secret", string(data))
+}

--- a/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
@@ -96,6 +96,32 @@ func TestSourceProcessor(t *testing.T) {
 			},
 		},
 		{
+			name: "secret decryption combined attachement",
+			fileData: map[string]string{
+				"config.yaml":   "{{ .encryptedSecrets.secret }}",
+				"resource.yaml": "echo {{ .attachment.config }}",
+			},
+			attachConfig: config.Attachment{
+				Sources: map[string]string{
+					"config": "config.yaml",
+				},
+				Targets: []string{
+					"resource.yaml",
+				},
+			},
+			secretConfig: config.SecretEncryption{
+				EncryptedSecrets: map[string]string{
+					"secret": "encrypted-secret",
+				},
+				DecryptionTargets: []string{
+					"config.yaml",
+				},
+			},
+			expected: map[string]string{
+				"resource.yaml": "echo decrypted-encrypted-secret",
+			},
+		},
+		{
 			name: "sprig function",
 			fileData: map[string]string{
 				"config.yaml":   "config-data",

--- a/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
+++ b/pkg/app/piped/sourceprocesser/sourceprocesser_test.go
@@ -63,13 +63,6 @@ func TestSourceProcessor(t *testing.T) {
 			expectedErrorPrefix: "failed to parse target file not-found-resource.yaml",
 		},
 		{
-			name: "no target file specified",
-			fileData: map[string]string{
-				"resource.yaml": "resource-data",
-			},
-			expectedErrorPrefix: "no target file path was specified",
-		},
-		{
 			name: "attachment work with secret decryption",
 			fileData: map[string]string{
 				"config.yaml":   "config-data",
@@ -175,7 +168,7 @@ func TestSourceProcessor(t *testing.T) {
 
 			atp := NewAttachmentProcessor(&tc.attachConfig)
 			sdp := NewSecretDecrypterProcessor(&tc.secretConfig, dcr)
-			sp := NewSourceProcessor(appDir, []SourceTemplateProcessor{atp, sdp}...)
+			sp := NewSourceProcessor(appDir, []SourceTemplateProcessor{sdp, atp}...)
 
 			err = sp.Process()
 			if tc.expectedErrorPrefix != "" {

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -171,21 +171,24 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 	}
 	fmt.Fprintln(lw, "Successfully loaded the application configuration file")
 
+	var templProcessors []sourceprocesser.SourceTemplateProcessor
 	// Decrypt the sealed secrets if needed.
-	if gac.Encryption != nil && p.secretDecrypter != nil && len(gac.Encryption.DecryptionTargets) > 0 {
-		if err := sourceprocesser.DecryptSecrets(appDir, *gac.Encryption, p.secretDecrypter); err != nil {
-			fmt.Fprintf(lw, "Unable to decrypt the secrets (%v)\n", err)
-			return nil, err
-		}
-		fmt.Fprintf(lw, "Successfully decrypted secrets: %v\n", gac.Encryption.DecryptionTargets)
+	if gac.Encryption != nil && p.secretDecrypter != nil {
+		templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gac.Encryption, p.secretDecrypter))
+	}
+	// Attach the data if needed.
+	if gac.Attachment != nil {
+		templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gac.Attachment))
 	}
 
-	if gac.Attachment != nil && len(gac.Attachment.Targets) > 0 {
-		if err := sourceprocesser.AttachData(appDir, *gac.Attachment); err != nil {
-			fmt.Fprintf(lw, "Unable to attach the data (%v)\n", err)
+	// Process templating source files.
+	if len(templProcessors) > 0 {
+		sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+		if err := sp.Process(); err != nil {
+			fmt.Fprintf(lw, "Unable to process the source files (%v)\n", err)
 			return nil, err
 		}
-		fmt.Fprintf(lw, "Successfully attached data: %v\n", gac.Attachment.Targets)
+		fmt.Fprintln(lw, "Successfully process the source files")
 	}
 
 	return &DeploySource{

--- a/pkg/app/pipedv1/driftdetector/cloudrun/detector.go
+++ b/pkg/app/pipedv1/driftdetector/cloudrun/detector.go
@@ -267,16 +267,19 @@ func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo
 			appDir = filepath.Join(repoDir, app.GitPath.Path)
 		}
 
+		var templProcessors []sourceprocesser.SourceTemplateProcessor
 		// Decrypting secrets to manifests.
 		if encryptionUsed {
-			if err := sourceprocesser.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {
-				return provider.ServiceManifest{}, fmt.Errorf("failed to decrypt secrets (%w)", err)
-			}
+			templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gds.Encryption, d.secretDecrypter))
 		}
 		// Then attaching configurated files to manifests.
 		if attachmentUsed {
-			if err := sourceprocesser.AttachData(appDir, *gds.Attachment); err != nil {
-				return provider.ServiceManifest{}, fmt.Errorf("failed to attach files (%w)", err)
+			templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gds.Attachment))
+		}
+		if len(templProcessors) > 0 {
+			sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+			if err := sp.Process(); err != nil {
+				return provider.ServiceManifest{}, fmt.Errorf("failed to process source files: %w", err)
 			}
 		}
 

--- a/pkg/app/pipedv1/driftdetector/terraform/detector.go
+++ b/pkg/app/pipedv1/driftdetector/terraform/detector.go
@@ -210,16 +210,19 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		appDir = filepath.Join(repoDir, app.GitPath.Path)
 	}
 
+	var templProcessors []sourceprocesser.SourceTemplateProcessor
 	// Decrypting secrets to manifests.
 	if encryptionUsed {
-		if err := sourceprocesser.DecryptSecrets(appDir, *gds.Encryption, d.secretDecrypter); err != nil {
-			return fmt.Errorf("failed to decrypt secrets (%w)", err)
-		}
+		templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gds.Encryption, d.secretDecrypter))
 	}
 	// Then attaching configurated files to manifests.
 	if attachmentUsed {
-		if err := sourceprocesser.AttachData(appDir, *gds.Attachment); err != nil {
-			return fmt.Errorf("failed to attach files (%w)", err)
+		templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gds.Attachment))
+	}
+	if len(templProcessors) > 0 {
+		sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+		if err := sp.Process(); err != nil {
+			return fmt.Errorf("failed to process source files: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, I reimplemented the sourceprosser logic by introducing the `SourceProcessor` interface.

Previously, we called two functions, `DecryptSecret` and `Attach`, to perform templating data separately. Both of them use golang `text/template` functions, which causes conflict on key not found whenever using both `{{ .attachment }}` and `{{ .secretEncrytion }}` for those two features at the same time.

By introducing the SourceProcessor interface, updated the logic to call golang `text/template` function once. Both SecretDecryption and Attachment functions would only focus on building the templating data, and then `SourceProcesser.Process` would perform the templating task.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
