### PR TITLE
Add function to find ConfigMaps and Secrets in manifests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -156,3 +156,16 @@ func findUpdatedWorkloads(olds, news []provider.Manifest) []workloadPair {
 	}
 	return pairs
 }
+
+func findConfigs(manifests []provider.Manifest) map[provider.ResourceKey]provider.Manifest {
+	configs := make(map[provider.ResourceKey]provider.Manifest)
+	for _, m := range manifests {
+		if m.Key.IsConfigMap() {
+			configs[m.Key] = m
+		}
+		if m.Key.IsSecret() {
+			configs[m.Key] = m
+		}
+	}
+	return configs
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -157,7 +157,8 @@ func findUpdatedWorkloads(olds, news []provider.Manifest) []workloadPair {
 	return pairs
 }
 
-func findConfigs(manifests []provider.Manifest) map[provider.ResourceKey]provider.Manifest {
+// findConfigsAndSecrets returns the manifests that are ConfigMap or Secret.
+func findConfigsAndSecrets(manifests []provider.Manifest) map[provider.ResourceKey]provider.Manifest {
 	configs := make(map[provider.ResourceKey]provider.Manifest)
 	for _, m := range manifests {
 		if m.Key.IsConfigMap() {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -1059,7 +1059,7 @@ data:
 			for _, data := range tt.manifests {
 				manifests = append(manifests, mustParseManifests(t, data)...)
 			}
-			got := findConfigs(manifests)
+			got := findConfigsAndSecrets(manifests)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -849,3 +849,218 @@ spec:
 		})
 	}
 }
+func TestFindConfigs(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []string
+		want      map[provider.ResourceKey]provider.Manifest
+	}{
+		{
+			name: "find ConfigMap and Secret",
+			manifests: []string{
+				`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: default
+data:
+  key: value
+`,
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  key: dmFsdWU=
+`,
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+  spec:
+    containers:
+    - name: nginx
+    image: nginx:1.19.3
+`,
+			},
+			want: map[provider.ResourceKey]provider.Manifest{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "my-config",
+					Namespace:  "default",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: default
+data:
+  key: value
+`)[0],
+				{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "my-secret",
+					Namespace:  "default",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  key: dmFsdWU=
+`)[0],
+			},
+		},
+		{
+			name: "no ConfigMap or Secret",
+			manifests: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+  spec:
+    containers:
+    - name: nginx
+    image: nginx:1.19.3
+`,
+			},
+			want: map[provider.ResourceKey]provider.Manifest{},
+		},
+		{
+			name: "only ConfigMap",
+			manifests: []string{
+				`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: default
+data:
+  key: value
+`,
+			},
+			want: map[provider.ResourceKey]provider.Manifest{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "my-config",
+					Namespace:  "default",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: default
+data:
+  key: value
+`)[0],
+			},
+		},
+		{
+			name: "only Secret",
+			manifests: []string{
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  key: dmFsdWU=
+`,
+			},
+			want: map[provider.ResourceKey]provider.Manifest{
+				{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "my-secret",
+					Namespace:  "default",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  key: dmFsdWU=
+`)[0],
+			},
+		},
+		{
+			name: "non-default namespace",
+			manifests: []string{
+				`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: custom-namespace
+data:
+  key: value
+`,
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: custom-namespace
+data:
+  key: dmFsdWU=
+`,
+			},
+			want: map[provider.ResourceKey]provider.Manifest{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "my-config",
+					Namespace:  "custom-namespace",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: custom-namespace
+data:
+  key: value
+`)[0],
+				{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "my-secret",
+					Namespace:  "custom-namespace",
+				}: mustParseManifests(t, `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: custom-namespace
+data:
+  key: dmFsdWU=
+`)[0],
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifests []provider.Manifest
+			for _, data := range tt.manifests {
+				manifests = append(manifests, mustParseManifests(t, data)...)
+			}
+			got := findConfigs(manifests)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
@@ -60,6 +60,7 @@ var builtInAPIVersions = map[string]struct{}{
 const (
 	KindDeployment = "Deployment"
 	KindSecret     = "Secret"
+	KindConfigMap  = "ConfigMap"
 
 	DefaultNamespace = "default"
 )
@@ -87,6 +88,16 @@ func MakeResourceKey(obj *unstructured.Unstructured) ResourceKey {
 		Name:       obj.GetName(),
 	}
 	return k
+}
+
+func (k ResourceKey) IsConfigMap() bool {
+	if k.Kind != KindConfigMap {
+		return false
+	}
+	if !IsKubernetesBuiltInResource(k.APIVersion) {
+		return false
+	}
+	return true
 }
 
 func (k ResourceKey) IsSecret() bool {


### PR DESCRIPTION
**What this PR does**:

This PR adds the function `findConfigs` to find ConfigMaps and Secrets in manifests.

**Why we need it**:

To determine sync strategies, we need to find updated ConfigMaps or Secrets. This PR adds functionalities for finding these candidates.

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
