### PR TITLE
Add pod annotations for piped helm

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- if .Values.args.forceRestart }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "piped.serviceAccountName" . }}
       containers:

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -97,6 +97,8 @@ priorityClassName: {}
 
 podLabels: {}
 
+podAnnotations: {}
+
 # Specifies how much of each resource the Piped container needs.
 resources: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to add custom pod annotations for piped pod with Helm.

**Which issue(s) this PR fixes**:

Fixes #5033

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: `Enable to add pod annotations, but default is empty, means no breaking changes`
- **Is this breaking change**: `No`
- **How to migrate (if breaking change)**: `-`

`helm template demo piped --debug` with `podAnnotations` ( `podAnnotationsInjected: true` )
```diff
# Source: piped/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: demo-piped
  labels:
    helm.sh/chart: piped-0.0.0
    app.kubernetes.io/name: piped
    app.kubernetes.io/instance: demo
    app.kubernetes.io/version: "0.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/name: piped
      app.kubernetes.io/instance: demo
  template:
    metadata:
      labels:
        app.kubernetes.io/name: piped
        app.kubernetes.io/instance: demo
      annotations:
        sidecar.istio.io/inject: "false"
        rollme: "ff8ru"
+       podAnnotationsInjected: true
```