### PR TITLE
Remove fossabot in `make gen/contributions`

### DIFF
--- a/hack/gen-contributions.sh
+++ b/hack/gen-contributions.sh
@@ -42,6 +42,9 @@ The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fpipe-cd%2Fpipecd.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fpipe-cd%2Fpipecd?ref=badge_large)
 EOF
 
+# Remove fossabot from the contributors list.
+sed -i '/fossabot/d' README.md.tmp
+
 mv README.md.tmp README.md
 
 echo "Successfully update the contributions list on README.md"


### PR DESCRIPTION
**What this PR does / why we need it**:

Although we removed `fossabot` in https://github.com/pipe-cd/pipecd/pull/4945, 
we need to remove it automatically when using `make gen/contributoins`.


**Note**

Even though the following `sed -i` won't work well on Mac, thatt doesn't matter.
That's because `make gen/contributions` will be used only by [this GitHub Action](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/update-contributors.yaml)(which uses ubuntu), not developers' PC.

```
# Remove fossabot from the contributors list.
sed -i '/fossabot/d' README.md.tmp
```





