### PR TITLE
Remove global tracer provider to avoid non-expected spans are sent

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -252,7 +252,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		input.Logger.Error("failed to create tracer provider", zap.Error(err))
 		return err
 	}
-	otel.SetTracerProvider(tracerProvider)
+	// we don't set the global tracer provider because 3rd-party library may use the global one.
 
 	// Send the newest piped meta to the control-plane.
 	if err := p.sendPipedMeta(ctx, apiClient, cfg, input.Logger); err != nil {
@@ -446,6 +446,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			appManifestsCache,
 			p.gracePeriod,
 			input.Logger,
+			tracerProvider,
 		)
 
 		group.Go(func() error {

--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -145,6 +146,7 @@ type controller struct {
 	syncInternal time.Duration
 	gracePeriod  time.Duration
 	logger       *zap.Logger
+	tracerProvider trace.TracerProvider
 }
 
 // NewController creates a new instance for DeploymentController.
@@ -162,6 +164,7 @@ func NewController(
 	appManifestsCache cache.Cache,
 	gracePeriod time.Duration,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) DeploymentController {
 
 	var (
@@ -194,6 +197,7 @@ func NewController(
 		syncInternal: 10 * time.Second,
 		gracePeriod:  gracePeriod,
 		logger:       lg,
+		tracerProvider: tracerProvider,
 	}
 }
 
@@ -504,6 +508,7 @@ func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (
 		c.pipedConfig,
 		c.appManifestsCache,
 		c.logger,
+		c.tracerProvider,
 	)
 
 	cleanup := func() {
@@ -646,6 +651,7 @@ func (c *controller) startNewScheduler(ctx context.Context, d *model.Deployment)
 		c.pipedConfig,
 		c.appManifestsCache,
 		c.logger,
+		c.tracerProvider,
 	)
 
 	cleanup := func() {

--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -84,6 +83,7 @@ func newPlanner(
 	pipedConfig *config.PipedSpec,
 	appManifestsCache cache.Cache,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) *planner {
 
 	logger = logger.Named("planner").With(
@@ -111,7 +111,7 @@ func newPlanner(
 		cancelledCh:                  make(chan *model.ReportableCommand, 1),
 		nowFunc:                      time.Now,
 		logger:                       logger,
-		tracer:                       otel.GetTracerProvider().Tracer("controller/planner"),
+		tracer:                       tracerProvider.Tracer("controller/planner"),
 	}
 	return p
 }

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -98,6 +97,7 @@ func newScheduler(
 	pipedConfig *config.PipedSpec,
 	appManifestsCache cache.Cache,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) *scheduler {
 	logger = logger.Named("scheduler").With(
 		zap.String("deployment-id", d.Id),
@@ -126,7 +126,7 @@ func newScheduler(
 		doneDeploymentStatus: d.Status,
 		cancelledCh:          make(chan *model.ReportableCommand, 1),
 		logger:               logger,
-		tracer:               otel.GetTracerProvider().Tracer("controller/scheduler"),
+		tracer:               tracerProvider.Tracer("controller/scheduler"),
 		nowFunc:              time.Now,
 	}
 

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/spf13/cobra"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -183,7 +182,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		input.Logger.Error("failed to create tracer provider", zap.Error(err))
 		return err
 	}
-	otel.SetTracerProvider(tracerProvider)
+	// we don't set the global tracer provider because 3rd-party library may use the global one.
 
 	// Send the newest piped meta to the control-plane.
 	if err := p.sendPipedMeta(ctx, apiClient, cfg, input.Logger); err != nil {
@@ -347,6 +346,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			appManifestsCache,
 			p.gracePeriod,
 			input.Logger,
+			tracerProvider,
 		)
 
 		group.Go(func() error {

--- a/pkg/app/pipedv1/controller/controller.go
+++ b/pkg/app/pipedv1/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -137,6 +138,7 @@ type controller struct {
 	syncInternal time.Duration
 	gracePeriod  time.Duration
 	logger       *zap.Logger
+	tracerProvider trace.TracerProvider
 }
 
 // NewController creates a new instance for DeploymentController.
@@ -153,6 +155,7 @@ func NewController(
 	appManifestsCache cache.Cache,
 	gracePeriod time.Duration,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) DeploymentController {
 
 	var (
@@ -183,6 +186,7 @@ func NewController(
 		syncInternal: 10 * time.Second,
 		gracePeriod:  gracePeriod,
 		logger:       lg,
+		tracerProvider: tracerProvider,
 	}
 }
 
@@ -478,6 +482,7 @@ func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (
 		c.gitClient,
 		c.notifier,
 		c.logger,
+		c.tracerProvider,
 	)
 
 	cleanup := func() {
@@ -621,6 +626,7 @@ func (c *controller) startNewScheduler(ctx context.Context, d *model.Deployment)
 		c.pipedCfg,
 		c.appManifestsCache,
 		c.logger,
+		c.tracerProvider,
 	)
 
 	cleanup := func() {

--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
@@ -96,6 +95,7 @@ func newPlanner(
 	gitClient gitClient,
 	notifier notifier,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) *planner {
 
 	logger = logger.Named("planner").With(
@@ -130,7 +130,7 @@ func newPlanner(
 		cancelledCh:                  make(chan *model.ReportableCommand, 1),
 		nowFunc:                      time.Now,
 		logger:                       logger,
-		tracer:                       otel.GetTracerProvider().Tracer("controller/planner"),
+		tracer:                       tracerProvider.Tracer("controller/planner"),
 	}
 	return p
 }

--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -95,6 +94,7 @@ func newScheduler(
 	pipedConfig *config.PipedSpec,
 	appManifestsCache cache.Cache,
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 ) *scheduler {
 	logger = logger.Named("scheduler").With(
 		zap.String("deployment-id", d.Id),
@@ -122,7 +122,7 @@ func newScheduler(
 		doneDeploymentStatus: d.Status,
 		cancelledCh:          make(chan *model.ReportableCommand, 1),
 		logger:               logger,
-		tracer:               otel.GetTracerProvider().Tracer("controller/scheduler"),
+		tracer:               tracerProvider.Tracer("controller/scheduler"),
 		nowFunc:              time.Now,
 	}
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

There are the spans sent, which we didn't implement and don't expect to send.
It seems the otelhttp library sends the trace with the global tracer provider, so I remove the global tracer provider.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
