### PR TITLE
Use singleflight to clone/update repository cache

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -42,14 +43,15 @@ type Client interface {
 }
 
 type client struct {
-	username     string
-	email        string
-	gcAutoDetach bool // whether to be executed `git gc`in the foreground when some git commands (e.g. merge, commit and so on) are executed.
-	gitPath      string
-	cacheDir     string
-	mu           sync.Mutex
-	repoLocks    map[string]*sync.Mutex
-	password     string
+	username          string
+	email             string
+	gcAutoDetach      bool // whether to be executed `git gc`in the foreground when some git commands (e.g. merge, commit and so on) are executed.
+	gitPath           string
+	cacheDir          string
+	mu                sync.Mutex
+	repoSingleFlights *singleflight.Group
+	repoLocks         map[string]*sync.Mutex
+	password          string
 
 	gitEnvs       []string
 	gitEnvsByRepo map[string][]string
@@ -114,14 +116,15 @@ func NewClient(opts ...Option) (Client, error) {
 	}
 
 	c := &client{
-		username:      defaultUsername,
-		email:         defaultEmail,
-		gcAutoDetach:  false, // Disable this by default. See issue #4760, discussion #4758.
-		gitPath:       gitPath,
-		cacheDir:      cacheDir,
-		repoLocks:     make(map[string]*sync.Mutex),
-		gitEnvsByRepo: make(map[string][]string, 0),
-		logger:        zap.NewNop(),
+		username:          defaultUsername,
+		email:             defaultEmail,
+		gcAutoDetach:      false, // Disable this by default. See issue #4760, discussion #4758.
+		gitPath:           gitPath,
+		cacheDir:          cacheDir,
+		repoSingleFlights: new(singleflight.Group),
+		repoLocks:         make(map[string]*sync.Mutex),
+		gitEnvsByRepo:     make(map[string][]string, 0),
+		logger:            zap.NewNop(),
 	}
 
 	for _, opt := range opts {
@@ -150,48 +153,54 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 		authArgs = append(authArgs, "-c", fmt.Sprintf("http.extraHeader=%s", header))
 	}
 
-	c.lockRepo(repoID)
-	defer c.unlockRepo(repoID)
+	_, err, _ := c.repoSingleFlights.Do(repoID, func() (interface{}, error) {
+		_, err := os.Stat(repoCachePath)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
 
-	_, err := os.Stat(repoCachePath)
-	if err != nil && !os.IsNotExist(err) {
+		if os.IsNotExist(err) {
+			// Cache miss, clone for the first time.
+			logger.Info(fmt.Sprintf("cloning %s for the first time", repoID))
+			if err := os.MkdirAll(filepath.Dir(repoCachePath), os.ModePerm); err != nil && !os.IsExist(err) {
+				return nil, err
+			}
+			out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
+				args := []string{"clone", "--mirror", remote, repoCachePath}
+				args = append(authArgs, args...)
+				return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
+			})
+			if err != nil {
+				logger.Error("failed to clone from remote",
+					zap.String("out", string(out)),
+					zap.Error(err),
+				)
+				return nil, fmt.Errorf("failed to clone from remote: %v", err)
+			}
+		} else {
+			// Cache hit. Do a git fetch to keep updated.
+			c.logger.Info(fmt.Sprintf("fetching %s to update the cache", repoID))
+			out, err := retryCommand(3, time.Second, c.logger, func() ([]byte, error) {
+				args := []string{"fetch"}
+				args = append(authArgs, args...)
+				return runGitCommand(ctx, c.gitPath, repoCachePath, c.envsForRepo(remote), args...)
+			})
+			if err != nil {
+				logger.Error("failed to fetch from remote",
+					zap.String("out", string(out)),
+					zap.Error(err),
+				)
+				return nil, fmt.Errorf("failed to fetch: %v", err)
+			}
+		}
+		return nil, nil
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	if os.IsNotExist(err) {
-		// Cache miss, clone for the first time.
-		logger.Info(fmt.Sprintf("cloning %s for the first time", repoID))
-		if err := os.MkdirAll(filepath.Dir(repoCachePath), os.ModePerm); err != nil && !os.IsExist(err) {
-			return nil, err
-		}
-		out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
-			args := []string{"clone", "--mirror", remote, repoCachePath}
-			args = append(authArgs, args...)
-			return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
-		})
-		if err != nil {
-			logger.Error("failed to clone from remote",
-				zap.String("out", string(out)),
-				zap.Error(err),
-			)
-			return nil, fmt.Errorf("failed to clone from remote: %v", err)
-		}
-	} else {
-		// Cache hit. Do a git fetch to keep updated.
-		c.logger.Info(fmt.Sprintf("fetching %s to update the cache", repoID))
-		out, err := retryCommand(3, time.Second, c.logger, func() ([]byte, error) {
-			args := []string{"fetch"}
-			args = append(authArgs, args...)
-			return runGitCommand(ctx, c.gitPath, repoCachePath, c.envsForRepo(remote), args...)
-		})
-		if err != nil {
-			logger.Error("failed to fetch from remote",
-				zap.String("out", string(out)),
-				zap.Error(err),
-			)
-			return nil, fmt.Errorf("failed to fetch: %v", err)
-		}
-	}
+	c.lockRepo(repoID)
+	defer c.unlockRepo(repoID)
 
 	if destination != "" {
 		err = os.MkdirAll(destination, os.ModePerm)


### PR DESCRIPTION
**What this PR does / why we need it**:

I profiled goroutines with the [debug/pprof/goroutine endpoint](http://localhost:9085/debug/pprof/goroutine?debug=1) and noticed goroutines are waiting at the lockRepo method.

<details>
<summary>goroutines waiting at the lockRepo</summary>
I triggered 50 deployments simultaneously, and 45 goroutines are waiting at the lockRepo method.

```txt
goroutine profile: total 367
35 @ 0x51358 0x65768 0x65745 0x86708 0xaabf4 0x89bb98 0x89bb45 0x89a0d4 0x1091c74 0x1090f0c 0x109073c 0x12a0ed4 0x17a5f84 0x17a27a4 0x8afa4
#	0x86707		sync.runtime_SemacquireMutex+0x27								/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/runtime/sema.go:77
#	0xaabf3		sync.(*Mutex).lockSlow+0x173									/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/sync/mutex.go:171
#	0x89bb97	sync.(*Mutex).Lock+0x1e7									/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/sync/mutex.go:90
#	0x89bb44	github.com/pipe-cd/pipecd/pkg/git.(*client).lockRepo+0x194					/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/git/client.go:263
#	0x89a0d3	github.com/pipe-cd/pipecd/pkg/git.(*client).Clone+0x473						/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/git/client.go:153
#	0x1091c73	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*gitSourceCloner).Clone+0x63		/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/sourcecloner.go:59
#	0x1090f0b	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*provider).prepare+0x1eb			/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/deploysource.go:146
#	0x109073b	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*provider).Get+0x15b			/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/deploysource.go:92
#	0x12a0ed3	github.com/pipe-cd/pipecd/pkg/app/piped/planner/kubernetes.(*Planner).Plan+0x63			/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/planner/kubernetes/kubernetes.go:56
#	0x17a5f83	github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*planner).Run+0xa33				/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/controller/planner.go:218
#	0x17a27a3	github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*controller).startNewPlanner.func2+0x83	/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/controller/controller.go:497

...


10 @ 0x51358 0x65768 0x65745 0x86708 0xaabf4 0x89bb98 0x89bb45 0x89a0d4 0x1091c74 0x1090f0c 0x1090afc 0x17a922c 0x17a3fb4 0x8afa4
#	0x86707		sync.runtime_SemacquireMutex+0x27								/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/runtime/sema.go:77
#	0xaabf3		sync.(*Mutex).lockSlow+0x173									/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/sync/mutex.go:171
#	0x89bb97	sync.(*Mutex).Lock+0x1e7									/home/warashi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-arm64/src/sync/mutex.go:90
#	0x89bb44	github.com/pipe-cd/pipecd/pkg/git.(*client).lockRepo+0x194					/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/git/client.go:263
#	0x89a0d3	github.com/pipe-cd/pipecd/pkg/git.(*client).Clone+0x473						/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/git/client.go:153
#	0x1091c73	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*gitSourceCloner).Clone+0x63		/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/sourcecloner.go:59
#	0x1090f0b	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*provider).prepare+0x1eb			/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/deploysource.go:146
#	0x1090afb	github.com/pipe-cd/pipecd/pkg/app/piped/deploysource.(*provider).GetReadOnly+0x15b		/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/deploysource/deploysource.go:116
#	0x17a922b	github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*scheduler).Run+0x97b			/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/controller/scheduler.go:264
#	0x17a3fb3	github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*controller).startNewScheduler.func2+0x83	/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/controller/controller.go:646

...
```
</details>

The lock/unlock line is here.
https://github.com/pipe-cd/pipecd/blob/a61c3972a1209317f6d3915bf3b3f26d5e73a0cc/pkg/git/client.go#L153-L154

The git clone/fetch operation is heavy, so we can put these in the singleflight, not guarding with the mutex.

I got the performance improvement on my local machine, about 10x 〜 20x faster when triggering 50 deployments simultaneously.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
