### PR TITLE
Fix type error for dummyApplicationLiveState

### DIFF
--- a/web/src/__fixtures__/dummy-application-live-state.ts
+++ b/web/src/__fixtures__/dummy-application-live-state.ts
@@ -1,9 +1,9 @@
-import { ApplicationKind } from "pipecd/web/model/common_pb";
 import {
   ApplicationLiveStateVersion,
   KubernetesApplicationLiveState,
   KubernetesResourceState,
 } from "pipecd/web/model/application_live_state_pb";
+import { ApplicationKind } from "pipecd/web/model/common_pb";
 import {
   ApplicationLiveState,
   ApplicationLiveStateSnapshot,
@@ -65,6 +65,7 @@ export const dummyApplicationLiveState: ApplicationLiveState = {
   version: { index: 1, timestamp: 0 },
   projectId: "project-1",
   cloudrun: { resourcesList: [] },
+  ecs: { resourcesList: [] },
   lambda: {},
   terraform: {},
   kubernetes: { resourcesList },


### PR DESCRIPTION
**What this PR does / why we need it**:

I found the type some errors. This is for type ApplicationLiveState.

It does not affect the behavior because it's just a fixture.
The proto definition has changed in https://github.com/pipe-cd/pipecd/pull/4979.

I checked the type error for ApplicationLiveState disappeared.


**Before**
```
% npm run typecheck                                                                            (git)-[fix-dummy-fixture]

> pipecd-web@1.0.0 typecheck
> tsc --noEmit

src/__fixtures__/dummy-application-live-state.ts:60:14 - error TS2741: Property 'ecs' is missing in type '{ applicationId: string; healthStatus: ApplicationLiveStateSnapshot.Status.HEALTHY; kind: ApplicationKind.KUBERNETES; pipedId: string; version: { index: number; timestamp: number; }; ... 4 more ...; kubernetes: { ...; }; }' but required in type 'Required<AsObject>'.

60 export const dummyApplicationLiveState: ApplicationLiveState = {
                ~~~~~~~~~~~~~~~~~~~~~~~~~

  model/application_live_state_pb.d.ts:72:5
    72     ecs?: ECSApplicationLiveState.AsObject,
           ~~~
    'ecs' is declared here.

src/api/client.ts:10:17 - error TS2694: Namespace '"grpc-web"' has no exported member 'Error'.

10   (err: grpcWeb.Error, response: { toObject: () => Res }): void;
                   ~~~~~


Found 2 errors.
```

**After**

```
% npm run typecheck                                                                            (git)-[fix-dummy-fixture]

> pipecd-web@1.0.0 typecheck
> tsc --noEmit

src/api/client.ts:10:17 - error TS2694: Namespace '"grpc-web"' has no exported member 'Error'.

10   (err: grpcWeb.Error, response: { toObject: () => Res }): void;
                   ~~~~~


Found 1 error.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
