### PR TITLE
Revert "Release v0.46.1"

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.46.1
+tag: v0.46.0
 
 releaseNoteGenerator:
   showCommitter: false


### PR DESCRIPTION
Reverts pipe-cd/pipecd#4859

to modify the release version from v0.46.1 to v0.47.0