### PR TITLE
Fix the docs for the script run feature status

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
@@ -8,7 +8,7 @@ description: >
 
 `SCRIPT_RUN` stage is one stage in the pipeline and you can execute any commands.
 
-> Note: This feature is at the alpha status and currently only for the application kind of KubernetesApp.
+> Note: This feature is at the alpha status. Currently you can use it on all application kinds, but the rollback feature is only for the application kind of KubernetesApp.
 
 ## How to configure SCRIPT_RUN stage
 
@@ -88,6 +88,8 @@ You can use jq command to refer to the values from `SR_CONTEXT_RAW`.
 
 
 ## Rollback
+
+> Note: Currently, this feature is only for the application kind of KubernetesApp.
 
 You can define the command as `onRollback` to execute when to rollback similar to `run`.
 Execute the command to rollback SCRIPT_RUN to the point where the deployment was canceled or failed.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the description of the script run feature.
Currently, we can use the script run stage without the rollback feature on all kinds of applications.

**background**
I implemented the script run stage without rollback feature In this PR https://github.com/pipe-cd/pipecd/pull/4720.
But later, I implemented the rollback feature for the k8s app: https://github.com/pipe-cd/pipecd/pull/4743.

**Which issue(s) this PR fixes**:

Part of #4643

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
