### PR TITLE
Add requires for stages in case of multi plugins quicksync pattern

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -422,6 +422,18 @@ func (p *planner) buildQuickSyncStages(ctx context.Context, cfg *config.GenericA
 	sort.Sort(model.PipelineStages(stages))
 	sort.Sort(model.PipelineStages(rollbackStages))
 
+	// In case there is more than one forward stage, build requires for each stage
+	// based on the order of stages.
+	if len(stages) > 1 {
+		preStageID := ""
+		for _, s := range stages {
+			if preStageID != "" {
+				s.Requires = []string{preStageID}
+			}
+			preStageID = s.Id
+		}
+	}
+
 	stages = append(stages, rollbackStages...)
 	if len(stages) == 0 {
 		return nil, fmt.Errorf("unable to build quick sync stages for deployment")

--- a/pkg/app/pipedv1/controller/planner_test.go
+++ b/pkg/app/pipedv1/controller/planner_test.go
@@ -185,8 +185,9 @@ func TestBuildQuickSyncStages(t *testing.T) {
 					Index: 0,
 				},
 				{
-					Id:    "plugin-2-stage-1",
-					Index: 1,
+					Id:       "plugin-2-stage-1",
+					Index:    1,
+					Requires: []string{"plugin-1-stage-1"},
 				},
 				{
 					Id:       "plugin-1-rollback",
@@ -244,8 +245,9 @@ func TestBuildQuickSyncStages(t *testing.T) {
 					Index: 0,
 				},
 				{
-					Id:    "plugin-2-stage-1",
-					Index: 1,
+					Id:       "plugin-2-stage-1",
+					Index:    1,
+					Requires: []string{"plugin-1-stage-1"},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of multi plugins for a single application, and the deployment of the application is triggered in quick sync strategy, we need to add requires for stages to ensure they run in order instead of all at one.

**Which issue(s) this PR fixes**:

Part of #4980 
Follow PR #5231 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
