### PR TITLE
Add workflow steps to build and publish quickstart manifests

### DIFF
--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -7,7 +7,6 @@ on:
 
 env:
   GO_VERSION: 1.22.4
-  HELM_VERSION: 3.8.2
 
 jobs:
   gh_release:
@@ -55,28 +54,3 @@ jobs:
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_linux_arm64
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_darwin_amd64
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_darwin_arm64
-
-      # Building and publishing quickstart manifests.
-      - name: Install Helm
-        uses: Azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-      - name: Build quickstart manifests
-        run: |
-          helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version ${{ env.PIPECD_VERSION }} -n pipecd -f quickstart/control-plane-values.yaml > quickstart/manifests/control-plane.yaml
-          helm template piped oci://ghcr.io/pipe-cd/chart/piped --version ${{ env.PIPECD_VERSION }} -n pipecd --set quickstart.enabled=true --set quickstart.pipedId=\<YOUR_PIPED_ID\> --set quickstart.pipedKeyData=\<YOUR_PIPED_KEY_DATA\> > quickstart/manifests/piped.yaml
-      - name: Publish quickstart manifests
-        uses: peter-evans/create-pull-request@v6
-        with:
-          title: "[bot] Publish quickstart manifests"
-          commit-message: "[bot] Publish quickstart manifests"
-          branch: "create-pull-request/publish-quickstart-manifests"
-          body: |
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
-            The workflow is defined [here](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/publish_binary.yaml).
-
-            **Note:** You need to **close and reopen this PR** manually to trigger status check workflows. (Or just click `Update branch` if possible.)
-            For details, see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs.
-          delete-branch: true
-          signoff: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   GO_VERSION: 1.22.4
+  HELM_VERSION: 3.8.2
 
 jobs:
   gh_release:
@@ -54,3 +55,28 @@ jobs:
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_linux_arm64
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_darwin_amd64
             ./.artifacts/pipectl_${{ env.PIPECD_VERSION }}_darwin_arm64
+
+      # Building and publishing quickstart manifests.
+      - name: Install Helm
+        uses: Azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - name: Build quickstart manifests
+        run: |
+          helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version ${{ env.PIPECD_VERSION }} -n pipecd -f quickstart/control-plane-values.yaml > quickstart/manifests/control-plane.yaml
+          helm template piped oci://ghcr.io/pipe-cd/chart/piped --version ${{ env.PIPECD_VERSION }} -n pipecd --set quickstart.enabled=true --set quickstart.pipedId=\<YOUR_PIPED_ID\> --set quickstart.pipedKeyData=\<YOUR_PIPED_KEY_DATA\> > quickstart/manifests/piped.yaml
+      - name: Publish quickstart manifests
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[bot] Publish quickstart manifests"
+          commit-message: "[bot] Publish quickstart manifests"
+          branch: "create-pull-request/publish-quickstart-manifests"
+          body: |
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
+            The workflow is defined [here](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/publish_binary.yaml).
+
+            **Note:** You need to **close and reopen this PR** manually to trigger status check workflows. (Or just click `Update branch` if possible.)
+            For details, see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs.
+          delete-branch: true
+          signoff: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -6,8 +6,6 @@ on:
       - master
     tags:
       - 'v*'
-  release:
-    types: [created]
 
 env:
   GHCR: ghcr.io
@@ -151,12 +149,12 @@ jobs:
 
       # Building and publishing quickstart manifests.
       - name: Build quickstart manifests
-        if: ${{ github.event_name == 'release' }}
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version ${{ env.PIPECD_VERSION }} -n pipecd -f quickstart/control-plane-values.yaml > quickstart/manifests/control-plane.yaml
           helm template piped oci://ghcr.io/pipe-cd/chart/piped --version ${{ env.PIPECD_VERSION }} -n pipecd --set quickstart.enabled=true --set quickstart.pipedId=\<YOUR_PIPED_ID\> --set quickstart.pipedKeyData=\<YOUR_PIPED_KEY_DATA\> > quickstart/manifests/piped.yaml
       - name: Publish quickstart manifests
-        if: ${{ github.event_name == 'release' }}
+        if: startsWith(github.ref, 'refs/tags/')
         uses: peter-evans/create-pull-request@v6
         with:
           title: "[bot] Publish quickstart manifests"

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - 'v*'
+  release:
+    types: [created]
 
 env:
   GHCR: ghcr.io
@@ -146,3 +148,26 @@ jobs:
           event-name: helm-release
           labels: helmRepo=pipecd
           data: ${{ env.PIPECD_VERSION }}
+
+      # Building and publishing quickstart manifests.
+      - name: Build quickstart manifests
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version ${{ env.PIPECD_VERSION }} -n pipecd -f quickstart/control-plane-values.yaml > quickstart/manifests/control-plane.yaml
+          helm template piped oci://ghcr.io/pipe-cd/chart/piped --version ${{ env.PIPECD_VERSION }} -n pipecd --set quickstart.enabled=true --set quickstart.pipedId=\<YOUR_PIPED_ID\> --set quickstart.pipedKeyData=\<YOUR_PIPED_KEY_DATA\> > quickstart/manifests/piped.yaml
+      - name: Publish quickstart manifests
+        if: ${{ github.event_name == 'release' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "[bot] Publish quickstart manifests"
+          commit-message: "[bot] Publish quickstart manifests"
+          branch: "create-pull-request/publish-quickstart-manifests"
+          body: |
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
+            The workflow is defined [here](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/publish_binary.yaml).
+
+            **Note:** You need to **close and reopen this PR** manually to trigger status check workflows. (Or just click `Update branch` if possible.)
+            For details, see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs.
+          delete-branch: true
+          signoff: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -164,7 +164,7 @@ jobs:
           branch: "create-pull-request/publish-quickstart-manifests"
           body: |
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
-            The workflow is defined [here](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/publish_binary.yaml).
+            The workflow is defined [here](https://github.com/pipe-cd/pipecd/blob/master/.github/workflows/publish_image_chart.yaml).
 
             **Note:** You need to **close and reopen this PR** manually to trigger status check workflows. (Or just click `Update branch` if possible.)
             For details, see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the workflow to automate the quickstart manifest release process. A PR to update quickstart manifests will be opened after the release process finishes updating the binary to the PipeCD release page.

**Which issue(s) this PR fixes**:

Part of #5148

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
