### PR TITLE
Add quiet option for cherry-pick script

### DIFF
--- a/.github/workflows/cherry_pick.yaml
+++ b/.github/workflows/cherry_pick.yaml
@@ -20,6 +20,6 @@ jobs:
         run: |
           git config user.name "pipecd-bot"
           git config user.email "pipecd.dev@gmail.com"
-          make release/pick branch=${{ inputs.releaseBranch }} pull_numbers="$(gh pr list --label cherry-pick --label ${{ inputs.version }} --state merged | awk '{print $1}' | sort | paste -sd ' ' -)"
+          ./hack/cherry-pick.sh -q ${{ inputs.releaseBranch }} $(gh pr list --label cherry-pick --label ${{ inputs.version }} --state merged | awk '{print $1}' | sort | paste -sd ' ' -)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

disable prompt for cherry-pick script
ref: https://github.com/pipe-cd/pipecd/pull/5080

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
