### PR TITLE
Fix to add -n opiton for echo

### DIFF
--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -34,7 +34,7 @@ For the full list of available commands, please see the Makefile at the root of 
       # FIXME: Replace here with your piped ID.
       pipedID: 7accd470-1786-49ee-ac09-3c4d4e31dc12
       # Base64 encoded string of the piped private key. You can generate it by the following command.
-      # echo "your-piped-key" | base64
+      # echo -n "your-piped-key" | base64
       # FIXME: Replace here with your piped key file path.
       pipedKeyData: OTl4c2RqdjUxNTF2OW1sOGw5ampndXUyZjB2aGJ4dGw0bHVkamF4Mmc3a3l1enFqY20K
       # Write in a format like "host:443" because the communication is done via gRPC.


### PR DESCRIPTION
**What this PR does / why we need it**:

Added `-n` option to avoid the unexpected base64 encoded value.
The echo command adds `\n` at the end of the output by default. We can remove it by adding the option `-n`.


```
DESCRIPTION
     The echo utility writes any specified operands, separated by single blank (‘ ') characters and followed by a
     newline ('\n') character, to the standard output.
```

```
     -n    Do not print the trailing newline character.  This may also be achieved by appending ‘\c’ to the end of the
           string, as is done by iBCS2 compatible systems.  Note that this option as well as the effect of ‘\c’ are
           implementation-defined in IEEE Std 1003.1-2001 (“POSIX.1”) as amended by Cor. 1-2002.  Applications aiming
           for maximum portability are strongly encouraged to use printf(1) to suppress the newline character.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
