### PR TITLE
remove a validation check in notification-mention

### DIFF
--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -672,9 +672,6 @@ type NotificationMention struct {
 }
 
 func (n *NotificationMention) Validate() error {
-	if len(n.Slack) == 0 && len(n.SlackGroups) == 0 && len(n.SlackUsers) == 0 {
-		return fmt.Errorf("slack, slackusers or slackGroups must not be empty")
-	}
 	if n.Event == allEventsSymbol {
 		return nil
 	}
@@ -779,7 +776,7 @@ func (dd *DriftDetection) Validate() error {
 }
 
 func LoadApplication(repoPath, configRelPath string, appKind model.ApplicationKind) (*GenericApplicationSpec, error) {
-	var absPath = filepath.Join(repoPath, configRelPath)
+	absPath := filepath.Join(repoPath, configRelPath)
 
 	cfg, err := LoadFromYAML(absPath)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes an  validation check in the Validate method of the NotificationMention struct. 
This contradicts our documentation( https://pipecd.dev/docs-v0.48.x/user-guide/configuration-reference/#notificationmention ), which states these fields are optional, and the omitempty JSON tags on the struct fields.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
