### PR TITLE
Fix: Update latest version of docs to v0.48.x

### DIFF
--- a/docs/main.go
+++ b/docs/main.go
@@ -28,7 +28,7 @@ import (
 const dir = "/public"
 
 // Don't update here manually. /hack/gen-release-docs.sh does.
-const latestPath = "/docs-v0.47.x/"
+const latestPath = "/docs-v0.48.x/"
 
 func main() {
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest version of docs is still v0.47.x although we released v0.48.0.
The cause is not clear yet.

I executed the following command to fix it.
https://github.com/pipe-cd/pipecd/blob/6439f977a8c3a327bdb84d86eceb7686119d9ad6/hack/gen-release-docs.sh#L63-L64


**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no
- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
