### PR TITLE
Remove decrecated template

### DIFF
--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -12,7 +12,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}

--- a/docs/themes/docsy/layouts/partials/head.html
+++ b/docs/themes/docsy/layouts/partials/head.html
@@ -24,7 +24,6 @@
 {{ end }}
 
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When executing `make run/site,` the error happened like the one below.
```
% make run/site                                                                                                                                                                                                                       
env RELEASE=v0.47.1 hugo server --source=docs
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
WARN  deprecated: config: languages.en.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Watching for changes in /Users/s14218/oss/pipe-cd/pipecd/docs/{assets,content,layouts,package.json,static,themes}
Watching for config changes in /Users/s14218/oss/pipe-cd/pipecd/docs/config.toml, /Users/s14218/oss/pipe-cd/pipecd/docs/themes/docsy/config.toml
Start building sites …
hugo v0.121.1-00b46fed8e47f7bb0a85d7cfc2d9f1356379b740+extended darwin/arm64 BuildDate=2023-12-08T08:47:45Z VendorInfo=brew

ERROR render of "page" failed: "/Users/s14218/oss/pipe-cd/pipecd/docs/themes/docsy/layouts/blog/baseof.html:4:7": execute of template failed: template: blog/single.html:4:7: executing "blog/single.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:15:13: no such template "_internal/google_news.html"
Built in 576 ms
Error: error building site: render: failed to render pages: render of "page" failed: "/Users/s14218/oss/pipe-cd/pipecd/docs/themes/docsy/layouts/_default/baseof.html:4:7": execute of template failed: template: _default/search.html:4:7: executing "_default/search.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:15:13: no such template "_internal/google_news.html"
make: *** [run/site] Error 1
```

As https://github.com/gohugoio/hugo/issues/9172, google_news internal template is deprecated.
So I removed the reference of the template.
ref: https://discourse.gohugo.io/t/issue-while-upgrading-the-hugo-and-docsy/45963

**After removing**
It works.

```
% make run/site                                                                                                                                                                                                   (git)-[remove-deprecated-template]
env RELEASE=v0.47.1 hugo server --source=docs
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
WARN  deprecated: config: languages.en.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Watching for changes in /Users/s14218/oss/pipe-cd/pipecd/docs/{assets,content,layouts,package.json,static,themes}
Watching for config changes in /Users/s14218/oss/pipe-cd/pipecd/docs/config.toml, /Users/s14218/oss/pipe-cd/pipecd/docs/themes/docsy/config.toml
Start building sites …
hugo v0.121.1-00b46fed8e47f7bb0a85d7cfc2d9f1356379b740+extended darwin/arm64 BuildDate=2023-12-08T08:47:45Z VendorInfo=brew

WARN  .Path when the page is backed by a file is deprecated. We plan to use Path for a canonical source path and you probably want to check the source is a file. To get the current behaviour, you can use a construct similar to the one below:

  {{ $path := "" }}
  {{ with .File }}
	{{ $path = .Path }}
  {{ else }}
	{{ $path = .Path }}
  {{ end }}

                   | EN
-------------------+------
  Pages            | 906
  Paginator pages  |   1
  Non-page files   |   0
  Static files     | 135
  Processed images |  23
  Aliases          |   1
  Sitemaps         |   1
  Cleaned          |   0

Built in 2207 ms
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
