### PR TITLE
Fix Lambda config docs

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -448,6 +448,8 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
+
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
@@ -495,9 +497,6 @@ One of `yamlField` or `regex` is required.
 | securityGroupIDs| []string | List of security group IDs  | No       |
 | subnetIDs       | []string | List of subnet IDs          | No       |
 
-- Note
-    - See more Details
-        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -467,7 +467,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
-| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -476,7 +476,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-### SourceCode
+#### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
@@ -484,19 +484,19 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | ref   | string | Git branch/tag/reference| Yes      |
 | path  | string | Path within the repository | Yes    |
 
-### Architecture
+#### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
 | name  | string | Name of the architecture | Yes     |
 
-### EphemeralStorage
+#### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
 | size  | int32 | Size of the ephemeral storage| Yes       |
 
-### VPCConfig
+#### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -448,21 +448,27 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+One of `image`, `s3Bucket`, or `sourceCode` is required.
+
+- If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
+
+- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
 | role             | string           | IAM role ARN                       | Yes      |
-| image            | string           | URI of the container image         | Yes      |
-| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| s3Key            | string           | S3 key for code package            | Yes      |
-| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| handler          | string           | Lambda function handler            | Yes      |
+| image            | string           | URI of the container image         | No      |
+| s3Bucket         | string           | S3 bucket name for code package   | No      |
+| s3Key            | string           | S3 key for code package            | No      |
+| s3ObjectVersion  | string           | S3 object version for code package | No      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| handler          | string           | Lambda function handler            | No      |
+| runtime          | string           | Runtime environment                | No      |
 | architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| runtime          | string           | Runtime environment                | Yes      |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |
 | tags             | map[string]string| Key-value pairs for tags           | No       |
@@ -488,7 +494,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| Yes       |
 
 ### VPCConfig
 

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -452,7 +452,7 @@ One of `yamlField` or `regex` is required.
 |------------------|------------------|------------------------------------|----------|
 | Name             | string           | Name of the Lambda function        | Yes      |
 | Role             | string           | IAM role ARN                       | Yes      |
