### PR TITLE
Sort subnet in live manifest of ECS Drift Detection

### DIFF
--- a/pkg/app/piped/driftdetector/ecs/detector.go
+++ b/pkg/app/piped/driftdetector/ecs/detector.go
@@ -280,12 +280,18 @@ func ignoreParameters(liveManifests provider.ECSManifests, headManifests provide
 	}
 	if headService.NetworkConfiguration != nil && headService.NetworkConfiguration.AwsvpcConfiguration != nil {
 		awsvpcCfg := headService.NetworkConfiguration.AwsvpcConfiguration
-		slices.Sort(awsvpcCfg.Subnets) // Livestate's Subnets are sorted by ECS. (SecurityGroups and ContainerDefinitions are not sorted)
+		slices.Sort(awsvpcCfg.Subnets)
 		if len(awsvpcCfg.AssignPublicIp) == 0 {
 			// AssignPublicIp is DISABLED by default.
 			// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AwsVpcConfiguration.html#ECS-Type-AwsVpcConfiguration-assignPublicIp.
 			awsvpcCfg.AssignPublicIp = types.AssignPublicIpDisabled
 		}
+	}
+
+	// Sort the subnets of the live service as well
+	if liveService.NetworkConfiguration != nil && liveService.NetworkConfiguration.AwsvpcConfiguration != nil {
+		awsvpcCfg := liveService.NetworkConfiguration.AwsvpcConfiguration
+		slices.Sort(awsvpcCfg.Subnets)
 	}
 
 	// TODO: In order to check diff of the tags, we need to add pipecd-managed tags and sort.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Issue**: When viewing the details of the drift-detector on the PipeCD console, the order of subnets in the live state (red) matches the defined resource (servicedef.yaml), but the Git state (green) shows subnets in reverse order.

**Investigation**: After reviewing the [AWS DescribeServices documentation](https://awscli.amazonaws.com/v2/documentation/api/2.0.33/reference/ecs/describe-services.html), I found no evidence that AWS guarantees any sorting of subnets in the returned live state. It appears that PipeCD fetches the live state using DescribeServices.

**Proposed Solution**: I suggest adding explicit sorting of subnets in PipeCD before performing comparisons in the drift detector to avoid confusion.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: The diff will be changed on the ECS app.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
