### PR TITLE
Add default env for script run

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
@@ -67,7 +67,7 @@ You can use the envrionment values related to the deployment.
 |SR_TRIGGERED_AT| The timestamp when the deployment is triggered  | 1719571113 |
 |SR_TRIGGERED_COMMIT_HASH| The commit hash that triggered the deployment | 2bf969a3dad043aaf8ae6419943255e49377da0d |
 |SR_REPOSITORY_URL| The repository url configured in the piped config  | git@github.com:org/repo.git, https://github.com/org/repo |
-|SR_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
+|SR_CONTEXT_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
 |SR_LABEL_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABEL_ENV` and `SR_LABEL_TEAM` are registered.  | prd, server |
 
 ## Rollback

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
@@ -55,7 +55,22 @@ The commands run in the directory where this application configuration file exis
 
 ![](/images/script-run.png)
 
-# When to rollback
+## Default environment values
+
+You can use the envrionment values related to the deployment.
+
+| Name | Description | Example |
+|-|-|-|
+|SR_DEPLOYMENT_ID| The deployment id | 877625fc-196a-40f9-b6a9-99decd5494a0 |
+|SR_APPLICATION_ID| The application id | 8d7609e0-9ff6-4dc7-a5ac-39660768606a |
+|SR_APPLICATION_NAME| The application name | example |
+|SR_TRIGGERED_AT| The timestamp when the deployment is triggered  | 1719571113 |
+|SR_TRIGGERED_COMMIT_HASH| The commit hash that triggered the deployment | 2bf969a3dad043aaf8ae6419943255e49377da0d |
+|SR_REPOSITORY_URL| The repository url configured in the piped config  | git@github.com:org/repo.git, https://github.com/org/repo |
+|SR_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
+|SR_LABEL_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABEL_ENV` and `SR_LABEL_TEAM` are registered.  | prd, server |
+
+## Rollback
 
 You can define the command as `onRollback` to execute when to rollback similar to `run`.
 Execute the command to rollback SCRIPT_RUN to the point where the deployment was canceled or failed.
@@ -114,7 +129,7 @@ Then
 - If 4 is canceled or fails while running, only SCRIPT_RUN of 3 will be rollbacked.
 - If 6 is canceled or fails while running, only SCRIPT_RUNs 3 and 5 will be rollbacked. The order of executing is 3 -> 5.
 
-# Note
+## Note
 1. You can use `SCRIPT_RUN` stage with only the application kind of `KubernetesApp`. Soon we will implement it. for other application kinds.
 
 2. The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX command available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). If you want to use your commands, you can:

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
@@ -67,6 +67,8 @@ You can use the envrionment values related to the deployment.
 |SR_TRIGGERED_AT| The timestamp when the deployment is triggered  | 1719571113 |
 |SR_TRIGGERED_COMMIT_HASH| The commit hash that triggered the deployment | 2bf969a3dad043aaf8ae6419943255e49377da0d |
 |SR_REPOSITORY_URL| The repository url configured in the piped config  | git@github.com:org/repo.git, https://github.com/org/repo |
