### PR TITLE
Remove GetReadOnly from deploysource.Provider interface

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -255,7 +255,7 @@ func (s *scheduler) Run(ctx context.Context) error {
 		*s.deployment.GitPath,
 		nil,
 	)
-	ds, err := configDSP.GetReadOnly(ctx, io.Discard)
+	ds, err := configDSP.Get(ctx, io.Discard)
 	if err != nil {
 		deploymentStatus = model.DeploymentStatus_DEPLOYMENT_FAILURE
 		statusReason = fmt.Sprintf("Unable to prepare application configuration source data at target commit (%v)", err)

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -39,7 +39,6 @@ type DeploySource struct {
 type Provider interface {
 	Revision() string
 	Get(ctx context.Context, logWriter io.Writer) (*DeploySource, error)
-	GetReadOnly(ctx context.Context, logWriter io.Writer) (*DeploySource, error)
 }
 
 type secretDecrypter interface {
@@ -104,25 +103,6 @@ func (p *provider) Get(ctx context.Context, lw io.Writer) (*DeploySource, error)
 
 	fmt.Fprintf(lw, "Successfully prepared deploy source at %s commit (%s)\n", p.revisionName, p.revision)
 	return ds, nil
-}
-
-func (p *provider) GetReadOnly(ctx context.Context, lw io.Writer) (*DeploySource, error) {
-	fmt.Fprintf(lw, "Preparing deploy source at %s commit (%s)\n", p.revisionName, p.revision)
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if !p.done {
-		p.source, p.err = p.prepare(ctx, lw)
-		p.done = true
-	}
-
-	if p.err != nil {
-		return nil, p.err
-	}
-
-	fmt.Fprintf(lw, "Successfully prepared deploy source at %s commit (%s)\n", p.revisionName, p.revision)
-	return p.source, nil
 }
 
 func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, error) {

--- a/pkg/app/pipedv1/executor/cloudrun/deploy.go
+++ b/pkg/app/pipedv1/executor/cloudrun/deploy.go
@@ -44,7 +44,7 @@ type deployExecutor struct {
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	ctx := sig.Context()
-	ds, err := e.TargetDSP.GetReadOnly(ctx, e.LogPersister)
+	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
@@ -152,7 +152,7 @@ func (e *deployExecutor) ensurePromote(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	runningDS, err := e.RunningDSP.GetReadOnly(ctx, e.LogPersister)
+	runningDS, err := e.RunningDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/executor/cloudrun/rollback.go
+++ b/pkg/app/pipedv1/executor/cloudrun/rollback.go
@@ -65,7 +65,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	runningDS, err := e.RunningDSP.GetReadOnly(ctx, e.LogPersister)
+	runningDS, err := e.RunningDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/executor/ecs/deploy.go
+++ b/pkg/app/pipedv1/executor/ecs/deploy.go
@@ -36,7 +36,7 @@ type deployExecutor struct {
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	ctx := sig.Context()
-	ds, err := e.TargetDSP.GetReadOnly(ctx, e.LogPersister)
+	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/executor/ecs/rollback.go
+++ b/pkg/app/pipedv1/executor/ecs/rollback.go
@@ -56,7 +56,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	runningDS, err := e.RunningDSP.GetReadOnly(ctx, e.LogPersister)
+	runningDS, err := e.RunningDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/executor/lambda/deploy.go
+++ b/pkg/app/pipedv1/executor/lambda/deploy.go
@@ -39,7 +39,7 @@ type deployExecutor struct {
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	ctx := sig.Context()
-	ds, err := e.TargetDSP.GetReadOnly(ctx, e.LogPersister)
+	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/executor/lambda/rollback.go
+++ b/pkg/app/pipedv1/executor/lambda/rollback.go
@@ -53,7 +53,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	runningDS, err := e.RunningDSP.GetReadOnly(ctx, e.LogPersister)
+	runningDS, err := e.RunningDSP.Get(ctx, e.LogPersister)
 	if err != nil {
 		e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/platform/kubernetes/planner/server.go
+++ b/pkg/app/pipedv1/plugin/platform/kubernetes/planner/server.go
@@ -97,7 +97,7 @@ func (ps *PlannerService) QuickSyncPlan(ctx context.Context, in *platform.QuickS
 		ps.Decrypter,
 	)
 
-	ds, err := p.GetReadOnly(ctx, io.Discard /* TODO */)
+	ds, err := p.Get(ctx, io.Discard /* TODO */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes GetReadOnly from deloysource.Provider interface in pipedv1 package. The implementation of GetReadOnly does not provide any protections but only means that "please ensure not to modify the deploy source" or things will go wrong.

Concerning point: The GetReadOnly does not copy the deploy source directory, while the Get interface does, which means using the Get interface is more costly than using the GetReadOnly. But, for the new implementation of pipedv1, we will introduce another mechanism for controlling the deploy source, which is: instead of lazied cloning the deployment source (as the current usage of the deploy source package), we will force the piped clone the deployment source before call to plugins interfaces.

**Also, this change is in the pipedv1 package, which means it would not affect our current users** 👍 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
