### PR TITLE
Fix quickstart workflow not to run by matrix

### DIFF
--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -147,14 +147,31 @@ jobs:
           labels: helmRepo=pipecd
           data: ${{ env.PIPECD_VERSION }}
 
+  update-quickstart:
+    runs-on: ubuntu-latest
+    needs: artifacts
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      # setup tools and repositories
+      - name: Install helm
+        uses: Azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
+
       # Building and publishing quickstart manifests.
       - name: Build quickstart manifests
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version ${{ env.PIPECD_VERSION }} -n pipecd -f quickstart/control-plane-values.yaml > quickstart/manifests/control-plane.yaml
           helm template piped oci://ghcr.io/pipe-cd/chart/piped --version ${{ env.PIPECD_VERSION }} -n pipecd --set quickstart.enabled=true --set quickstart.pipedId=\<YOUR_PIPED_ID\> --set quickstart.pipedKeyData=\<YOUR_PIPED_KEY_DATA\> > quickstart/manifests/piped.yaml
       - name: Publish quickstart manifests
-        if: startsWith(github.ref, 'refs/tags/')
         uses: peter-evans/create-pull-request@v6
         with:
           title: "[bot] Publish quickstart manifests"

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -147,7 +147,7 @@ jobs:
           labels: helmRepo=pipecd
           data: ${{ env.PIPECD_VERSION }}
 
-  update-quickstart:
+  release-quickstart-manifests:
     runs-on: ubuntu-latest
     needs: artifacts
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
**What this PR does / why we need it**:

Move steps, which creates PR to update quickstarts, as another job.
Without this PR, the step runs multiple times using matrix runs.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
