### PR TITLE
Upgrade google-cloud-sdk

### DIFF
--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -6,9 +6,9 @@ RUN \
     apk add --no-cache \
         python3 \
         curl && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
-    tar -zxvf ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
-    rm ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    tar -zxvf ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     ./google-cloud-sdk/install.sh --quiet
 
 ENV PATH="/google-cloud-sdk/bin:${PATH}"

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-ARG GOOGLE_CLOUD_SDK_VERSION=324.0.0
+ARG GOOGLE_CLOUD_SDK_VERSION=477.0.0
 
 RUN \
     apk add --no-cache \


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upgrade google-cloud-sdk to latest
- Use x86_64 version of google-cloud-sdk

**Which issue(s) this PR fixes**:

We upgraded the alpine to 3.20 [in this PR](https://github.com/pipe-cd/pipecd/pull/5014)
Alpine 3.20 uses the newer Python, so this issue occurred.
https://issuetracker.google.com/issues/303280713?pli=1

The issue is already fixed in the latest google-cloud-sdk, so I upgrade it.

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
