### PR TITLE
Add a labeler rule of area/pipedv1

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -25,3 +25,6 @@ area/examples:
 area/tool:
 - tool/*
 - tool/**/*
+
+area/pipedv1:
+- pkg/app/pipedv1/**/*


### PR DESCRIPTION
**What this PR does / why we need it**:

- This rule will tag `area/pipedv1` when a PR contains any change under pkg/app/pipedv1/ recursively.
- I want to clarify whether a PR is made for pipedv1.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no
