### PR TITLE
Fix Release env of site in publish_site workflow

### DIFF
--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -39,7 +39,7 @@ jobs:
           cd docs
           npm install autoprefixer
           npm install postcss-cli
-          env HUGO_ENV="production" RELEASE="$(head -n 1 ../RELEASE | cut -d ' ' -f 2)" hugo
+          env HUGO_ENV="production" RELEASE="$(grep '^tag:' ../RELEASE | awk '{print $2}')" hugo
 
       # Building and pushing container images.
       - name: Log in to the container registry


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this PR, the published site still shows `Generated`, although https://github.com/pipe-cd/pipecd/pull/5192 is merged.

<img width="436" alt="image" src="https://github.com/user-attachments/assets/dcc5d2d8-adf8-4e10-9a64-1ca572212107">






**Which issue(s) this PR fixes**:

Follows #5192

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
