### PR TITLE
 Add checkReplicasChange function to detect changes in replicas field 

### DIFF
--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -426,24 +426,25 @@ func checkReplicasChange(ns diff.Nodes) (before, after string, changed bool) {
 	const replicasQuery = `^spec\.replicas$`
 	node, err := ns.FindOne(replicasQuery)
 	if err != nil {
-		// not found or unknown error
+		// no difference between the before and after manifests, or unknown error occurred.
 		return "", "", false
 	}
 
-	before = node.StringX()
 	if node.TypeX == nil {
-		// The replicas field is not found in the old manifest.
-		before = ""
+		// The replicas field is not found in the before manifest.
+		// There is difference between the before and after manifests, So it means the replicas field is added in the after manifest.
+		// So the replicas field in the before manifest is nil, we should return "<nil>" as the before value.
+		return "<nil>", node.StringY(), true
 	}
 
-	after = node.StringY()
 	if node.TypeY == nil {
-		// The replicas field is not found in the new manifest.
-		after = ""
+		// The replicas field is not found in the after manifest.
+		// There is difference between the before and after manifests, So it means the replicas field is removed in the after manifest.
+		// So the replicas field in the after manifest is nil, we should return "<nil>" as the after value.
+		return node.StringX(), "<nil>", true
 	}
 
-	changed = true
-	return before, after, changed
+	return node.StringX(), node.StringY(), true
 }
 
 type containerImage struct {

--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -421,17 +421,29 @@ func checkImageChange(ns diff.Nodes) (string, bool) {
 	return desc, true
 }
 
+// checkReplicasChange checks if the replicas field is changed.
 func checkReplicasChange(ns diff.Nodes) (before, after string, changed bool) {
 	const replicasQuery = `^spec\.replicas$`
 	node, err := ns.FindOne(replicasQuery)
 	if err != nil {
-		return
+		// not found or unknown error
+		return "", "", false
 	}
 
 	before = node.StringX()
+	if node.TypeX == nil {
+		// The replicas field is not found in the old manifest.
+		before = ""
+	}
+
 	after = node.StringY()
+	if node.TypeY == nil {
+		// The replicas field is not found in the new manifest.
+		after = ""
+	}
+
 	changed = true
-	return
+	return before, after, changed
 }
 
 type containerImage struct {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -193,3 +193,28 @@ func checkImageChange(ns diff.Nodes) (string, bool) {
 	desc := fmt.Sprintf("Sync progressively because of updating %s", strings.Join(images, ", "))
 	return desc, true
 }
+
+// checkReplicasChange checks if the replicas field is changed.
+func checkReplicasChange(ns diff.Nodes) (before, after string, changed bool) {
+	const replicasQuery = `^spec\.replicas$`
+	node, err := ns.FindOne(replicasQuery)
+	if err != nil {
+		// not found or unknown error
+		return "", "", false
+	}
+
+	before = node.StringX()
+	if node.TypeX == nil {
+		// The replicas field is not found in the old manifest.
+		before = ""
+	}
+
+	after = node.StringY()
+	if node.TypeY == nil {
+		// The replicas field is not found in the new manifest.
+		after = ""
+	}
+
+	changed = true
+	return before, after, changed
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -199,22 +199,23 @@ func checkReplicasChange(ns diff.Nodes) (before, after string, changed bool) {
 	const replicasQuery = `^spec\.replicas$`
 	node, err := ns.FindOne(replicasQuery)
 	if err != nil {
-		// not found or unknown error
+		// no difference between the before and after manifests, or unknown error occurred.
 		return "", "", false
 	}
 
-	before = node.StringX()
 	if node.TypeX == nil {
-		// The replicas field is not found in the old manifest.
-		before = ""
+		// The replicas field is not found in the before manifest.
+		// There is difference between the before and after manifests, So it means the replicas field is added in the after manifest.
+		// So the replicas field in the before manifest is nil, we should return "<nil>" as the before value.
+		return "<nil>", node.StringY(), true
 	}
 
-	after = node.StringY()
 	if node.TypeY == nil {
-		// The replicas field is not found in the new manifest.
-		after = ""
+		// The replicas field is not found in the after manifest.
+		// There is difference between the before and after manifests, So it means the replicas field is removed in the after manifest.
+		// So the replicas field in the after manifest is nil, we should return "<nil>" as the after value.
+		return node.StringX(), "<nil>", true
 	}
 
-	changed = true
-	return before, after, changed
+	return node.StringX(), node.StringY(), true
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -1345,7 +1345,7 @@ spec:
         image: nginx:1.19.3
 `,
 			wantBefore:  "3",
-			wantAfter:   "",
+			wantAfter:   "<nil>",
 			wantChanged: true,
 		},
 		{
@@ -1375,7 +1375,7 @@ spec:
       - name: nginx
         image: nginx:1.19.3
 `,
-			wantBefore:  "",
+			wantBefore:  "<nil>",
 			wantAfter:   "3",
 			wantChanged: true,
 		},

--- a/pkg/plugin/diff/renderer.go
+++ b/pkg/plugin/diff/renderer.go
@@ -218,6 +218,9 @@ func RenderPrimitiveValue(v reflect.Value) string {
 	case reflect.Float32, reflect.Float64:
 		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
 
+	case reflect.Interface, reflect.Pointer:
+		return RenderPrimitiveValue(v.Elem())
+
 	default:
 		return v.String()
 	}

--- a/pkg/plugin/diff/renderer_test.go
+++ b/pkg/plugin/diff/renderer_test.go
@@ -188,6 +188,14 @@ func TestRenderPrimitiveValue(t *testing.T) {
 			expected: "1.25",
 		},
 		{
+			name: "pointer to int",
+			value: func() *int {
+				v := 1
+				return &v
+			}(),
+			expected: "1",
+		},
+		{
 			name: "map",
 			value: map[string]int{
 				"one": 1,


### PR DESCRIPTION
**What this PR does**:

- [Add checkReplicasChange function to detect changes in replicas field](https://github.com/pipe-cd/pipecd/commit/609e3f344b4dd976cc4e8669f6edaaf0cbebef26)
  - there is a bug in original checkReplicasChange, so [I backported the fix](https://github.com/pipe-cd/pipecd/pull/5341/commits/26616b6ac5d5e95a214e1bf15769ade221ee3ce8)
- [Add support for rendering interface and pointer types in RenderPrimit…](https://github.com/pipe-cd/pipecd/commit/3ea6403feed6d364c3a8e55bbe9672a1b0d362b5)
  - We need this because reflect.Interface are returned as their kind when the replicas field is absent either of before/after manifests

**Why we need it**:

We chose a quick sync strategy when the diffs are only replicas.
We must build a summary message with the workload changed, so we must check it.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
When users delete or add the spec.replicas field on the Deployment manifest, they can view the plan summary as expected. Without this PR, they will see an invalid value.

- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
