### PR TITLE
Enabled to configure the interval of livestate store for Lambda

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -130,7 +130,7 @@ Must be one of the following structs:
 | roleARN | string | The IAM role arn to use when assuming an role. Required if you want to use the AWS SecurityTokenService. | No |
 | tokenFile | string | The path to the WebIdentity token the SDK should use to assume a role with. Required if you want to use the AWS SecurityTokenService. | No |
 | profile | string | The profile to use for logging into AWS cluster. The default value is `default`. | No |
-| liveStateInterval | duration | The interval to fetch the live state of Lambda functions. Default is 15s. | No |
+| awsAPIPollingInterval | duration | The interval of periodical calls of AWS APIs. Currently, this is an interval of refreshing the live state of Lambda functions. Default is 15s. | No |
 
 ### PlatformProviderECSConfig
 

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -130,6 +130,7 @@ Must be one of the following structs:
 | roleARN | string | The IAM role arn to use when assuming an role. Required if you want to use the AWS SecurityTokenService. | No |
 | tokenFile | string | The path to the WebIdentity token the SDK should use to assume a role with. Required if you want to use the AWS SecurityTokenService. | No |
 | profile | string | The profile to use for logging into AWS cluster. The default value is `default`. | No |
+| liveStateInterval | duration | The interval to fetch the live state of Lambda functions. Default is 15s. | No |
 
 ### PlatformProviderECSConfig
 

--- a/pkg/app/piped/livestatestore/lambda/lambda.go
+++ b/pkg/app/piped/livestatestore/lambda/lambda.go
@@ -58,7 +58,7 @@ func NewStore(cfg *config.PlatformProviderLambdaConfig, platformProvider string,
 			client: client,
 			logger: logger.Named("store"),
 		},
-		interval:      15 * time.Second,
+		interval:      time.Duration(cfg.LiveStateInterval),
 		logger:        logger,
 		firstSyncedCh: make(chan error, 1),
 	}

--- a/pkg/app/piped/livestatestore/lambda/lambda.go
+++ b/pkg/app/piped/livestatestore/lambda/lambda.go
@@ -58,7 +58,7 @@ func NewStore(cfg *config.PlatformProviderLambdaConfig, platformProvider string,
 			client: client,
 			logger: logger.Named("store"),
 		},
-		interval:      time.Duration(cfg.LiveStateInterval),
+		interval:      time.Duration(cfg.AwsAPIPollingInterval),
 		logger:        logger,
 		firstSyncedCh: make(chan error, 1),
 	}

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -712,6 +712,10 @@ type PlatformProviderLambdaConfig struct {
 	// If empty, the environment variable "AWS_PROFILE" is used.
 	// "default" is populated if the environment variable is also not set.
 	Profile string `json:"profile,omitempty"`
+	// The interval to fetch the live state of Lambda functions.
+	// Default is 15s.
+	// To reduce AWS API calls, this interval should be larger.
+	LiveStateInterval Duration `json:"liveStateInterval,omitempty" default:"15s"`
 }
 
 func (c *PlatformProviderLambdaConfig) Mask() {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -712,10 +712,12 @@ type PlatformProviderLambdaConfig struct {
 	// If empty, the environment variable "AWS_PROFILE" is used.
 	// "default" is populated if the environment variable is also not set.
 	Profile string `json:"profile,omitempty"`
-	// The interval to fetch the live state of Lambda functions.
+	// The interval of periodical calls of AWS APIs.
+	// Currently this is used for live state of Lambda functions,
+	// but in the future, this might also be used for other polling features.
 	// Default is 15s.
 	// To reduce AWS API calls, this interval should be larger.
-	LiveStateInterval Duration `json:"liveStateInterval,omitempty" default:"15s"`
+	AwsAPIPollingInterval Duration `json:"awsAPIPollingInterval,omitempty" default:"15s"`
 }
 
 func (c *PlatformProviderLambdaConfig) Mask() {

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -146,8 +146,8 @@ func TestPipedConfig(t *testing.T) {
 						Name: "lambda",
 						Type: model.PlatformProviderLambda,
 						LambdaConfig: &PlatformProviderLambdaConfig{
-							Region:            "us-east-1",
-							LiveStateInterval: Duration(15 * time.Second),
+							Region:                "us-east-1",
+							AwsAPIPollingInterval: Duration(15 * time.Second),
 						},
 					},
 				},

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -146,7 +146,8 @@ func TestPipedConfig(t *testing.T) {
 						Name: "lambda",
 						Type: model.PlatformProviderLambda,
 						LambdaConfig: &PlatformProviderLambdaConfig{
-							Region: "us-east-1",
+							Region:            "us-east-1",
+							LiveStateInterval: Duration(15 * time.Second),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Enabled to configure the interval of get livestate of Lambda in piped-config.

What for: 
- To reduce the number of API calls (for cost etc.)
    - LiveStateStore periodically calls a lot of APIs to get Lambda resources.
    - The number of API calls depends on the number of Lambda functions.
    - When a user has a lot of Lambda functions, the cost of AWS CloudTrail or filtering it will go high.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