-| ImageURI         | string           | URI of the container image         | Yes      |
+| Image            | string           | URI of the container image         | Yes      |
 | S3Bucket         | string           | S3 bucket name for code package   | Yes      |
 | S3Key            | string           | S3 key for code package            | Yes      |
 | S3ObjectVersion  | string           | S3 object version for code package | Yes      |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -464,7 +464,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| source       | [source](#sourcecode)       | Git settings                | No      |
+| source       | [source](#source)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -450,50 +450,50 @@ One of `yamlField` or `regex` is required.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
-| Name             | string           | Name of the Lambda function        | Yes      |
-| Role             | string           | IAM role ARN                       | Yes      |
-| Image            | string           | URI of the container image         | Yes      |
-| S3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| S3Key            | string           | S3 key for code package            | Yes      |
-| S3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| SourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| Handler          | string           | Lambda function handler            | Yes      |
-| Architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
-| EphemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| Runtime          | string           | Runtime environment                | Yes      |
-| Memory           | int32            | Memory allocation (in MB)          | Yes      |
-| Timeout          | int32            | Function timeout (in seconds)      | Yes      |
-| Tags             | map[string]string| Key-value pairs for tags           | No       |
-| Environments     | map[string]string| Environment variables              | No       |
-| VPCConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
-| Layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
+| name             | string           | Name of the Lambda function        | Yes      |
+| role             | string           | IAM role ARN                       | Yes      |
+| image            | string           | URI of the container image         | Yes      |
+| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
+| s3Key            | string           | S3 key for code package            | Yes      |
+| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
+| handler          | string           | Lambda function handler            | Yes      |
+| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
+| runtime          | string           | Runtime environment                | Yes      |
+| memory           | int32            | Memory allocation (in MB)          | Yes      |
+| timeout          | int32            | Function timeout (in seconds)      | Yes      |
+| tags             | map[string]string| Key-value pairs for tags           | No       |
+| environments     | map[string]string| Environment variables              | No       |
+| vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
+| layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
 ### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
-| Git   | string | Git repository URL       | Yes      |
-| Ref   | string | Git branch/tag/reference| Yes      |
-| Path  | string | Path within the repository | Yes    |
+| git   | string | Git repository URL       | Yes      |
+| ref   | string | Git branch/tag/reference| Yes      |
+| path  | string | Path within the repository | Yes    |
 
 ### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
-| Name  | string | Name of the architecture | Yes     |
+| name  | string | Name of the architecture | Yes     |
 
 ### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| Size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| No       |
 
 ### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| SecurityGroupIDs| []string | List of security group IDs  | No       |
-| SubnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIDs| []string | List of security group IDs  | No       |
+| subnetIDs       | []string | List of subnet IDs          | No       |
 
 - Note
     - See more Details

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -448,11 +448,11 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
-One of `image`, `s3Bucket`, or `sourceCode` is required.
+One of `image`, `s3Bucket`, or `source` is required.
 
 - If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
 
-- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+- If you use `s3Bucket` or `source`, `handler` and `runtime` are required.
 
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
@@ -464,7 +464,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| source       | [source](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
@@ -476,7 +476,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-#### SourceCode
+#### Source
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -497,7 +497,7 @@ One of `yamlField` or `regex` is required.
 
 - Note
     - See more Details
-        - [Configuration Lambda application](../managing-application/defining-app-configuration/lambda)
+        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -494,8 +494,8 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| securityGroupIDs| []string | List of security group IDs  | No       |
-| subnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIds| []string | List of security group IDs  | No       |
+| subnetIds       | []string | List of subnet IDs          | No       |
 
 
 ## LambdaQuickSync

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -449,50 +449,50 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
-| Name             | string           | Name of the Lambda function        | Yes      |
-| Role             | string           | IAM role ARN                       | Yes      |
-| Image            | string           | URI of the container image         | Yes      |
-| S3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| S3Key            | string           | S3 key for code package            | Yes      |
-| S3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| SourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| Handler          | string           | Lambda function handler            | Yes      |
-| Architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
-| EphemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| Runtime          | string           | Runtime environment                | Yes      |
-| Memory           | int32            | Memory allocation (in MB)          | Yes      |
-| Timeout          | int32            | Function timeout (in seconds)      | Yes      |
-| Tags             | map[string]string| Key-value pairs for tags           | No       |
-| Environments     | map[string]string| Environment variables              | No       |
-| VPCConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
-| Layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
+| name             | string           | Name of the Lambda function        | Yes      |
+| role             | string           | IAM role ARN                       | Yes      |
+| image            | string           | URI of the container image         | Yes      |
+| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
+| s3Key            | string           | S3 key for code package            | Yes      |
+| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
+| handler          | string           | Lambda function handler            | Yes      |
+| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
+| runtime          | string           | Runtime environment                | Yes      |
+| memory           | int32            | Memory allocation (in MB)          | Yes      |
+| timeout          | int32            | Function timeout (in seconds)      | Yes      |
+| tags             | map[string]string| Key-value pairs for tags           | No       |
+| environments     | map[string]string| Environment variables              | No       |
+| vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
+| layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
 ### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
-| Git   | string | Git repository URL       | Yes      |
-| Ref   | string | Git branch/tag/reference| Yes      |
-| Path  | string | Path within the repository | Yes    |
+| git   | string | Git repository URL       | Yes      |
+| ref   | string | Git branch/tag/reference| Yes      |
+| path  | string | Path within the repository | Yes    |
 
 ### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
-| Name  | string | Name of the architecture | Yes     |
+| name  | string | Name of the architecture | Yes     |
 
 ### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| Size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| No       |
 
 ### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| SecurityGroupIDs| []string | List of security group IDs  | No       |
-| SubnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIDs| []string | List of security group IDs  | No       |
+| subnetIDs       | []string | List of subnet IDs          | No       |
 
 
 ## LambdaQuickSync

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -464,7 +464,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
-| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -491,8 +491,8 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| securityGroupIDs| []string | List of security group IDs  | No       |
-| subnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIds| []string | List of security group IDs  | No       |
+| subnetIds       | []string | List of subnet IDs          | No       |
 
 
 ## LambdaQuickSync

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -473,7 +473,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-### SourceCode
+#### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
@@ -481,19 +481,19 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | ref   | string | Git branch/tag/reference| Yes      |
 | path  | string | Path within the repository | Yes    |
 
-### Architecture
+#### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
 | name  | string | Name of the architecture | Yes     |
 
-### EphemeralStorage
+#### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
 | size  | int32 | Size of the ephemeral storage| Yes       |
 
-### VPCConfig
+#### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -494,7 +494,7 @@ One of `yamlField` or `regex` is required.
 
 - Note
     - See more Details
-        - [Configuration Lambda application](../managing-application/defining-app-configuration/lambda)
+        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -445,11 +445,11 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
-One of `image`, `s3Bucket`, or `sourceCode` is required.
+One of `image`, `s3Bucket`, or `source` is required.
 
 - If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
 
-- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+- If you use `s3Bucket` or `source`, `handler` and `runtime` are required.
 
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
@@ -461,7 +461,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
@@ -473,7 +473,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-#### SourceCode
+#### Source
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -445,6 +445,8 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
+
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | Name             | string           | Name of the Lambda function        | Yes      |
@@ -492,9 +494,6 @@ One of `yamlField` or `regex` is required.
 | SecurityGroupIDs| []string | List of security group IDs  | No       |
 | SubnetIDs       | []string | List of subnet IDs          | No       |
 
-- Note
-    - See more Details
-        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -449,7 +449,7 @@ One of `yamlField` or `regex` is required.
 |------------------|------------------|------------------------------------|----------|
 | Name             | string           | Name of the Lambda function        | Yes      |
 | Role             | string           | IAM role ARN                       | Yes      |
-| ImageURI         | string           | URI of the container image         | Yes      |
+| Image            | string           | URI of the container image         | Yes      |
 | S3Bucket         | string           | S3 bucket name for code package   | Yes      |
 | S3Key            | string           | S3 key for code package            | Yes      |
 | S3ObjectVersion  | string           | S3 object version for code package | Yes      |

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -461,7 +461,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| source       | [Source](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#source)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -445,21 +445,27 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+One of `image`, `s3Bucket`, or `sourceCode` is required.
+
+- If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
+
+- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
 | role             | string           | IAM role ARN                       | Yes      |
-| image            | string           | URI of the container image         | Yes      |
-| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| s3Key            | string           | S3 key for code package            | Yes      |
-| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| handler          | string           | Lambda function handler            | Yes      |
+| image            | string           | URI of the container image         | No      |
+| s3Bucket         | string           | S3 bucket name for code package   | No      |
+| s3Key            | string           | S3 key for code package            | No      |
+| s3ObjectVersion  | string           | S3 object version for code package | No      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| handler          | string           | Lambda function handler            | No      |
+| runtime          | string           | Runtime environment                | No      |
 | architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| runtime          | string           | Runtime environment                | Yes      |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |
 | tags             | map[string]string| Key-value pairs for tags           | No       |
@@ -485,7 +491,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| Yes       |
 
 ### VPCConfig
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -462,7 +462,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| source       | [Source](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#source)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -492,8 +492,8 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| securityGroupIDs| []string | List of security group IDs  | No       |
-| subnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIds| []string | List of security group IDs  | No       |
+| subnetIds       | []string | List of subnet IDs          | No       |
 
 
 ## LambdaQuickSync

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -474,7 +474,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-### SourceCode
+#### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
@@ -482,19 +482,19 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | ref   | string | Git branch/tag/reference| Yes      |
 | path  | string | Path within the repository | Yes    |
 
-### Architecture
+#### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
 | name  | string | Name of the architecture | Yes     |
 
-### EphemeralStorage
+#### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
 | size  | int32 | Size of the ephemeral storage| Yes       |
 
-### VPCConfig
+#### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -446,6 +446,8 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
+
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
@@ -493,9 +495,6 @@ One of `yamlField` or `regex` is required.
 | securityGroupIDs| []string | List of security group IDs  | No       |
 | subnetIDs       | []string | List of subnet IDs          | No       |
 
-- Note
-    - See more Details
-        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -446,11 +446,11 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
-One of `image`, `s3Bucket`, or `sourceCode` is required.
+One of `image`, `s3Bucket`, or `source` is required.
 
 - If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
 
-- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+- If you use `s3Bucket` or `source`, `handler` and `runtime` are required.
 
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
@@ -462,7 +462,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
@@ -474,7 +474,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-#### SourceCode
+#### Source
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -495,7 +495,7 @@ One of `yamlField` or `regex` is required.
 
 - Note
     - See more Details
-        - [Configuration Lambda application](../managing-application/defining-app-configuration/lambda)
+        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -448,50 +448,50 @@ One of `yamlField` or `regex` is required.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
-| Name             | string           | Name of the Lambda function        | Yes      |
-| Role             | string           | IAM role ARN                       | Yes      |
-| Image            | string           | URI of the container image         | Yes      |
-| S3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| S3Key            | string           | S3 key for code package            | Yes      |
-| S3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| SourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| Handler          | string           | Lambda function handler            | Yes      |
-| Architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
-| EphemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| Runtime          | string           | Runtime environment                | Yes      |
-| Memory           | int32            | Memory allocation (in MB)          | Yes      |
-| Timeout          | int32            | Function timeout (in seconds)      | Yes      |
-| Tags             | map[string]string| Key-value pairs for tags           | No       |
-| Environments     | map[string]string| Environment variables              | No       |
-| VPCConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
-| Layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
+| name             | string           | Name of the Lambda function        | Yes      |
+| role             | string           | IAM role ARN                       | Yes      |
+| image            | string           | URI of the container image         | Yes      |
+| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
+| s3Key            | string           | S3 key for code package            | Yes      |
+| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
+| handler          | string           | Lambda function handler            | Yes      |
+| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
+| runtime          | string           | Runtime environment                | Yes      |
+| memory           | int32            | Memory allocation (in MB)          | Yes      |
+| timeout          | int32            | Function timeout (in seconds)      | Yes      |
+| tags             | map[string]string| Key-value pairs for tags           | No       |
+| environments     | map[string]string| Environment variables              | No       |
+| vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
+| layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
 ### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
-| Git   | string | Git repository URL       | Yes      |
-| Ref   | string | Git branch/tag/reference| Yes      |
-| Path  | string | Path within the repository | Yes    |
+| git   | string | Git repository URL       | Yes      |
+| ref   | string | Git branch/tag/reference| Yes      |
+| path  | string | Path within the repository | Yes    |
 
 ### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
-| Name  | string | Name of the architecture | Yes     |
+| name  | string | Name of the architecture | Yes     |
 
 ### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| Size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| No       |
 
 ### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| SecurityGroupIDs| []string | List of security group IDs  | No       |
-| SubnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIDs| []string | List of security group IDs  | No       |
+| subnetIDs       | []string | List of subnet IDs          | No       |
 
 - Note
     - See more Details

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -450,7 +450,7 @@ One of `yamlField` or `regex` is required.
 |------------------|------------------|------------------------------------|----------|
 | Name             | string           | Name of the Lambda function        | Yes      |
 | Role             | string           | IAM role ARN                       | Yes      |
-| ImageURI         | string           | URI of the container image         | Yes      |
+| Image            | string           | URI of the container image         | Yes      |
 | S3Bucket         | string           | S3 bucket name for code package   | Yes      |
 | S3Key            | string           | S3 key for code package            | Yes      |
 | S3ObjectVersion  | string           | S3 object version for code package | Yes      |

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -446,21 +446,27 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+One of `image`, `s3Bucket`, or `sourceCode` is required.
+
+- If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
+
+- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
 | role             | string           | IAM role ARN                       | Yes      |
-| image            | string           | URI of the container image         | Yes      |
-| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| s3Key            | string           | S3 key for code package            | Yes      |
-| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| handler          | string           | Lambda function handler            | Yes      |
+| image            | string           | URI of the container image         | No      |
+| s3Bucket         | string           | S3 bucket name for code package   | No      |
+| s3Key            | string           | S3 key for code package            | No      |
+| s3ObjectVersion  | string           | S3 object version for code package | No      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| handler          | string           | Lambda function handler            | No      |
+| runtime          | string           | Runtime environment                | No      |
 | architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| runtime          | string           | Runtime environment                | Yes      |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |
 | tags             | map[string]string| Key-value pairs for tags           | No       |
@@ -486,7 +492,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| Yes       |
 
 ### VPCConfig
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -465,7 +465,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
-| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -462,7 +462,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| source       | [Source](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#source)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -492,8 +492,8 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| securityGroupIDs| []string | List of security group IDs  | No       |
-| subnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIds| []string | List of security group IDs  | No       |
+| subnetIds       | []string | List of subnet IDs          | No       |
 
 
 ## LambdaQuickSync

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -474,7 +474,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-### SourceCode
+#### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
@@ -482,19 +482,19 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | ref   | string | Git branch/tag/reference| Yes      |
 | path  | string | Path within the repository | Yes    |
 
-### Architecture
+#### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
 | name  | string | Name of the architecture | Yes     |
 
-### EphemeralStorage
+#### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
 | size  | int32 | Size of the ephemeral storage| Yes       |
 
-### VPCConfig
+#### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -446,6 +446,8 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
+
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
@@ -493,9 +495,6 @@ One of `yamlField` or `regex` is required.
 | securityGroupIDs| []string | List of security group IDs  | No       |
 | subnetIDs       | []string | List of subnet IDs          | No       |
 
-- Note
-    - See more Details
-        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -446,11 +446,11 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
-One of `image`, `s3Bucket`, or `sourceCode` is required.
+One of `image`, `s3Bucket`, or `source` is required.
 
 - If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
 
-- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+- If you use `s3Bucket` or `source`, `handler` and `runtime` are required.
 
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
@@ -462,7 +462,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| source       | [Source](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
@@ -474,7 +474,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
 | layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
-#### SourceCode
+#### Source
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -495,7 +495,7 @@ One of `yamlField` or `regex` is required.
 
 - Note
     - See more Details
-        - [Configuration Lambda application](../managing-application/defining-app-configuration/lambda)
+        - [Configuring Lambda application](../managing-application/defining-app-configuration/lambda)
 
 ## LambdaQuickSync
 

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -448,50 +448,50 @@ One of `yamlField` or `regex` is required.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
-| Name             | string           | Name of the Lambda function        | Yes      |
-| Role             | string           | IAM role ARN                       | Yes      |
-| Image            | string           | URI of the container image         | Yes      |
-| S3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| S3Key            | string           | S3 key for code package            | Yes      |
-| S3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| SourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| Handler          | string           | Lambda function handler            | Yes      |
-| Architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
-| EphemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| Runtime          | string           | Runtime environment                | Yes      |
-| Memory           | int32            | Memory allocation (in MB)          | Yes      |
-| Timeout          | int32            | Function timeout (in seconds)      | Yes      |
-| Tags             | map[string]string| Key-value pairs for tags           | No       |
-| Environments     | map[string]string| Environment variables              | No       |
-| VPCConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
-| Layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
+| name             | string           | Name of the Lambda function        | Yes      |
+| role             | string           | IAM role ARN                       | Yes      |
+| image            | string           | URI of the container image         | Yes      |
+| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
+| s3Key            | string           | S3 key for code package            | Yes      |
+| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
+| handler          | string           | Lambda function handler            | Yes      |
+| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
+| runtime          | string           | Runtime environment                | Yes      |
+| memory           | int32            | Memory allocation (in MB)          | Yes      |
+| timeout          | int32            | Function timeout (in seconds)      | Yes      |
+| tags             | map[string]string| Key-value pairs for tags           | No       |
+| environments     | map[string]string| Environment variables              | No       |
+| vpcConfig        | [VPCConfig](#vpcconfig)       | VPC configuration                  | No       |
+| layers        | []string       | ARNs of [layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html) to depend on                | No       |
 
 ### SourceCode
 
 | Field | Type   | Description              | Required |
 |-------|--------|--------------------------|----------|
-| Git   | string | Git repository URL       | Yes      |
-| Ref   | string | Git branch/tag/reference| Yes      |
-| Path  | string | Path within the repository | Yes    |
+| git   | string | Git repository URL       | Yes      |
+| ref   | string | Git branch/tag/reference| Yes      |
+| path  | string | Path within the repository | Yes    |
 
 ### Architecture
 
 | Field | Type   | Description            | Required |
 |-------|--------|------------------------|----------|
-| Name  | string | Name of the architecture | Yes     |
+| name  | string | Name of the architecture | Yes     |
 
 ### EphemeralStorage
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| Size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| No       |
 
 ### VPCConfig
 
 | Field           | Type     | Description                 | Required |
 |-----------------|----------|-----------------------------|----------|
-| SecurityGroupIDs| []string | List of security group IDs  | No       |
-| SubnetIDs       | []string | List of subnet IDs          | No       |
+| securityGroupIDs| []string | List of security group IDs  | No       |
+| subnetIDs       | []string | List of subnet IDs          | No       |
 
 - Note
     - See more Details

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -450,7 +450,7 @@ One of `yamlField` or `regex` is required.
 |------------------|------------------|------------------------------------|----------|
 | Name             | string           | Name of the Lambda function        | Yes      |
 | Role             | string           | IAM role ARN                       | Yes      |
-| ImageURI         | string           | URI of the container image         | Yes      |
+| Image            | string           | URI of the container image         | Yes      |
 | S3Bucket         | string           | S3 bucket name for code package   | Yes      |
 | S3Key            | string           | S3 key for code package            | Yes      |
 | S3ObjectVersion  | string           | S3 object version for code package | Yes      |

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -446,21 +446,27 @@ One of `yamlField` or `regex` is required.
 
 ### Specific function.yaml
 
+One of `image`, `s3Bucket`, or `sourceCode` is required.
+
+- If you use `s3Bucket`, `s3Key` and `s3ObjectVersion` are required.
+
+- If you use `s3Bucket` or `sourceCode`, `handler` and `runtime` are required.
+
 See [Configuring Lambda application](../managing-application/defining-app-configuration/lambda) for more details.
 
 | Field            | Type             | Description                        | Required |
 |------------------|------------------|------------------------------------|----------|
 | name             | string           | Name of the Lambda function        | Yes      |
 | role             | string           | IAM role ARN                       | Yes      |
-| image            | string           | URI of the container image         | Yes      |
-| s3Bucket         | string           | S3 bucket name for code package   | Yes      |
-| s3Key            | string           | S3 key for code package            | Yes      |
-| s3ObjectVersion  | string           | S3 object version for code package | Yes      |
-| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | Yes      |
-| handler          | string           | Lambda function handler            | Yes      |
+| image            | string           | URI of the container image         | No      |
+| s3Bucket         | string           | S3 bucket name for code package   | No      |
+| s3Key            | string           | S3 key for code package            | No      |
+| s3ObjectVersion  | string           | S3 object version for code package | No      |
+| sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
+| handler          | string           | Lambda function handler            | No      |
+| runtime          | string           | Runtime environment                | No      |
 | architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
-| runtime          | string           | Runtime environment                | Yes      |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |
 | tags             | map[string]string| Key-value pairs for tags           | No       |
@@ -486,7 +492,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 | Field | Type  | Description                  | Required |
 |-------|-------|------------------------------|----------|
-| size  | int32 | Size of the ephemeral storage| No       |
+| size  | int32 | Size of the ephemeral storage| Yes       |
 
 ### VPCConfig
 

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -465,7 +465,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | sourceCode       | [SourceCode](#sourcecode)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
-| architectures    | [[]Architecture](#architecture)   | Supported architectures            | No       |
+| architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
 | ephemeralStorage | [EphemeralStorage](#ephemeralstorage)| Ephemeral storage configuration    | No       |
 | memory           | int32            | Memory allocation (in MB)          | Yes      |
 | timeout          | int32            | Function timeout (in seconds)      | Yes      |


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix Lambda config docs in the configuration-reference.
The main changes are:
- Fix field names: UpperCamelCase -> lowerCamelCase
- Fix field names:  
    - `ImageURI` -> `image`
    - `SecurityGroupIDs` -> `securityGroupIds`
    - `SubnetIDs` -> `subnetIds`
    - `SourceCode` -> `source` _[edited in [709ac39](https://github.com/pipe-cd/pipecd/pull/5087/commits/709ac391d8bf05b68ad188f7d35280d4d481630b)]_
- Fix `Required` values and add explanations


**For Reviewers**

See [function.go](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/lambda/function.go).

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
