### PR TITLE
Make configv1.Config generic type

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -272,12 +272,12 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *deployment
 		}
 	}
 
-	cfg, err := config.DecodeYAML(targetDS.GetApplicationConfig())
+	cfg, err := config.DecodeYAML[*config.GenericApplicationSpec](targetDS.GetApplicationConfig())
 	if err != nil {
 		p.logger.Error("unable to parse application config", zap.Error(err))
 		return nil, err
 	}
-	spec := cfg.ApplicationSpec
+	spec := cfg.Spec
 
 	// In case the strategy has been decided by trigger.
 	// For example: user triggered the deployment via web console.

--- a/pkg/configv1/analysis_template.go
+++ b/pkg/configv1/analysis_template.go
@@ -47,12 +47,12 @@ func LoadAnalysisTemplate(repoRoot string) (*AnalysisTemplateSpec, error) {
 			continue
 		}
 		path := filepath.Join(dir, f.Name())
-		cfg, err := LoadFromYAML(path)
+		cfg, err := LoadFromYAML[*AnalysisTemplateSpec](path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config file %s: %w", path, err)
 		}
 		if cfg.Kind == KindAnalysisTemplate {
-			return cfg.AnalysisTemplateSpec, nil
+			return cfg.Spec, nil
 		}
 	}
 	return nil, ErrNotFound

--- a/pkg/configv1/application_test.go
+++ b/pkg/configv1/application_test.go
@@ -409,12 +409,12 @@ func TestGenericTriggerConfiguration(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			cfg, err := LoadFromYAML(tc.fileName)
+			cfg, err := LoadFromYAML[*GenericApplicationSpec](tc.fileName)
 			require.Equal(t, tc.expectedError, err)
 			if err == nil {
 				assert.Equal(t, tc.expectedKind, cfg.Kind)
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
-				assert.Equal(t, tc.expectedSpec, cfg.spec)
+				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
 		})
 	}
@@ -494,12 +494,12 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			cfg, err := LoadFromYAML(tc.fileName)
+			cfg, err := LoadFromYAML[*GenericApplicationSpec](tc.fileName)
 			require.Equal(t, tc.expectedError, err)
 			if err == nil {
 				assert.Equal(t, tc.expectedKind, cfg.Kind)
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
-				assert.Equal(t, tc.expectedSpec, cfg.spec)
+				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
 		})
 	}
@@ -555,12 +555,12 @@ func TestGenericPostSyncConfiguration(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			cfg, err := LoadFromYAML(tc.fileName)
+			cfg, err := LoadFromYAML[*GenericApplicationSpec](tc.fileName)
 			require.Equal(t, tc.expectedError, err)
 			if err == nil {
 				assert.Equal(t, tc.expectedKind, cfg.Kind)
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
-				assert.Equal(t, tc.expectedSpec, cfg.spec)
+				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
 		})
 	}

--- a/pkg/configv1/control_plane_test.go
+++ b/pkg/configv1/control_plane_test.go
@@ -96,20 +96,20 @@ func TestControlPlaneConfig(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			cfg, err := LoadFromYAML(tc.fileName)
+			cfg, err := LoadFromYAML[*ControlPlaneSpec](tc.fileName)
 			require.Equal(t, tc.expectedError, err)
 			if err == nil {
 				assert.Equal(t, tc.expectedKind, cfg.Kind)
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
 				require.Equal(t, 1, len(tc.expectedSpec.SharedSSOConfigs))
-				require.Equal(t, 1, len(cfg.ControlPlaneSpec.SharedSSOConfigs))
+				require.Equal(t, 1, len(cfg.Spec.SharedSSOConfigs))
 				// Why don't we use assert.Equal to compare?
 				// https://github.com/stretchr/testify/issues/758
-				assert.True(t, proto.Equal(&tc.expectedSpec.SharedSSOConfigs[0].ProjectSSOConfig, &cfg.ControlPlaneSpec.SharedSSOConfigs[0].ProjectSSOConfig))
+				assert.True(t, proto.Equal(&tc.expectedSpec.SharedSSOConfigs[0].ProjectSSOConfig, &cfg.Spec.SharedSSOConfigs[0].ProjectSSOConfig))
 
 				tc.expectedSpec.SharedSSOConfigs = nil
-				cfg.ControlPlaneSpec.SharedSSOConfigs = nil
-				assert.Equal(t, tc.expectedSpec, cfg.ControlPlaneSpec)
+				cfg.Spec.SharedSSOConfigs = nil
+				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
 		})
 	}

--- a/pkg/configv1/event_watcher.go
+++ b/pkg/configv1/event_watcher.go
@@ -132,12 +132,12 @@ func LoadEventWatcher(repoRoot string, includePatterns, excludePatterns []string
 	}
 	for _, f := range filtered {
 		path := filepath.Join(dir, f)
-		cfg, err := LoadFromYAML(path)
+		cfg, err := LoadFromYAML[*EventWatcherSpec](path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config file %s: %w", path, err)
 		}
 		if cfg.Kind == KindEventWatcher {
-			spec.Events = append(spec.Events, cfg.EventWatcherSpec.Events...)
+			spec.Events = append(spec.Events, cfg.Spec.Events...)
 		}
 	}
 

--- a/pkg/configv1/piped_test.go
+++ b/pkg/configv1/piped_test.go
@@ -366,12 +366,12 @@ func TestPipedConfig(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.fileName, func(t *testing.T) {
-			cfg, err := LoadFromYAML(tc.fileName)
+			cfg, err := LoadFromYAML[*PipedSpec](tc.fileName)
 			require.Equal(t, tc.expectedError, err)
 			if err == nil {
 				assert.Equal(t, tc.expectedKind, cfg.Kind)
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
-				assert.Equal(t, tc.expectedSpec, cfg.spec)
+				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does**:

This PR makes configv1.Config generic type, and makes LoadFromYAML and DecodeYAML as generic functions.

**Why we need it**:

I want to decode the plugin-specific config in the same way as the piped configs.
The piped-side implementations have no information about plugin-specific config, so I made the decoding function generic.
The plugins can use LoadFromYAML and DecodeYAML with their original type as type parameters.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
