### PR TITLE
Improve Terraform plan result handling

### DIFF
--- a/pkg/app/piped/platformprovider/terraform/terraform_test.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform_test.go
@@ -61,13 +61,13 @@ func TestParsePlanResult(t *testing.T) {
 		{
 			name:        "older than v1.5.0",
 			input:       `Plan: 1 to add, 2 to change, 3 to destroy.`,
-			expected:    PlanResult{Adds: 1, Changes: 2, Destroys: 3, PlanOutput: "Plan: 1 to add, 2 to change, 3 to destroy."},
+			expected:    PlanResult{Adds: 1, Changes: 2, Destroys: 3, HasStateChanges: true},
 			expectedErr: false,
 		},
 		{
 			name:        "later than v1.5.0",
 			input:       `Plan: 1 to import, 1 to add, 2 to change, 3 to destroy.`,
-			expected:    PlanResult{Imports: 1, Adds: 1, Changes: 2, Destroys: 3, PlanOutput: "Plan: 1 to import, 1 to add, 2 to change, 3 to destroy."},
+			expected:    PlanResult{Imports: 1, Adds: 1, Changes: 2, Destroys: 3, HasStateChanges: true},
 			expectedErr: false,
 		},
 		{
@@ -81,8 +81,106 @@ func TestParsePlanResult(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "No changes",
-			input:       `No changes. Infrastructure is up-to-date.`,
+			name: "Changes to outputs",
+			input: `terraform init -no-color
+Initializing the backend...
+
+Successfully configured the backend "gcs"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Initializing provider plugins...
+- Finding hashicorp/google versions matching "x.xx.x"...
+- Installing hashicorp/google vx.xx.x...
+- Installed hashicorp/google vx.xx.x (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+terraform plan -lock=false -detailed-exitcode -no-colorgoogle_compute_global_address.xxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxx]
+google_service_account.xxxxx: Refreshing state... [id=projects/xxxx/serviceAccounts/xxxxx@xxxxx.iam.gserviceaccount.com]
+google_compute_global_address.xxxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxxxx]
+google_dns_record_set.xxxxx: Refreshing state... [id=xxxxx/A]
+
+Changes to Outputs:
+  + global_address = xxxx
+
+You can apply this plan to save these new output values to the Terraform
+state, without changing any real infrastructure.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.`,
+			expected:    PlanResult{HasStateChanges: true},
+			expectedErr: false,
+		},
+		{
+			name: "Refactor", // when using moved blocks or removed blocks
+			input: `terraform init -no-color
+Initializing the backend...
+
+Successfully configured the backend "gcs"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Initializing provider plugins...
+- Finding hashicorp/google versions matching "x.xx.x"...
+- Installing hashicorp/google vx.xx.x...
+- Installed hashicorp/google vx.xx.x (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+terraform plan -lock=false -detailed-exitcode -no-colorgoogle_compute_global_address.xxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxx]
+google_service_account.xxxxx: Refreshing state... [id=projects/xxxx/serviceAccounts/xxxxx@xxxxx.iam.gserviceaccount.com]
+google_compute_global_address.xxxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxxxx]
+google_dns_record_set.xxxxx: Refreshing state... [id=xxxxx/A]
+
+Terraform will perform the following actions:
+
+  # google_dns_record_set.xxx has moved to google_dns_record_set.xxx
+    resource "google_compute_global_forwarding_rule" "xxx" {
+        id           = "xxxx"
+        managed_zone = "xxxx"
+        name         = "xxxx.xxxx.xxxx."
+        # (4 unchanged attributes hidden)
+    }
+
+ # google_compute_global_address.xxx will no longer be managed by Terraform, but will not be destroyed
+ # (destroy = false is set in the configuration)
+ . resource "google_compute_global_address" "xxx" {
+        id                 = "xxxx"
+        name               = "xxxx"
+        # (5 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.`,
+			expected:    PlanResult{HasStateChanges: true},
 			expectedErr: false,
 		},
 	}
@@ -93,6 +191,7 @@ func TestParsePlanResult(t *testing.T) {
 			t.Parallel()
 			result, err := parsePlanResult(tc.input, false)
 			assert.Equal(t, tc.expectedErr, err != nil)
+			result.PlanOutput = ""
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -138,6 +237,53 @@ Plan: 1 to import, 2 to add, 3 to change, 4 to destroy.
 Plan: 1 to import, 2 to add, 3 to change, 4 to destroy.
 `,
 			expectedErr: false,
+		},
+		{
+			name: "New outputs",
+			planResult: &PlanResult{
+				HasStateChanges: true,
+				PlanOutput: `terraform init -no-color
+Initializing the backend...
+
+Successfully configured the backend "gcs"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Initializing provider plugins... 
+- Finding hashicorp/google versions matching "x.xx.x"...
+- Installing hashicorp/google vx.xx.x...
+- Installed hashicorp/google vx.xx.x (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+terraform plan -lock=false -detailed-exitcode -no-colorgoogle_compute_global_address.xxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxx]
+google_service_account.xxxxx: Refreshing state... [id=projects/xxxx/serviceAccounts/xxxxx@xxxxx.iam.gserviceaccount.com]
+google_compute_global_address.xxxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxxxx]
+google_dns_record_set.xxxxx: Refreshing state... [id=xxxxx/A]
+
+Changes to Outputs:
+  + global_address = xxxx
+
+You can apply this plan to save these new output values to the Terraform
+state, without changing any real infrastructure.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.`,
+			},
+			expected: "",
 		},
 	}
 

--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -152,6 +152,8 @@ const (
 
 	// Terraform plan format
 	prefixTerraformPlan = "Terraform will perform the following actions:"
+	// Terraform changes to outputs format
+	prefixTerraformChangesToOutput = "Changes to Outputs:"
 )
 
 func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
@@ -320,7 +322,7 @@ func generateTerraformShortPlanDetails(details string) (string, error) {
 	// NOTE: scanner.Scan() return false if the buffer size of one line exceed bufio.MaxScanTokenSize(65536 byte).
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, prefixTerraformPlan) {
+		if strings.Contains(line, prefixTerraformPlan) || strings.Contains(line, prefixTerraformChangesToOutput) {
 			start = length
 			break
 		}

--- a/tool/actions-plan-preview/planpreview_test.go
+++ b/tool/actions-plan-preview/planpreview_test.go
@@ -581,6 +581,124 @@ guarantee to take exactly these actions if you run "terraform apply" now.
 2 to add, 1 to change, 0 to destroy`,
 			wantErr: false,
 		},
