### PR TITLE
Show username on the header

### DIFF
--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -197,9 +197,10 @@ export const Header: FC = memo(function Header() {
                 aria-controls="user-menu"
                 aria-haspopup="true"
                 onClick={(e) => setUserAnchorEl(e.currentTarget)}
-              >
+                >
                 <Avatar className={classes.userAvatar} src={me.avatarUrl} />
               </IconButton>
+              <span>{me.subject}</span>
             </>
           ) : (
             <Link

--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -197,7 +197,7 @@ export const Header: FC = memo(function Header() {
                 aria-controls="user-menu"
                 aria-haspopup="true"
                 onClick={(e) => setUserAnchorEl(e.currentTarget)}
-                >
+              >
                 <Avatar className={classes.userAvatar} src={me.avatarUrl} />
               </IconButton>
               <span>{me.subject}</span>


### PR DESCRIPTION
**What this PR does / why we need it**:

As title.  
Since avatar images are not shown on the header for OIDC users, users want to know which account they logged in to.

- GitHub:  GitHub user ID

    <img width="414" alt="image" src="https://github.com/user-attachments/assets/55bdc702-60b1-4f46-8965-30d62706eeab">


- OIDC: username from IdP

     <img width="432" alt="image" src="https://github.com/user-attachments/assets/e0102490-91ea-4577-86d5-764f14104d54">


I think `role` is not necessary to show.

**Which issue(s) this PR fixes**:

Related to #5008

See https://github.com/pipe-cd/pipecd/pull/5008#issuecomment-2277603291

**Does this PR introduce a user-facing change?**: Users can see their username.

- **How are users affected by this change**: N/A
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no



**For Reviewers**

See here to understand why `subject` is used.
https://github.com/pipe-cd/pipecd/blob/034054133543b7ae9d57efd360e1b0a9aae7c7db/pkg/app/server/httpapi/callback.go#L92-L103
