### PR TITLE
Define in-test function at the head of test

### DIFF
--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -188,6 +188,21 @@ func TestCommitChanges(t *testing.T) {
 }
 
 func Test_setGCAutoDetach(t *testing.T) {
+	getGCAutoDetach := func(ctx context.Context, repo *repo) (bool, error) {
+		cmd := exec.CommandContext(ctx, repo.gitPath, "config", "--get", "gc.autoDetach")
+		cmd.Dir = repo.dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return false, err
+		}
+		v, err := strconv.ParseBool(strings.TrimSuffix(string(out), "\n"))
+		if err != nil {
+			return false, err
+		}
+
+		return v, nil
+	}
+
 	faker, err := newFaker()
 	require.NoError(t, err)
 	defer faker.clean()
@@ -200,24 +215,10 @@ func Test_setGCAutoDetach(t *testing.T) {
 
 	err = faker.makeRepo(org, repoName)
 	require.NoError(t, err)
+
 	r := &repo{
 		dir:     faker.repoDir(org, repoName),
 		gitPath: faker.gitPath,
-	}
-
-	getGCAutoDetach := func(ctx context.Context, repo *repo) (bool, error) {
-		cmd := exec.CommandContext(ctx, repo.gitPath, "config", "--get", "gc.autoDetach")
-		cmd.Dir = r.dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return false, err
-		}
-		v, err := strconv.ParseBool(strings.TrimSuffix(string(out), "\n"))
-		if err != nil {
-			return false, err
-		}
-
-		return v, nil
 	}
 
 	// set  as true firstly, and then set as false.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves the definition of the in-test function to the top of the test.
This makes the in-test function unable to capture variables other than `*testing.T`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
