### PR TITLE
Enable support for both EncryptedSecrets and AttachmentData in a single file

### DIFF
--- a/pkg/app/piped/sourceprocesser/combiner.go
+++ b/pkg/app/piped/sourceprocesser/combiner.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceprocesser
+
+import (
+	"maps"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
+)
+
+func EmbedCombination(appDir string, enc config.SecretEncryption, dcr secretDecrypter, atc config.Attachment) error {
+	secretData, err := PrepareSecretData(enc, dcr)
+	if err != nil {
+		return err
+	}
+
+	attachData, err := PrepareAttachmentData(appDir, atc)
+	if err != nil {
+		return err
+	}
+
+	data := make(map[string](map[string]string))
+	maps.Copy(data, secretData)
+	maps.Copy(data, attachData)
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	if err := EmbedSecret(appDir, enc.DecryptionTargets, data); err != nil {
+		return err
+	}
+
+	if err := EmbedAttach(appDir, atc.Targets, data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/app/piped/sourceprocesser/combiner_test.go
+++ b/pkg/app/piped/sourceprocesser/combiner_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceprocesser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
+)
+
+func TestCombinedData(t *testing.T) {
+	t.Parallel()
+
+	workspace, err := os.MkdirTemp("", "test-combined-data")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(workspace)
+	})
+	dcr := testSecretDecrypter{
+		prefix: "decrypted-",
+	}
+
+	testcases := []struct {
+		name                string
+		fileData            map[string]string
+		attachConfig        config.Attachment
+		encryption          config.SecretEncryption
+		expected            map[string]string
+		expectedErrorPrefix string
+	}{
+		{
+			name: "single target",
+			fileData: map[string]string{
+				"config.yaml":   "config-data",
+				"resource.yaml": "echo {{ .attachment.config }}\nresource-data: {{ .encryptedSecrets.password }}",
+			},
+			attachConfig: config.Attachment{
+				Sources: map[string]string{
+					"config": "config.yaml",
+				},
+				Targets: []string{
+					"resource.yaml",
+				},
+			},
+			encryption: config.SecretEncryption{
+				EncryptedSecrets: map[string]string{
+					"password": "encrypted-password",
+				},
+				DecryptionTargets: []string{
+					"resource.yaml",
+				},
+			},
+			expected: map[string]string{
+				"resource.yaml": "echo config-data\nresource-data: decrypted-encrypted-password",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			appDir, err := os.MkdirTemp(workspace, "app-dir")
+			require.NoError(t, err)
+
+			for p, c := range tc.fileData {
+				p = filepath.Join(appDir, p)
+				err := os.MkdirAll(filepath.Dir(p), 0700)
+				require.NoError(t, err)
+				err = os.WriteFile(p, []byte(c), 0600)
+				require.NoError(t, err)
+			}
+
+			err = EmbedCombination(appDir, tc.encryption, dcr, tc.attachConfig)
+			if tc.expectedErrorPrefix != "" {
+				require.Error(t, err)
+				assert.True(t, strings.HasPrefix(err.Error(), tc.expectedErrorPrefix), fmt.Sprintf("Error: %v", err))
+			} else {
+				require.NoError(t, err)
+			}
+
+			for p, c := range tc.expected {
+				p = filepath.Join(appDir, p)
+				data, err := os.ReadFile(p)
+				require.NoError(t, err)
+				assert.Equal(t, c, string(data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

## Problem I faced

When I used AttachmentData and EncryptedSecret in the same file (`taskdef.yaml`), I received this error: `map has no entry for key "attachment".` So, I can only use one feature on a single file.

## What is the problem

AttachmentData and EncryptedSecret have similar code handling: Get the value and load it into template target files.
It is handled sequence by sequence: EncryptedSecret first and AttachmentData after. When we use both, the EncryptedSecret handling part would not have any information about the AttachmentData; parsing using the template file raised an error because of missing data.

## What do I do

In the case of AttachmentData and EncryptedSecret, I prepare data for both parts and pass it to the template target files.

## Does this change affect other parts

It keeps the original handling of `DecryptSecrets` and `AttachData`,  it doesn't affect other parts.

## About test

Because there isn't any new logic, test cases in `decrypter` and `attacher` have not been written again. Only both AttachmentData and EncryptedSecret data exist in a single file test is added.

##  Other concerns

I also see the handling of `decrypter` and  `attacher` in `driftdetector` package, but I don't see the occurrence of ECSApp, so I guess it is unnecessary to change that part (at least now)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
