### PR TITLE
Add link to Tutorial on the header bar

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -101,7 +101,7 @@ github_subdir = "docs"
 # gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 offlineSearch = true
 
-# First one is picked as the Twitter card image if not set on page.
+ # First one is picked as the Twitter card image if not set on page.
 images = ["images/ogp-logo.png"]
 
 # User interface configuration

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -76,6 +76,11 @@ style = "tango"
 
 # Everything below this are Site Params
 
+[[menu.main]]
+name = "Tutorial"
+url = "https://github.com/pipe-cd/tutorial"
+weight = 25
+
 [params]
 copyright = "The PipeCD Authors"
 
@@ -95,7 +100,7 @@ github_subdir = "docs"
 # gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 offlineSearch = true
 
- # First one is picked as the Twitter card image if not set on page.
+# First one is picked as the Twitter card image if not set on page.
 images = ["images/ogp-logo.png"]
 
 # User interface configuration
@@ -124,75 +129,75 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-	name ="Twitter"
-	url = "https://twitter.com/pipecd_dev"
-	icon = "fab fa-twitter"
-        desc = "Follow us on Twitter to get the latest news!"
+name ="Twitter"
+url = "https://twitter.com/pipecd_dev"
+icon = "fab fa-twitter"
+desc = "Follow us on Twitter to get the latest news!"
 [[params.links.user]]
-	name = "Stack Overflow"
-	url = "https://stackoverflow.com/questions/tagged/pipecd"
-	icon = "fab fa-stack-overflow"
-        desc = "Practical questions and curated answers"
+name = "Stack Overflow"
+url = "https://stackoverflow.com/questions/tagged/pipecd"
+icon = "fab fa-stack-overflow"
+desc = "Practical questions and curated answers"
 [[params.links.user]]
-	name = "User mailing list"
-	url = "mailto:pipecd.dev@gmail.com"
-	icon = "fa fa-envelope"
-        desc = "Discussion and help from your fellow users"
+name = "User mailing list"
+url = "mailto:pipecd.dev@gmail.com"
+icon = "fa fa-envelope"
+desc = "Discussion and help from your fellow users"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
-	name = "GitHub"
-	url = "https://github.com/pipe-cd"
-	icon = "fab fa-github"
-        desc = "Development takes place here!"
+name = "GitHub"
+url = "https://github.com/pipe-cd"
+icon = "fab fa-github"
+desc = "Development takes place here!"
 [[params.links.developer]]
-	name = "Slack"
-	url = "https://slack.cncf.io"
-	icon = "fab fa-slack"
-        desc = "Chat with other project developers"
+name = "Slack"
+url = "https://slack.cncf.io"
+icon = "fab fa-slack"
+desc = "Chat with other project developers"
 [[params.links.developer]]
-	name = "Developer mailing list"
-	url = "mailto:pipecd.dev@gmail.com"
-	icon = "fa fa-envelope"
-        desc = "Discuss development issues around the project"
+name = "Developer mailing list"
+url = "mailto:pipecd.dev@gmail.com"
+icon = "fa fa-envelope"
+desc = "Discuss development issues around the project"
 
 # Append the release versions here.
 [[params.versions]]
-  version = "dev"
-  githubbranch = "master"
-  url = "/docs-dev/"
+version = "dev"
+githubbranch = "master"
+url = "/docs-dev/"
 
 [[params.versions]]
-  version = "v0.47.x"
-  url = "/docs-v0.47.x/"
+version = "v0.47.x"
+url = "/docs-v0.47.x/"
 
 [[params.versions]]
-  version = "v0.46.x"
-  url = "/docs-v0.46.x/"
+version = "v0.46.x"
+url = "/docs-v0.46.x/"
 
 [[params.versions]]
-  version = "v0.45.x"
-  url = "/docs-v0.45.x/"
+version = "v0.45.x"
+url = "/docs-v0.45.x/"
 
 [[params.versions]]
-  version = "v0.44.x"
-  url = "/docs-v0.44.x/"
+version = "v0.44.x"
+url = "/docs-v0.44.x/"
 
 [[params.versions]]
-  version = "v0.43.x"
-  url = "/docs-v0.43.x/"
+version = "v0.43.x"
+url = "/docs-v0.43.x/"
 
 [[params.versions]]
-  version = "v0.42.x"
-  url = "/docs-v0.42.x/"
+version = "v0.42.x"
+url = "/docs-v0.42.x/"
 
 [[params.versions]]
-  version = "v0.41.x"
-  url = "/docs-v0.41.x/"
+version = "v0.41.x"
+url = "/docs-v0.41.x/"
 
 [[params.versions]]
-  version = "v0.40.x"
-  url = "/docs-v0.40.x/"
+version = "v0.40.x"
+url = "/docs-v0.40.x/"
 
 [[params.versions]]
-  version = "v0.39.x"
-  url = "/docs-v0.39.x/"
+version = "v0.39.x"
+url = "/docs-v0.39.x/"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -77,6 +77,7 @@ style = "tango"
 # Everything below this are Site Params
 
 [[menu.main]]
+# This section add 'Tutorial' to the header navigation bar.
 name = "Tutorial"
 url = "https://github.com/pipe-cd/tutorial"
 weight = 25
