### PR TITLE
Update promql for deployment count by project on overview controlplane dashboard

### DIFF
--- a/manifests/pipecd/grafana-dashboards/control-plane/overview.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/overview.json
@@ -531,7 +531,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "grpcapi_create_deployment_total{project=~\"$project\"}",
+          "expr": "sum by (project) (grpcapi_create_deployment_total)",
           "interval": "",
           "legendFormat": "{{project}}",
           "refId": "A"


### PR DESCRIPTION
**What this PR does / why we need it**:

Group the deployment counter based on "project" label, previously without `sum by` the project counters are showing separately because of the `instance` label diff of `grpcapi_create_deployment_total` metric.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
