### PR TITLE
Enable rendering Mermaid diagrams in docs

### DIFF
--- a/docs/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/docs/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,5 @@
+{{/*  Enable rendering Mermaid diagrams. See https://gohugo.io/content-management/diagrams/#mermaid-diagrams.  */}}
+<pre class="mermaid">
+    {{- .Inner | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/docs/layouts/partials/scripts.html
+++ b/docs/layouts/partials/scripts.html
@@ -18,3 +18,11 @@
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end }}
 {{ partial "hooks/body-end.html" . }}
+
+{{/*  Enable rendering Mermaid diagrams. See https://gohugo.io/content-management/diagrams/#mermaid-diagrams.   */}}
+{{ if .Store.Get "hasMermaid" }}
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+{{ end }}


### PR DESCRIPTION
**What this PR does**:

as title.

**Why we need it**:

Currently, Mermaid diagrams cannot be rendered in docs.
We want to write diagrams by Mermaid in several cases.

Current:

![image](https://github.com/user-attachments/assets/c8203c81-496e-4dc7-9b02-171647bdcba5)


By this PR:
![image](https://github.com/user-attachments/assets/8046aec6-5231-4421-975f-c1de7a80e084)


**For Reviewers**

- See https://gohugo.io/content-management/diagrams/#mermaid-diagrams for details.
- `docs/layouts/partials/scripts.html` is loaded in all `baseof.html`.
    - e.g. https://github.com/pipe-cd/pipecd/blob/7e5d4ea1912dbbdc504b591da35357c501a7ac5f/docs/layouts/docs-dev/baseof.html#L30

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