+		{
+			name: "moved resources",
+			planDetails: `terraform init -no-color
+Initializing the backend...
+
+Successfully configured the backend "gcs"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Initializing provider plugins...
+- Finding hashicorp/google versions matching "x.xx.x"...
+- Installing hashicorp/google vx.xx.x...
+- Installed hashicorp/google vx.xx.x (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+terraform plan -lock=false -detailed-exitcode -no-colorgoogle_compute_global_address.xxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxx]
+google_service_account.xxxxx: Refreshing state... [id=projects/xxxx/serviceAccounts/xxxxx@xxxxx.iam.gserviceaccount.com]
+google_compute_global_address.xxxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxxxx]
+google_dns_record_set.xxxxx: Refreshing state... [id=xxxxx/A]
+
+Terraform will perform the following actions:
+
+  # google_dns_record_set.xxx has moved to google_dns_record_set.xxx
+    resource "google_compute_global_forwarding_rule" "xxx" {
+        id           = "xxxx"
+        managed_zone = "xxxx"
+        name         = "xxxx.xxxx.xxxx."
+        # (4 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.`,
+			want: `Terraform will perform the following actions:
+
+  # google_dns_record_set.xxx has moved to google_dns_record_set.xxx
+    resource "google_compute_global_forwarding_rule" "xxx" {
+        id           = "xxxx"
+        managed_zone = "xxxx"
+        name         = "xxxx.xxxx.xxxx."
+        # (4 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.`,
+			wantErr: false,
+		},
+		{
+			name: "Only new outputs",
+			planDetails: `terraform init -no-color
+Initializing the backend...
+
+Successfully configured the backend "gcs"! Terraform will automatically
+use this backend unless the backend configuration changes.
+
+Initializing provider plugins...
+- Finding hashicorp/google versions matching "x.xx.x"...
+- Installing hashicorp/google vx.xx.x...
+- Installed hashicorp/google vx.xx.x (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+terraform plan -lock=false -detailed-exitcode -no-colorgoogle_compute_global_address.xxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxx]
+google_service_account.xxxxx: Refreshing state... [id=projects/xxxx/serviceAccounts/xxxxx@xxxxx.iam.gserviceaccount.com]
+google_compute_global_address.xxxx: Refreshing state... [id=projects/xxxx/global/addresses/xxxxxx]
+google_dns_record_set.xxxxx: Refreshing state... [id=xxxxx/A]
+
+Changes to Outputs:
+  + global_address = xxxx
+
+You can apply this plan to save these new output values to the Terraform
+state, without changing any real infrastructure.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.`,
+			want: `Changes to Outputs:
+  + global_address = xxxx
+
+You can apply this plan to save these new output values to the Terraform
+state, without changing any real infrastructure.
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.`,
+			wantErr: false,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Make it possible to handle terraform plan results when:
  - adding new outputs
  - removing resources from state using removed block
  - refactoring *.tf files using moved block

without these modifications, pipecd returns `no changes` or `unable to parse plan output`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
