### PR TITLE
Add force-sync-by-replace annotation option

### DIFF
--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -240,27 +240,48 @@ func applyManifests(ctx context.Context, ag applierGetter, manifests []provider.
 			return err
 		}
 
-		annotation := m.GetAnnotations()[provider.LabelSyncReplace]
-		if annotation != provider.UseReplaceEnabled {
-			if err := applier.ApplyManifest(ctx, m); err != nil {
-				lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableString(), err)
+		// The force annotation has higher priority, so we need to check the annotation in the following order:
+		// 1. force-sync-by-replace
+		// 2. sync-by-replace
+		// 3. others
+		if annotation := m.GetAnnotations()[provider.LabelForceSyncReplace]; annotation == provider.UseReplaceEnabled {
+			// Always try to replace first and create if it fails due to resource not found error.
+			// This is because we cannot know whether resource already exists before executing command.
+			err = applier.ForceReplaceManifest(ctx, m)
+			if errors.Is(err, provider.ErrNotFound) {
+				lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableString(), err)
+				err = applier.CreateManifest(ctx, m)
+			}
+			if err != nil {
+				lp.Errorf("Failed to forcefully replace or create manifest: %s (%w)", m.Key.ReadableString(), err)
 				return err
 			}
-			lp.Successf("- applied manifest: %s", m.Key.ReadableString())
+			lp.Successf("- forcefully replaced or created manifest: %s", m.Key.ReadableString())
 			continue
 		}
-		// Always try to replace first and create if it fails due to resource not found error.
-		// This is because we cannot know whether resource already exists before executing command.
-		err = applier.ReplaceManifest(ctx, m)
-		if errors.Is(err, provider.ErrNotFound) {
-			lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableString(), err)
-			err = applier.CreateManifest(ctx, m)
+
+		if annotation := m.GetAnnotations()[provider.LabelSyncReplace]; annotation == provider.UseReplaceEnabled {
+			// Always try to replace first and create if it fails due to resource not found error.
+			// This is because we cannot know whether resource already exists before executing command.
+			err = applier.ReplaceManifest(ctx, m)
+			if errors.Is(err, provider.ErrNotFound) {
+				lp.Infof("Specified resource does not exist, so create the resource: %s (%w)", m.Key.ReadableString(), err)
+				err = applier.CreateManifest(ctx, m)
+			}
+			if err != nil {
+				lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableString(), err)
+				return err
+			}
+			lp.Successf("- replaced or created manifest: %s", m.Key.ReadableString())
+			continue
 		}
