### PR TITLE
Add Homebrew Formula

### DIFF
--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -51,6 +51,12 @@ asdf plugin add pipectl && asdf install pipectl latest && asdf global pipectl la
 aqua g -i pipe-cd/pipecd/pipectl && aqua i
 ```
 
+##### Method 4: [Homebrew](https://brew.sh/) Supported Installation
+
+```console
+brew install pipe-cd/tap/pipectl
+```
+
 #### 1.2. Installing PipeCD's components
 
 We can simply use __pipectl quickstart__ command to start the PipeCD installation process and follow the instruction

--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -83,6 +83,24 @@ The Pipectl command-line tool can be installed using one of the following method
     pipectl version
     ```
 
+### Using [Homebrew](https://brew.sh/)
+
+1. Add the `pipe-cd/tap` and fetch new formulae from GitHub.
+    ```console
+    brew tap pipe-cd/tap
+    brew update
+    ```
+
+2. Install pipectl.
+    ```console
+    brew install pipectl
+    ```
+
+3. Test to ensure the version you installed is up-to-date.
+    ```console
+    pipectl version
+    ```
+
 ### Run in Docker container
 
 We are storing every version of docker image for pipectl on Google Cloud Container Registry.
@@ -102,7 +120,7 @@ There are two kinds of key role: `READ_ONLY` and `READ_WRITE`. Depending on the 
 Adding a new API key from Settings tab
 </p>
 
-When executing a command of pipectl you have to specify either a string of API key via `--api-key` flag or a path to the API key file via `--api-key-file` flag. 
+When executing a command of pipectl you have to specify either a string of API key via `--api-key` flag or a path to the API key file via `--api-key-file` flag.
 
 ## Usage
 
@@ -338,7 +356,7 @@ Note: The docs for pipectl available command is maybe outdated, we suggest users
 Generate an app.pipecd.yaml interactively:
 
 ``` console
-$ pipectl init 
+$ pipectl init
 Which platform? Enter the number [0]Kubernetes [1]ECS: 1
 Name of the application: myApp
 ...

--- a/docs/content/en/docs-v0.47.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.47.x/quickstart/_index.md
@@ -51,6 +51,12 @@ asdf plugin add pipectl && asdf install pipectl latest && asdf global pipectl la
 aqua g -i pipe-cd/pipecd/pipectl && aqua i
 ```
 
+##### Method 4: [Homebrew](https://brew.sh/) Supported Installation
+
+```console
+brew install pipe-cd/tap/pipectl
+```
+
 #### 1.2. Installing PipeCD's components
 
 We can simply use __pipectl quickstart__ command to start the PipeCD installation process and follow the instruction

--- a/docs/content/en/docs-v0.47.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/command-line-tool.md
@@ -83,6 +83,24 @@ The Pipectl command-line tool can be installed using one of the following method
     pipectl version
     ```
 
+### Using [Homebrew](https://brew.sh/)
+
+1. Add the `pipe-cd/tap` and fetch new formulae from GitHub.
+    ```console
+    brew tap pipe-cd/tap
+    brew update
+    ```
+
+2. Install pipectl.
+    ```console
+    brew install pipectl
+    ```
+
+3. Test to ensure the version you installed is up-to-date.
+    ```console
+    pipectl version
+    ```
+
 ### Run in Docker container
 
 We are storing every version of docker image for pipectl on Google Cloud Container Registry.
@@ -102,7 +120,7 @@ There are two kinds of key role: `READ_ONLY` and `READ_WRITE`. Depending on the 
 Adding a new API key from Settings tab
 </p>
 
-When executing a command of pipectl you have to specify either a string of API key via `--api-key` flag or a path to the API key file via `--api-key-file` flag. 
+When executing a command of pipectl you have to specify either a string of API key via `--api-key` flag or a path to the API key file via `--api-key-file` flag.
 
 ## Usage
 
@@ -338,7 +356,7 @@ Note: The docs for pipectl available command is maybe outdated, we suggest users
 Generate an app.pipecd.yaml interactively:
 
 ``` console
-$ pipectl init 
+$ pipectl init
 Which platform? Enter the number [0]Kubernetes [1]ECS: 1
 Name of the application: myApp
 ...


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds the way to install pipectl using brew. The installation will be available by the following pull request.

- https://github.com/pipe-cd/homebrew-tap/pull/1

Documentation updates:

* `docs/content/en/docs-dev/quickstart/_index.md` and `docs/content/en/docs-v0.47.x/quickstart/_index.md`: Added a new section detailing how to install `pipectl` using Homebrew.
* `docs/content/en/docs-dev/user-guide/command-line-tool.md` and `docs/content/en/docs-v0.47.x/user-guide/command-line-tool.md`: Updated the documentation to include Homebrew as a method for installing `pipectl`. The new sections provide step-by-step instructions on how to add the `pipe-cd/tap` tap and install `pipectl` using Homebrew.

**Which issue(s) this PR fixes**:

- Fixes https://github.com/pipe-cd/pipecd/issues/4879

**Does this PR introduce a user-facing change?**:

No.
