### PR TITLE
Pipedv1 using auto rollback config from spec.Planner instead

### DIFF
--- a/pkg/app/pipedv1/plugin/platform/kubernetes/planner/server.go
+++ b/pkg/app/pipedv1/plugin/platform/kubernetes/planner/server.go
@@ -108,7 +108,7 @@ func (ps *PlannerService) QuickSyncPlan(ctx context.Context, in *platform.QuickS
 	}
 
 	return &platform.QuickSyncPlanResponse{
-		Stages: buildQuickSyncPipeline(*cfg.Input.AutoRollback, now),
+		Stages: buildQuickSyncPipeline(*cfg.Planner.AutoRollback, now),
 	}, nil
 }
 

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -64,6 +64,9 @@ type DeploymentPlanner struct {
 	// Disable auto-detecting to use QUICK_SYNC or PROGRESSIVE_SYNC.
 	// Always use the speficied pipeline for all deployments.
 	AlwaysUsePipeline bool `json:"alwaysUsePipeline"`
+	// Automatically reverts all deployment changes on failure.
+	// Default is true.
+	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
 }
 
 type Trigger struct {

--- a/pkg/config/application_cloudrun.go
+++ b/pkg/config/application_cloudrun.go
@@ -37,6 +37,8 @@ type CloudRunDeploymentInput struct {
 	ServiceManifestFile string `json:"serviceManifestFile"`
 	// Automatically reverts to the previous state when the deployment is failed.
 	// Default is true.
+	//
+	// Deprecated: Use Planner.AutoRollback instead.
 	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
 }
 

--- a/pkg/config/application_cloudrun_test.go
+++ b/pkg/config/application_cloudrun_test.go
@@ -52,6 +52,9 @@ func TestCloudRunApplicationConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: CloudRunDeploymentInput{
 					AutoRollback: newBoolPointer(true),

--- a/pkg/config/application_ecs.go
+++ b/pkg/config/application_ecs.go
@@ -63,6 +63,8 @@ type ECSDeploymentInput struct {
 	TargetGroups ECSTargetGroups `json:"targetGroups,omitempty"`
 	// Automatically reverts all changes from all stages when one of them failed.
 	// Default is true.
+	//
+	// Deprecated: Use Planner.AutoRollback instead.
 	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
 	// Run standalone task during deployment.
 	// Default is true.

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -54,6 +54,9 @@ func TestECSApplicationConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: ECSDeploymentInput{
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",
@@ -95,6 +98,9 @@ func TestECSApplicationConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: ECSDeploymentInput{
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",
@@ -128,6 +134,9 @@ func TestECSApplicationConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: ECSDeploymentInput{

--- a/pkg/config/application_kubernetes.go
+++ b/pkg/config/application_kubernetes.go
@@ -93,6 +93,8 @@ type KubernetesDeploymentInput struct {
 
 	// Automatically reverts all deployment changes on failure.
 	// Default is true.
+	//
+	// Deprecated: Use Planner.AutoRollback instead.
 	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
 
 	// Automatically create a new namespace if it does not exist.

--- a/pkg/config/application_kubernetes_test.go
+++ b/pkg/config/application_kubernetes_test.go
@@ -41,6 +41,7 @@ func TestKubernetesApplicationConfig(t *testing.T) {
 					Description: "application description first string\napplication description second string\n",
 					Planner: DeploymentPlanner{
 						AlwaysUsePipeline: true,
+						AutoRollback:      newBoolPointer(true),
 					},
 					Pipeline: &DeploymentPipeline{
 						Stages: []PipelineStage{
@@ -132,6 +133,9 @@ func TestKubernetesApplicationConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: KubernetesDeploymentInput{

--- a/pkg/config/application_lambda.go
+++ b/pkg/config/application_lambda.go
@@ -37,6 +37,8 @@ type LambdaDeploymentInput struct {
 	FunctionManifestFile string `json:"functionManifestFile" default:"function.yaml"`
 	// Automatically reverts all changes from all stages when one of them failed.
 	// Default is true.
+	//
+	// Deprecated: Use Planner.AutoRollback instead.
 	AutoRollback *bool `json:"autoRollback,omitempty" default:"true"`
 }
 

--- a/pkg/config/application_lambda_test.go
+++ b/pkg/config/application_lambda_test.go
@@ -54,6 +54,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: LambdaDeploymentInput{
 					FunctionManifestFile: "function.yaml",
@@ -104,6 +107,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: LambdaDeploymentInput{
 					FunctionManifestFile: "function.yaml",
@@ -144,6 +150,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: LambdaDeploymentInput{

--- a/pkg/config/application_terraform.go
+++ b/pkg/config/application_terraform.go
@@ -48,6 +48,8 @@ type TerraformDeploymentInput struct {
 	VarFiles []string `json:"varFiles,omitempty"`
 	// Automatically reverts all changes from all stages when one of them failed.
 	// Default is false.
+	//
+	// Deprecated: Use Planner.AutoRollback instead.
 	AutoRollback bool `json:"autoRollback"`
 	// List of additional flags will be used while executing terraform commands.
 	CommandFlags TerraformCommandFlags `json:"commandFlags"`

--- a/pkg/config/application_terraform_test.go
+++ b/pkg/config/application_terraform_test.go
@@ -54,6 +54,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: TerraformDeploymentInput{},
 			},
@@ -80,6 +83,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: TerraformDeploymentInput{
@@ -110,6 +116,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 					Encryption: &SecretEncryption{
 						EncryptedSecrets: map[string]string{
@@ -169,6 +178,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -220,6 +232,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: TerraformDeploymentInput{

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -426,6 +426,9 @@ func TestGenericTriggerConfiguration(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: newBoolPointer(true),
@@ -477,6 +480,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: newBoolPointer(true),
@@ -506,6 +512,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 							Disabled: newBoolPointer(true),
 						},
 					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
+					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: newBoolPointer(false),
@@ -534,6 +543,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: KubernetesDeploymentInput{
@@ -585,6 +597,9 @@ func TestGenericPostSyncConfiguration(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 					PostSync: &PostSync{
 						DeploymentChain: &DeploymentChain{
@@ -654,6 +669,9 @@ func TestGenericAnalysisConfiguration(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 					Pipeline: &DeploymentPipeline{
 						Stages: []PipelineStage{
@@ -789,6 +807,9 @@ func TestCustomSyncConfig(t *testing.T) {
 						OnChain: OnChain{
 							Disabled: newBoolPointer(true),
 						},
+					},
+					Planner: DeploymentPlanner{
+						AutoRollback: newBoolPointer(true),
 					},
 				},
 				Input: LambdaDeploymentInput{


### PR DESCRIPTION
**What this PR does / why we need it**:

The auto rollback configuration is generic for all applications kinds, so it should be placed in `spec.Planner` instead of `spec(Kind).Input`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