-		if err != nil {
-			lp.Errorf("Failed to replace or create manifest: %s (%w)", m.Key.ReadableString(), err)
+
+		if err := applier.ApplyManifest(ctx, m); err != nil {
+			lp.Errorf("Failed to apply manifest: %s (%w)", m.Key.ReadableString(), err)
 			return err
 		}
-		lp.Successf("- replaced or created manifest: %s", m.Key.ReadableString())
+		lp.Successf("- applied manifest: %s", m.Key.ReadableString())
+		continue
 
 	}
 	lp.Successf("Successfully applied %d manifests", len(manifests))

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -360,6 +360,32 @@ spec:
 			wantErr:   true,
 		},
 		{
+			name: "unable to force replace manifest",
+			applier: func() provider.Applier {
+				p := kubernetestest.NewMockApplier(ctrl)
+				p.EXPECT().ForceReplaceManifest(gomock.Any(), gomock.Any()).Return(errors.New("unexpected error"))
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/force-sync-by-replace: "enabled"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   true,
+		},
+		{
 			name: "unable to create manifest",
 			applier: func() provider.Applier {
 				p := kubernetestest.NewMockApplier(ctrl)
@@ -374,6 +400,33 @@ metadata:
   name: simple
   annotations:
     pipecd.dev/sync-by-replace: "enabled"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   true,
+		},
+		{
+			name: "unable to create manifest",
+			applier: func() provider.Applier {
+				p := kubernetestest.NewMockApplier(ctrl)
+				p.EXPECT().ForceReplaceManifest(gomock.Any(), gomock.Any()).Return(provider.ErrNotFound)
+				p.EXPECT().CreateManifest(gomock.Any(), gomock.Any()).Return(errors.New("unexpected error"))
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/force-sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:
@@ -437,6 +490,32 @@ spec:
 			wantErr:   false,
 		},
 		{
+			name: "successfully force replace manifest",
+			applier: func() provider.Applier {
+				p := kubernetestest.NewMockApplier(ctrl)
+				p.EXPECT().ForceReplaceManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/force-sync-by-replace: "enabled"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+		{
 			name: "successfully create manifest",
 			applier: func() provider.Applier {
 				p := kubernetestest.NewMockApplier(ctrl)
@@ -451,6 +530,33 @@ metadata:
   name: simple
   annotations:
     pipecd.dev/sync-by-replace: "enabled"
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			namespace: "",
+			wantErr:   false,
+		},
+		{
+			name: "successfully force create manifest",
+			applier: func() provider.Applier {
+				p := kubernetestest.NewMockApplier(ctrl)
+				p.EXPECT().ForceReplaceManifest(gomock.Any(), gomock.Any()).Return(provider.ErrNotFound)
+				p.EXPECT().CreateManifest(gomock.Any(), gomock.Any()).Return(nil)
+				return p
+			}(),
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  annotations:
+    pipecd.dev/force-sync-by-replace: "enabled"
 spec:
   selector:
     matchLabels:

--- a/pkg/app/piped/platformprovider/kubernetes/applier.go
+++ b/pkg/app/piped/platformprovider/kubernetes/applier.go
@@ -33,6 +33,8 @@ type Applier interface {
 	CreateManifest(ctx context.Context, manifest Manifest) error
 	// ReplaceManifest does replacing resource from given manifest.
 	ReplaceManifest(ctx context.Context, manifest Manifest) error
+	// ForceReplaceManifest does force replacing resource from given manifest.
+	ForceReplaceManifest(ctx context.Context, manifest Manifest) error
 	// Delete deletes the given resource from Kubernetes cluster.
 	Delete(ctx context.Context, key ResourceKey) error
 }
@@ -121,6 +123,32 @@ func (a *applier) ReplaceManifest(ctx context.Context, manifest Manifest) error 
 	}
 
 	err := a.kubectl.Replace(
+		ctx,
+		a.platformProvider.KubeConfigPath,
+		a.getNamespaceToRun(manifest.Key),
+		manifest,
+	)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, errorReplaceNotFound) {
+		return ErrNotFound
+	}
+
+	return err
+}
+
+// ReplaceManifest uses kubectl to replace the given manifests.
+func (a *applier) ForceReplaceManifest(ctx context.Context, manifest Manifest) error {
+	a.initOnce.Do(func() {
+		a.kubectl, a.initErr = a.findKubectl(ctx, a.getToolVersionToRun())
+	})
+	if a.initErr != nil {
+		return a.initErr
+	}
+
+	err := a.kubectl.ForceReplace(
 		ctx,
 		a.platformProvider.KubeConfigPath,
 		a.getNamespaceToRun(manifest.Key),
@@ -231,6 +259,15 @@ func (a *multiApplier) CreateManifest(ctx context.Context, manifest Manifest) er
 func (a *multiApplier) ReplaceManifest(ctx context.Context, manifest Manifest) error {
 	for _, a := range a.appliers {
 		if err := a.ReplaceManifest(ctx, manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *multiApplier) ForceReplaceManifest(ctx context.Context, manifest Manifest) error {
+	for _, a := range a.appliers {
+		if err := a.ForceReplaceManifest(ctx, manifest); err != nil {
 			return err
 		}
 	}

--- a/pkg/app/piped/platformprovider/kubernetes/applier.go
+++ b/pkg/app/piped/platformprovider/kubernetes/applier.go
@@ -139,7 +139,7 @@ func (a *applier) ReplaceManifest(ctx context.Context, manifest Manifest) error 
 	return err
 }
 
-// ReplaceManifest uses kubectl to replace the given manifests.
+// ForceReplaceManifest uses kubectl to forcefully replace the given manifests.
 func (a *applier) ForceReplaceManifest(ctx context.Context, manifest Manifest) error {
 	a.initOnce.Do(func() {
 		a.kubectl, a.initErr = a.findKubectl(ctx, a.getToolVersionToRun())

--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -31,6 +31,7 @@ const (
 	LabelOriginalAPIVersion   = "pipecd.dev/original-api-version"   // The api version defined in git configuration. e.g. apps/v1
 	LabelIgnoreDriftDirection = "pipecd.dev/ignore-drift-detection" // Whether the drift detection should ignore this resource.
 	LabelSyncReplace          = "pipecd.dev/sync-by-replace"        // Use replace instead of apply.
+	LabelForceSyncReplace     = "pipecd.dev/force-sync-by-replace"  // Use replace --force instead of apply.
 	LabelServerSideApply      = "pipecd.dev/server-side-apply"      // Use server side apply instead of client side apply.
 	AnnotationConfigHash      = "pipecd.dev/config-hash"            // The hash value of all mouting config resources.
 	AnnotationOrder           = "pipecd.dev/order"                  // The order number of resource used to sort them before using.

--- a/pkg/app/piped/platformprovider/kubernetes/kubernetestest/kubernetes.mock.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetestest/kubernetes.mock.go
@@ -77,6 +77,20 @@ func (mr *MockApplierMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockApplier)(nil).Delete), arg0, arg1)
 }
 
+// ForceReplaceManifest mocks base method.
+func (m *MockApplier) ForceReplaceManifest(arg0 context.Context, arg1 kubernetes.Manifest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceReplaceManifest", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceReplaceManifest indicates an expected call of ForceReplaceManifest.
+func (mr *MockApplierMockRecorder) ForceReplaceManifest(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceReplaceManifest", reflect.TypeOf((*MockApplier)(nil).ForceReplaceManifest), arg0, arg1)
+}
+
 // ReplaceManifest mocks base method.
 func (m *MockApplier) ReplaceManifest(arg0 context.Context, arg1 kubernetes.Manifest) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an option to replace the Kubernetes resources forcefully.

**Which issue(s) this PR fixes**:

Fixes #5174 

**Does this PR introduce a user-facing change?**:
Yes

- **How are users affected by this change**:
Users can replace resources forcefully.
This allows users to run the k8s job each time deployment occurs.

- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
