### PR TITLE
Regard DSP as done only when preparation is successful considering of reuse the provider

### DIFF
--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -90,7 +90,7 @@ func (p *provider) Get(ctx context.Context, lw io.Writer) (*DeploySource, error)
 
 	if !p.done {
 		p.source, p.err = p.prepare(ctx, lw)
-		p.done = true
+		p.done = p.err == nil // If there is an error, we should re-prepare it next time.
 	}
 
 	if p.err != nil {

--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -114,7 +114,7 @@ func (p *provider) GetReadOnly(ctx context.Context, lw io.Writer) (*DeploySource
 
 	if !p.done {
 		p.source, p.err = p.prepare(ctx, lw)
-		p.done = true
+		p.done = p.err == nil // If there is an error, we should re-prepare it next time.
 	}
 
 	if p.err != nil {

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -89,7 +89,7 @@ func (p *provider) Get(ctx context.Context, lw io.Writer) (*DeploySource, error)
 
 	if !p.done {
 		p.source, p.err = p.prepare(ctx, lw)
-		p.done = true
+		p.done = p.err == nil // If there is an error, we should re-prepare it next time.
 	}
 
 	if p.err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This modification is necessary to avoid an error when executing a cancellation while executing deploySourceProvider.Get in another stage.

I encountered such a situation when canceling the deployment via WebUI during the SCRIPT_RUN stage execution. 
I reproduced the behavior when checking the behavior for the PR https://github.com/pipe-cd/pipecd/pull/5215 like this↓ 
<img width="1136" alt="Cursor_と_PipeCD__1__png" src="https://github.com/user-attachments/assets/b9765e3a-0b9d-49d0-844d-9f20db164dcf">

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5214

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
