### PR TITLE
add 'exempt-pr-labels' for 'not-auto-close' PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -22,3 +22,4 @@ jobs:
           days-before-pr-stale: 30
           days-before-pr-close: 7
           delete-branch: true
+          exempt-pr-labels: 'not-auto-close'


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR stops staling PRs with the 'not-auto-close' tag.

- Background: 
    - https://github.com/pipe-cd/pipecd/pull/4739 was closed unintentionally by the stale action although the `not-auto-close` tag was assigned.
    - Cause: We needed `exempt-pr-labels`, not only `exempt-issue-labels.`
         - cf. https://github.com/actions/stale?tab=readme-ov-file#list-of-input-options
