### PR TITLE
Put tags and categories to blog pages

### DIFF
--- a/docs/content/en/blog/announcing-pipecd.md
+++ b/docs/content/en/blog/announcing-pipecd.md
@@ -7,6 +7,8 @@ description: "Continuous Delivery for declarative Kubernetes, Serverless and Inf
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
 images: 
  - images/deployment-details.png
+categories: ["Announcement"]
+tags: []
 ---
 
 Today we are excited to announce the open-source availability of PipeCD: a continuous delivery system for declarative Kubernetes, Serverless, and Infrastructure applications.

--- a/docs/content/en/blog/cncf-sandbox-admission.md
+++ b/docs/content/en/blog/cncf-sandbox-admission.md
@@ -6,6 +6,8 @@ weight: 991
 description: "Official announcement of CNCF Sandbox admission"
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
 images: ["/images/pipecd-cncf-sandbox.png"]
+categories: ["Announcement"]
+tags: ["CNCF"]
 ---
 
 ![](/images/pipecd-cncf-sandbox.png)

--- a/docs/content/en/blog/control-plane-local-docker-compose.md
+++ b/docs/content/en/blog/control-plane-local-docker-compose.md
@@ -5,6 +5,8 @@ linkTitle: "Control Plane on local by docker-compose"
 weight: 989
 description: "This blog shows you how to install a PipeCD Control Plane on local machine easily."
 author: Tetsuya Kikuchi ([@t-kikuc](https://github.com/t-kikuc))
+categories: ["Example"]
+tags: ["Control Plane"]
 ---
 
 Currently, you can deploy and operate a PipeCD Control Plane on a Kubernetes cluster or [on Amazon ECS](/blog/2023/02/07/pipecd-best-practice-02-control-plane-on-ecs/).

--- a/docs/content/en/blog/control-plane-on-ecs.md
+++ b/docs/content/en/blog/control-plane-on-ecs.md
@@ -5,6 +5,8 @@ linkTitle: "PipeCD best practice 02"
 weight: 992
 description: "This blog is a guideline for you to operate your own PipeCD on Amazon ECS."
 author: Yohei Namba ([@kevin_namba](https://twitter.com/kevin_namba))
+categories: ["Example"]
+tags: ["Control Plane", "AWS"]
 ---
 
 This blog is a part of PipeCD best practice series, a guideline for you to operate your own PipeCD.

--- a/docs/content/en/blog/february-2022-update.md
+++ b/docs/content/en/blog/february-2022-update.md
@@ -5,6 +5,8 @@ linkTitle: "February 2022 update"
 weight: 995
 description: "Development status update to recap what happened in January"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
+categories: ["Announcement"]
+tags: ["What's new"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2022/01/05/january-2022-update/) if you want to see the last status update._

--- a/docs/content/en/blog/february-2022-update.md
+++ b/docs/content/en/blog/february-2022-update.md
@@ -6,7 +6,7 @@ weight: 995
 description: "Development status update to recap what happened in January"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
 categories: ["Announcement"]
-tags: ["What's new"]
+tags: ["News"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2022/01/05/january-2022-update/) if you want to see the last status update._

--- a/docs/content/en/blog/january-2022-update.md
+++ b/docs/content/en/blog/january-2022-update.md
@@ -6,7 +6,7 @@ weight: 997
 description: "Development status update to recap what happened in December"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
 categories: ["Announcement"]
-tags: ["What's new"]
+tags: ["News"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2021/11/01/november-2021-update/) if you want to see the last status update._

--- a/docs/content/en/blog/january-2022-update.md
+++ b/docs/content/en/blog/january-2022-update.md
@@ -5,6 +5,8 @@ linkTitle: "January 2022 update"
 weight: 997
 description: "Development status update to recap what happened in December"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
+categories: ["Announcement"]
+tags: ["What's new"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2021/11/01/november-2021-update/) if you want to see the last status update._

--- a/docs/content/en/blog/may-2022-update.md
+++ b/docs/content/en/blog/may-2022-update.md
@@ -6,7 +6,7 @@ weight: 993
 description: "Development status update to recap what happened last few months"
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
 categories: ["Announcement"]
-tags: ["What's new"]
+tags: ["News"]
 ---
 
 _Published by the PipeCD dev team every few months, this update will provide you with news and updates about the project! Please click [here](/blog/2022/02/10/february-2022-update/) if you want to see the last status update._

--- a/docs/content/en/blog/may-2022-update.md
+++ b/docs/content/en/blog/may-2022-update.md
@@ -5,6 +5,8 @@ linkTitle: "May 2022 update"
 weight: 993
 description: "Development status update to recap what happened last few months"
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
+categories: ["Announcement"]
+tags: ["What's new"]
 ---
 
 _Published by the PipeCD dev team every few months, this update will provide you with news and updates about the project! Please click [here](/blog/2022/02/10/february-2022-update/) if you want to see the last status update._

--- a/docs/content/en/blog/november-2021-update.md
+++ b/docs/content/en/blog/november-2021-update.md
@@ -6,7 +6,7 @@ weight: 998
 description: "Development status update to recap what happened in October"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
 categories: ["Announcement"]
-tags: ["What's new"]
+tags: ["News"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2021/11/01/november-2021-update/) if you want to see the last status update._

--- a/docs/content/en/blog/november-2021-update.md
+++ b/docs/content/en/blog/november-2021-update.md
@@ -5,6 +5,8 @@ linkTitle: "November 2021 update"
 weight: 998
 description: "Development status update to recap what happened in October"
 author: Le Van Nghia ([@nghialv](https://twitter.com/nghialv2607))
+categories: ["Announcement"]
+tags: ["What's new"]
 ---
 
 _Published by the PipeCD dev team every month, this update will provide you with news and updates about the project! Please click [here](/blog/2021/11/01/november-2021-update/) if you want to see the last status update._

--- a/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
+++ b/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
@@ -5,7 +5,7 @@ linkTitle: "PipeCD at CNCF KubeCon EU 2024"
 weight: 988
 author: Khanh Tran ([@khanhtc1202](https://github.com/khanhtc1202))
 categories: ["Announcement"]
-tags: ["Conference"]
+tags: ["Conference", "News"]
 ---
 
 KubeCon EU 2024 is only four more weeks away!

--- a/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
+++ b/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
@@ -4,6 +4,8 @@ title: "PipeCD at CNCF KubeCon EU 2024"
 linkTitle: "PipeCD at CNCF KubeCon EU 2024"
 weight: 988
 author: Khanh Tran ([@khanhtc1202](https://github.com/khanhtc1202))
+categories: ["Announcement"]
+tags: ["Conference"]
 ---
 
 KubeCon EU 2024 is only four more weeks away!

--- a/docs/content/en/blog/pipecd-best-practice-01.md
+++ b/docs/content/en/blog/pipecd-best-practice-01.md
@@ -5,6 +5,8 @@ linkTitle: "PipeCD best practice 01"
 weight: 996
 description: "This blog is a part of PipeCD best practice series, a guideline for you to operate your own PipeCD cluster."
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
+categories: ["Practice"]
+tags: ["Control Plane"]
 ---
 
 PipeCD is an open source project, you can freely use the released versions of PipeCD to create and operate a continuous delivery system for your service or company. [Quickstart](/docs/quickstart/) docs - a complete guide for you to install required components of PipeCD and deploy a simple application via PipeCD is a good point to get started. However, for the sake of the simplicity of that tutorial, some points to keep in mind when operating a PipeCD cluster have been omitted. You will review the PipeCD architecture again and get some tips on how to operate a PipeCD cluster in this post.

--- a/docs/content/en/blog/play-environment.md
+++ b/docs/content/en/blog/play-environment.md
@@ -5,6 +5,8 @@ linkTitle: "The PipeCD play environment"
 weight: 994
 description: "In this post, we will have a glance at the play environment of PipeCD, how to access and what you can get from the environment."
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
+categories: ["Announcement"]
+tags: ["Getting Started"]
 ---
 
 Good news, PipeCD team's happy to bring you a place where you can have a look at the PipeCD platform in use. We call it the `play environment` - [https://play.pipecd.dev](https://play.pipecd.dev).

--- a/docs/content/en/blog/play-environment.md
+++ b/docs/content/en/blog/play-environment.md
@@ -6,7 +6,7 @@ weight: 994
 description: "In this post, we will have a glance at the play environment of PipeCD, how to access and what you can get from the environment."
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
 categories: ["Announcement"]
-tags: ["Getting Started"]
+tags: ["Getting Started", "News"]
 ---
 
 Good news, PipeCD team's happy to bring you a place where you can have a look at the PipeCD platform in use. We call it the `play environment` - [https://play.pipecd.dev](https://play.pipecd.dev).

--- a/docs/content/en/blog/terraform-provider-pipecd.md
+++ b/docs/content/en/blog/terraform-provider-pipecd.md
@@ -5,6 +5,8 @@ linkTitle: "Terraform Provider for PipeCD"
 weight: 990
 description: "In this post, we announce the release of Terraform provider for PipeCD."
 author: Kenta Kozuka ([@kentakozuka](https://twitter.com/kenta_kozuka))
+categories: ["Announcement"]
+tags: ["Ecosystem", "Terraform"]
 ---
 
 Now PipeCD resources can be managed by Terraform🎉


### PR DESCRIPTION
**What this PR does / why we need it**:

as title.

**Which issue(s) this PR fixes**:

Fixes #4958

**Does this PR introduce a user-facing change?**:　N/A

- **How are users affected by this change**:N/A
- **Is this breaking change**:N/A
- **How to migrate (if breaking change)**:N/A

**Example**

each blog page:

<img width="1725" alt="image" src="https://github.com/pipe-cd/pipecd/assets/97105818/a5a4d94b-3485-4fb6-88dc-60f5fe55a408">

search by category (click any category):

<img width="1708" alt="image" src="https://github.com/pipe-cd/pipecd/assets/97105818/a72b3dc3-2bc6-44c5-a4d5-8b8ea5b5fb5e">

search by tag (click any tag):

<img width="1662" alt="image" src="https://github.com/pipe-cd/pipecd/assets/97105818/c2afd956-ef48-4034-b0e6-db795943236e">


