### PR TITLE
Refactor and implement k8s pipeline builds

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline.go
@@ -15,9 +15,12 @@
 package deployment
 
 import (
+	"fmt"
+	"slices"
 	"time"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 )
 
 type Stage string
@@ -113,6 +116,50 @@ func buildQuickSyncPipeline(autoRollback bool, now time.Time) []*model.PipelineS
 			Id:        s.GetId(),
 			Name:      s.GetName(),
 			Desc:      s.GetDesc(),
+			Rollback:  s.GetRollback(),
+			Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+			CreatedAt: now.Unix(),
+			UpdatedAt: now.Unix(),
+		})
+	}
+
+	return out
+}
+
+func buildPipelineStages(stages []*deployment.BuildPipelineSyncStagesRequest_StageConfig, autoRollback bool, now time.Time) []*model.PipelineStage {
+	out := make([]*model.PipelineStage, 0, len(stages)+1)
+
+	for _, s := range stages {
+		id := s.GetId()
+		if id == "" {
+			id = fmt.Sprintf("stage-%d", s.GetIndex())
+		}
+		stage := &model.PipelineStage{
+			Id:        id,
+			Name:      s.GetName(),
+			Desc:      s.GetDesc(),
+			Index:     s.GetIndex(),
+			Rollback:  false,
+			Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+			CreatedAt: now.Unix(),
+			UpdatedAt: now.Unix(),
+		}
+		out = append(out, stage)
+	}
+
+	if autoRollback {
+		// we set the index of the rollback stage to the minimum index of all stages.
+		minIndex := slices.MinFunc(stages, func(a, b *deployment.BuildPipelineSyncStagesRequest_StageConfig) int {
+			return int(a.GetIndex() - b.GetIndex())
+		}).GetIndex()
+
+		s, _ := GetPredefinedStage(PredefinedStageRollback)
+		// we copy the predefined stage to avoid modifying the original one.
+		out = append(out, &model.PipelineStage{
+			Id:        s.GetId(),
+			Name:      s.GetName(),
+			Desc:      s.GetDesc(),
+			Index:     minIndex,
 			Rollback:  s.GetRollback(),
 			Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
 			CreatedAt: now.Unix(),

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
@@ -18,8 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 func TestBuildQuickSyncPipeline(t *testing.T) {
@@ -37,16 +38,15 @@ func TestBuildQuickSyncPipeline(t *testing.T) {
 			autoRollback: false,
 			expected: []*model.PipelineStage{
 				{
-					Id:         PredefinedStageK8sSync,
-					Name:       StageK8sSync.String(),
-					Desc:       "Sync by applying all manifests",
-					Index:      0,
-					Predefined: true,
-					Visible:    true,
-					Status:     model.StageStatus_STAGE_NOT_STARTED_YET,
-					Metadata:   nil,
-					CreatedAt:  now.Unix(),
-					UpdatedAt:  now.Unix(),
+					Id:        PredefinedStageK8sSync,
+					Name:      StageK8sSync.String(),
+					Desc:      "Sync by applying all manifests",
+					Index:     0,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					Metadata:  nil,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
 				},
 			},
 		},
@@ -55,26 +55,24 @@ func TestBuildQuickSyncPipeline(t *testing.T) {
 			autoRollback: true,
 			expected: []*model.PipelineStage{
 				{
-					Id:         PredefinedStageK8sSync,
-					Name:       StageK8sSync.String(),
-					Desc:       "Sync by applying all manifests",
-					Index:      0,
-					Predefined: true,
-					Visible:    true,
-					Status:     model.StageStatus_STAGE_NOT_STARTED_YET,
-					Metadata:   nil,
-					CreatedAt:  now.Unix(),
-					UpdatedAt:  now.Unix(),
+					Id:        PredefinedStageK8sSync,
+					Name:      StageK8sSync.String(),
+					Desc:      "Sync by applying all manifests",
+					Index:     0,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					Metadata:  nil,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
 				},
 				{
-					Id:         PredefinedStageRollback,
-					Name:       StageK8sRollback.String(),
-					Desc:       "Rollback the deployment",
-					Predefined: true,
-					Visible:    false,
-					Status:     model.StageStatus_STAGE_NOT_STARTED_YET,
-					CreatedAt:  now.Unix(),
-					UpdatedAt:  now.Unix(),
+					Id:        PredefinedStageRollback,
+					Name:      StageK8sRollback.String(),
+					Desc:      "Rollback the deployment",
+					Rollback:  true,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
 				},
 			},
 		},

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 )
 
 func TestBuildQuickSyncPipeline(t *testing.T) {
@@ -81,6 +82,117 @@ func TestBuildQuickSyncPipeline(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := buildQuickSyncPipeline(tt.autoRollback, now)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestBuildPipelineStages(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		stages       []*deployment.BuildPipelineSyncStagesRequest_StageConfig
+		autoRollback bool
+		expected     []*model.PipelineStage
+	}{
+		{
+			name: "without auto rollback",
+			stages: []*deployment.BuildPipelineSyncStagesRequest_StageConfig{
+				{
+					Id:    "stage-1",
+					Name:  "Stage 1",
+					Desc:  "Description 1",
+					Index: 0,
+				},
+				{
+					Id:    "stage-2",
+					Name:  "Stage 2",
+					Desc:  "Description 2",
+					Index: 1,
+				},
+			},
+			autoRollback: false,
+			expected: []*model.PipelineStage{
+				{
+					Id:        "stage-1",
+					Name:      "Stage 1",
+					Desc:      "Description 1",
+					Index:     0,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+				{
+					Id:        "stage-2",
+					Name:      "Stage 2",
+					Desc:      "Description 2",
+					Index:     1,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+			},
+		},
+		{
+			name: "with auto rollback",
+			stages: []*deployment.BuildPipelineSyncStagesRequest_StageConfig{
+				{
+					Id:    "stage-1",
+					Name:  "Stage 1",
+					Desc:  "Description 1",
+					Index: 0,
+				},
+				{
+					Id:    "stage-2",
+					Name:  "Stage 2",
+					Desc:  "Description 2",
+					Index: 1,
+				},
+			},
+			autoRollback: true,
+			expected: []*model.PipelineStage{
+				{
+					Id:        "stage-1",
+					Name:      "Stage 1",
+					Desc:      "Description 1",
+					Index:     0,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+				{
+					Id:        "stage-2",
+					Name:      "Stage 2",
+					Desc:      "Description 2",
+					Index:     1,
+					Rollback:  false,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+				{
+					Id:        PredefinedStageRollback,
+					Name:      StageK8sRollback.String(),
+					Desc:      "Rollback the deployment",
+					Index:     0,
+					Rollback:  true,
+					Status:    model.StageStatus_STAGE_NOT_STARTED_YET,
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := buildPipelineStages(tt.stages, tt.autoRollback, now)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -88,8 +88,12 @@ func (a *DeploymentService) DetermineVersions(ctx context.Context, request *depl
 }
 
 // BuildPipelineSyncStages implements deployment.DeploymentServiceServer.
-func (a *DeploymentService) BuildPipelineSyncStages(context.Context, *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
-	panic("unimplemented")
+func (a *DeploymentService) BuildPipelineSyncStages(ctx context.Context, request *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
+	now := time.Now()
+	stages := buildPipelineStages(request.GetStages(), request.GetRollback(), now)
+	return &deployment.BuildPipelineSyncStagesResponse{
+		Stages: stages,
+	}, nil
 }
 
 // BuildQuickSyncStages implements deployment.DeploymentServiceServer.


### PR DESCRIPTION
**What this PR does**:

This PR does follow two things

- Refactor `buildQuickSyncPipeline`
- Implement `BuildPipelineSyncStages`

**Why we need it**:

- Refactor `buildQuickSyncPipeline`
    - I want to refactor this because there are some unnecessary codes.
    - My poor understanding of the codes introduced them in the past PR.
- Implement `BuildPipelineSyncStages`
    - the pipedv1 deployment plugin spec needs this.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
