### PR TITLE
Install jq in piped-base images

### DIFF
--- a/tool/piped-base-okd/Dockerfile
+++ b/tool/piped-base-okd/Dockerfile
@@ -16,6 +16,7 @@ RUN \
         libc-dev \
         musl-nscd-dev \
         make \
+        jq \
         cmake && \
 
     # Install glibc to be used for building nss_wrapper.

--- a/tool/piped-base/Dockerfile
+++ b/tool/piped-base/Dockerfile
@@ -16,6 +16,7 @@ RUN \
         ca-certificates \
         git \
         openssh \
+        jq \
         curl && \
     update-ca-certificates && \
     mkdir -p ${PIPED_TOOLS_DIR} && \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR installs jq to the piped-base images.

PR #5002 introduces environment variables in the SCRIPT_RUN stage.
One of these environment variables has JSON format, so we need jq to deal with it.
After merging this PR, we need to update other Dockefiles to use new piped-base images.

**Which issue(s) this PR fixes**:

Part of #4814 

**Does this PR introduce a user-facing change?**: No
- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
