### PR TITLE
[docs] Remove Compatibilities from ECS examples

### DIFF
--- a/examples/ecs/attachment/taskdef.yaml
+++ b/examples/ecs/attachment/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/bluegreen/taskdef.yaml
+++ b/examples/ecs/bluegreen/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/canary/taskdef.yaml
+++ b/examples/ecs/canary/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/secret-management/taskdef.yaml
+++ b/examples/ecs/secret-management/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/servicediscovery/canary/taskdef.yaml
+++ b/examples/ecs/servicediscovery/canary/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/servicediscovery/simple/taskdef.yaml
+++ b/examples/ecs/servicediscovery/simple/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/simple/taskdef.yaml
+++ b/examples/ecs/simple/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc

--- a/examples/ecs/standalone-task/launch-type/ec2/network-mode/awsvpc/taskdef.yaml
+++ b/examples/ecs/standalone-task/launch-type/ec2/network-mode/awsvpc/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - EC2
 requiresCompatibilities:
   - EC2
 networkMode: awsvpc

--- a/examples/ecs/standalone-task/launch-type/ec2/network-mode/bridge/taskdef.yaml
+++ b/examples/ecs/standalone-task/launch-type/ec2/network-mode/bridge/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - EC2
 requiresCompatibilities:
   - EC2
 networkMode: bridge

--- a/examples/ecs/standalone-task/launch-type/fargate/taskdef.yaml
+++ b/examples/ecs/standalone-task/launch-type/fargate/taskdef.yaml
@@ -9,8 +9,6 @@ containerDefinitions:
     name: web
     portMappings:
       - containerPort: 80
-compatibilities:
-  - FARGATE
 requiresCompatibilities:
   - FARGATE
 networkMode: awsvpc


### PR DESCRIPTION
**What this PR does**:

as title


**Why we need it**:

`Compatibilities` cannot be used because `RegisterTaskDefinitionInput` does not have it.
It's confusing for users.

cf. 
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs@v1.46.2#RegisterTaskDefinitionInput
- Although `types.TaskDefinition` has it, we cannot pass it when registering.
https://github.com/pipe-cd/pipecd/blob/ad3c8779717d91d0415baec5128f91508a8f9fc0/pkg/app/piped/platformprovider/ecs/client.go#L180-L195


**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
