### PR TITLE
Release/init v0.48.3

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.48.2
+tag: v0.48.3
 
 releaseNoteGenerator:
   showCommitter: false


### PR DESCRIPTION
**What this PR does / why we need it**:

I executed `make release/init version=v0.48.3` to release v0.48.3
