### PR TITLE
Execute git clean partially when drift detection for every app is done

### DIFF
--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -179,7 +179,7 @@ func (d *detector) check(ctx context.Context) {
 				zap.String("app-id", app.Id),
 				zap.String("app-path", app.GitPath.Path),
 			)
-			if err := gitRepo.CleanPartially(ctx, app.GitPath.Path); err != nil {
+			if err := gitRepo.CleanPath(ctx, app.GitPath.Path); err != nil {
 				d.logger.Error("failed to clean partially cloned repository",
 					zap.String("repo-id", repoID),
 					zap.String("app-id", app.Id),

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -169,6 +169,23 @@ func (d *detector) check(ctx context.Context) {
 			if err := d.checkApplication(ctx, app, gitRepo, headCommit); err != nil {
 				d.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
 			}
+
+			// Reset the app dir to the head commit.
+			// Some tools may create temporary files locally to render manifests.
+			// The detector reuses the same located local repository and it causes unexpected behavior by reusing such temporary files.
+			// So regularly run git clean on the app dir after each detection.
+			d.logger.Info("cleaning partially cloned repository",
+				zap.String("repo-id", repoID),
+				zap.String("app-id", app.Id),
+				zap.String("app-path", app.GitPath.Path),
+			)
+			if err := gitRepo.CleanPartially(ctx, app.GitPath.Path); err != nil {
+				d.logger.Error("failed to clean partially cloned repository",
+					zap.String("repo-id", repoID),
+					zap.String("app-id", app.Id),
+					zap.String("app-path", app.GitPath.Path),
+					zap.Error(err))
+			}
 		}
 	}
 }

--- a/pkg/git/gittest/git.mock.go
+++ b/pkg/git/gittest/git.mock.go
@@ -92,6 +92,20 @@ func (mr *MockRepoMockRecorder) Clean() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clean", reflect.TypeOf((*MockRepo)(nil).Clean))
 }
 
+// CleanPartially mocks base method.
+func (m *MockRepo) CleanPartially(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanPartially", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanPartially indicates an expected call of CleanPartially.
+func (mr *MockRepoMockRecorder) CleanPartially(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanPartially", reflect.TypeOf((*MockRepo)(nil).CleanPartially), arg0, arg1)
+}
+
 // CommitChanges mocks base method.
 func (m *MockRepo) CommitChanges(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 map[string][]byte, arg5 map[string]string) error {
 	m.ctrl.T.Helper()

--- a/pkg/git/gittest/git.mock.go
+++ b/pkg/git/gittest/git.mock.go
@@ -92,18 +92,18 @@ func (mr *MockRepoMockRecorder) Clean() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clean", reflect.TypeOf((*MockRepo)(nil).Clean))
 }
 
-// CleanPartially mocks base method.
-func (m *MockRepo) CleanPartially(arg0 context.Context, arg1 string) error {
+// CleanPath mocks base method.
+func (m *MockRepo) CleanPath(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanPartially", arg0, arg1)
+	ret := m.ctrl.Call(m, "CleanPath", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CleanPartially indicates an expected call of CleanPartially.
-func (mr *MockRepoMockRecorder) CleanPartially(arg0, arg1 interface{}) *gomock.Call {
+// CleanPath indicates an expected call of CleanPath.
+func (mr *MockRepoMockRecorder) CleanPath(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanPartially", reflect.TypeOf((*MockRepo)(nil).CleanPartially), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanPath", reflect.TypeOf((*MockRepo)(nil).CleanPath), arg0, arg1)
 }
 
 // CommitChanges mocks base method.

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -43,6 +43,7 @@ type Repo interface {
 	Checkout(ctx context.Context, commitish string) error
 	CheckoutPullRequest(ctx context.Context, number int, branch string) error
 	Clean() error
+	CleanPartially(ctx context.Context, relativePath string) error
 
 	Pull(ctx context.Context, branch string) error
 	MergeRemoteBranch(ctx context.Context, branch, commit, mergeCommitMessage string) error
@@ -257,6 +258,15 @@ func (r *repo) CommitChanges(ctx context.Context, branch, message string, newBra
 // Clean deletes all local git data.
 func (r repo) Clean() error {
 	return os.RemoveAll(r.dir)
+}
+
+// CleanPartially deletes data in the given relative path in the repo with git clean.
+func (r repo) CleanPartially(ctx context.Context, relativePath string) error {
+	out, err := r.runGitCommand(ctx, "clean", "-f", relativePath)
+	if err != nil {
+		return formatCommandError(err, out)
+	}
+	return nil
 }
 
 func (r *repo) checkoutNewBranch(ctx context.Context, branch string) error {

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -43,7 +43,7 @@ type Repo interface {
 	Checkout(ctx context.Context, commitish string) error
 	CheckoutPullRequest(ctx context.Context, number int, branch string) error
 	Clean() error
-	CleanPartially(ctx context.Context, relativePath string) error
+	CleanPath(ctx context.Context, relativePath string) error
 
 	Pull(ctx context.Context, branch string) error
 	MergeRemoteBranch(ctx context.Context, branch, commit, mergeCommitMessage string) error
@@ -260,8 +260,8 @@ func (r repo) Clean() error {
 	return os.RemoveAll(r.dir)
 }
 
-// CleanPartially deletes data in the given relative path in the repo with git clean.
-func (r repo) CleanPartially(ctx context.Context, relativePath string) error {
+// CleanPath deletes data in the given relative path in the repo with git clean.
+func (r repo) CleanPath(ctx context.Context, relativePath string) error {
 	out, err := r.runGitCommand(ctx, "clean", "-f", relativePath)
 	if err != nil {
 		return formatCommandError(err, out)

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -280,7 +280,7 @@ func TestGetCommitForRev(t *testing.T) {
 	assert.Equal(t, commits[0].Hash, commit.Hash)
 }
 
-func TestCleanPartially(t *testing.T) {
+func TestCleanPath(t *testing.T) {
 	faker, err := newFaker()
 	require.NoError(t, err)
 	defer faker.clean()
@@ -313,7 +313,7 @@ func TestCleanPartially(t *testing.T) {
 	}
 
 	// clean the repo-dir/part1
-	err = r.CleanPartially(ctx, "part1")
+	err = r.CleanPath(ctx, "part1")
 	require.NoError(t, err)
 
 	// check the repo-dir/part1 is removed


### PR DESCRIPTION
**What this PR does**:

Fixed to execute `git clean -f` for every app dir after doing k8s drift detection.

**Why we need it**:

During drift detection, a Git repository is cloned and reused, and a common manifest cache is utilized for various operations like drift detection, plan preview, plan, and deploy.
If an incorrect manifest is cached, it can affect other processes. When running kustomize build --enable-helm, a charts directory is created, and the Helm chart is downloaded locally.
However, before kustomize v5.3.0, this directory is not updated if the Helm chart version in kustomization.yaml changes, causing drift detection to load outdated manifests.
These manifests are cached based on commit hash, leading to incorrect manifests being applied during Plan or Deploy if the same commit hash is used.

For the context, see https://github.com/pipe-cd/pipecd/issues/5124#issuecomment-2277628373

**Which issue(s) this PR fixes**:

Fixes #5124

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
