### PR TITLE
Fix the kubernetes manifest diff

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/diff.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff.go
@@ -63,13 +63,13 @@ func Diff(old, new Manifest, logger *zap.Logger, opts ...diff.Option) (*diff.Res
 
 	normalizedOld, err := remarshal(old.u)
 	if err != nil {
-		logger.Info("compare manifests directly since it was unable to remarshal Kubernetes manifest to normalize special fields", zap.Error(err))
+		logger.Info("compare manifests directly since it was unable to remarshal old Kubernetes manifest to normalize special fields", zap.Error(err))
 		return diff.DiffUnstructureds(*old.u, *new.u, key, opts...)
 	}
 
 	normalizedNew, err := remarshal(new.u)
 	if err != nil {
-		logger.Info("compare manifests directly since it was unable to remarshal Kubernetes manifest to normalize special fields", zap.Error(err))
+		logger.Info("compare manifests directly since it was unable to remarshal new Kubernetes manifest to normalize special fields", zap.Error(err))
 		return diff.DiffUnstructureds(*old.u, *new.u, key, opts...)
 	}
 

--- a/pkg/app/piped/platformprovider/kubernetes/diff.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff.go
@@ -60,13 +60,20 @@ func Diff(old, new Manifest, logger *zap.Logger, opts ...diff.Option) (*diff.Res
 	}
 
 	key := old.Key.String()
-	normalized, err := remarshal(new.u)
+
+	normalizedOld, err := remarshal(old.u)
 	if err != nil {
 		logger.Info("compare manifests directly since it was unable to remarshal Kubernetes manifest to normalize special fields", zap.Error(err))
 		return diff.DiffUnstructureds(*old.u, *new.u, key, opts...)
 	}
 
-	return diff.DiffUnstructureds(*old.u, *normalized, key, opts...)
+	normalizedNew, err := remarshal(new.u)
+	if err != nil {
+		logger.Info("compare manifests directly since it was unable to remarshal Kubernetes manifest to normalize special fields", zap.Error(err))
+		return diff.DiffUnstructureds(*old.u, *new.u, key, opts...)
+	}
+
+	return diff.DiffUnstructureds(*normalizedOld, *normalizedNew, key, opts...)
 }
 
 func DiffList(olds, news []Manifest, logger *zap.Logger, opts ...diff.Option) (*DiffListResult, error) {

--- a/pkg/app/piped/platformprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff_test.go
@@ -414,7 +414,7 @@ func TestNoDiff(t *testing.T) {
 		manifest string
 	}{
 		{
-			name: "limits.memory",
+			name: "limits.memory 1.5Gi",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -430,7 +430,7 @@ spec:
             memory: 1.5Gi`,
 		},
 		{
-			name: "limits.cpu",
+			name: "limits.cpu 1.5",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -446,7 +446,7 @@ spec:
             cpu: "1.5"`,
 		},
 		{
-			name: "limits.memory",
+			name: "limits.memory 1Gi",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -462,7 +462,7 @@ spec:
             memory: 1Gi`,
 		},
 		{
-			name: "limits.cpu",
+			name: "limits.cpu 1",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -478,7 +478,7 @@ spec:
             cpu: "1"`,
 		},
 		{
-			name: "requests.memory",
+			name: "requests.memory 1.5Gi",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -494,7 +494,7 @@ spec:
             memory: 1.5Gi`,
 		},
 		{
-			name: "requests.cpu",
+			name: "requests.cpu 1.5",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -510,7 +510,7 @@ spec:
             cpu: "1.5"`,
 		},
 		{
-			name: "requests.memory",
+			name: "requests.memory 1Gi",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -526,7 +526,7 @@ spec:
             memory: 1Gi`,
 		},
 		{
-			name: "requests.cpu",
+			name: "requests.cpu 1",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/pkg/app/piped/platformprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff_test.go
@@ -414,65 +414,36 @@ func TestNoDiff(t *testing.T) {
 		manifest string
 	}{
 		{
-			name: "no diff",
-			manifest: `apiVersion: v1
-kind: Service
-metadata:
-  name: simple
-spec:
-  ports:
-  - port: 9085
-    protocol: TCP
-    targetPort: 9085
-  selector:
-    app: simple
----
-apiVersion: apps/v1
+			name: "limits.memory",
+			manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: simple
   name: simple
 spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: simple
-      pipecd.dev/variant: primary
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: simple
-        pipecd.dev/variant: primary
     spec:
       containers:
-      - args:
-        - server
-        env:
-        - name: JVM_MEM_MIN
-          value: 750m
-        - name: JVM_MEM_MAX
-          value: 2000m
-        image: ghcr.io/pipe-cd/helloworld:v0.32.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - sh
-              - -c
-              - sleep 20
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
         name: helloworld
-        ports:
-        - containerPort: 9085
         resources:
           limits:
-            cpu: "3"
-            memory: 1.5Gi
-          requests:
-            cpu: 150m
-            memory: 1Gi`,
+            memory: 1.5Gi`,
+		},
+		{
+			name: "limits.cpu",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          limits:
+            cpu: "1.5"`,
 		},
 	}
 

--- a/pkg/app/piped/platformprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff_test.go
@@ -445,6 +445,102 @@ spec:
           limits:
             cpu: "1.5"`,
 		},
+		{
+			name: "limits.memory",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          limits:
+            memory: 1Gi`,
+		},
+		{
+			name: "limits.cpu",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          limits:
+            cpu: "1"`,
+		},
+		{
+			name: "requests.memory",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          requests:
+            memory: 1.5Gi`,
+		},
+		{
+			name: "requests.cpu",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          requests:
+            cpu: "1.5"`,
+		},
+		{
+			name: "requests.memory",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          requests:
+            memory: 1Gi`,
+		},
+		{
+			name: "requests.cpu",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        name: helloworld
+        resources:
+          requests:
+            cpu: "1"`,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/app/piped/platformprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff_test.go
@@ -405,3 +405,151 @@ spec:
 		})
 	}
 }