@@ -129,75 +130,75 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-name ="Twitter"
-url = "https://twitter.com/pipecd_dev"
-icon = "fab fa-twitter"
-desc = "Follow us on Twitter to get the latest news!"
+	name ="Twitter"
+	url = "https://twitter.com/pipecd_dev"
+	icon = "fab fa-twitter"
+        desc = "Follow us on Twitter to get the latest news!"
 [[params.links.user]]
-name = "Stack Overflow"
-url = "https://stackoverflow.com/questions/tagged/pipecd"
-icon = "fab fa-stack-overflow"
-desc = "Practical questions and curated answers"
+	name = "Stack Overflow"
+	url = "https://stackoverflow.com/questions/tagged/pipecd"
+	icon = "fab fa-stack-overflow"
+        desc = "Practical questions and curated answers"
 [[params.links.user]]
-name = "User mailing list"
-url = "mailto:pipecd.dev@gmail.com"
-icon = "fa fa-envelope"
-desc = "Discussion and help from your fellow users"
+	name = "User mailing list"
+	url = "mailto:pipecd.dev@gmail.com"
+	icon = "fa fa-envelope"
+        desc = "Discussion and help from your fellow users"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
-name = "GitHub"
-url = "https://github.com/pipe-cd"
-icon = "fab fa-github"
-desc = "Development takes place here!"
+	name = "GitHub"
+	url = "https://github.com/pipe-cd"
+	icon = "fab fa-github"
+        desc = "Development takes place here!"
 [[params.links.developer]]
-name = "Slack"
-url = "https://slack.cncf.io"
-icon = "fab fa-slack"
-desc = "Chat with other project developers"
+	name = "Slack"
+	url = "https://slack.cncf.io"
+	icon = "fab fa-slack"
+        desc = "Chat with other project developers"
 [[params.links.developer]]
-name = "Developer mailing list"
-url = "mailto:pipecd.dev@gmail.com"
-icon = "fa fa-envelope"
-desc = "Discuss development issues around the project"
+	name = "Developer mailing list"
+	url = "mailto:pipecd.dev@gmail.com"
+	icon = "fa fa-envelope"
+        desc = "Discuss development issues around the project"
 
 # Append the release versions here.
 [[params.versions]]
-version = "dev"
-githubbranch = "master"
-url = "/docs-dev/"
+  version = "dev"
+  githubbranch = "master"
+  url = "/docs-dev/"
 
 [[params.versions]]
-version = "v0.47.x"
-url = "/docs-v0.47.x/"
+  version = "v0.47.x"
+  url = "/docs-v0.47.x/"
 
 [[params.versions]]
-version = "v0.46.x"
-url = "/docs-v0.46.x/"
+  version = "v0.46.x"
+  url = "/docs-v0.46.x/"
 
 [[params.versions]]
-version = "v0.45.x"
-url = "/docs-v0.45.x/"
+  version = "v0.45.x"
+  url = "/docs-v0.45.x/"
 
 [[params.versions]]
-version = "v0.44.x"
-url = "/docs-v0.44.x/"
+  version = "v0.44.x"
+  url = "/docs-v0.44.x/"
 
 [[params.versions]]
-version = "v0.43.x"
-url = "/docs-v0.43.x/"
+  version = "v0.43.x"
+  url = "/docs-v0.43.x/"
 
 [[params.versions]]
-version = "v0.42.x"
-url = "/docs-v0.42.x/"
+  version = "v0.42.x"
+  url = "/docs-v0.42.x/"
 
 [[params.versions]]
-version = "v0.41.x"
-url = "/docs-v0.41.x/"
+  version = "v0.41.x"
+  url = "/docs-v0.41.x/"
 
 [[params.versions]]
-version = "v0.40.x"
-url = "/docs-v0.40.x/"
+  version = "v0.40.x"
+  url = "/docs-v0.40.x/"
 
 [[params.versions]]
-version = "v0.39.x"
-url = "/docs-v0.39.x/"
+  version = "v0.39.x"
+  url = "/docs-v0.39.x/"

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -18,8 +18,8 @@ linkTitle = "PipeCD"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" target="_blank" href="https://play.pipecd.dev?project=play">
 		Live Demo <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://pipecd.dev/docs/quickstart/">
-		Quick Start <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/pipe-cd/tutorial">
+		Tutorial <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" target="_blank" href="https://github.com/pipe-cd/pipecd">
 		GitHub <i class="fab fa-github ml-2 "></i>

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -18,8 +18,8 @@ linkTitle = "PipeCD"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" target="_blank" href="https://play.pipecd.dev?project=play">
 		Live Demo <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/pipe-cd/tutorial">
-		Tutorial <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://pipecd.dev/docs/quickstart/">
+		Quick Start <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" target="_blank" href="https://github.com/pipe-cd/pipecd">
 		GitHub <i class="fab fa-github ml-2 "></i>


### PR DESCRIPTION
**What this PR does / why we need it**:

I replaced the link to Tutorial as we published [the tutorial](https://github.com/pipe-cd/tutorial).

The tutorial would be the best entrance for those who got interested in PipeCD.

**Does this PR introduce a user-facing change?**: N/A

**Image**

current:
<img width="1009" alt="image" src="https://github.com/pipe-cd/pipecd/assets/97105818/b90f0750-f328-4112-9728-7e95377c054c">


after this commit: 
<img width="1066" alt="image" src="https://github.com/pipe-cd/pipecd/assets/97105818/135d1df8-6914-4596-9e4f-a579c7c9953e">
