### PR TITLE
Revert "Enable the persistence of the Grafana Tempo"

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -265,8 +265,6 @@ grafana:
 # Head to the below link to see all available values.
 # https://github.com/grafana/helm-charts/tree/main/charts/tempo
 tempo:
-  persistence:
-    enabled: true
   tempo:
     metricsGenerator:
       enabled: true


### PR DESCRIPTION
Reverts pipe-cd/pipecd#5208

After merging the above PR, Grafana Tempo's pod becomes CrashLoopBackOff in the dev environment.
The logs say there is a permission issue of persistent volume.

```
{"caller":"main.go:121","err":"failed to init module services: error initialising module: store: failed to create store: mkdir /var/tempo/traces: permission denied","level":"error","msg":"error running Tempo","ts":"2024-09-12T09:24:39.054661796Z"}                                                                                                                    
```

I think we have encountered this issue.
https://github.com/grafana/helm-charts/issues/3197