### PR TITLE
Support `EphemeralStorage` in TaskDefinition [ECS]

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -187,6 +187,7 @@ func (c *client) RegisterTaskDefinition(ctx context.Context, taskDefinition type
 		NetworkMode:             taskDefinition.NetworkMode,
 		Volumes:                 taskDefinition.Volumes,
 		RuntimePlatform:         taskDefinition.RuntimePlatform,
+		EphemeralStorage:        taskDefinition.EphemeralStorage,
 		// Requires defined at task level in case Fargate is used.
 		Cpu:    taskDefinition.Cpu,
 		Memory: taskDefinition.Memory,


### PR DESCRIPTION
**What this PR does / why we need it**:

Enabled to configure `ephemeralStorage` in TaskDefinition.

Because it is not supported yet.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no

**How to use it**

You can configure like this in your taskdef.yaml:
<img width="261" alt="image" src="https://github.com/user-attachments/assets/d2a37a9e-7b49-4fe2-90bb-0dc7414604f5">

