### PR TITLE
Fix bug possible to override project rbac built-in roles

### DIFF
--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -476,14 +476,14 @@ func (p *Project) AddRBACRole(name string, policies []*ProjectRBACPolicy) error 
 // UpdateRBACRole updates a custom RBAC role.
 // Built-in role cannot be updated.
 func (p *Project) UpdateRBACRole(name string, policies []*ProjectRBACPolicy) error {
+	if isBuiltinRBACRole(name) {
+		return fmt.Errorf("built-in role cannot be updated")
+	}
 	for _, v := range p.RbacRoles {
 		if v.Name == name {
 			v.Policies = policies
 			return nil
 		}
-	}
-	if isBuiltinRBACRole(name) {
-		return fmt.Errorf("built-in role cannot be updated")
 	}
 	return fmt.Errorf("%s role does not exist", name)
 }

--- a/pkg/model/project_test.go
+++ b/pkg/model/project_test.go
@@ -779,7 +779,9 @@ func TestProject_UpdateRBACRole(t *testing.T) {
 					},
 				},
 			},
-			project: &Project{},
+			project: &Project{
+				RbacRoles: []*ProjectRBACRole{builtinAdminRBACRole},
+			},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

As a spec, we don't allow users to update the project built-in RBAC roles. This PR changes the UpdateRBACRoles logic to ensure that.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
