### PR TITLE
Update applications info stored in the filestore when deleting apps

### DIFF
--- a/pkg/app/ops/insightcollector/application_collector.go
+++ b/pkg/app/ops/insightcollector/application_collector.go
@@ -64,6 +64,7 @@ func (c *applicationDataCollector) Execute(ctx context.Context) {
 			appsByProject[project] = make([]*insight.ApplicationData, 0)
 		}
 
+		// Do not count the deleted application.
 		if app.Status == model.ApplicationActiveStatus_DELETED.String() {
 			continue
 		}

--- a/pkg/app/ops/insightcollector/application_collector.go
+++ b/pkg/app/ops/insightcollector/application_collector.go
@@ -90,6 +90,8 @@ func (c *applicationDataCollector) Execute(ctx context.Context) {
 	}
 }
 
+// listApplications queries the datastore and gets all projects' applications (including disabled/deleted apps)
+// to ensure projects with all applications disabled/deleted are listed as well.
 func (c *applicationDataCollector) listApplications(ctx context.Context) ([]*model.Application, error) {
 	const limit = 100
 	var cursor string

--- a/pkg/app/ops/insightcollector/application_collector.go
+++ b/pkg/app/ops/insightcollector/application_collector.go
@@ -59,6 +59,15 @@ func (c *applicationDataCollector) Execute(ctx context.Context) {
 			project = a.ProjectId
 			app     = insight.BuildApplicationData(a)
 		)
+
+		if _, ok := appsByProject[project]; !ok {
+			appsByProject[project] = make([]*insight.ApplicationData, 0)
+		}
+
+		if app.Status == model.ApplicationActiveStatus_DELETED.String() {
+			continue
+		}
+
 		appsByProject[project] = append(appsByProject[project], &app)
 	}
 
@@ -88,13 +97,7 @@ func (c *applicationDataCollector) listApplications(ctx context.Context) ([]*mod
 
 	for {
 		apps, next, err := c.lister.List(ctx, datastore.ListOptions{
-			Filters: []datastore.ListFilter{
-				{
-					Field:    "Deleted",
-					Operator: datastore.OperatorEqual,
-					Value:    false,
-				},
-			},
+			Filters: []datastore.ListFilter{},
 			Orders: []datastore.Order{
 				{
 					Field:     "CreatedAt",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is that the ops in the Cotrol Plane don't show `insight_applications_total` for the project deleted all apps.

We can get the metrics from the ops component in the Control Plane by calling `/metrics`.
`insight_applications_total` is the metric created by the flow below.

![insight-metrics-total-before](https://github.com/pipe-cd/pipecd/assets/40124947/ea1aa6de-9f02-4809-bb71-5d48845f560a)

Currently, the insight collector doesn't update application info in the filestore for the project which is deleted all apps.
This is because the only not deleted application info is updated after deleting all apps in the project.

So I fixed to update the app info as an empty array after deleting all apps in the project.

**Fixes**
- get all status apps and check them later to init `appsByProject` to store the app info as an empty array [feae904](https://github.com/pipe-cd/pipecd/pull/4953/commits/feae904e8b639251d01fec05349f0344e15dc100)

**Which issue(s) this PR fixes**:

Fixes #4941

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
