### PR TITLE
[docs] Add notes about drift detection

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -807,7 +807,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.This is available for only `KubernetesApp`. | No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -807,7 +807,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.This is available for only `KubernetesApp`. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`. | No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,6 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,8 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,6 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,8 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,6 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,8 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,6 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,6 +50,8 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,6 +52,6 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.

--- a/docs/content/en/docs-v0.43.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/configuration-reference.md
@@ -661,7 +661,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.44.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/configuration-reference.md
@@ -682,7 +682,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/configuration-reference.md
@@ -703,7 +703,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/configuration-reference.md
@@ -771,7 +771,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/configuration-reference.md
@@ -792,7 +792,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -803,7 +803,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. | No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,7 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-This feature is automatically enabled for all applications.
+By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,7 +52,7 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
+If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
@@ -52,9 +52,9 @@ This status means the application is deploying and the configuration drift detec
 
 This feature is automatically enabled for all applications.
 
-If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
-
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
+
+Note: If you want to trigger deployment automatically when `OUT_OF_SYNC` occurs, see [Trigger configuration](./triggering-a-deployment/#trigger-configuration).
 
 ### Ignore drift detection for specific fields
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/configuration-drift-detection.md
@@ -50,7 +50,9 @@ This status means the application is deploying and the configuration drift detec
 
 ### How to enable
 
-By default, drift detection is **NOT** enabled. You can enable it for each application by configuring application's [OnOutOfSync.disabled](../configuration-reference/#onoutofsync).
+This feature is automatically enabled for all applications.
+
+If you want to deploy automatically when `OUT_OF_SYNC` occures, configure each application's [OnOutOfSync](../configuration-reference/#onoutofsync).
 
 You can change the checking interval as well as [configure the notification](../../managing-piped/configuring-notifications/) for these events in `piped` configuration.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1. ~~Fix:  DriftDetection is **DISABLED** by default.~~.  Add Note: DriftDetection is enabled by default, but automatic deployment is disabled by default.

2. Add Note:  `ignoreFields` is supported for only K8sApp.
   - Only used in here: https://github.com/pipe-cd/pipecd/blob/7ed87bcb1c0a4c603a24b78bb9ff89f98d54d0f1/pkg/app/piped/driftdetector/kubernetes/detector.go#L196
