### PR TITLE
[docs] Describe restrictions in configuring ECS serviceDef & taskDef

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -505,11 +505,31 @@ One of `yamlField` or `regex` is required.
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `service.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html) for parameters.| No |
-| taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for parameters. | No |
+| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `service.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html) and [Restrictions](#restrictions-of-service-definition) for parameters.| No |
+| taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) and [Restrictions](#restrictions-of-task-definition) for parameters. | No |
 | targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes (if you want to perform progressive delivery) |
 | runStandaloneTask | bool | Run standalone tasks during deployments. About standalone task, see [here](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs_run_task-v2.html). The default value is `true`. |
 | accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/ecs/servicediscovery/simple). The default value is `ELB`. |
+
+### Restrictions of Service Definition
+
+There are some restrictions in configuring a service definition file.
+
+- `capacityProviderStrategy` is not supported.
+- `clientToken` is not supported.
+- `deploymentController` is required and must be `EXTERNAL`.
+- `loadBalancers` is not supported. Use `targetGroups` in [ECSDeploymentInput](#ecsdeploymentinput) instead.
+- `platformFamily` is not supported.
+- `propagateTags` is always set as `SERVICE`.
+- `taskDefinition` is not supported. PipeCD uses the definition in `taskDefinitionFile` in [ECSDeploymentInput](#ecsdeploymentinput).
+
+### Restrictions of Task Definition
+
+There are some restrictions in configuring a task definition file.
+
+- `placementConstraints` is not supported.
+- `proxyConfiguration` is not supported.
+- `tags` is not supported.
 
 ### ECSTargetGroupInput
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -511,6 +511,26 @@ One of `yamlField` or `regex` is required.
 | runStandaloneTask | bool | Run standalone tasks during deployments. About standalone task, see [here](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs_run_task-v2.html). The default value is `true`. |
 | accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/ecs/servicediscovery/simple). The default value is `ELB`. |
 
+### Restrictions of Service Definition
+
+There are some restrictions in configuring a service definition file.
+
+- `capacityProviderStrategy` is not supported.
+- `clientToken` is not supported.
+- `deploymentController` is required and must be `EXTERNAL`.
+- `loadBalancers` is not supported. Use `targetGroups` in [ECSDeploymentInput](#ecsdeploymentinput) instead.
+- `platformFamily` is not supported.
+- `propagateTags` is always set as `SERVICE`.
+- `taskDefinition` is not supported. PipeCD uses the definition in `taskDefinitionFile` in [ECSDeploymentInput](#ecsdeploymentinput).
+
+### Restrictions of Task Definition
+
+There are some restrictions in configuring a task definition file.
+
+- `placementConstraints` is not supported.
+- `proxyConfiguration` is not supported.
+- `tags` is not supported.
+
 ### ECSTargetGroupInput
 
 | Field | Type | Description | Required |

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -505,8 +505,8 @@ One of `yamlField` or `regex` is required.
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `service.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html) for parameters.| No |
-| taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for parameters. | No |
+| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `service.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html) and [Restrictions](#restrictions-of-service-definition) for parameters.| No |
+| taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) and [Restrictions](#restrictions-of-task-definition) for parameters. | No |
 | targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes (if you want to perform progressive delivery) |
 | runStandaloneTask | bool | Run standalone tasks during deployments. About standalone task, see [here](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs_run_task-v2.html). The default value is `true`. |
 | accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/ecs/servicediscovery/simple). The default value is `ELB`. |


### PR DESCRIPTION
**What this PR does / why we need it**:

as title.

**Which issue(s) this PR fixes**:

Fixes #4961

**Does this PR introduce a user-facing change?**: N/A

- **How are users affected by this change**: N/A
- **Is this breaking change**: N/A
- **How to migrate (if breaking change)**: N/A


**How I listed**

- Read AWS docs
  - servicedef: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html
  - taskdef: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
- Read PipeCD code: ECS>client.go
  - https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/ecs/client.go
- Checked AWS SDK's structs