+
+func TestLoadAndDiff(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name           string
+		manifests      [2]string
+		noChangeAssert assert.BoolAssertionFunc
+	}{
+		{
+			name: "no diff",
+			manifests: [2]string{
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  ports:
+  - port: 9085
+    protocol: TCP
+    targetPort: 9085
+  selector:
+    app: simple
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: simple
+  name: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+      - args:
+        - server
+        env:
+        - name: JVM_MEM_MIN
+          value: 750m
+        - name: JVM_MEM_MAX
+          value: 2000m
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 20
+        name: helloworld
+        ports:
+        - containerPort: 9085
+        resources:
+          limits:
+            cpu: "3"
+            memory: 1.5Gi
+          requests:
+            cpu: 150m
+            memory: 1Gi
+`,
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  ports:
+  - port: 9085
+    protocol: TCP
+    targetPort: 9085
+  selector:
+    app: simple
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: simple
+  name: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+      - args:
+        - server
+        env:
+        - name: JVM_MEM_MIN
+          value: 750m
+        - name: JVM_MEM_MAX
+          value: 2000m
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 20
+        name: helloworld
+        ports:
+        - containerPort: 9085
+        resources:
+          limits:
+            cpu: "3"
+            memory: 1.5Gi
+          requests:
+            cpu: 150m
+            memory: 1Gi
+`,
+			},
+			noChangeAssert: assert.True,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var manifests [2][]Manifest
+			manifests[0], _ = ParseManifests(tc.manifests[0])
+			manifests[1], _ = ParseManifests(tc.manifests[1])
+
+			result, err := DiffList(manifests[0], manifests[1], zap.NewNop(), diff.WithEquateEmpty(), diff.WithIgnoreAddingMapKeys(), diff.WithCompareNumberAndNumericString())
+			require.NoError(t, err)
+
+			tc.noChangeAssert(t, result.NoChange())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Normalize both old and new manifests when calculating diff.

Without this PR, the unexpected difference is calculated when resource/limit numbers have floating-point values such as `cpu: "1.5"`
The diff signs 1.5 and 1500m are different.
This occurs because the new manifests are normalized, but the old ones are not.

**Which issue(s) this PR fixes**: 

N/A

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
Users can get the correct plan-preview diffs.
Some deployments triggered by incorrect diffs become not triggered.

- **Is this breaking change**:
- **How to migrate (if breaking change)**:
