### PR TITLE
Fix gen-contributions.sh: Not to remove FOSSA Status

### DIFF
--- a/hack/gen-contributions.sh
+++ b/hack/gen-contributions.sh
@@ -36,6 +36,10 @@ cat << EOF >> README.md.tmp
 <img src="https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" width=300 />
 
 The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/).
+
+
+## License
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fpipe-cd%2Fpipecd.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fpipe-cd%2Fpipecd?ref=badge_large)
 EOF
 
 mv README.md.tmp README.md


### PR DESCRIPTION
**What this PR does / why we need it**:

To keep 'FOSSA Status' even after `make gen/contributions` because it needs update due to 
https://github.com/pipe-cd/pipecd/commit/8326ad0668608f041af5a3a1f1757c68aba17056

**Does this PR introduce a user-facing change?**: N/A
