### PR TITLE
Update docs for Google SSO

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -120,7 +120,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support file store as data store | Alpha |

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.39.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.39.x/feature-status/_index.md
@@ -113,7 +113,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Incubating |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-controlplane/configuration-reference.md
@@ -125,7 +125,6 @@ Must be one of the following objects:
 | name | string | The unique name of the configuration. | Yes |
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -136,10 +135,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.40.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.40.x/feature-status/_index.md
@@ -113,7 +113,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Incubating |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-controlplane/configuration-reference.md
@@ -125,7 +125,6 @@ Must be one of the following objects:
 | name | string | The unique name of the configuration. | Yes |
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -136,10 +135,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.41.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.41.x/feature-status/_index.md
@@ -113,7 +113,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Incubating |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.42.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.42.x/feature-status/_index.md
@@ -113,7 +113,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.43.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.43.x/feature-status/_index.md
@@ -113,7 +113,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.44.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.44.x/feature-status/_index.md
@@ -118,7 +118,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.45.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.45.x/feature-status/_index.md
@@ -118,7 +118,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support GCP [GCS](https://cloud.google.com/storage) as file store | Beta |

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.46.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.46.x/feature-status/_index.md
@@ -120,7 +120,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support file store as data store | Alpha |

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.47.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.47.x/feature-status/_index.md
@@ -120,7 +120,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support file store as data store | Alpha |

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |

--- a/docs/content/en/docs-v0.48.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.48.x/feature-status/_index.md
@@ -120,7 +120,6 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | RBAC on PipeCD resources such as Application, Piped... | Alpha |
 | Authentication by username/password for static admin | Beta |
 | GitHub & GitHub Enterprise Server SSO | Beta |
-| Google SSO | Incubating |
 | Support GCP [Firestore](https://cloud.google.com/firestore) as data store | Beta |
 | Support [MySQL v8.0](https://www.mysql.com/) as data store | Beta |
 | Support file store as data store | Alpha |

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/auth.md
@@ -16,7 +16,12 @@ After logging, the project admin should change the provided username and passwor
 
 ### Single Sign-On (SSO)
 
-Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service such as GitHub, GitHub Enterprise Server, Google Gmail, Bitbucket...
+Single sign-on (SSO) allows users to log in to PipeCD by relying on a trusted third-party service.
+
+**Supported service**
+- GitHub
+
+> Note: In the future, we want to support such as Google Gmail, Bitbucket...
 
 Before configuring the SSO, you need an OAuth application of the using service. For example, GitHub SSO requires creating a GitHub OAuth application as described in this page:
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/configuration-reference.md
@@ -149,7 +149,6 @@ Must be one of the following objects:
 | provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | sessionTtl | int | The time to live of session for SSO login. Unit is `hour`. Default is 7 * 24 hours. | No |
 | github | [SSOConfigGitHub](#ssoconfiggithub) | GitHub sso configuration. | No |
-| google | [SSOConfigGoogle](#ssoconfiggoogle) | Google sso configuration. | No |
 
 ## SSOConfigGitHub
 
@@ -160,10 +159,3 @@ Must be one of the following objects:
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
 | uploadUrl | string | The upload url of GitHub service. | No |
 | proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
-
-## SSOConfigGoogle
-
-| Field | Type | Description | Required |
-|-|-|-|-|
-| clientId | string | The client id string of Google oauth app. | Yes |
-| clientSecret | string | The client secret string of Google oauth app. | Yes |


### PR DESCRIPTION
**What this PR does / why we need it**:

Google SSO is not yet supported, but some documents describe it.
It's confusing, so I fixed them.

This is because we previously planned the feature but didn't Implement it.

**Which issue(s) this PR fixes**:

Part of #1161

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
