### PR TITLE
Add empty line to fix the CI `gen`

### DIFF
--- a/tool/codegen/protoc-gen-auth/main.go
+++ b/tool/codegen/protoc-gen-auth/main.go
@@ -92,6 +92,7 @@ func main() {
 				return fmt.Errorf("template execute error: %v", err)
 			}
 			gf.P(string(buf.Bytes()))
+
 		}
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR expects to fix the CI `gen` fails.
This is just a workaround to pass CI.

**How to reproduce**

- build the image for  with linux/amd64 `docker buildx`.
- Fix Makefile and execute `make gen/code`.

```
docker buildx build --platform linux/amd64 tool/codegen -t codegen-buildx-amd
```

Fix the Makefile like this↓
```
gen/code:
	# NOTE: Specify a specific version temporally until the next release.
	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh codegen-buildx-amd  /repo #v0.44.0-38-g7229285
```

**Which issue(s) this PR fixes**:

Related to https://github.com/pipe-cd/pipecd/pull/4970

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
