### PR TITLE
Add typecheck for typescript on lint/web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,10 @@ lint/web: FIX ?= false
 lint/web:
 ifeq ($(FIX),true)
 	yarn --cwd web lint:fix
+	yarn --cwd web typecheck
 else
 	yarn --cwd web lint
+	yarn --cwd web typecheck
 endif
 
 # Update commands


### PR DESCRIPTION
**What this PR does / why we need it**:

Add typecheck for typescript on lint/web to check the type error.
https://github.com/pipe-cd/pipecd/blob/b0e40d594396de90f11eb6cad07d50a76c94db26/web/package.json#L14

We should notice and fix it in the PR phase. So I added it on the lint phase.

**Which issue(s) this PR fixes**:

Refs
- https://github.com/pipe-cd/pipecd/pull/5071
- https://github.com/pipe-cd/pipecd/pull/5072

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
