### PR TITLE
Add route to opentelemetry collector at the ingress

### DIFF
--- a/manifests/pipecd/templates/ingress.yaml
+++ b/manifests/pipecd/templates/ingress.yaml
@@ -50,6 +50,13 @@ spec:
             name: {{ include "pipecd.fullname" . }}
             port:
               number: {{ .Values.service.port }}
+      - path: /opentelemetry.proto.collector.trace.v1.TraceService/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ include "pipecd.fullname" . }}
+            port:
+              number: {{ .Values.service.port }}
   {{ else }}
   defaultBackend:
     service:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a route to the pipecd-gateway for the OpenTelemetry Collector path.

**Which issue(s) this PR fixes**:

Follows #5016 
Fixes #4977 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
