### PR TITLE
Fix to get the resource key from the annoation

### DIFF
--- a/pkg/app/piped/livestatestore/kubernetes/reflector.go
+++ b/pkg/app/piped/livestatestore/kubernetes/reflector.go
@@ -249,7 +249,11 @@ func (r *reflector) start(_ context.Context) error {
 
 func (r *reflector) onObjectAdd(obj interface{}) {
 	u := obj.(*unstructured.Unstructured)
-	key := provider.MakeResourceKey(u)
+	key := provider.GetResourceKeyFromActualResource(u)
+	if anoKey := u.GetAnnotations()[provider.LabelResourceKey]; anoKey != "" {
+		key, _ = provider.DecodeResourceKey(anoKey)
+
+	}
 
 	// Ignore all predefined ones.
 	if _, ok := ignoreResourceKeys[key.String()]; ok {
@@ -283,7 +287,7 @@ func (r *reflector) onObjectUpdate(oldObj, obj interface{}) {
 	oldU := oldObj.(*unstructured.Unstructured)
 
 	// Ignore all predefined ones.
-	key := provider.MakeResourceKey(u)
+	key := provider.GetResourceKeyFromActualResource(u)
 	if _, ok := ignoreResourceKeys[key.String()]; ok {
 		kubernetesmetrics.IncResourceEventsCounter(
 			kubernetesmetrics.LabelEventUpdate,
@@ -312,7 +316,7 @@ func (r *reflector) onObjectUpdate(oldObj, obj interface{}) {
 
 func (r *reflector) onObjectDelete(obj interface{}) {
 	u := obj.(*unstructured.Unstructured)
-	key := provider.MakeResourceKey(u)
+	key := provider.GetResourceKeyFromActualResource(u)
 
 	// Ignore all predefined ones.
 	if _, ok := ignoreResourceKeys[key.String()]; ok {

--- a/pkg/app/piped/livestatestore/kubernetes/store.go
+++ b/pkg/app/piped/livestatestore/kubernetes/store.go
@@ -73,7 +73,7 @@ func (s *store) initialize() {
 		}
 
 		// Add the missing resource into the dependedResources of the app.
-		key := provider.MakeResourceKey(an.resource)
+		key := provider.GetResourceKeyFromActualResource(an.resource)
 
 		// Ignore in case appNodes with appID not existed in store.
 		if s.apps[appID] == nil {
@@ -103,7 +103,7 @@ func (s *store) initialize() {
 func (s *store) addResource(obj *unstructured.Unstructured, appID string) {
 	var (
 		uid    = string(obj.GetUID())
-		key    = provider.MakeResourceKey(obj)
+		key    = provider.GetResourceKeyFromActualResource(obj)
 		owners = obj.GetOwnerReferences()
 		now    = time.Now()
 	)
@@ -189,7 +189,7 @@ func (s *store) onDeleteResource(obj *unstructured.Unstructured) {
 	var (
 		uid    = string(obj.GetUID())
 		appID  = obj.GetAnnotations()[provider.LabelApplication]
-		key    = provider.MakeResourceKey(obj)
+		key    = provider.GetResourceKeyFromActualResource(obj)
 		owners = obj.GetOwnerReferences()
 		now    = time.Now()
 	)

--- a/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
@@ -246,6 +246,21 @@ func (k ResourceKey) IsEqualWithIgnoringNamespace(a ResourceKey) bool {
 	return true
 }
 
+// GetResourceKeyFromActualResource extracts the ResourceKey from the given resource object.
+// If the ResourceKey is not found in the annotations, it will create a new one.
+func GetResourceKeyFromActualResource(obj *unstructured.Unstructured) ResourceKey {
+	annotation, ok := obj.GetAnnotations()[LabelResourceKey]
+	if !ok {
+		return MakeResourceKey(obj)
+	}
+
+	key, err := DecodeResourceKey(annotation)
+	if err != nil {
+		return MakeResourceKey(obj)
+	}
+	return key
+}
+
 func MakeResourceKey(obj *unstructured.Unstructured) ResourceKey {
 	k := ResourceKey{
 		APIVersion: obj.GetAPIVersion(),

--- a/pkg/app/piped/platformprovider/kubernetes/resourcekey_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/resourcekey_test.go
@@ -1,0 +1,197 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetResourceKeyFromActualResource(t *testing.T) {
+	type args struct {
+		resource *unstructured.Unstructured
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want ResourceKey
+	}{
+		{
+			name: "get resource key from annotation",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"annotations": map[string]interface{}{
+								"pipecd.dev/resource-key": "v1:Pod:my-namespace:my-pod",
+							},
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "my-namespace",
+				Name:       "my-pod",
+			},
+		},
+		{
+			name: "prioritize the resource key from annotation when both metadata.annotation and metadata.namespace are available",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name":      "my-pod",
+							"namespace": "test",
+							"annotations": map[string]interface{}{
+								"pipecd.dev/resource-key": "v1:Pod:my-namespace:my-pod",
+							},
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "my-namespace",
+				Name:       "my-pod",
+			},
+		},
+		{
+			name: "make resource key when annotation is not available",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name":      "my-pod",
+							"namespace": "my-namespace",
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "my-namespace",
+				Name:       "my-pod",
+			},
+		},
+		{
+			name: "make resource key when the value of annotation is invalid",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name":      "my-pod",
+							"namespace": "my-namespace",
+							"annotations": map[string]interface{}{
+								"pipecd.dev/resource-key": "invalid-value",
+							},
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "my-namespace",
+				Name:       "my-pod",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetResourceKeyFromActualResource(tt.args.resource)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMakeResourceKey(t *testing.T) {
+	type args struct {
+		resource *unstructured.Unstructured
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want ResourceKey
+	}{
+		{
+			name: "default case",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name":      "my-pod",
+							"namespace": "my-namespace",
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "my-namespace",
+				Name:       "my-pod",
+			},
+		},
+		{
+			name: "use 'default' when namespace is empty",
+			args: args{
+				resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+						},
+					},
+				},
+			},
+			want: ResourceKey{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  DefaultNamespace,
+				Name:       "my-pod",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := MakeResourceKey(tt.args.resource)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the resource key from the annotation to store it as a livestate.
This fix is expected to be able to delete the cluster scoped resource.

**Which issue(s) this PR fixes**:

Fixes #4269

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
