### PR TITLE
Support PipelineSync on OUT_OF_SYNC

### DIFF
--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -287,10 +287,6 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			deploymentChainID = c.command.GetChainSyncApplication().DeploymentChainId
 			deploymentChainBlockIndex = c.command.GetChainSyncApplication().BlockIndex
 
-		case model.TriggerKind_ON_OUT_OF_SYNC:
-			strategy = model.SyncStrategy_QUICK_SYNC
-			strategySummary = "Quick sync to attempt to resolve the detected configuration drift"
-
 		default:
 			strategy = model.SyncStrategy_AUTO
 		}

--- a/pkg/app/pipedv1/trigger/trigger.go
+++ b/pkg/app/pipedv1/trigger/trigger.go
@@ -287,10 +287,6 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			deploymentChainID = c.command.GetChainSyncApplication().DeploymentChainId
 			deploymentChainBlockIndex = c.command.GetChainSyncApplication().BlockIndex
 
-		case model.TriggerKind_ON_OUT_OF_SYNC:
-			strategy = model.SyncStrategy_QUICK_SYNC
-			strategySummary = "Quick sync to attempt to resolve the detected configuration drift"
-
 		default:
 			strategy = model.SyncStrategy_AUTO
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, sync strategy on OUT_OF_SYNC is QUICK_SYNC and this is unchangeable feature.
This can be fixed by using SyncStrategy_AUTO to entrust strategy detection to planner.

**Which issue(s) this PR fixes**:

NONE

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
  ppl who configure pipeline sync and expect to use OnOutOfSync trigger forcibly QUICK_SYNC, experience PIPELINE_SYNC (I believe this is rare case)
- **Is this breaking change**:
  I don't think so

- **How to migrate (if breaking change)**:
  NONE
