### PR TITLE
Implement find manifests in k8s plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -1,0 +1,22 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// K8sResourceReference represents a reference to a Kubernetes resource.
+// It is used to specify the resources which are treated as the workload of an application.
+type K8sResourceReference struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -91,6 +91,7 @@ func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion,
 	return versions, nil
 }
 
+// findManifests returns the manifests that have the specified kind and name.
 func findManifests(kind, name string, manifests []provider.Manifest) []provider.Manifest {
 	out := make([]provider.Manifest, 0, len(manifests))
 	for _, m := range manifests {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -106,6 +106,8 @@ func findManifests(kind, name string, manifests []provider.Manifest) []provider.
 	return out
 }
 
+// findWorkloadManifests returns the manifests that have the specified references.
+// the default kind is Deployment if it is not specified.
 func findWorkloadManifests(manifests []provider.Manifest, refs []config.K8sResourceReference) []provider.Manifest {
 	if len(refs) == 0 {
 		return findManifests(provider.KindDeployment, "", manifests)

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -20,6 +20,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -88,4 +89,35 @@ func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion,
 	}
 
 	return versions, nil
+}
+
+func findManifests(kind, name string, manifests []provider.Manifest) []provider.Manifest {
+	out := make([]provider.Manifest, 0, len(manifests))
+	for _, m := range manifests {
+		if m.Body.GetKind() != kind {
+			continue
+		}
+		if name != "" && m.Body.GetName() != name {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func findWorkloadManifests(manifests []provider.Manifest, refs []config.K8sResourceReference) []provider.Manifest {
+	if len(refs) == 0 {
+		return findManifests(provider.KindDeployment, "", manifests)
+	}
+
+	workloads := make([]provider.Manifest, 0)
+	for _, ref := range refs {
+		kind := provider.KindDeployment
+		if ref.Kind != "" {
+			kind = ref.Kind
+		}
+		ms := findManifests(kind, ref.Name, manifests)
+		workloads = append(workloads, ms...)
+	}
+	return workloads
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -433,6 +434,189 @@ spec:
 				manifests = append(manifests, mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(data))))
 			}
 			got := findManifests(tt.kind, tt.nameField, manifests)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestFindWorkloadManifests(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []string
+		refs      []config.K8sResourceReference
+		want      []provider.Manifest
+	}{
+		{
+			name: "default to Deployment kind",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+`,
+			},
+			refs: nil,
+			want: []provider.Manifest{
+				mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`))),
+			},
+		},
+		{
+			name: "specified kind and name",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+`,
+			},
+			refs: []config.K8sResourceReference{
+				{
+					Kind: "Deployment",
+					Name: "nginx-deployment",
+				},
+			},
+			want: []provider.Manifest{
+				mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`))),
+			},
+		},
+		{
+			name: "specified kind only",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+				`
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-statefulset
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+`,
+			},
+			refs: []config.K8sResourceReference{
+				{
+					Kind: "StatefulSet",
+				},
+			},
+			want: []provider.Manifest{
+				mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(`
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-statefulset
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+`))),
+			},
+		},
+		{
+			name: "no match",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			},
+			refs: []config.K8sResourceReference{
+				{
+					Kind: "StatefulSet",
+					Name: "redis-statefulset",
+				},
+			},
+			want: []provider.Manifest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifests []provider.Manifest
+			for _, data := range tt.manifests {
+				manifests = append(manifests, mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(data))))
+			}
+			got := findWorkloadManifests(manifests, tt.refs)
 			assert.ElementsMatch(t, tt.want, got)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
@@ -1,0 +1,17 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+const KindDeployment = "Deployment"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add findManifests and findWorkloadManifests implementations at k8s plugin.
They will be used in the DetermineStrategy gRPC method.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
