### PR TITLE
[doc] Update the feature status of ECS Plan Preview to Alpha

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -84,7 +84,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | Quick sync deployment for [ECS Service Discovery](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html) | Alpha |
 | Deployment with a defined pipeline for [ECS Service Discovery](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html) | Alpha |
 | Support [AWS App Mesh](https://aws.amazon.com/app-mesh/) | Incubating |
-| [Plan preview](../user-guide/plan-preview) | Incubating |
+| [Plan preview](../user-guide/plan-preview) | Alpha |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
 ## Piped Agent


### PR DESCRIPTION
**What this PR does / why we need it**:


Since https://github.com/pipe-cd/pipecd/pull/4881 is merged and it will be released in v0.48.0-rcX, 
we can update the feature status.