+|SR_SUMMARY| The summary of the deployment | Sync with the specified pipeline because piped received a command from user via web console or pipectl
+ |
 |SR_CONTEXT_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
 |SR_LABEL_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABEL_ENV` and `SR_LABEL_TEAM` are registered.  | prd, server |
 

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -206,7 +206,15 @@ func (e *rollbackExecutor) ensureScriptRunRollback(ctx context.Context) model.St
 		}
 	}
 
-	envs := make([]string, 0, len(env))
+	defaultEnvs := map[string]string{
+		"DEPLOYMENT_ID":  e.Deployment.Id,
+		"APPLICATION_ID": e.Deployment.ApplicationId,
+	}
+
+	envs := make([]string, 0, len(env)+len(defaultEnvs))
+	for key, value := range defaultEnvs {
+		envs = append(envs, "SR_"+key+"="+value)
+	}
 	for key, value := range env {
 		envs = append(envs, key+"="+value)
 	}

--- a/pkg/app/piped/executor/scriptrun/script_run_test.go
+++ b/pkg/app/piped/executor/scriptrun/script_run_test.go
@@ -27,6 +27,7 @@ func Test_ContextInfo_BuildEnv(t *testing.T) {
 					"key1": "value1",
 					"key2": "value2",
 				},
+				Summary: "summary",
 			},
 			want: map[string]string{
 				"SR_DEPLOYMENT_ID":         "deployment-id",
@@ -35,6 +36,7 @@ func Test_ContextInfo_BuildEnv(t *testing.T) {
 				"SR_TRIGGERED_AT":          "1234567890",
 				"SR_TRIGGERED_COMMIT_HASH": "commit-hash",
 				"SR_REPOSITORY_URL":        "repo-url",
+				"SR_SUMMARY":               "summary",
 				"SR_LABELS_KEY1":           "value1",
 				"SR_LABELS_KEY2":           "value2",
 			},

--- a/pkg/app/piped/executor/scriptrun/script_run_test.go
+++ b/pkg/app/piped/executor/scriptrun/script_run_test.go
@@ -1,0 +1,63 @@
+package scriptrun
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ContextInfo_BuildEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		ci      *ContextInfo
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			ci: &ContextInfo{
+				DeploymentID:        "deployment-id",
+				ApplicationID:       "application-id",
+				ApplicationName:     "application-name",
+				TriggeredAt:         1234567890,
+				TriggeredCommitHash: "commit-hash",
+				RepositoryURL:       "repo-url",
+				Labels: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			want: map[string]string{
+				"SR_DEPLOYMENT_ID":         "deployment-id",
+				"SR_APPLICATION_ID":        "application-id",
+				"SR_APPLICATION_NAME":      "application-name",
+				"SR_TRIGGERED_AT":          "1234567890",
+				"SR_TRIGGERED_COMMIT_HASH": "commit-hash",
+				"SR_REPOSITORY_URL":        "repo-url",
+				"SR_LABELS_KEY1":           "value1",
+				"SR_LABELS_KEY2":           "value2",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.ci.BuildEnv()
+			assert.Equal(t, tt.wantErr, err != nil)
+
+			for k, v := range got {
+				if k == "SR_CONTEXT_RAW" {
+					continue
+				}
+				assert.Equal(t, tt.want[k], v)
+			}
+
+			var gotRaw ContextInfo
+			err = json.Unmarshal([]byte(got["SR_CONTEXT_RAW"]), &gotRaw)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.ci, &gotRaw)
+		})
+	}
+}

--- a/pkg/app/piped/executor/scriptrun/scriptrun.go
+++ b/pkg/app/piped/executor/scriptrun/scriptrun.go
@@ -131,12 +131,12 @@ func (e *Executor) executeCommand() model.StageStatus {
 
 // ContextInfo is the information that will be passed to the script run stage.
 type ContextInfo struct {
-	DeploymentID        string            `json:"deploymentID"`
-	ApplicationID       string            `json:"applicationID"`
+	DeploymentID        string            `json:"deploymentID,omitempty"`
+	ApplicationID       string            `json:"applicationID,omitempty"`
 	ApplicationName     string            `json:"applicationName,omitempty"`
-	TriggeredAt         int64             `json:"triggeredAt"`
-	TriggeredCommitHash string            `json:"triggeredCommitHash"`
-	RepositoryURL       string            `json:"repositoryURL"`
+	TriggeredAt         int64             `json:"triggeredAt,omitempty"`
+	TriggeredCommitHash string            `json:"triggeredCommitHash,omitempty"`
+	RepositoryURL       string            `json:"repositoryURL,omitempty"`
 	Summary             string            `json:"summary,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty"`
 }

--- a/pkg/app/piped/executor/scriptrun/scriptrun.go
+++ b/pkg/app/piped/executor/scriptrun/scriptrun.go
@@ -167,7 +167,7 @@ func (src *ContextInfo) BuildEnv() (map[string]string, error) {
 		"SR_TRIGGERED_AT":          strconv.FormatInt(src.TriggeredAt, 10),
 		"SR_TRIGGERED_COMMIT_HASH": src.TriggeredCommitHash,
 		"SR_REPOSITORY_URL":        src.RepositoryURL,
-		"SR_RAW":                   string(b), // Add the raw json string as an environment variable.
+		"SR_CONTEXT_RAW":           string(b), // Add the raw json string as an environment variable.
 	}
 
 	for k, v := range src.Labels {

--- a/pkg/app/piped/executor/scriptrun/scriptrun.go
+++ b/pkg/app/piped/executor/scriptrun/scriptrun.go
@@ -137,6 +137,7 @@ type ContextInfo struct {
 	TriggeredAt         int64             `json:"triggeredAt"`
 	TriggeredCommitHash string            `json:"triggeredCommitHash"`
 	RepositoryURL       string            `json:"repositoryURL"`
+	Summary             string            `json:"summary,omitempty"`
 	Labels              map[string]string `json:"labels,omitempty"`
 }
 
@@ -149,6 +150,7 @@ func NewContextInfo(d *model.Deployment) *ContextInfo {
 		TriggeredAt:         d.Trigger.Timestamp,
 		TriggeredCommitHash: d.Trigger.Commit.Hash,
 		RepositoryURL:       d.GitPath.Repo.Remote,
+		Summary:             d.Summary,
 		Labels:              d.Labels,
 	}
 }
@@ -167,6 +169,7 @@ func (src *ContextInfo) BuildEnv() (map[string]string, error) {
 		"SR_TRIGGERED_AT":          strconv.FormatInt(src.TriggeredAt, 10),
 		"SR_TRIGGERED_COMMIT_HASH": src.TriggeredCommitHash,
 		"SR_REPOSITORY_URL":        src.RepositoryURL,
+		"SR_SUMMARY":               src.Summary,
 		"SR_CONTEXT_RAW":           string(b), // Add the raw json string as an environment variable.
 	}
 

--- a/pkg/app/piped/executor/scriptrun/scriptrun.go
+++ b/pkg/app/piped/executor/scriptrun/scriptrun.go
@@ -99,7 +99,16 @@ func (e *Executor) executeCommand() model.StageStatus {
 		}
 	}
 
-	envs := make([]string, 0, len(opts.Env))
+	defautEnvs := map[string]string{
+		"DEPLOYMENT_ID":  e.Deployment.Id,
+		"APPLICATION_ID": e.Deployment.ApplicationId,
+	}
+
+	envs := make([]string, 0, len(opts.Env)+len(defautEnvs))
+	for key, value := range defautEnvs {
+		envs = append(envs, "SR_"+key+"="+value)
+	}
+
 	for key, value := range opts.Env {
 		envs = append(envs, key+"="+value)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Added default env value for the deployment information (such as deployment id, application id...)

Current values are below.

| Name | Description | Example |
|-|-|-|
|SR_DEPLOYMENT_ID| The deployment id | 877625fc-196a-40f9-b6a9-99decd5494a0 |
|SR_APPLICATION_ID| The application id | 8d7609e0-9ff6-4dc7-a5ac-39660768606a |
|SR_APPLICATION_NAME| The application name | example |
|SR_TRIGGERED_AT| The timestamp when the deployment is triggered  | 1719571113 |
|SR_TRIGGERED_COMMIT_HASH| The commit hash that triggered the deployment | 2bf969a3dad043aaf8ae6419943255e49377da0d |
|SR_REPOSITORY_URL| The repository url configured in the piped config  | git@github.com:org/repo.git, https://github.com/org/repo |
|SR_SUMMARY| The summary of the deployment | Sync with the specified pipeline because piped received a command from user via web console or pipectl|
|SR_CONTEXT_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
|SR_LABEL_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABEL_ENV` and `SR_LABEL_TEAM` are registered.  | prd, server |

