### PR TITLE
Add opentelemetry-collector chart as deps and add values

### DIFF
--- a/manifests/pipecd/Chart.lock
+++ b/manifests/pipecd/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.16.2
-digest: sha256:2d733ccc35073795a41f9dd5aa6e03dcab3e195fd313db97751d23de3b6899bc
-generated: "2022-04-22T22:31:08.89498+09:00"
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.93.3
+digest: sha256:4025b0e61e9889d55016505f93a4718b548bc7a36599cf4cfe29ba31fdfd1503
+generated: "2024-06-17T15:44:50.374800619+09:00"

--- a/manifests/pipecd/Chart.yaml
+++ b/manifests/pipecd/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
   version: "6.16.2"
   repository: "https://grafana.github.io/helm-charts"
   condition: monitoring.enabled
+- name: opentelemetry-collector
+  version: "0.93.3"
+  repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+  condition: monitoring.enabled

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -258,3 +258,28 @@ grafana:
           allowUiUpdates: false
           options:
             path: /tmp/dashboards/piped
+
+opentelemetry-collector:
+  mode: "deployment"
+  replicaCount: 1
+  image:
+    repository: "otel/opentelemetry-collector-k8s"
+  config:
+    receivers:
+      # helm warns below configs, but these are from this example and works fine.
+      # ref; https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-collector/0.43.3#basic-top-level-configuration
+      jaeger: null
+      prometheus: null
+      zipkin: null
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317 # collector is deployed mith deployment mode, so listen not only for local.
+          http: null
+    service:
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+        metrics: null
+        logs: null


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds helm chart dependency of opentelemetry-collector, and adds its values.
ref; [RFC](https://github.com/pipe-cd/pipecd/blob/ead279816f991d1d8fb6b07774807632ce16ceba/docs/rfcs/0013-export-deployment-traces-with-otlp.md)

**Which issue(s) this PR fixes**:

Part of #4977 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
