### PR TITLE
Refactor the git clone to make the variable scope smaller

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -145,15 +145,15 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 		)
 	)
 
-	authArgs := []string{}
-	if c.username != "" && c.password != "" {
-		token := fmt.Sprintf("%s:%s", c.username, c.password)
-		encodedToken := base64.StdEncoding.EncodeToString([]byte(token))
-		header := fmt.Sprintf("Authorization: Basic %s", encodedToken)
-		authArgs = append(authArgs, "-c", fmt.Sprintf("http.extraHeader=%s", header))
-	}
-
 	_, err, _ := c.repoSingleFlights.Do(repoID, func() (interface{}, error) {
+		authArgs := []string{}
+		if c.username != "" && c.password != "" {
+			token := fmt.Sprintf("%s:%s", c.username, c.password)
+			encodedToken := base64.StdEncoding.EncodeToString([]byte(token))
+			header := fmt.Sprintf("Authorization: Basic %s", encodedToken)
+			authArgs = append(authArgs, "-c", fmt.Sprintf("http.extraHeader=%s", header))
+		}
+
 		_, err := os.Stat(repoCachePath)
 		if err != nil && !os.IsNotExist(err) {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the authArgs into the singleflight closure, as they are only used within it.

**Which issue(s) this PR fixes**:

Follows #5171

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
