### PR TITLE
Make it clear to attach IAM policies to ECS task-role

### DIFF
--- a/docs/content/en/docs-dev/installation/install-piped/required-permissions.md
+++ b/docs/content/en/docs-dev/installation/install-piped/required-permissions.md
@@ -8,6 +8,8 @@ description: >
 
 A Piped requires some permissions to deploy applications, depending on the platform.
 
+Note: If you run a piped as an ECS task, you need to attach the permissions on the piped task's `task role`, not `task execution role`.
+
 ## For ECSApp
 
 You need IAM actions like the following example. You can restrict `Resource`.

--- a/docs/content/en/docs-v0.47.x/installation/install-piped/required-permissions.md
+++ b/docs/content/en/docs-v0.47.x/installation/install-piped/required-permissions.md
@@ -8,6 +8,8 @@ description: >
 
 A Piped requires some permissions to deploy applications, depending on the platform.
 
+Note: If you run a piped as an ECS task, you need to attach the permissions on the piped task's `task role`, not `task execution role`.
+
 ## For ECSApp
 
 You need IAM actions like the following example. You can restrict `Resource`.

--- a/docs/content/en/docs-v0.48.x/installation/install-piped/required-permissions.md
+++ b/docs/content/en/docs-v0.48.x/installation/install-piped/required-permissions.md
@@ -8,6 +8,8 @@ description: >
 
 A Piped requires some permissions to deploy applications, depending on the platform.
 
+Note: If you run a piped as an ECS task, you need to attach the permissions on the piped task's `task role`, not `task execution role`.
+
 ## For ECSApp
 
 You need IAM actions like the following example. You can restrict `Resource`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Make it clear which role to attach IAM policies to because ECS's `task-role` and `task-execution-role` are confusing.