### PR TITLE
Implement LoadManifests with Kustomize template

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+
+	"go.uber.org/zap"
+)
+
+type Kustomize struct {
+	execPath string
+	logger   *zap.Logger
+}
+
+func NewKustomize(path string, logger *zap.Logger) *Kustomize {
+	return &Kustomize{
+		execPath: path,
+		logger:   logger,
+	}
+}
+
+func (c *Kustomize) Template(ctx context.Context, appName, appDir string, opts map[string]string) (string, error) {
+	args := []string{
+		"build",
+		".",
+	}
+
+	for k, v := range opts {
+		args = append(args, fmt.Sprintf("--%s", k))
+		if v != "" {
+			args = append(args, v)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, c.execPath, args...)
+	cmd.Dir = appDir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	c.logger.Info(fmt.Sprintf("start templating a Kustomize application %s", appName),
+		zap.Any("args", args),
+	)
+
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return stdout.String(), nil
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/toolregistry/toolregistrytest"
+)
+
+func TestKustomizeTemplate(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx     = context.TODO()
+		appName = "testapp"
+		appDir  = "testdata/testkustomize"
+	)
+
+	c, err := toolregistrytest.NewToolRegistry(t)
+	require.NoError(t, err)
+
+	r := toolregistry.NewRegistry(c)
+
+	t.Cleanup(func() { c.Close() })
+
+	kustomizePath, err := r.Kustomize(context.Background(), "5.4.3")
+	require.NoError(t, err)
+	require.NotEmpty(t, kustomizePath)
+
+	kustomize := NewKustomize(kustomizePath, zap.NewNop())
+	out, err := kustomize.Template(ctx, appName, appDir, map[string]string{
+		"load-restrictor": "LoadRestrictionsNone",
+	})
+	require.NoError(t, err)
+	assert.True(t, len(out) > 0)
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/testdata/testkustomize/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/testdata/testkustomize/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      deployment: hello
+  template:
+    metadata:
+      labels:
+        deployment: hello
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.49.2
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/testdata/testkustomize/kustomization.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/testdata/testkustomize/kustomization.yaml
@@ -1,0 +1,5 @@
+commonLabels:
+    app: hello
+  
+resources:
+  - deployment.yaml


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We must support the kustomize templating method in the k8s plugin because the pipedv0 supports it.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
