### PR TITLE
Bump the Grafana chart version

### DIFF
--- a/manifests/pipecd/Chart.lock
+++ b/manifests/pipecd/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 14.6.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.16.2
+  version: 8.4.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.93.3
-digest: sha256:4025b0e61e9889d55016505f93a4718b548bc7a36599cf4cfe29ba31fdfd1503
-generated: "2024-06-17T15:44:50.374800619+09:00"
+digest: sha256:70a2b5c168161cb0708b53d1f13e8d8d5c2bdd4e7a3d2164dbfb7b0c64c02588
+generated: "2024-08-02T09:51:22.670788848+09:00"

--- a/manifests/pipecd/Chart.yaml
+++ b/manifests/pipecd/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
   repository: "https://prometheus-community.github.io/helm-charts"
   condition: monitoring.enabled
 - name: grafana
-  version: "6.16.2"
+  version: "8.4.0"
   repository: "https://grafana.github.io/helm-charts"
   condition: monitoring.enabled
 - name: opentelemetry-collector

--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- include "pipecd.labels" . | nindent 4 }}
     grafana_dashboard: "1"
   annotations:
-    k8s-sidecar-target-directory: "/tmp/dashboards/cluster"
+    k8s-sidecar-target-directory: "/tmp/dashboards/Cluster"
 data:
 {{ range $path, $_ :=  .Files.Glob  "grafana-dashboards/cluster/**.json" }}
   {{ trimPrefix "grafana-dashboards/cluster/" $path | nindent 2 }}: |-
@@ -39,7 +39,7 @@ metadata:
     {{- include "pipecd.labels" . | nindent 4 }}
     grafana_dashboard: "1"
   annotations:
-    k8s-sidecar-target-directory: "/tmp/dashboards/control-plane"
+    k8s-sidecar-target-directory: "/tmp/dashboards/Control-Plane"
 data:
 {{ range $path, $_ :=  .Files.Glob  "grafana-dashboards/control-plane/**.json" }}
   {{ trimPrefix "grafana-dashboards/control-plane/" $path | nindent 2 }}: |-
@@ -55,7 +55,7 @@ metadata:
     {{- include "pipecd.labels" . | nindent 4 }}
     grafana_dashboard: "1"
   annotations:
-    k8s-sidecar-target-directory: "/tmp/dashboards/piped"
+    k8s-sidecar-target-directory: "/tmp/dashboards/Piped"
 data:
 {{ range $path, $_ :=  .Files.Glob  "grafana-dashboards/piped/**.json" }}
   {{ trimPrefix "grafana-dashboards/piped/" $path | nindent 2 }}: |-

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -241,7 +241,7 @@ grafana:
           disableDeletion: false
           allowUiUpdates: false
           options:
-            path: /tmp/dashboards/cluster
+            path: /tmp/dashboards/Cluster
         - name: 'Control-Plane'
           orgId: 1
           folder: 'Control-Plane'
@@ -249,7 +249,7 @@ grafana:
           disableDeletion: false
           allowUiUpdates: false
           options:
-            path: /tmp/dashboards/control-plane
+            path: /tmp/dashboards/Control-Plane
         - name: 'Piped'
           orgId: 1
           folder: 'Piped'
@@ -257,7 +257,7 @@ grafana:
           disableDeletion: false
           allowUiUpdates: false
           options:
-            path: /tmp/dashboards/piped
+            path: /tmp/dashboards/Piped
 
 opentelemetry-collector:
   mode: "deployment"


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade the Grafana sub-chart in the pipecd chart.

**Which issue(s) this PR fixes**:

Part of #4431 

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
    The control plane manager who uses the pipecd charts and specifies the non-default image registry for the Grafana sub-chart
- **Is this breaking change**:
    Yes
- **How to migrate (if breaking change)**:
    Specify image registry not with `grafana.global.image.registry` but with `grafana.global.imageRegistry`.
