### PR TITLE
[doc] Added note that Canary or Blue/Green for ECS Service Connect is not supported yet

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,7 +152,8 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
-- For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+  - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+- When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment because Service Connect does not support the external deployment.
 
 ## Reference
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,7 +152,8 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
-- For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+  - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+- When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment because Service Connect does not support the external deployment.
 
 ## Reference
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,7 +152,8 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
-- For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+  - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
+- When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment because Service Connect does not support the external deployment.
 
 ## Reference
 


### PR DESCRIPTION
**What this PR does / why we need it**:

as title.

We haven't specified it in the docs.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
