### PR TITLE
[docs] change the order of managing-piped, managing-controlplane

### DIFF
--- a/docs/content/en/docs-dev/user-guide/event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/event-watcher.md
@@ -1,7 +1,7 @@
 ---
 title: "Connect between CI and CD with event watcher"
 linkTitle: "Event watcher"
-weight: 3
+weight: 5
 description: >
   A helper facility to automatically update files when it finds out a new event.
 ---

--- a/docs/content/en/docs-dev/user-guide/insights.md
+++ b/docs/content/en/docs-dev/user-guide/insights.md
@@ -1,7 +1,7 @@
 ---
 title: "Insights"
 linkTitle: "Insights"
-weight: 5
+weight: 7
 description: >
   This page describes how to see delivery performance.
 ---

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/_index.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Control Plane"
 linkTitle: "Managing Control Plane"
-weight: 6
+weight: 4
 description: >
   This guide is for administrators and operators wanting to install and configure PipeCD for other developers.
 ---

--- a/docs/content/en/docs-dev/user-guide/managing-piped/_index.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Piped"
 linkTitle: "Managing Piped"
-weight: 7
+weight: 3
 description: >
   This guide is for administrators and operators wanting to install and configure piped for other developers.
 ---

--- a/docs/content/en/docs-dev/user-guide/plan-preview.md
+++ b/docs/content/en/docs-dev/user-guide/plan-preview.md
@@ -1,7 +1,7 @@
 ---
 title: "Confidently review your changes with Plan Preview"
 linkTitle: "Plan preview"
-weight: 4
+weight: 6
 description: >
   Enables the ability to preview the deployment plan against a given commit before merging.
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

I changed the order under UserGuide.

`Managing application/piped/ControlPlane` should be close to each other and at the top of the UserGuide section.

Current:
![image](https://github.com/user-attachments/assets/6680b500-6280-4941-a722-d8f16ec093a8)

New:
![image](https://github.com/user-attachments/assets/882c0177-35f3-4c6c-994d-a5dbea693c7a)