<img width="1704" alt="PipeCD" src="https://github.com/pipe-cd/pipecd/assets/40124947/70496f9a-20f1-490e-bdab-8954f47c1f85">


example of app.pipecd.yaml
```
apiVersion: pipecd.dev/v1beta1
kind: KubernetesApp
spec:
  name: script-run-like-jenkins
  labels:
    env: example
    team: product
  pipeline:
    stages:
      - name: K8S_CANARY_ROLLOUT
        with:
          replicas: 10%
      - name: SCRIPT_RUN
        with:
          run: |
            echo $SR_DEPLOYMENT_ID
            echo $SR_APPLICATION_ID
            echo $SR_APPLICATION_NAME
            echo $SR_TRIGGERED_AT
            echo $SR_TRIGGERED_COMMIT_HASH
            echo $SR_REPOSITORY_URL
            echo $SR_RAW
            echo $
          env:
            REPOSITORY_URL: "https://github.com/pipecd/pipecd"
          onRollback: |
            echo $SR_DEPLOYMENT_ID
            echo $SR_APPLICATION_ID
            echo $SR_APPLICATION_NAME
            echo $SR_TRIGGERED_AT
            echo $SR_TRIGGERED_COMMIT_HASH
            echo $SR_REPOSITORY_URL
            echo $SR_RAW
...
```

**Which issue(s) this PR fixes**:

Fixes #4814

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
