### PR TITLE
Set fetch-depth as 0 to create correct patches during git cherry-pick as much as possible

### DIFF
--- a/.github/workflows/cherry_pick.yaml
+++ b/.github/workflows/cherry_pick.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: make a cherry-pick PR
         run: |
           git config user.name "pipecd-bot"


### PR DESCRIPTION
**What this PR does / why we need it**:

Set fetch-depth for actions/checkout as 0 to create correct patches during git cherry-pick as much as possible.
https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches

By default, actions/checkout set fetch-depth as 1. It means that only the latest commit is fetched.
In the cherry-pick process, some patches are created based on the commits in the fetched repo and merged into the target branch.
It would be nice to fetch commits as much as possible to avoid conflict with cherry-pick.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
