### PR TITLE
Fix script run rollback

### DIFF
--- a/pkg/app/piped/planner/kubernetes/pipeline.go
+++ b/pkg/app/piped/planner/kubernetes/pipeline.go
@@ -128,7 +128,7 @@ func buildProgressivePipeline(pp *config.DeploymentPipeline, autoRollback bool, 
 				}
 				ss, _ := planner.GetPredefinedStage(planner.PredefinedStageScriptRunRollback)
 				out = append(out, &model.PipelineStage{
-					Id:         ss.ID,
+					Id:         fmt.Sprintf("%d-%d", ss.ID, i),
 					Name:       ss.Name.String(),
 					Desc:       ss.Desc,
 					Predefined: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

I fixed to finish executing the SCRIPT_RUN_ROLLBACK stage successfully when the pipeline has multiple SCRIPT_RUN stages.

Currently, the SCRIPT_RUN_ROLLBACK stage is predefined, and it is assumed that there are multiple in the pipeline.
But we should modify the spec to execute only one SCRIPT_RUN_ROLLBACK.
context: https://github.com/pipe-cd/pipecd/issues/5163#issuecomment-2333248785

<img width="1713" alt="PipeCD" src="https://github.com/user-attachments/assets/4ce98db9-a9b4-490c-8f91-2fdc4a40f2b4">


**app.pipecd.yaml** 
```
apiVersion: pipecd.dev/v1beta1
kind: KubernetesApp
spec:
  name: script-run-like-jenkins
  labels:
    env: example
    team: product
  pipeline:
    stages:
      - name: SCRIPT_RUN
        with:
          run: |
            sh script.sh
          onRollback: |
            echo rollback
      - name: SCRIPT_RUN
        with:
          run: |
            sleep 10
            sh script.sh
          onRollback: |
            echo $SR_DEPLOYMENT_ID
            echo $SR_APPLICATION_ID
            echo $SR_APPLICATION_NAME
            echo $SR_TRIGGERED_AT
            echo $SR_TRIGGERED_COMMIT_HASH
            echo $SR_REPOSITORY_URL
            echo $SR_SUMMARY
            echo $SR_CONTEXT_RAW
            sh script.sh
      - name: SCRIPT_RUN
        with:
          run: |
            sleep 10
            sh script.sh

  trigger:
    onChain:
      disabled: false
  description: |
    This app demonstrates how to use ANALYSIS stage to analyze the deployment.\
    After new version has been deployed to receive 10% of traffic, Piped periodically sends http requests to the endpoint of the new version to verify its responses.\
    References: [adding a new app](https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs/user-guide/configuration-reference/)
```

**The execution flow**

The example scenario is when canceling the last SCRIPT_RUN stage with above pipeline.

on planning
- Add some metadata to the SCRIPT_RUN_ROLLBACK stage.
  - key: `scriptRunBaseStageIDs` value: comma-separated stage ID for each SCRIPTRUN stage.
  - key: `scriptRun.<stage-id>.option` value: JSON encoded string of `config.ScriptRunStageOptions`.

```json
{
  "scriptRunBaseStageIDs": "stage-0,stage-1,stage-2",
  "scriptRun.stage-0.option": {"env":null,"run":"sh script.sh\n","timeout":"6h0m0s","onRollback":"echo rollback\n","skipOn":{}},
  "scriptRun.stage-1.option": {"env":null,"run":"sleep 10\nsh script.sh\n","timeout":"6h0m0s","onRollback":"echo $SR_DEPLOYMENT_ID\necho $SR_APPLICATION_ID\necho $SR_APPLICATION_NAME\necho $SR_TRIGGERED_AT\necho $SR_TRIGGERED_COMMIT_HASH\necho $SR_REPOSITORY_URL\necho $SR_SUMMARY\necho $SR_CONTEXT_RAW\nsh script.sh\n","skipOn":{}},
  "scriptRun.stage-2.option": {"env":null,"run":"sleep 10\nsh script.sh\n","timeout":"6h0m0s","onRollback":"","skipOn":{}},
}
```

on scheduling
- Check and add the SCRIPT_RUN stages stage IDs that are completed or running as `scriptRunTargetStageIDs`.

```
{
  "scriptRunTargetStageIDs": "stage-0,stage-1,stage-2",
}
```

on deploying
- Get the stage IDs with `scriptRunTargetStageIDs`
- Get ScriptRunOpts with `scriptRun.<stage-id>.option`
- Execute `ScriptRunOpts.OnRollback` command

**Which issue(s) this PR fixes**:

Fixes #5163

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
