### PR TITLE
Discard the otel logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.12.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
 	github.com/fsouza/fake-gcs-server v1.21.0
+	github.com/go-logr/logr v1.4.2
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/goccy/go-yaml v1.9.8
 	github.com/golang-jwt/jwt v3.2.1+incompatible
@@ -114,7 +115,6 @@ require (
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -33,6 +33,7 @@ import (
 	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awssecretsmanager "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/spf13/cobra"
@@ -240,6 +241,11 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		return err
 	}
 	otel.SetTracerProvider(tracerProvider)
+
+	// if control plane's flag monitoring.enabled is false, otel provider logs errors.
+	// it's no problem but we don't want to see it.
+	// so we discard the logger.
+	otel.SetLogger(logr.Discard())
 
 	// Send the newest piped meta to the control-plane.
 	if err := p.sendPipedMeta(ctx, apiClient, cfg, input.Logger); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

If the control plane disables the monitoring feature, piped's OTEL TracerProvider logs some errors.
It's not a problem, but we don't want to see error logs.
So we discard the otel logs.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
