### PR TITLE
Add notes of linking target groups and ELB listener rules in advance

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,6 +152,7 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
+  - That means you need to link target groups to your listener rules before deployments.
   - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
 - When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment yet because Service Connect does not support the external deployment yet.
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,6 +152,7 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
+  - That means you need to link target groups to your listener rules before deployments.
   - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
 - When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment yet because Service Connect does not support the external deployment yet.
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,6 +152,7 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
+  - That means you need to link target groups to your listener rules before deployments.
   - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
 - When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment yet because Service Connect does not support the external deployment yet.
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -152,6 +152,7 @@ spec:
 ## NOTE
 
 - When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.
+  - That means you need to link target groups to your listener rules before deployments.
   - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
 - When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment yet because Service Connect does not support the external deployment yet.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add notes that a user needs to link target groups and ELB listener rules in advance.

If not, a piped will not control traffic weights and a new taskset cannot receive traffic.

**Which issue(s) this PR fixes**:

-

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**:no
- **How to migrate (if breaking change)**: no
