### PR TITLE
[Lambda] Support Drift Detection for Lambda

### DIFF
--- a/pkg/app/piped/driftdetector/detector.go
+++ b/pkg/app/piped/driftdetector/detector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/cloudrun"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/ecs"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/kubernetes"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/lambda"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/driftdetector/terraform"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/livestatestore"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
@@ -158,6 +159,23 @@ func NewDetector(
 				return nil, fmt.Errorf(format, cp.Name)
 			}
 			d.detectors = append(d.detectors, ecs.NewDetector(
+				cp,
+				appLister,
+				gitClient,
+				sg,
+				d,
+				appManifestsCache,
+				cfg,
+				sd,
+				logger,
+			))
+
+		case model.PlatformProviderLambda:
+			sg, ok := stateGetter.LambdaGetter(cp.Name)
+			if !ok {
+				return nil, fmt.Errorf(format, cp.Name)
+			}
+			d.detectors = append(d.detectors, lambda.NewDetector(
 				cp,
 				appLister,
 				gitClient,

--- a/pkg/app/piped/driftdetector/lambda/detector.go
+++ b/pkg/app/piped/driftdetector/lambda/detector.go
@@ -237,9 +237,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 //
 // sorts: (Lambda sorts them in liveSpec)
 //   - Architectures in headSpec
-//   - Environments in headSpec
 //   - SubnetIDs in headSpec
-//   - Tags in headSpec
 func ignoreAndSortParameters(headSpec *provider.FunctionManifestSpec) {
 	// We cannot compare SourceCode and S3 packaging because live states do not have them.
 	headSpec.SourceCode = provider.SourceCode{}
@@ -253,26 +251,9 @@ func ignoreAndSortParameters(headSpec *provider.FunctionManifestSpec) {
 			return strings.Compare(headSpec.Architectures[i].Name, headSpec.Architectures[j].Name) < 0
 		})
 	}
-	headSpec.Environments = sortMap(headSpec.Environments)
 	if headSpec.VPCConfig != nil && len(headSpec.VPCConfig.SubnetIDs) > 1 {
 		slices.Sort(headSpec.VPCConfig.SubnetIDs)
 	}
-	headSpec.Tags = sortMap(headSpec.Tags)
-}
-
-// sortMap sorts the given map by keys and returns a new map.
-func sortMap(m map[string]string) map[string]string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-
-	sorted := make(map[string]string)
-	for _, k := range keys {
-		sorted[k] = m[k]
-	}
-	return sorted
 }
 
 func (d *detector) loadHeadFunctionManifest(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.FunctionManifest, error) {

--- a/pkg/app/piped/driftdetector/lambda/detector.go
+++ b/pkg/app/piped/driftdetector/lambda/detector.go
@@ -13,3 +13,331 @@
 // limitations under the License.
 
 package lambda
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/piped/livestatestore/lambda"
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/lambda"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/sourceprocesser"
+	"github.com/pipe-cd/pipecd/pkg/cache"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/diff"
+	"github.com/pipe-cd/pipecd/pkg/git"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type applicationLister interface {
+	ListByPlatformProvider(name string) []*model.Application
+}
+
+type gitClient interface {
+	Clone(ctx context.Context, repoID, remote, branch, destination string) (git.Repo, error)
+}
+
+type secretDecrypter interface {
+	Decrypt(string) (string, error)
+}
+
+type reporter interface {
+	ReportApplicationSyncState(ctx context.Context, appID string, state model.ApplicationSyncState) error
+}
+
+type Detector interface {
+	Run(ctx context.Context) error
+	ProviderName() string
+}
+
+type detector struct {
+	provider          config.PipedPlatformProvider
+	appLister         applicationLister
+	gitClient         gitClient
+	stateGetter       lambda.Getter
+	reporter          reporter
+	appManifestsCache cache.Cache
+	interval          time.Duration
+	config            *config.PipedSpec
+	secretDecrypter   secretDecrypter
+	logger            *zap.Logger
+
+	gitRepos map[string]git.Repo
+}
+
+func NewDetector(
+	cp config.PipedPlatformProvider,
+	appLister applicationLister,
+	gitClient gitClient,
+	stateGetter lambda.Getter,
+	reporter reporter,
+	appManifestsCache cache.Cache,
+	cfg *config.PipedSpec,
+	sd secretDecrypter,
+	logger *zap.Logger,
+) Detector {
+
+	logger = logger.Named("lambda-detector").With(
+		zap.String("platform-provider", cp.Name),
+	)
+	return &detector{
+		provider:          cp,
+		appLister:         appLister,
+		gitClient:         gitClient,
+		stateGetter:       stateGetter,
+		reporter:          reporter,
+		appManifestsCache: appManifestsCache,
+		interval:          time.Minute,
+		config:            cfg,
+		secretDecrypter:   sd,
+		gitRepos:          make(map[string]git.Repo),
+		logger:            logger,
+	}
+}
+
+func (d *detector) Run(ctx context.Context) error {
+	d.logger.Info("start running drift detector for lambda applications")
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.Info("drift detector for lambda applications has been stopped")
+			return nil
+
+		case <-ticker.C:
+			d.check(ctx)
+		}
+	}
+}
+
+func (d *detector) ProviderName() string {
+	return d.provider.Name
+}
+
+func (d *detector) check(ctx context.Context) {
+	appsByRepo := d.listGroupedApplication()
+
+	for repoID, apps := range appsByRepo {
+		gitRepo, ok := d.gitRepos[repoID]
+		if !ok {
+			// Clone repository for the first time.
+			gr, err := d.cloneGitRepository(ctx, repoID)
+			if err != nil {
+				d.logger.Error("failed to clone git repository",
+					zap.String("repo-id", repoID),
+					zap.Error(err),
+				)
+				continue
+			}
+			gitRepo = gr
+			d.gitRepos[repoID] = gitRepo
+		}
+
+		// Fetch the latest commit to compare the states.
+		branch := gitRepo.GetClonedBranch()
+		if err := gitRepo.Pull(ctx, branch); err != nil {
+			d.logger.Error("failed to pull repository branch",
+				zap.String("repo-id", repoID),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Get the head commit of the repository.
+		headCommit, err := gitRepo.GetLatestCommit(ctx)
+		if err != nil {
+			d.logger.Error("failed to get head commit hash",
+				zap.String("repo-id", repoID),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Start checking all applications in this repository.
+		for _, app := range apps {
+			if err := d.checkApplication(ctx, app, gitRepo, headCommit); err != nil {
+				d.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
+			}
+		}
+	}
+}
+
+func (d *detector) cloneGitRepository(ctx context.Context, repoID string) (git.Repo, error) {
+	repoCfg, ok := d.config.GetRepository(repoID)
+	if !ok {
+		return nil, fmt.Errorf("repository %s was not found in piped configuration", repoID)
+	}
+	return d.gitClient.Clone(ctx, repoID, repoCfg.Remote, repoCfg.Branch, "")
+}
+
+// listGroupedApplication retrieves all applications those should be handled by this director
+// and then groups them by repoID.
+func (d *detector) listGroupedApplication() map[string][]*model.Application {
+	var (
+		apps = d.appLister.ListByPlatformProvider(d.provider.Name)
+		m    = make(map[string][]*model.Application)
+	)
+	for _, app := range apps {
+		repoID := app.GitPath.Repo.Id
+		m[repoID] = append(m[repoID], app)
+	}
+	return m
+}
+
+func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit) error {
+	headManifest, err := d.loadHeadFunctionManifest(app, repo, headCommit)
+	if err != nil {
+		return err
+	}
+	d.logger.Info(fmt.Sprintf("application %s has a function manifest at commit %s", app.Id, headCommit.Hash))
+
+	liveManifest, ok := d.stateGetter.GetFunctionManifest(app.Id)
+	if !ok {
+		return fmt.Errorf("failed to get a live function manifest of application %s", app.Id)
+	}
+	d.logger.Info(fmt.Sprintf("application %s has a live function manifest", app.Id))
+
+	result, err := provider.Diff(
+		liveManifest,
+		headManifest,
+		diff.WithEquateEmpty(),
+		diff.WithIgnoreAddingMapKeys(),
+		diff.WithCompareNumberAndNumericString(),
+	)
+	if err != nil {
+		return err
+	}
+
+	state := makeSyncState(result, headCommit.Hash)
+
+	return d.reporter.ReportApplicationSyncState(ctx, app.Id, state)
+}
+
+func (d *detector) loadHeadFunctionManifest(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.FunctionManifest, error) {
+	var (
+		manifestCache = provider.FunctionManifestCache{
+			AppID:  app.Id,
+			Cache:  d.appManifestsCache,
+			Logger: d.logger,
+		}
+		repoDir = repo.GetPath()
+		appDir  = filepath.Join(repoDir, app.GitPath.Path)
+	)
+
+	manifest, ok := manifestCache.Get(headCommit.Hash)
+	if !ok {
+		// When the manifests were not in the cache, we have to load them.
+		cfg, err := d.loadApplicationConfiguration(repoDir, app)
+		if err != nil {
+			return provider.FunctionManifest{}, fmt.Errorf("failed to load application configuration: %w", err)
+		}
+
+		gds, ok := cfg.GetGenericApplication()
+		if !ok {
+			return provider.FunctionManifest{}, fmt.Errorf("unsupport application kind %s", cfg.Kind)
+		}
+
+		var (
+			encryptionUsed = d.secretDecrypter != nil && gds.Encryption != nil
+			attachmentUsed = gds.Attachment != nil
+		)
+
+		// We have to copy repository into another directory because
+		// decrypting the sealed secrets or attaching files might change the git repository.
+		if attachmentUsed || encryptionUsed {
+			dir, err := os.MkdirTemp("", "detector-git-processing")
+			if err != nil {
+				return provider.FunctionManifest{}, fmt.Errorf("failed to prepare a temporary directory for git repository (%w)", err)
+			}
+			defer os.RemoveAll(dir)
+
+			repo, err = repo.Copy(filepath.Join(dir, "repo"))
+			if err != nil {
+				return provider.FunctionManifest{}, fmt.Errorf("failed to copy the cloned git repository (%w)", err)
+			}
+			repoDir := repo.GetPath()
+			appDir = filepath.Join(repoDir, app.GitPath.Path)
+		}
+
+		var templProcessors []sourceprocesser.SourceTemplateProcessor
+		// Decrypting secrets to manifests.
+		if encryptionUsed {
+			templProcessors = append(templProcessors, sourceprocesser.NewSecretDecrypterProcessor(gds.Encryption, d.secretDecrypter))
+		}
+		// Then attaching configurated files to manifests.
+		if attachmentUsed {
+			templProcessors = append(templProcessors, sourceprocesser.NewAttachmentProcessor(gds.Attachment))
+		}
+		if len(templProcessors) > 0 {
+			sp := sourceprocesser.NewSourceProcessor(appDir, templProcessors...)
+			if err := sp.Process(); err != nil {
+				return provider.FunctionManifest{}, fmt.Errorf("failed to process source files: %w", err)
+			}
+		}
+
+		var manifestFile string
+		if cfg.LambdaApplicationSpec != nil {
+			manifestFile = cfg.LambdaApplicationSpec.Input.FunctionManifestFile
+		}
+
+		manifest, err = provider.LoadFunctionManifest(appDir, manifestFile)
+		if err != nil {
+			return provider.FunctionManifest{}, fmt.Errorf("failed to load new function manifest: %w", err)
+		}
+		manifestCache.Put(headCommit.Hash, manifest)
+	}
+	return manifest, nil
+}
+
+func (d *detector) loadApplicationConfiguration(repoPath string, app *model.Application) (*config.Config, error) {
+	path := filepath.Join(repoPath, app.GitPath.GetApplicationConfigFilePath())
+	cfg, err := config.LoadFromYAML(path)
+	if err != nil {
+		return nil, err
+	}
+	if appKind, ok := cfg.Kind.ToApplicationKind(); !ok || appKind != app.Kind {
+		return nil, fmt.Errorf("application in application configuration file is not match, got: %s, expected: %s", appKind, app.Kind)
+	}
+	return cfg, nil
+}
+
+func makeSyncState(r *provider.DiffResult, commit string) model.ApplicationSyncState {
+	if r.NoChange() {
+		return model.ApplicationSyncState{
+			Status:    model.ApplicationSyncStatus_SYNCED,
+			Timestamp: time.Now().Unix(),
+		}
+	}
+
+	shortReason := "The function manifest doesn't be synced"
+	if len(commit) >= 7 {
+		commit = commit[:7]
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual live state:\n\n", commit))
+	b.WriteString("--- Actual   (LiveState)\n+++ Expected (Git)\n\n")
+
+	details := r.Render(provider.DiffRenderOptions{
+		// Currently, we do not use the diff command to render the result
+		// because Lambda adds a large number of default values to the
+		// running manifest that causes a wrong diff text.
+		UseDiffCommand: false,
+	})
+	b.WriteString(details)
+
+	return model.ApplicationSyncState{
+		Status:      model.ApplicationSyncStatus_OUT_OF_SYNC,
+		ShortReason: shortReason,
+		Reason:      b.String(),
+		Timestamp:   time.Now().Unix(),
+	}
+}

--- a/pkg/app/piped/driftdetector/lambda/detector_test.go
+++ b/pkg/app/piped/driftdetector/lambda/detector_test.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/lambda"
+	"github.com/pipe-cd/pipecd/pkg/diff"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgnoreAndSortParameters(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name       string
+		liveSpec   provider.FunctionManifestSpec
+		headSpec   provider.FunctionManifestSpec
+		expectDiff bool
+	}{
+		{
+			name: "Ignore packaging types S3 and SourceCode",
+			liveSpec: provider.FunctionManifestSpec{
+				ImageURI: "test-image-uri",
+			},
+			headSpec: provider.FunctionManifestSpec{
+				ImageURI:        "test-image-uri",
+				S3Bucket:        "test-bucket",
+				S3Key:           "test-key",
+				S3ObjectVersion: "test-version",
+				SourceCode: provider.SourceCode{
+					Git:  "https://test-repo.git",
+					Ref:  "test-ref",
+					Path: "test-path",
+				},
+			},
+			expectDiff: false,
+		},
+		{
+			name: "Ignore not sorted fields and pipecd managed tags",
+			liveSpec: provider.FunctionManifestSpec{
+				Architectures: []provider.Architecture{
+					{Name: string(types.ArchitectureArm64)},
+					{Name: string(types.ArchitectureX8664)},
+				},
+				Environments: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				Tags: map[string]string{
+					"key1":                    "value1",
+					"key2":                    "value2",
+					provider.LabelApplication: "test-app",
+					provider.LabelCommitHash:  "test-hash",
+					provider.LabelManagedBy:   "piped",
+					provider.LabelPiped:       "test-piped",
+				},
+				VPCConfig: &provider.VPCConfig{
+					SubnetIDs: []string{"subnet-1", "subnet-2"},
+				},
+			},
+			headSpec: provider.FunctionManifestSpec{
+				Architectures: []provider.Architecture{
+					{Name: string(types.ArchitectureX8664)},
+					{Name: string(types.ArchitectureArm64)},
+				},
+				Environments: map[string]string{
+					"key2": "value2",
+					"key1": "value1",
+				},
+				Tags: map[string]string{
+					"key2": "value2",
+					"key1": "value1",
+				},
+				VPCConfig: &provider.VPCConfig{
+					SubnetIDs: []string{"subnet-2", "subnet-1"},
+				},
+			},
+			expectDiff: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ignoreAndSortParameters(&tc.liveSpec, &tc.headSpec)
+			result, err := provider.Diff(
+				provider.FunctionManifest{Spec: tc.liveSpec},
+				provider.FunctionManifest{Spec: tc.headSpec},
+				diff.WithEquateEmpty(),
+				diff.WithIgnoreAddingMapKeys(),
+				diff.WithCompareNumberAndNumericString(),
+			)
+			assert.NoError(t, err)
+			fmt.Println(result.Render(provider.DiffRenderOptions{}))
+			assert.Equal(t, tc.expectDiff, result.Diff.HasDiff())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Supported DriftDetection for Lambda

When OutOfSync:
    ![image](https://github.com/user-attachments/assets/1191af1c-67d9-4c9b-83e7-ec679115475b)

Restrictions: 
- The following fields in [function.yaml](https://pipecd.dev/docs-v0.48.x/user-guide/configuration-reference/#specific-functionyaml) are ignored because livestates don't have them.
  - `source`
  - `s3Bucket`
  - `s3Key`
  - `s3ObjectVersion`

**Which issue(s) this PR fixes**:

Fixes #5182

**Does this PR introduce a user-facing change?**: Users can see drifts.

- **How are users affected by this change**: N/A
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no

**Note:**

To use this feature, users need to add the following IAM Actions to their Piped's IAM Role.

- [GetFunction](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html)
- [ListFunctions](https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html)

Later I'll describe the details in another PR.

