### PR TITLE
Change resource key logic for k8s

### DIFF
--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -159,6 +159,7 @@ func (p *planner) Run(ctx context.Context) error {
 	in := pln.Input{
 		ApplicationID:                  p.deployment.ApplicationId,
 		ApplicationName:                p.deployment.ApplicationName,
+		PlatformProviderName:           p.deployment.PlatformProvider,
 		GitPath:                        *p.deployment.GitPath,
 		Trigger:                        *p.deployment.Trigger,
 		MostRecentSuccessfulCommitHash: p.lastSuccessfulCommitHash,

--- a/pkg/app/piped/executor/kubernetes/baseline.go
+++ b/pkg/app/piped/executor/kubernetes/baseline.go
@@ -55,6 +55,7 @@ func (e *deployExecutor) ensureBaselineRollout(ctx context.Context) model.StageS
 		ds.RepoDir,
 		e.Deployment.GitPath.ConfigFilename,
 		e.appCfg.Input,
+		e.isNamespacedResources,
 		e.GitClient,
 		e.Logger,
 	)

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -24,6 +24,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/pipe-cd/pipecd/pkg/app/piped/executor"
 	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/kubernetes"
@@ -36,8 +39,9 @@ import (
 type deployExecutor struct {
 	executor.Input
 
-	commit string
-	appCfg *config.KubernetesApplicationSpec
+	commit                string
+	appCfg                *config.KubernetesApplicationSpec
+	isNamespacedResources map[schema.GroupVersionKind]bool
 
 	loader        provider.Loader
 	applierGetter applierGetter
@@ -75,6 +79,39 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	ctx := sig.Context()
 	e.commit = e.Deployment.Trigger.Commit.Hash
 
+	// Use discovery to discover APIs supported by the Kubernetes API server.
+	// This should be run periodically with a low rate because the APIs are not added frequently.
+	// https://godoc.org/k8s.io/client-go/discovery
+	cp, ok := e.PipedConfig.FindPlatformProvider(e.Deployment.PlatformProvider, model.ApplicationKind_KUBERNETES)
+	if !ok {
+		e.LogPersister.Errorf("provider %s was not found", e.Deployment.PlatformProvider)
+		return model.StageStatus_STAGE_FAILURE
+	}
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(cp.KubernetesConfig.MasterURL, cp.KubernetesConfig.KubeConfigPath)
+	if err != nil {
+		e.LogPersister.Errorf("failed to build kube config", zap.Error(err))
+		return model.StageStatus_STAGE_FAILURE
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	if err != nil {
+		e.LogPersister.Errorf("failed to create discovery client: %v", zap.Error(err))
+		return model.StageStatus_STAGE_FAILURE
+	}
+	groupResources, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		e.LogPersister.Errorf("failed to fetch preferred resources: %v", zap.Error(err))
+		return model.StageStatus_STAGE_FAILURE
+	}
+	e.LogPersister.Info(fmt.Sprintf("successfully preferred resources that contains for %d groups", len(groupResources)))
+
+	e.isNamespacedResources = make(map[schema.GroupVersionKind]bool)
+	for _, gr := range groupResources {
+		for _, resource := range gr.APIResources {
+			gvk := schema.FromAPIVersionAndKind(gr.GroupVersion, resource.Kind)
+			e.isNamespacedResources[gvk] = resource.Namespaced
+		}
+	}
+
 	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
@@ -110,6 +147,7 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		ds.RepoDir,
 		e.Deployment.GitPath.ConfigFilename,
 		e.appCfg.Input,
+		e.isNamespacedResources,
 		e.GitClient,
 		e.Logger,
 	)

--- a/pkg/app/piped/executor/kubernetes/primary.go
+++ b/pkg/app/piped/executor/kubernetes/primary.go
@@ -170,6 +170,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 		ds.RepoDir,
 		e.Deployment.GitPath.ConfigFilename,
 		e.appCfg.Input,
+		e.isNamespacedResources,
 		e.GitClient,
 		e.Logger,
 	)

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -17,7 +17,6 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -69,7 +68,7 @@ func (e *rollbackExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		e.LogPersister.Errorf("failed to fetch preferred resources: %v", zap.Error(err))
 		return model.StageStatus_STAGE_FAILURE
 	}
-	e.LogPersister.Info(fmt.Sprintf("successfully preferred resources that contains for %d groups", len(groupResources)))
+	e.LogPersister.Infof("successfully preferred resources that contains for %d groups", len(groupResources))
 
 	e.isNamespacedResources = make(map[schema.GroupVersionKind]bool)
 	for _, gr := range groupResources {

--- a/pkg/app/piped/planner/planner.go
+++ b/pkg/app/piped/planner/planner.go
@@ -44,6 +44,7 @@ type gitClient interface {
 type Input struct {
 	ApplicationID                  string
 	ApplicationName                string
+	PlatformProviderName           string
 	GitPath                        model.ApplicationGitPath
 	Trigger                        model.DeploymentTrigger
 	MostRecentSuccessfulCommitHash string

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -335,9 +335,10 @@ func (b *builder) plan(ctx context.Context, app *model.Application, targetDSP de
 	}
 
 	in := planner.Input{
-		ApplicationID:   app.Id,
-		ApplicationName: app.Name,
-		GitPath:         *app.GitPath,
+		ApplicationID:        app.Id,
+		ApplicationName:      app.Name,
+		PlatformProviderName: app.PlatformProvider,
+		GitPath:              *app.GitPath,
 		Trigger: model.DeploymentTrigger{
 			Commit: &model.Commit{
 				Branch: b.repoCfg.Branch,

--- a/pkg/app/piped/planpreview/kubernetesdiff.go
+++ b/pkg/app/piped/planpreview/kubernetesdiff.go
@@ -53,17 +53,17 @@ func (b *builder) kubernetesDiff(
 	}
 	kubeConfig, err := clientcmd.BuildConfigFromFlags(cp.KubernetesConfig.MasterURL, cp.KubernetesConfig.KubeConfigPath)
 	if err != nil {
-		err = fmt.Errorf("failed to build kube config", zap.Error(err))
+		err = fmt.Errorf("failed to build kube config: %w", err)
 		return nil, err
 	}
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
 	if err != nil {
-		err = fmt.Errorf("failed to create discovery client: %v", zap.Error(err))
+		err = fmt.Errorf("failed to create discovery client: %w", err)
 		return nil, err
 	}
 	groupResources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
-		err = fmt.Errorf("failed to fetch preferred resources: %v", zap.Error(err))
+		err = fmt.Errorf("failed to fetch preferred resources: %w", err)
 		return nil, err
 	}
 

--- a/pkg/app/piped/platformprovider/kubernetes/applier.go
+++ b/pkg/app/piped/platformprovider/kubernetes/applier.go
@@ -158,7 +158,7 @@ func (a *applier) Delete(ctx context.Context, k ResourceKey) (err error) {
 		return err
 	}
 
-	if k.String() != m.GetAnnotations()[LabelResourceKey] {
+	if k.String() != m.Key.String() {
 		return ErrNotFound
 	}
 

--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -16,6 +16,11 @@ package kubernetes
 
 import (
 	"errors"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -42,3 +47,31 @@ const (
 
 	kustomizationFileName = "kustomization.yaml"
 )
+
+// GetIsNamespacedResources return the map to determine whether the given GroupVersionKind is namespaced or not.
+// The key is GroupVersionKind and the value is a boolean value.
+// This function will get the information from the Kubernetes cluster using the given PlatformProviderKubernetesConfig.
+func GetIsNamespacedResources(cp *config.PlatformProviderKubernetesConfig) (map[schema.GroupVersionKind]bool, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(cp.MasterURL, cp.KubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	groupResources, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+
+	isNamespacedResources := make(map[schema.GroupVersionKind]bool)
+	for _, gr := range groupResources {
+		for _, resource := range gr.APIResources {
+			gvk := schema.FromAPIVersionAndKind(gr.GroupVersion, resource.Kind)
+			isNamespacedResources[gvk] = resource.Namespaced
+		}
+	}
+
+	return isNamespacedResources, nil
+}

--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -17,10 +17,11 @@ package kubernetes
 import (
 	"errors"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
 )
 
 var (

--- a/pkg/app/piped/platformprovider/kubernetes/loader.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader.go
@@ -171,7 +171,7 @@ func (l *loader) LoadManifests(ctx context.Context) (manifests []Manifest, err e
 	// because the namespace is determined not only by its own namespace on the file but also the namespace on the app.pipecd.yaml.
 	for i := range manifests {
 		m := manifests[i]
-		err := l.refineNamespace(&m)
+		err := l.determineNamespace(&m)
 		if err != nil {
 			return nil, err
 		}
@@ -180,14 +180,14 @@ func (l *loader) LoadManifests(ctx context.Context) (manifests []Manifest, err e
 	return
 }
 
-// refineNamespace fix the namespace of the given manifest.
+// determineNamespace fix the namespace of the given manifest.
 // The priority is as follows:
 // If the resource is cluster-scoped, it returns an empty string.
 // Otherwise, it is the namespace-scoped resource and the namespace is determined by the following order:
 // 1. The namespace set in the application configuration.
 // 2. The namespace set in the manifest.
 // 3. The default namespace.
-func (l *loader) refineNamespace(m *Manifest) error {
+func (l *loader) determineNamespace(m *Manifest) error {
 	namespaced, ok := l.isNamespacedResources[m.u.GroupVersionKind()]
 	if !ok {
 		return fmt.Errorf("unknown resource kind %s", m.u.GroupVersionKind().String())

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -206,10 +206,11 @@ func Test_loader_refineNamespace(t *testing.T) {
 				isNamespacedResources: tc.isNamespacedResources,
 				input:                 tc.cfgK8sInput,
 			}
-			got, err := l.refineNamespace(tc.manifest)
+			err := l.refineNamespace(&tc.manifest)
 
 			assert.Equal(t, tc.wantErr, err != nil)
-			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.want, tc.manifest.Key.Namespace)
+			assert.Equal(t, tc.want, tc.manifest.u.GetNamespace())
 		})
 	}
 }

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -17,10 +17,11 @@ package kubernetes
 import (
 	"testing"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/pipe-cd/pipecd/pkg/config"
 )
 
 func TestSortManifests(t *testing.T) {

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -17,8 +17,10 @@ package kubernetes
 import (
 	"testing"
 
+	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestSortManifests(t *testing.T) {
@@ -73,6 +75,141 @@ func TestSortManifests(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sortManifests(tc.manifests)
 			assert.Equal(t, tc.want, tc.manifests)
+		})
+	}
+}
+
+func Test_loader_refineNamespace(t *testing.T) {
+	testcases := []struct {
+		name                  string
+		manifest              Manifest
+		isNamespacedResources map[schema.GroupVersionKind]bool
+		cfgK8sInput           config.KubernetesDeploymentInput
+		want                  string
+		wantErr               bool
+	}{
+		{
+			name: "failed because unknown resource kind",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "unknown",
+						"kind":       "Unknown",
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{},
+			want:                  "",
+			wantErr:               true,
+		},
+		{
+			name: "cluster-scoped resource: use '' as namespace",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Namespace",
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{
+				{Group: "", Version: "v1", Kind: "Namespace"}: false,
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "cluster-scoped resource: use '' even though the app.pipecd.yaml has 'spec.input.namespace'",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Namespace",
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{
+				{Group: "", Version: "v1", Kind: "Namespace"}: false,
+			},
+			cfgK8sInput: config.KubernetesDeploymentInput{
+				Namespace: "test",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "namespace-scoped resource: use the namespace set in the app.pipecd.yaml if it is not empty and the manifest has no namespace",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata":   map[string]interface{}{},
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{
+				{Group: "", Version: "v1", Kind: "Pod"}: true,
+			},
+			cfgK8sInput: config.KubernetesDeploymentInput{
+				Namespace: "inputNamespace",
+			},
+			want:    "inputNamespace",
+			wantErr: false,
+		},
+		{
+			name: "namespace-scoped resource: use the namespace set in the app.pipecd.yaml even though the manifest has a namespace",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{
+				{Group: "", Version: "v1", Kind: "Pod"}: true,
+			},
+			cfgK8sInput: config.KubernetesDeploymentInput{
+				Namespace: "inputNamespace",
+			},
+			want:    "inputNamespace",
+			wantErr: false,
+		},
+		{
+			name: "namespace-scoped resource: use 'default' namespace when input namespace is empty and the namespace in the app.pipecd.yaml is empty",
+			manifest: Manifest{
+				u: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata":   map[string]interface{}{},
+					},
+				},
+			},
+			isNamespacedResources: map[schema.GroupVersionKind]bool{
+				{Group: "", Version: "v1", Kind: "Pod"}: true,
+			},
+			cfgK8sInput: config.KubernetesDeploymentInput{},
+			want:        "default",
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			l := &loader{
+				isNamespacedResources: tc.isNamespacedResources,
+				input:                 tc.cfgK8sInput,
+			}
+			got, err := l.refineNamespace(tc.manifest)
+
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -79,7 +79,7 @@ func TestSortManifests(t *testing.T) {
 	}
 }
 
-func Test_loader_refineNamespace(t *testing.T) {
+func Test_loader_determineNamespace(t *testing.T) {
 	testcases := []struct {
 		name                  string
 		manifest              Manifest
@@ -206,7 +206,7 @@ func Test_loader_refineNamespace(t *testing.T) {
 				isNamespacedResources: tc.isNamespacedResources,
 				input:                 tc.cfgK8sInput,
 			}
-			err := l.refineNamespace(&tc.manifest)
+			err := l.determineNamespace(&tc.manifest)
 
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, tc.manifest.Key.Namespace)

--- a/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/manifest_test.go
@@ -24,12 +24,13 @@ import (
 
 func TestParseManifests(t *testing.T) {
 	maker := func(name, kind string, metadata map[string]interface{}) Manifest {
+		namespace, _ := metadata["namespace"].(string)
 		return Manifest{
 			Key: ResourceKey{
 				APIVersion: "v1",
 				Kind:       kind,
 				Name:       name,
-				Namespace:  "default",
+				Namespace:  namespace,
 			},
 			u: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -72,11 +73,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: envoy-config
+  namespace: default
   creationTimestamp: "2022-12-09T01:23:45Z"
 `,
 			want: []Manifest{
 				maker("envoy-config", "ConfigMap", map[string]interface{}{
 					"name":              "envoy-config",
+					"namespace":         "default",
 					"creationTimestamp": "2022-12-09T01:23:45Z",
 				}),
 			},
@@ -88,13 +91,15 @@ apiVersion: v1
 kind: Kind1
 metadata:
   name: config
+  namespace: default
   extra: |
     single-new-line
 `,
 			want: []Manifest{
 				maker("config", "Kind1", map[string]interface{}{
-					"name":  "config",
-					"extra": "single-new-line\n",
+					"name":      "config",
+					"namespace": "default",
+					"extra":     "single-new-line\n",
 				}),
 			},
 		},
@@ -105,12 +110,14 @@ apiVersion: v1
 kind: Kind1
 metadata:
   name: config
+  namespace: default
   extra: |
     no-new-line`,
 			want: []Manifest{
 				maker("config", "Kind1", map[string]interface{}{
-					"name":  "config",
-					"extra": "no-new-line",
+					"name":      "config",
+					"namespace": "default",
+					"extra":     "no-new-line",
 				}),
 			},
 		},
@@ -121,6 +128,7 @@ apiVersion: v1
 kind: Kind1
 metadata:
   name: config1
+  namespace: default
   extra: |-
     no-new-line
 ---
@@ -128,6 +136,7 @@ apiVersion: v1
 kind: Kind2
 metadata:
   name: config2
+  namespace: default
   extra: |
     single-new-line-1
 ---
@@ -135,6 +144,7 @@ apiVersion: v1
 kind: Kind3
 metadata:
   name: config3
+  namespace: default
   extra: |
     single-new-line-2
 
@@ -144,6 +154,7 @@ apiVersion: v1
 kind: Kind4
 metadata:
   name: config4
+  namespace: default
   extra: |+
     multiple-new-line-1
 
@@ -153,6 +164,7 @@ apiVersion: v1
 kind: Kind5
 metadata:
   name: config5
+  namespace: default
   extra: |+
     multiple-new-line-2
 
@@ -160,24 +172,29 @@ metadata:
 `,
 			want: []Manifest{
 				maker("config1", "Kind1", map[string]interface{}{
-					"name":  "config1",
-					"extra": "no-new-line",
+					"name":      "config1",
+					"namespace": "default",
+					"extra":     "no-new-line",
 				}),
 				maker("config2", "Kind2", map[string]interface{}{
-					"name":  "config2",
-					"extra": "single-new-line-1\n",
+					"name":      "config2",
+					"namespace": "default",
+					"extra":     "single-new-line-1\n",
 				}),
 				maker("config3", "Kind3", map[string]interface{}{
-					"name":  "config3",
-					"extra": "single-new-line-2\n",
+					"name":      "config3",
+					"namespace": "default",
+					"extra":     "single-new-line-2\n",
 				}),
 				maker("config4", "Kind4", map[string]interface{}{
-					"name":  "config4",
-					"extra": "multiple-new-line-1\n\n\n",
+					"name":      "config4",
+					"namespace": "default",
+					"extra":     "multiple-new-line-1\n\n\n",
 				}),
 				maker("config5", "Kind5", map[string]interface{}{
-					"name":  "config5",
-					"extra": "multiple-new-line-2\n\n\n",
+					"name":      "config5",
+					"namespace": "default",
+					"extra":     "multiple-new-line-2\n\n\n",
 				}),
 			},
 		},

--- a/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
+++ b/pkg/app/piped/platformprovider/kubernetes/resourcekey.go
@@ -253,9 +253,6 @@ func MakeResourceKey(obj *unstructured.Unstructured) ResourceKey {
 		Namespace:  obj.GetNamespace(),
 		Name:       obj.GetName(),
 	}
-	if k.Namespace == "" {
-		k.Namespace = DefaultNamespace
-	}
 	return k
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fix will solve the problem that the cluster-scoped resource can't be deleted when we set the namespace in app.pipecd.yaml.
context: https://github.com/pipe-cd/pipecd/issues/4269#issuecomment-2104055928

**expected behavior**
- We can delete the cluster-scoped resource.

**livestate side**
- use "" for the cluster-scoped resource
- use the namespace for the namespace scoped resource

**When reading the manifests from git** 
- use "" for the cluster-scoped resource
-  for the namespace scoped resource,
   - use `spec.input.namespace` in app.pipecd.yaml if it is set.
   - use the namespace on the manifest from git if it is set.
   - use `default` if  both of `spec.input.namespace` and the namespace are not set

---

Currently, we use the resource key to identify each k8s resource.
It is created by `MakeResourceKey`, and the rule is below.

**livestate side**
- use `default` when the resource obj doesn't have the namespace.
- use the namespace when the resource obj has the namespace.

**When reading the manifests from git** 
- use `spec.input.namespace` in app.pipecd.yaml if it is set.
- use the namespace on the manifest from git if it is set.
- use `default` when the namespace on the manifest is "".

This rule doesn't consider the cluster-scoped resource.
So for example, cluster-scoped resource don't have any namespace, but if we set the `spec.input.namespace` in the app.pipecd.yaml, it sets the value as the namespace to the resource key.

This causes the problem that can't prune the resource because the resource key can't identify the resource correctly.
So I fixed the the logic like below.

**livestate side**
- use "" for the cluster-scoped resource
- use the namespace for the namespace scoped resource

**When reading the manifests from git** 
- use "" for the cluster-scoped resource
-  for the namespace scoped resource,
   - use `spec.input.namespace` in app.pipecd.yaml if it is set.
   - use the namespace on the manifest from git if it is set.
   - use `default` if  both of `spec.input.namespace` and the namespace are not set

**Which issue(s) this PR fixes**:

Part of #4269

- **Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
