### PR TITLE
Enable the persistence of the Grafana Tempo

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -265,6 +265,8 @@ grafana:
 # Head to the below link to see all available values.
 # https://github.com/grafana/helm-charts/tree/main/charts/tempo
 tempo:
+  persistence:
+    enabled: true
   tempo:
     metricsGenerator:
       enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this PR, the traces are lost when the tempo pod is evicted.
The StatefulSet manages the tempo's pod, so usually it does not occur, but it occurs with the times such as when the configmap is changed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: Yes only if users use the control plane version v0.49.0-rc0

- **How are users affected by this change**:
When users using control plane helm chart with monitoring.enabled as true, they cannot upgrade the control plane without manual operation.

- **Is this breaking change**: Yes
- **How to migrate (if breaking change)**:
Delete the Grafana Tempo's StatefulSet before applying the Helm Chart.
