### PR TITLE
[docs] Sync docs to docs-v0.48.x/

### DIFF
--- a/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/configuration-reference.md
@@ -300,7 +300,9 @@ One of `yamlField` or `regex` is required.
 | Field | Type | Description | Required |
 |-|-|-|-|
 | event | string | The event to be notified to users. | Yes |
-| slack | []string | List of user IDs for mentioning in Slack. See [here](https://api.slack.com/reference/surfaces/formatting#mentioning-users) for more information on how to check them. | No |
+| slack | []string | Deprecated: Please use `slackUsers` instead. List of user IDs for mentioning in Slack. See [here](https://api.slack.com/reference/surfaces/formatting#mentioning-users) for more information on how to check them. | No |
+| slackUsers | []string | List of user IDs for mentioning in Slack. See [here](https://api.slack.com/reference/surfaces/formatting#mentioning-users) for more information on how to check them. | No |
+| slackGroups | []string | List of group IDs for mentioning in Slack. See [here](https://api.slack.com/reference/surfaces/formatting#mentioning-groups) for more information on how to check them. | No |
 
 ## KubernetesDeploymentInput
 
@@ -462,7 +464,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | s3Bucket         | string           | S3 bucket name for code package   | No      |
 | s3Key            | string           | S3 key for code package            | No      |
 | s3ObjectVersion  | string           | S3 object version for code package | No      |
-| source       | [Source](#source)       | Git settings                | No      |
+| source       | [source](#source)       | Git settings                | No      |
 | handler          | string           | Lambda function handler            | No      |
 | runtime          | string           | Runtime environment                | No      |
 | architectures    | [][Architecture](#architecture)   | Supported architectures            | No       |
@@ -521,6 +523,8 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 
 There are some restrictions in configuring a service definition file.
 
+- As long as `desiredCount` is 0 or not set, `desiredCount` of your service will NOT be updated in deployments.
+  - If `desiredCount` is 0 or not set for a new service, the service's `desiredCount` will be 0.
 - `capacityProviderStrategy` is not supported.
 - `clientToken` is not supported.
 - `deploymentController` is required and must be `EXTERNAL`.
@@ -803,7 +807,7 @@ Note: By default, the sum of traffic is rounded to 100. If both `primary` and `c
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`.| No |
+| ignoreFields | []string | List of fields path in manifests, which its diff should be ignored. This is available for only `KubernetesApp`. | No |
 
 ## PipeCD rich defined types
 

--- a/docs/content/en/docs-v0.48.x/user-guide/event-watcher.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/event-watcher.md
@@ -1,7 +1,7 @@
 ---
 title: "Connect between CI and CD with event watcher"
 linkTitle: "Event watcher"
-weight: 3
+weight: 5
 description: >
   A helper facility to automatically update files when it finds out a new event.
 ---

--- a/docs/content/en/docs-v0.48.x/user-guide/insights.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/insights.md
@@ -1,7 +1,7 @@
 ---
 title: "Insights"
 linkTitle: "Insights"
-weight: 5
+weight: 7
 description: >
   This page describes how to see delivery performance.
 ---

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-application/defining-app-configuration/ecs.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-application/defining-app-configuration/ecs.md
@@ -155,6 +155,9 @@ spec:
   - That means you need to link target groups to your listener rules before deployments.
   - For more information and diagrams, see [Issue#4733 [ECS] Modify ELB listener rules other than defaults without adding config](https://github.com/pipe-cd/pipecd/pull/4733).
 - When you use [Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html), you cannot use Canary or Blue/Green deployment yet because Service Connect does not support the external deployment yet.
+- When you use AutoScaling for a service, you can disable reconciling `desiredCount` by following steps.
+  1. Create a service without defining `desiredCount` in the service definition file. See [Restrictions of Service Definition](../../../configuration-reference/#restrictions-of-service-definition).
+  2. Configure AutoScaling by yourself.
 
 ## Reference
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/_index.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-controlplane/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Control Plane"
 linkTitle: "Managing Control Plane"
-weight: 6
+weight: 4
 description: >
   This guide is for administrators and operators wanting to install and configure PipeCD for other developers.
 ---

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/_index.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Piped"
 linkTitle: "Managing Piped"
-weight: 7
+weight: 3
 description: >
   This guide is for administrators and operators wanting to install and configure piped for other developers.
 ---

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuration-reference.md
@@ -264,6 +264,7 @@ Must be one of the following structs:
 | oauthTokenFile | string | The path to the oautoken file | No |
 | channelID | string | The channel id which slack api send to. | No |
 | mentionedAccounts | []string | The accounts to which slack api referes. This field supports both `@username` and `username` writing styles.| No |
+| mentionedGroups | []string | The groups to which slack api referes. This field supports both `<!subteam^groupname>` and `groupname` writing styles.| No |
 
 #### NotificationReceiverWebhook
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
@@ -83,6 +83,23 @@ spec:
           mentionedAccounts:
             - '@user1'
             - 'user2'
+      - name: integration-slack-api-with-oauthTokenData-and-mentioned-groups
+        slack:
+          oauthTokenData: token
+          channelID: testid
+          mentionedGroups:
+            - 'group1'
+            - '<!subteam^group2>'
+      - name: integration-slack-api-with-oauthTokenData-and-mentioned-both-accounts-and-groups
+        slack:
+          oauthTokenData: token
+          channelID: testid
+          mentionedAccounts:
+            - 'user1'
+            - '@user2'
+          mentionedGroups:
+            - 'groupID1'
+            - '<!subteam^groupID2>'
 ```
 
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/runtime-options.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/runtime-options.md
@@ -17,7 +17,7 @@ Usage:
 Flags:
       --add-login-user-to-passwd                   Whether to add login user to $HOME/passwd. This is typically for applications running as a random user ID.
       --admin-port int                             The port number used to run a HTTP server for admin tasks such as metrics, healthz. (default 9085)
-      --app-manifest-cache-count int               The number of app manifests to cache. The cache-key contains the commit hash. The default is 150. (default 150)
+      --app-manifest-cache-count int               The number of app manifests to cache. The cache-key contains the commit hash. The default is 150. (default 150)     
       --cert-file string                           The path to the TLS certificate file.
       --config-aws-secret string                   The ARN of secret that contains Piped config and be stored in AWS Secrets Manager.
       --config-data string                         The base64 encoded string of the configuration data.

--- a/docs/content/en/docs-v0.48.x/user-guide/plan-preview.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/plan-preview.md
@@ -1,7 +1,7 @@
 ---
 title: "Confidently review your changes with Plan Preview"
 linkTitle: "Plan preview"
-weight: 4
+weight: 6
 description: >
   Enables the ability to preview the deployment plan against a given commit before merging.
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

I synced `docs-dev/` to `docs-v0.48.x/` by `make release/docs version=v0.48.x`.

This includes changes about:

1. Patch released features
- https://github.com/pipe-cd/pipecd/pull/4903
- https://github.com/pipe-cd/pipecd/pull/5030

2. Rearranging pages

- https://github.com/pipe-cd/pipecd/pull/5119



**Which issue(s) this PR fixes**:

N/A