### PR TITLE
Add k8s plugin's toolregistry implementation

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/toolregistry/registry.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/toolregistry/registry.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package toolregistry installs and manages the needed tools
+// such as kubectl, helm... for executing tasks in pipeline.
+package toolregistry
+
+import (
+	"context"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/toolregistry"
+)
+
+// Registry provides functions to get path to the needed tools.
+type Registry interface {
+	Kubectl(ctx context.Context, version string) (string, error)
+	Kustomize(ctx context.Context, version string) (string, error)
+	Helm(ctx context.Context, version string) (string, error)
+}
+
+func NewRegistry(client toolregistry.ToolRegistry) Registry {
+	return &registry{
+		client: client,
+	}
+}
+
+type registry struct {
+	client toolregistry.ToolRegistry
+}
+
+func (r *registry) Kubectl(ctx context.Context, version string) (string, error) {
+	return r.client.InstallTool(ctx, "kubectl", version, kubectlInstallScript)
+}
+
+func (r *registry) Kustomize(ctx context.Context, version string) (string, error) {
+	return r.client.InstallTool(ctx, "kustomize", version, kustomizeInstallScript)
+}
+
+func (r *registry) Helm(ctx context.Context, version string) (string, error) {
+	return r.client.InstallTool(ctx, "helm", version, helmInstallScript)
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/toolregistry/scripts.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/toolregistry/scripts.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolregistry
+
+const kubectlInstallScript = `
+cd {{ .TmpDir }}
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v{{ .Version }}/bin/{{ .Os }}/{{ .Arch }}/kubectl
+mv kubectl {{ .OutPath }}
+`
+
+const kustomizeInstallScript = `
+cd {{ .TmpDir }}
+curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v{{ .Version }}/kustomize_v{{ .Version }}_{{ .Os }}_{{ .Arch }}.tar.gz | tar xvz
+mv kustomize {{ .OutPath }}
+`
+
+const helmInstallScript = `
+cd {{ .TmpDir }}
+curl -L https://get.helm.sh/helm-v{{ .Version }}-{{ .Os }}-{{ .Arch }}.tar.gz | tar xvz
+mv {{ .Os }}-{{ .Arch }}/helm {{ .OutPath }}
+`

--- a/pkg/app/pipedv1/plugin/toolregistry/toolregistry.go
+++ b/pkg/app/pipedv1/plugin/toolregistry/toolregistry.go
@@ -24,10 +24,11 @@ type ToolRegistry struct {
 	client service.PluginServiceClient
 }
 
-func (r *ToolRegistry) InstallTool(ctx context.Context, name, version string) (path string, err error) {
+func (r *ToolRegistry) InstallTool(ctx context.Context, name, version, script string) (path string, err error) {
 	res, err := r.client.InstallTool(ctx, &service.InstallToolRequest{
-		Name:    name,
-		Version: version,
+		Name:          name,
+		Version:       version,
+		InstallScript: script,
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The plugin has to pass the tool install script to the piped.
I don't want to pass a script everywhere the plugin tries to install a tool.
So I wrote a wrapper package to hide install script from other implementations.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
