### PR TITLE
Add a caution comment of scrape_interval

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -201,7 +201,7 @@ data:
 
       - job_name: pipecd-ops
         # This scrape_interval must not be larger than the interval of piped's stats-reporting.
-        # ref: https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/statsreporter/reporter.go#L53
+        # ref: https://github.com/pipe-cd/pipecd/blob/a73d0913643ef1da05bc8898cf055c9893f16e0b/pkg/app/piped/statsreporter/reporter.go#L53
         scrape_interval: 1m
         kubernetes_sd_configs:
           - role: endpoints

--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -200,7 +200,7 @@ data:
             replacement: $1
 
       - job_name: pipecd-ops
-        # This scrape_interval must not be larger than 1m, which is the interval of piped's stats-reporting.
+        # This scrape_interval must not be larger than the interval of piped's stats-reporting.
         # ref: https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/statsreporter/reporter.go#L53
         scrape_interval: 1m
         kubernetes_sd_configs:

--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -200,6 +200,8 @@ data:
             replacement: $1
 
       - job_name: pipecd-ops
+        # This scrape_interval must not be larger than 1m, which is the interval of piped's stats-reporting.
+        # ref: https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/statsreporter/reporter.go#L53
         scrape_interval: 1m
         kubernetes_sd_configs:
           - role: endpoints


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a caution comment against changing `scrape_interval` of Prometheus to be larger than 1m.

**Which issue(s) this PR fixes**:

Related to https://github.com/pipe-cd/pipecd/pull/4857

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
