### PR TITLE
Fix to use target dsp in script run rollback

### DIFF
--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -195,6 +195,13 @@ func (e *rollbackExecutor) ensureScriptRunRollback(ctx context.Context) model.St
 		return model.StageStatus_STAGE_SUCCESS
 	}
 
+	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
+	if err != nil {
+		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
+		return model.StageStatus_STAGE_FAILURE
+	}
+	e.appDir = ds.AppDir
+
 	envStr, ok := e.Stage.Metadata["env"]
 	env := make(map[string]string, 0)
 	if ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed to use TargetDSP on the SCRIPT_RUN_ROLLBACK stage.
With these fixes, we can refer to the files located in the app dir when executing the SCRIPT_RUN_ROLLBACK stage.

I chose TargetDSP, not RunningDSP, because the commands on the `onRollback` are set in app.pipecd.yaml used when Deployment is executed. 
The purpose of the SCRIPT_RUN_ROLLBACK stage is to run whatever command is currently set in onRollback during rollback.

**Which issue(s) this PR fixes**:

Part of #5214

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
