### PR TITLE
Update the contributors list automatically by GitHub Actions

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -1,0 +1,25 @@
+name: update-contributors
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 3 * * 5" # 03:00(UTC) on Every Friday 
+
+jobs:
+  updateContributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - run: |
+          make gen/contributions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # `gh` command requires this token.
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[docs][bot] Update contributors"
+          commit-message: "[docs][bot] Update contributors"
+          branch: "create-pull-request/update-contributors"
+          delete-branch: true
+          signoff: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -3,7 +3,7 @@ name: update-contributors
 on:
   workflow_dispatch:
   schedule:
-    - cron: "00 3 * * 5" # 03:00(UTC) on Every Friday 
+    - cron: "00 3 * * 5" # 03:00(UTC) every Friday 
 
 jobs:
   updateContributors:

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          title: "[docs][bot] Update contributors"
-          commit-message: "[docs][bot] Update contributors"
+          title: "[bot] Update contributors"
+          commit-message: "[bot] Update contributors"
           branch: "create-pull-request/update-contributors"
           delete-branch: true
           signoff: true


### PR DESCRIPTION
**What this PR does / why we need it**:


Every Friday, a PR updating the contributors is automatically created at 03:00(UTC) (=12:00(JST)).
It uses `make gen/contributions`.

**Which issue(s) this PR fixes**:

Fixes #4929

**Does this PR introduce a user-facing change?**: N/A

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A


**How it works**

I tested it in my forked repository. A PR like following is created.

- PR

    ![スクリーンショット 2024-05-30 15 17 59](https://github.com/pipe-cd/pipecd/assets/97105818/95c5fd51-895b-4052-a6b2-d08259cb4c44)

- Commit

    ![スクリーンショット 2024-05-30 15 18 07](https://github.com/pipe-cd/pipecd/assets/97105818/9d5e19ef-bb12-4c73-9056-55c2a3cb13ba)

- Diff

    ![スクリーンショット 2024-05-30 15 18 17](https://github.com/pipe-cd/pipecd/assets/97105818/c6e6d494-a433-4c22-b8c2-2b5d0e8de5f7)


