### PR TITLE
Remove piped config bytes from planner pipedv1

### DIFF
--- a/pkg/app/pipedv1/controller/controller.go
+++ b/pkg/app/pipedv1/controller/controller.go
@@ -108,7 +108,6 @@ type controller struct {
 	applicationLister   applicationLister
 	analysisResultStore analysisResultStore
 	notifier            notifier
-	pipedConfig         []byte
 	secretDecrypter     secretDecrypter   // TODO: Remove this
 	pipedCfg            *config.PipedSpec // TODO: Remove this, use pipedConfig instead
 	appManifestsCache   cache.Cache
@@ -151,7 +150,6 @@ func NewController(
 	notifier notifier,
 	sd secretDecrypter,
 	pipedCfg *config.PipedSpec,
-	pipedConfig []byte,
 	appManifestsCache cache.Cache,
 	gracePeriod time.Duration,
 	logger *zap.Logger,
@@ -173,7 +171,6 @@ func NewController(
 		secretDecrypter:     sd,
 		appManifestsCache:   appManifestsCache,
 		pipedCfg:            pipedCfg,
-		pipedConfig:         pipedConfig,
 		logPersister:        lp,
 
 		planners:                              make(map[string]*planner),
@@ -480,7 +477,6 @@ func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (
 		c.apiClient,
 		c.gitClient,
 		c.notifier,
-		c.pipedConfig,
 		c.logger,
 	)
 

--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -54,7 +54,6 @@ type planner struct {
 	lastSuccessfulCommitHash     string
 	lastSuccessfulConfigFilename string
 	workingDir                   string
-	pipedConfig                  []byte
 
 	// The plugin clients are used to call plugin that actually
 	// performs planning deployment.
@@ -95,7 +94,6 @@ func newPlanner(
 	apiClient apiClient,
 	gitClient gitClient,
 	notifier notifier,
-	pipedConfig []byte,
 	logger *zap.Logger,
 ) *planner {
 
@@ -127,7 +125,6 @@ func newPlanner(
 		gitClient:                    gitClient,
 		metadataStore:                metadatastore.NewMetadataStore(apiClient, d),
 		notifier:                     notifier,
-		pipedConfig:                  pipedConfig,
 		doneDeploymentStatus:         d.Status,
 		cancelledCh:                  make(chan *model.ReportableCommand, 1),
 		nowFunc:                      time.Now,


### PR DESCRIPTION
**What this PR does / why we need it**:

As the title, I previously planned to pass the piped config to the plugin so that the plugin could build gitClient or decrypt by itself. However, my plan changed, and now we should not share such information with the plugins.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
