### PR TITLE
Fix type for grpcWeb.Error to grpcweb.RpcError

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -7,7 +7,7 @@ export const apiClient = new WebServiceClient(apiEndpoint, null, {
 });
 
 interface ApiCallback<Res> {
-  (err: grpcWeb.Error, response: { toObject: () => Res }): void;
+  (err: grpcWeb.RpcError, response: { toObject: () => Res }): void;
 }
 
 export async function apiRequest<Req, Res>(


### PR DESCRIPTION
**What this PR does / why we need it**:

I found the type some errors. This is for type grpcWeb.RpcError.

From grpc-web 1.3.0, grpcWeb.Error has changed to grpcWeb.RpcError.
https://github.com/grpc/grpc-web/releases/tag/1.3.0

> Major Features
#1139 Improve error type with RpcError & internal code sync (contributor: @TomiBelan)
(experimental) Typescript users need to update type references from Error -> RpcError

I checked the type error for grpcWeb.Error disappeared.

**Before**

```
% npm run typecheck                                                                   (git)-[fix-type-for-grpcWeb-error]

> pipecd-web@1.0.0 typecheck
> tsc --noEmit

src/__fixtures__/dummy-application-live-state.ts:60:14 - error TS2741: Property 'ecs' is missing in type '{ applicationId: string; healthStatus: ApplicationLiveStateSnapshot.Status.HEALTHY; kind: ApplicationKind.KUBERNETES; pipedId: string; version: { index: number; timestamp: number; }; ... 4 more ...; kubernetes: { ...; }; }' but required in type 'Required<AsObject>'.

60 export const dummyApplicationLiveState: ApplicationLiveState = {
                ~~~~~~~~~~~~~~~~~~~~~~~~~

  model/application_live_state_pb.d.ts:72:5
    72     ecs?: ECSApplicationLiveState.AsObject,
           ~~~
    'ecs' is declared here.

src/api/client.ts:10:17 - error TS2694: Namespace '"grpc-web"' has no exported member 'Error'.

10   (err: grpcWeb.Error, response: { toObject: () => Res }): void;
                   ~~~~~


Found 2 errors.
```

**After**

```
% npm run typecheck                                                                   (git)-[fix-type-for-grpcWeb-error]

> pipecd-web@1.0.0 typecheck
> tsc --noEmit

src/__fixtures__/dummy-application-live-state.ts:60:14 - error TS2741: Property 'ecs' is missing in type '{ applicationId: string; healthStatus: ApplicationLiveStateSnapshot.Status.HEALTHY; kind: ApplicationKind.KUBERNETES; pipedId: string; version: { index: number; timestamp: number; }; ... 4 more ...; kubernetes: { ...; }; }' but required in type 'Required<AsObject>'.

60 export const dummyApplicationLiveState: ApplicationLiveState = {
                ~~~~~~~~~~~~~~~~~~~~~~~~~

  model/application_live_state_pb.d.ts:72:5
    72     ecs?: ECSApplicationLiveState.AsObject,
           ~~~
    'ecs' is declared here.


Found 1 error.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
