### PR TITLE
Truncate `deploymentStatus` metrics after reporting stats

### DIFF
--- a/pkg/app/piped/controller/controllermetrics/metrics.go
+++ b/pkg/app/piped/controller/controllermetrics/metrics.go
@@ -54,3 +54,8 @@ func Register(r prometheus.Registerer) {
 		deploymentStatus,
 	)
 }
+
+// Reset deletes all deploymentStatus metrics, which should be called to remove old unnecessary metrics.
+func Reset() {
+	deploymentStatus.Reset()
+}

--- a/pkg/app/piped/statsreporter/reporter.go
+++ b/pkg/app/piped/statsreporter/reporter.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/pipe-cd/pipecd/pkg/app/piped/controller/controllermetrics"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
 )
 
@@ -98,5 +99,10 @@ func (r *reporter) report(ctx context.Context) error {
 		r.logger.Error("failed to report stats", zap.Error(err))
 		return err
 	}
+
+	// Delete deployment metrics which are already reported
+	// in order to avoid error of excess message size.
+	controllermetrics.Reset()
+
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Delete `deploymentStatus` metrics after reporting stats
in order to avoid the error of excess grpc message size by accumulated `deploymentStatus` records.



**Which issue(s) this PR fixes**:

Fixes #4786

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
