### PR TITLE
Implement POC for planner of pipedv1

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -210,6 +210,14 @@ func (p *planner) Run(ctx context.Context) error {
 	return p.reportDeploymentPlanned(ctx, out)
 }
 
+// buildPlan builds the deployment plan.
+// The strategy determination logic is based on the following order:
+//   - Direct trigger via web console
+//   - Force quick sync if there is no pipeline specified
+//   - Force pipeline if the `spec.planner.alwaysUsePipeline` was configured
+//   - CommitMatcher ensure pipeline/quick sync based on the commit message
+//   - Force quick sync if there is no previous deployment (aka. this is the first deploy)
+//   - Based on PlannerService.DetermineStrategy returned by plugins
 func (p *planner) buildPlan(ctx context.Context, targetDS *deploysource.DeploySource) (*plannerOutput, error) {
 	out := &plannerOutput{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides POC implementation for the Planner of pipedv1 (piped side). The logic of building plan as follow
```go
// The strategy determination logic is based on the following order:
//   - Direct trigger via web console
//   - Force quick sync if there is no pipeline specified
//   - Force pipeline if the `spec.planner.alwaysUsePipeline` was configured
//   - CommitMatcher ensure pipeline/quick sync based on the commit message
//   - Force quick sync if there is no previous deployment (aka. this is the first deploy)
//   - Based on PlannerService.DetermineStrategy returned by plugins
```

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
