### PR TITLE
Update go version to 1.22.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
   NODE_VERSION: 16.13.0
   HELM_VERSION: 3.8.2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
   NODE_VERSION: 16.13.0
   HELM_VERSION: 3.8.2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
   NODE_VERSION: 16.13.0
   GOLANGCI_LINT_VERSION: v1.46.2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
   NODE_VERSION: 16.13.0
   GOLANGCI_LINT_VERSION: v1.46.2
 

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
 
 jobs:
   gh_release:

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
 
 jobs:
   gh_release:

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -11,7 +11,7 @@ env:
   GHCR: ghcr.io
   GCR: gcr.io
   HELM_VERSION: 3.8.2
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -11,7 +11,7 @@ env:
   GHCR: ghcr.io
   GCR: gcr.io
   HELM_VERSION: 3.8.2
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -13,7 +13,7 @@ on:
       - tool/**
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.22.3
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -13,7 +13,7 @@ on:
       - tool/**
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
   NODE_VERSION: 16.13.0
 
 jobs:

--- a/cmd/pipecd/README.md
+++ b/cmd/pipecd/README.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-- [Go 1.19 or later](https://go.dev/)
+- [Go 1.22 or later](https://go.dev/)
 - [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)
 - [helm 3.8](https://helm.sh/docs/intro/install/) (If you want to run Control Plane locally)

--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-- [Go 1.19 or later](https://go.dev/)
+- [Go 1.22 or later](https://go.dev/)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine3.10 AS builder
+FROM golang:1.22.3-alpine3.19 AS builder
 COPY main.go .
 RUN go build -o /server main.go
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.19 AS builder
+FROM golang:1.22.4-alpine3.20 AS builder
 COPY main.go .
 RUN go build -o /server main.go
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/pipe-cd/pipecd
 
-go 1.22
-
-toolchain go1.22.3
+go 1.22.4
 
 require (
 	cloud.google.com/go/firestore v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/pipe-cd/pipecd
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require (
 	cloud.google.com/go/firestore v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -488,6 +489,7 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 h1:hRGSmZu7j271trc9sneMrpOW7GN5ngLm8YUZIPzf394=
+github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1127,6 +1129,7 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.2.0 h1:I0DwBVMGAx26dttAj1BtJLAkVGncrkkUXfJLC4Flt/I=
+gotest.tools/v3 v3.2.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tool/actions-gh-release/Dockerfile
+++ b/tool/actions-gh-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine3.18
+FROM golang:1.22.3-alpine3.19
 
 RUN apk update && apk add git
 

--- a/tool/actions-gh-release/Dockerfile
+++ b/tool/actions-gh-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.19
+FROM golang:1.22.4-alpine3.20
 
 RUN apk update && apk add git
 

--- a/tool/actions-gh-release/go.mod
+++ b/tool/actions-gh-release/go.mod
@@ -1,8 +1,6 @@
 module github.com/pipe-cd/actions-gh-release
 
-go 1.22
-
-toolchain go1.22.3
+go 1.22.4
 
 require (
 	github.com/creasty/defaults v1.5.2

--- a/tool/actions-gh-release/go.mod
+++ b/tool/actions-gh-release/go.mod
@@ -1,6 +1,8 @@
 module github.com/pipe-cd/actions-gh-release
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require (
 	github.com/creasty/defaults v1.5.2

--- a/tool/actions-gh-release/go.sum
+++ b/tool/actions-gh-release/go.sum
@@ -12,6 +12,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/tool/actions-plan-preview/Dockerfile
+++ b/tool/actions-plan-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.19 as builder
+FROM golang:1.22.4-alpine3.20 as builder
 WORKDIR /app
 COPY go.mod go.sum  ./
 RUN go mod download

--- a/tool/actions-plan-preview/Dockerfile
+++ b/tool/actions-plan-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine3.18 as builder
+FROM golang:1.22.3-alpine3.19 as builder
 WORKDIR /app
 COPY go.mod go.sum  ./
 RUN go mod download

--- a/tool/actions-plan-preview/go.mod
+++ b/tool/actions-plan-preview/go.mod
@@ -1,8 +1,6 @@
 module github.com/pipe-cd/actions-plan-preview
 
-go 1.22
-
-toolchain go1.22.3
+go 1.22.4
 
 require (
 	github.com/google/go-github/v36 v36.0.0

--- a/tool/actions-plan-preview/go.mod
+++ b/tool/actions-plan-preview/go.mod
@@ -1,6 +1,8 @@
 module github.com/pipe-cd/actions-plan-preview
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require (
 	github.com/google/go-github/v36 v36.0.0

--- a/tool/actions-plan-preview/go.sum
+++ b/tool/actions-plan-preview/go.sum
@@ -8,6 +8,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v36 v36.0.0 h1:ndCzM616/oijwufI7nBRa+5eZHLldT+4yIB68ib5ogs=
 github.com/google/go-github/v36 v36.0.0/go.mod h1:LFlKC047IOqiglRGNqNb9s/iAPTnnjtlshm+bxp+kwk=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/tool/codegen/protoc-gen-auth/go.mod
+++ b/tool/codegen/protoc-gen-auth/go.mod
@@ -1,7 +1,5 @@
 module github.com/pipe-cd/pipecd/tool/codegen/protoc-gen-auth
 
-go 1.22
-
-toolchain go1.22.3
+go 1.22.4
 
 require google.golang.org/protobuf v1.33.0

--- a/tool/codegen/protoc-gen-auth/go.mod
+++ b/tool/codegen/protoc-gen-auth/go.mod
@@ -1,5 +1,7 @@
 module github.com/pipe-cd/pipecd/tool/codegen/protoc-gen-auth
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require google.golang.org/protobuf v1.33.0

--- a/tool/codegen/protoc-gen-auth/go.sum
+++ b/tool/codegen/protoc-gen-auth/go.sum
@@ -1,4 +1,6 @@
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=


### PR DESCRIPTION
**What this PR does / why we need it**:

Update go version to 1.22.4

TODO:
- [x] Update the base image of Dockerfiles and go.mod in `tools/` 
    - [x]  actions-gh-release
    - [x]  actions-plan-preview
    - [x]  codegen
- [x]  Update the base image of Dockerfiles in `docs/`
- [x]  Update go version in docs document.
- [x]  Update env.GO_VERSION in github actions workflow definitions.
    - [x]  test.yaml
    - [x]  publish_image_chart.yaml
    - [x]  publish_binary.yaml
    - [x]  lint.yaml
    - [x]  test_tool.yaml
    - [x]  build.yaml
- [x]  Update go.mod in the root of the repo.

**Which issue(s) this PR fixes**:

Fixes #4874

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
