### PR TITLE
Set the envoy retry policy for external-authz filter

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
       containers:
         - name: envoy
-          image: envoyproxy/envoy-alpine:{{ .Values.gateway.imageTag }}
+          image: envoyproxy/envoy:{{ .Values.gateway.imageTag }}
           imagePullPolicy: IfNotPresent
           command:
           - envoy

--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -42,8 +42,12 @@ data:
                   transport_api_version: V3
                   include_peer_certificate: false
               - name: envoy.filters.http.grpc_web
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
 {{- if .Values.cors.enabled }}
               - name: envoy.filters.http.cors
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
 {{- end }}
               - name: envoy.filters.http.grpc_stats
                 typed_config:
@@ -51,6 +55,8 @@ data:
                   stats_for_all_methods: true
                   enable_upstream_stats: true
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               route_config:
                 name: local_route
                 virtual_hosts:

--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -38,6 +38,7 @@ data:
                   grpc_service:
                     envoy_grpc:
                       cluster_name: grpc-envoy-ext-authz
+                    timeout: 1s
                   transport_api_version: V3
                   include_peer_certificate: false
               - name: envoy.filters.http.grpc_web

--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -38,7 +38,13 @@ data:
                   grpc_service:
                     envoy_grpc:
                       cluster_name: grpc-envoy-ext-authz
-                    timeout: 1s
+                      retry_policy:
+                        num_retries: 3
+                        retry_back_off:
+                          base_interval: 0.25s
+                          max_interval: 1s
+                        retry_on: 5xx
+                    timeout: 3s
                   transport_api_version: V3
                   include_peer_certificate: false
               - name: envoy.filters.http.grpc_web

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
 # Workloads.
 gateway:
   replicasCount: 1
-  imageTag: v1.18.3
+  imageTag: v1.31.0
   resources: {}
   internalTLS:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

I saw the envoy access log sometimes records UAEX (UnauthorizedExternalService) errors even if the ext-authz service returns them as OK.
I checked the admin port of the envoy and realized the tx_reset had occurred.
I don't know how to reduce the tx_reset, so I want to try the retry_policy.
When we use the retry_policy, we have to bump the envoy version.
So, I bump the envoy version to the latest, then I configured the retry_policy.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
