### PR TITLE
fix(docs): "Edit this page" URLs to correctly point to GitHub repository structure

### DIFF
--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -5,13 +5,20 @@
 {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := "" }}
+{{ $editURL := printf "%s/edit/%s" $gh_repo $gh_branch }}
 {{ if .File }}
   {{ if .File.LogicalName }}
+    {{ if $gh_subdir }}
+      {{ $editURL = printf "%s/%s" $editURL $gh_subdir }}
+    {{ end }}
+    {{ $editURL = printf "%s/content" $editURL }}
+    {{ if .Site.Language.Lang }}
+      {{ $editURL = printf "%s/%s" $editURL .Site.Language.Lang }}
+    {{ end }}
     {{ if eq .File.LogicalName "_index.md" }}
-      {{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir .Site.Language.Lang (path.Dir .File.Path) }}
+      {{ $editURL = printf "%s/%s" $editURL (path.Dir .File.Path) }}
     {{ else }}
-      {{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir .Site.Language.Lang .File.Path }}
+      {{ $editURL = printf "%s/%s" $editURL .File.Path }}
     {{ end }}
   {{ end }}
 {{ end }}

--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -1,19 +1,21 @@
 {{ if .Path }}
-{{ $pathFormatted := replace .Path "\\" "/" }}
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ $gh_subdir := ($.Param "github_subdir") }}
 {{ $gh_project_repo := ($.Param "github_project_repo") }}
 {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $pathFormatted }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
-{{ else if .Site.Language.Lang }}
-{{ $editURL = printf "%s/edit/%s/content/%s/%s" $gh_repo $gh_branch ($.Site.Language.Lang) $pathFormatted }}
-{{ else if $gh_subdir }}
-{{ $editURL = printf "%s/edit/%s/%s/content/%s" $gh_repo $gh_branch $gh_subdir $pathFormatted }}
+{{ $editURL := "" }}
+{{ if .File }}
+  {{ if .File.LogicalName }}
+    {{ if eq .File.LogicalName "_index.md" }}
+      {{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir .Site.Language.Lang (path.Dir .File.Path) }}
+    {{ else }}
+      {{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir .Site.Language.Lang .File.Path }}
+    {{ end }}
+  {{ end }}
 {{ end }}
+
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank" rel="noreferrer"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank" rel="noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>

--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -15,11 +15,7 @@
     {{ if .Site.Language.Lang }}
       {{ $editURL = printf "%s/%s" $editURL .Site.Language.Lang }}
     {{ end }}
-    {{ if eq .File.LogicalName "_index.md" }}
-      {{ $editURL = printf "%s/%s" $editURL (path.Dir .File.Path) }}
-    {{ else }}
-      {{ $editURL = printf "%s/%s" $editURL .File.Path }}
-    {{ end }}
+    {{ $editURL = printf "%s/%s" $editURL .File.Path }}
   {{ end }}
 {{ end }}
 


### PR DESCRIPTION
**What this PR does**:
This PR fixes the "Edit this page" URLs in the documentation pages to correctly point to the appropriate locations in the GitHub repository structure.
**Why we need it**:
The current "Edit this page" URLs are incorrect, pointing to a wrong path in the repository (missing .md extension).
**Which issue(s) this PR fixes**:

Fixes #5287 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
