### PR TITLE
Add config for Grafana Tempo datasource

### DIFF
--- a/manifests/pipecd/Chart.lock
+++ b/manifests/pipecd/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.93.3
-digest: sha256:70a2b5c168161cb0708b53d1f13e8d8d5c2bdd4e7a3d2164dbfb7b0c64c02588
-generated: "2024-08-02T09:51:22.670788848+09:00"
+- name: tempo
+  repository: https://grafana.github.io/helm-charts
+  version: 1.10.2
+digest: sha256:2fa3e0df6d19e699e8ae52b415bed1a56f9890701eaa04cd48f4419eb4da01cc
+generated: "2024-08-08T10:45:50.558122029+09:00"

--- a/manifests/pipecd/Chart.yaml
+++ b/manifests/pipecd/Chart.yaml
@@ -31,3 +31,7 @@ dependencies:
   version: "0.93.3"
   repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
   condition: monitoring.enabled
+- name: tempo
+  version: "1.10.2"
+  repository: "https://grafana.github.io/helm-charts"
+  condition: monitoring.enabled

--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -84,6 +84,11 @@ data:
         access: proxy
         version: 1
         isDefault: true
+      - name: Tempo
+        type: tempo
+        url: http://{{ include "pipecd.fullname" . }}-tempo:3100
+        access: proxy
+        version: 1
 ---
 
 apiVersion: v1

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -199,6 +199,8 @@ prometheus:
       size: 4Gi
     strategy:
       type: Recreate
+    extraFlags:
+      - enable-feature=remote-write-receiver # To write trace metrics from Grafana Tempo
 
 # All directives inside this section will be directly sent to the grafana chart.
 # Head to the below link to see all available values.
@@ -259,6 +261,15 @@ grafana:
           options:
             path: /tmp/dashboards/Piped
 
+# All directives inside this section will be directly sent to the grafana-tempo chart.
+# Head to the below link to see all available values.
+# https://github.com/grafana/helm-charts/tree/main/charts/tempo
+tempo:
+  tempo:
+    metricsGenerator:
+      enabled: true
+      remoteWriteUrl: "http://pipecd-prometheus-server/api/v1/write" # TODO rewrite this like {{ include "pipecd.fullname" . }}-prometheus-server or like {{ include "prometheus.fullname" . }}-server
+
 opentelemetry-collector:
   mode: "deployment"
   replicaCount: 1
@@ -276,10 +287,17 @@ opentelemetry-collector:
           grpc:
             endpoint: 0.0.0.0:4317 # collector is deployed mith deployment mode, so listen not only for local.
           http: null
+    exporters:
+      otlp:
+        endpoint: pipecd-tempo:4317 # TODO rewrite this like {{ include "pipecd.fullname" . }}-tempo or like {{ include "tempo.fullname" }}
+        tls:
+          insecure: true
     service:
       pipelines:
         traces:
           receivers:
+            - otlp
+          exporters:
             - otlp
         metrics: null
         logs: null


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Grafana Tempo at the control plane.
Additionally, configure the OpenTelemetry Collector to send traces to the Grafana Tempo.

**Which issue(s) this PR fixes**:

Fixes #4977 

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
  the control plane has new components
- **Is this breaking change**:
  No
- **How to migrate (if breaking change)**:
  N/A
