### PR TITLE
[blog] Fix links

### DIFF
--- a/docs/content/en/blog/control-plane-local-docker-compose.md
+++ b/docs/content/en/blog/control-plane-local-docker-compose.md
@@ -7,7 +7,7 @@ description: "This blog shows you how to install a PipeCD Control Plane on local
 author: Tetsuya Kikuchi ([@t-kikuc](https://github.com/t-kikuc))
 ---
 
-Currently, you can deploy and operate a PipeCD Control Plane on a Kubernetes cluster or [on Amazon ECS](./control-plane-on-ecs.md).
+Currently, you can deploy and operate a PipeCD Control Plane on a Kubernetes cluster or [on Amazon ECS](https://pipecd.dev/blog/2023/02/07/pipecd-best-practice-02-control-plane-on-ecs/).
 However, some developers would like to build a Control Plane more easily for introduction or development.
 This blog shows you how to install a PipeCD Control Plane on local machine easily.
 
@@ -19,8 +19,7 @@ This blog is for those who would like to:
 The general architecture of PipeCD Control Plane is as below.
 ![](/images/control-plane-components.png)
 
-> Note: See [Architecture Overview](docs/user-guide/managing-controlplane/architecture-overview/) doc for details.
-
+> Note: See [Architecture Overview](https://pipecd.dev/docs/user-guide/managing-controlplane/architecture-overview/) doc for details.
 In this blog, you will build a Control Plane by these containers:
 
 - Server: pipecd server

--- a/docs/content/en/blog/control-plane-local-docker-compose.md
+++ b/docs/content/en/blog/control-plane-local-docker-compose.md
@@ -7,7 +7,7 @@ description: "This blog shows you how to install a PipeCD Control Plane on local
 author: Tetsuya Kikuchi ([@t-kikuc](https://github.com/t-kikuc))
 ---
 
-Currently, you can deploy and operate a PipeCD Control Plane on a Kubernetes cluster or [on Amazon ECS](https://pipecd.dev/blog/2023/02/07/pipecd-best-practice-02-control-plane-on-ecs/).
+Currently, you can deploy and operate a PipeCD Control Plane on a Kubernetes cluster or [on Amazon ECS](/blog/2023/02/07/pipecd-best-practice-02-control-plane-on-ecs/).
 However, some developers would like to build a Control Plane more easily for introduction or development.
 This blog shows you how to install a PipeCD Control Plane on local machine easily.
 
@@ -19,7 +19,7 @@ This blog is for those who would like to:
 The general architecture of PipeCD Control Plane is as below.
 ![](/images/control-plane-components.png)
 
-> Note: See [Architecture Overview](https://pipecd.dev/docs/user-guide/managing-controlplane/architecture-overview/) doc for details.
+> Note: See [Architecture Overview](/docs/user-guide/managing-controlplane/architecture-overview/) doc for details.
 In this blog, you will build a Control Plane by these containers:
 
 - Server: pipecd server

--- a/docs/content/en/blog/control-plane-on-ecs.md
+++ b/docs/content/en/blog/control-plane-on-ecs.md
@@ -11,7 +11,7 @@ This blog is a part of PipeCD best practice series, a guideline for you to opera
 Currently, you can deploy and operate the PipeCD control plane on a Kubernetes cluster easily, but some developers that would like to introduce PipeCD can not prepare Kubernetes environments. If you have the same problem, this blog is for you. We will show you how to deploy the PipeCD control plane on Amazon ECS.
 
 ### Architecture
-> Note: Please refer to [architecture-overview](https://pipecd.dev/docs/user-guide/managing-controlplane/architecture-overview/) docs for definitions of PipeCD components such as server, ops, cache, datastore and filestore.
+> Note: Please refer to [architecture-overview](/docs/user-guide/managing-controlplane/architecture-overview/) docs for definitions of PipeCD components such as server, ops, cache, datastore and filestore.
 
 ![](/images/control-plane-on-ecs.png)
 

--- a/docs/content/en/blog/control-plane-on-ecs.md
+++ b/docs/content/en/blog/control-plane-on-ecs.md
@@ -11,7 +11,7 @@ This blog is a part of PipeCD best practice series, a guideline for you to opera
 Currently, you can deploy and operate the PipeCD control plane on a Kubernetes cluster easily, but some developers that would like to introduce PipeCD can not prepare Kubernetes environments. If you have the same problem, this blog is for you. We will show you how to deploy the PipeCD control plane on Amazon ECS.
 
 ### Architecture
-> Note: Please refer to [architecture-overview](docs/user-guide/managing-controlplane/architecture-overview/) docs for definitions of PipeCD components such as server, ops, cache, datastore and filestore.
+> Note: Please refer to [architecture-overview](https://pipecd.dev/docs/user-guide/managing-controlplane/architecture-overview/) docs for definitions of PipeCD components such as server, ops, cache, datastore and filestore.
 
 ![](/images/control-plane-on-ecs.png)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I fixed two kinds of invalid URLs in the blogs.
- `docs/user-guide/managing-controlplane/architecture-overview/`
-> https://pipecd.dev/blog/2024/03/14/control-plane-on-local-by-docker-compose/control-plane-on-ecs.md (Not found)
- `./control-plane-on-ecs.md`
-> https://pipecd.dev/blog/2024/03/14/control-plane-on-local-by-docker-compose/control-plane-on-ecs.md (Not found)


**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A
