### PR TITLE
Implement checkImageChange and tests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -1194,6 +1194,39 @@ spec:
 			want:   "Sync progressively because of updating image nginx from 1.19.3 to 1.19.4, image redis from 6.0.9 to 6.0.10",
 			wantOk: true,
 		},
+		{
+			name: "change the order cause multi-image update",
+			old: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+      - name: redis
+        image: redis:6.0.9
+`,
+			new: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			want:   "Sync progressively because of updating image nginx:1.19.3 to redis:6.0.9, image redis:6.0.9 to nginx:1.19.3",
+			wantOk: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"sigs.k8s.io/yaml"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
@@ -1060,6 +1061,151 @@ data:
 				manifests = append(manifests, mustParseManifests(t, data)...)
 			}
 			got := findConfigsAndSecrets(manifests)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckImageChange(t *testing.T) {
+	tests := []struct {
+		name   string
+		old    string
+		new    string
+		want   string
+		wantOk bool
+	}{
+		{
+			name: "image updated",
+			old: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			new: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.4
+`,
+			want:   "Sync progressively because of updating image nginx from 1.19.3 to 1.19.4",
+			wantOk: true,
+		},
+		{
+			name: "image name changed",
+			old: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			new: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis
+        image: redis:6.0.9
+`,
+			want:   "Sync progressively because of updating image nginx:1.19.3 to redis:6.0.9",
+			wantOk: true,
+		},
+		{
+			name: "no image change",
+			old: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			new: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+`,
+			want:   "",
+			wantOk: false,
+		},
+		{
+			name: "multiple image updates",
+			old: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+      - name: redis
+        image: redis:6.0.9
+`,
+			new: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.4
+      - name: redis
+        image: redis:6.0.10
+`,
+			want:   "Sync progressively because of updating image nginx from 1.19.3 to 1.19.4, image redis from 6.0.9 to 6.0.10",
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldManifests := mustParseManifests(t, tt.old)
+			newManifests := mustParseManifests(t, tt.new)
+			logger := zap.NewNop() // or use a real logger if available
+			diffs, err := provider.Diff(oldManifests[0], newManifests[0], logger)
+			require.NoError(t, err)
+
+			got, ok := checkImageChange(diffs.Nodes())
+			assert.Equal(t, tt.wantOk, ok)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
**What this PR does**:

Implement checkImageChange and tests.
The checkImageChange detects changed images from the difference of manifests.

**Why we need it**:

We must detect whether there are changed images or not to determine the sync strategy and its descriptions.
If there are changed images in diffs, we choose the pipeline sync strategy.
If there are no changed images in diffs, we determine the sync strategy with other viewpoints.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
