### PR TITLE
Fix image uri for cloud run install

### DIFF
--- a/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-dev/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.39.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.39.x/installation/install-piped/installing-on-cloudrun.md
@@ -96,7 +96,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -138,7 +138,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.40.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.40.x/installation/install-piped/installing-on-cloudrun.md
@@ -96,7 +96,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -138,7 +138,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.41.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.41.x/installation/install-piped/installing-on-cloudrun.md
@@ -96,7 +96,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -138,7 +138,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.42.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.43.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.43.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.44.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.44.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.45.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.45.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.46.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.46.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.47.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.47.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.48.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.48.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml

--- a/docs/content/en/docs-v0.49.x/installation/install-piped/installing-on-cloudrun.md
+++ b/docs/content/en/docs-v0.49.x/installation/install-piped/installing-on-cloudrun.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1 to ensure Piped work correctly.
       containers:
-        - image: ghcr.io/pipe-cd/launcher:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/launcher:{{< blocks/latest_version >}}
           args:
             - launcher
             - --launcher-admin-port=9086
@@ -142,7 +142,7 @@ spec:
     spec:
       containerConcurrency: 1                           # This must be 1.
       containers:
-        - image: ghcr.io/pipe-cd/piped:{{< blocks/latest_version >}}
+        - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
           args:
             - piped
             - --config-file=/etc/piped-config/config.yaml


### PR DESCRIPTION
**What this PR does**:

as title.

Currently, Cloud Run can't use the container image hosted on the ghcr.io directly.
https://cloud.google.com/run/docs/deploying#images

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
