### PR TITLE
Fix test: default branch name was unstable

### DIFF
--- a/pkg/git/client_test.go
+++ b/pkg/git/client_test.go
@@ -134,7 +134,7 @@ func (f *faker) makeRepo(org, repo string) error {
 	}
 
 	err := commander.runGitCommands([][]string{
-		{"init"},
+		{"init", "--initial-branch", "master"},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

I made default branch name in the test fixed to `master`.
This change does not affect the production code.

**The Problem I faced**
`make test/go` failed locally, although it succeeded in CI.
```
--- FAIL: TestClone (0.74s)
    client_test.go:84: 
                Error Trace:    /dev/pipecd/pkg/git/client_test.go:84
                Error:          Received unexpected error:
                                failed to clone from local: exit status 128
                Test:           TestClone
FAIL
FAIL    github.com/pipe-cd/pipecd/pkg/git       1.311s
```

**The Cause**
- My local git command uses `main` as default branch, but the test uses `master`.
    https://github.com/pipe-cd/pipecd/blob/14eb4731cc33cb1bf0662cdfa7abe05764ff9b67/pkg/git/client_test.go#L83 
- CI passed the test because it uses `master` by default.
    cf. https://github.com/pipe-cd/pipecd/actions/runs/8746544045/job/24003580952#step:2:30

**Which issue(s) this PR fixes**:

N/A


**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
