### PR TITLE
Implement DetermineVersions of k8s plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -49,12 +49,13 @@ func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion,
 	for _, m := range manifests {
 		// TODO: we should consider other fields like spec.jobTempate.spec.template.spec.containers because CronJob uses this format.
 		containers, ok, err := unstructured.NestedSlice(m.Body.Object, "spec", "template", "spec", "containers")
-		if !ok {
-			continue
-		}
 		if err != nil {
 			// if the containers field is not an array, it will return an error.
+			// we define this as error because the 'containers' is plural form, so it should be an array.
 			return nil, err
+		}
+		if !ok {
+			continue
 		}
 		// Remove duplicate images on multiple manifests.
 		for _, c := range containers {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -1,0 +1,90 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type containerImage struct {
+	name string
+	tag  string
+}
+
+// parseContainerImage splits the container image into name and tag.
+// The image should be in the format of "name:tag".
+// If the tag is not specified, it will be empty.
+func parseContainerImage(image string) (img containerImage) {
+	parts := strings.Split(image, ":")
+	if len(parts) == 2 {
+		img.tag = parts[1]
+	}
+	paths := strings.Split(parts[0], "/")
+	img.name = paths[len(paths)-1]
+	return
+}
+
+// determineVersions decides artifact versions of an application.
+// It finds all container images that are being specified in the workload manifests then returns their names and tags.
+func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion, error) {
+	imageMap := map[string]struct{}{}
+	for _, m := range manifests {
+		// TODO: we should consider other fields like spec.jobTempate.spec.template.spec.containers because CronJob uses this format.
+		containers, ok, err := unstructured.NestedSlice(m.Body.Object, "spec", "template", "spec", "containers")
+		if !ok {
+			continue
+		}
+		if err != nil {
+			// if the containers field is not an array, it will return an error.
+			return nil, err
+		}
+		// Remove duplicate images on multiple manifests.
+		for _, c := range containers {
+			m, ok := c.(map[string]interface{})
+			if !ok {
+				// TODO: Add logging.
+				continue
+			}
+			img, ok := m["image"]
+			if !ok {
+				continue
+			}
+			imgStr, ok := img.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid image format: %T(%v)", img, img)
+			}
+			imageMap[imgStr] = struct{}{}
+		}
+	}
+
+	versions := make([]*model.ArtifactVersion, 0, len(imageMap))
+	for i := range imageMap {
+		image := parseContainerImage(i)
+		versions = append(versions, &model.ArtifactVersion{
+			Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+			Version: image.tag,
+			Name:    image.name,
+			Url:     i,
+		})
+	}
+
+	return versions, nil
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -239,8 +239,57 @@ spec:
         image: 12345
 `,
 			},
-			want: nil,
+			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "manifest with no containers field",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: no-containers-deployment
+spec:
+  template:
+    spec: {}
+`,
+			},
+			want:    []*model.ArtifactVersion{},
+			wantErr: false,
+		},
+		{
+			name: "manifest with invalid containers field -- returns error",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: no-containers-deployment
+spec:
+  template:
+    spec:
+      containers: "invalid-containers-field"
+`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "manifest with invalid containers field -- skipped",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: no-containers-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - "invalid-containers-field"
+`,
+			},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -1,0 +1,263 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+func mustUnmarshalYAML[T any](t *testing.T, data []byte) T {
+	t.Helper()
+
+	// Convert YAML to JSON.
+	// we define structs without defining UnmarshalYAML method, so we can't use yaml.Unmarshal directly.
+	// Instead, we convert YAML to JSON and then unmarshal JSON to the struct.
+	j, err := yaml.YAMLToJSON(data)
+	require.NoError(t, err)
+
+	// then, unmarshal JSON to the struct.
+	var m T
+	require.NoError(t, json.Unmarshal(j, &m))
+
+	return m
+}
+
+func TestParseContainerImage(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  containerImage
+	}{
+		{
+			name:  "image with tag",
+			image: "nginx:1.19.3",
+			want:  containerImage{name: "nginx", tag: "1.19.3"},
+		},
+		{
+			name:  "image without tag",
+			image: "nginx",
+			want:  containerImage{name: "nginx", tag: ""},
+		},
+		{
+			name:  "image with tag and registry",
+			image: "docker.io/nginx:1.19.3",
+			want:  containerImage{name: "nginx", tag: "1.19.3"},
+		},
+		{
+			name:  "image with tag and repository",
+			image: "myrepo/nginx:1.19.3",
+			want:  containerImage{name: "nginx", tag: "1.19.3"},
+		},
+		{
+			name:  "image with tag, registry and repository",
+			image: "docker.io/myrepo/nginx:1.19.3",
+			want:  containerImage{name: "nginx", tag: "1.19.3"},
+		},
+		{
+			name:  "image without tag, with registry and repository",
+			image: "docker.io/myrepo/nginx",
+			want:  containerImage{name: "nginx", tag: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseContainerImage(tt.image)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+func TestDetermineVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []string
+		want      []*model.ArtifactVersion
+		wantErr   bool
+	}{
+		{
+			name: "single manifest with one container",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			},
+			want: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "1.19.3",
+					Name:    "nginx",
+					Url:     "nginx:1.19.3",
+				},
+			},
+		},
+		{
+			name: "multiple manifests with multiple containers",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+`,
+			},
+			want: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "1.19.3",
+					Name:    "nginx",
+					Url:     "nginx:1.19.3",
+				},
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "6.0.9",
+					Name:    "redis",
+					Url:     "redis:6.0.9",
+				},
+			},
+		},
+		{
+			name: "manifest with duplicate images",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.19.3
+        - name: nginx
+          image: nginx:1.19.3
+`,
+			},
+			want: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "1.19.3",
+					Name:    "nginx",
+					Url:     "nginx:1.19.3",
+				},
+			},
+		},
+		{
+			name: "manifest with no containers",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-deployment
+spec:
+  template:
+    spec:
+      containers: []
+`,
+			},
+			want: []*model.ArtifactVersion{},
+		},
+		{
+			name: "manifest with missing image field",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: missing-image-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+`,
+			},
+			want: []*model.ArtifactVersion{},
+		},
+		{
+			name: "manifest with non-string image field",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: non-string-image-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: 12345
+`,
+			},
+			want: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifests []provider.Manifest
+			for _, data := range tt.manifests {
+				manifests = append(manifests, mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(data))))
+			}
+			got, err := determineVersions(manifests)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+type LoaderInput struct {
+	// TODO: define fields for LoaderInput.
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// Manifest represents a Kubernetes resource manifest.
+type Manifest struct {
+	// TODO: define ResourceKey and add as a field here.
+	Body *unstructured.Unstructured
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (m *Manifest) UnmarshalJSON(data []byte) error {
+	m.Body = new(unstructured.Unstructured)
+	return m.Body.UnmarshalJSON(data)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements DetermineVersions of the Kubernetes plugin.
I have not implemented the manifest loader yet, so this gRPC implementation does not work now.
Please see the tests to see how this implementation works.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
