### PR TITLE
Implement Kubernetes application configuration and deployment input structures

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -20,3 +20,28 @@ type K8sResourceReference struct {
 	Kind string `json:"kind"`
 	Name string `json:"name"`
 }
+
+// KubernetesApplicationSpec represents an application configuration for Kubernetes application.
+type KubernetesApplicationSpec struct {
+	// Input for Kubernetes deployment such as kubectl version, helm version, manifests filter...
+	Input KubernetesDeploymentInput `json:"input"`
+
+	// TODO: Define fields for KubernetesApplicationSpec.
+}
+
+func (s *KubernetesApplicationSpec) Validate() error {
+	// TODO: Validate KubernetesApplicationSpec fields.
+	return nil
+}
+
+// KubernetesDeploymentInput represents needed input for triggering a Kubernetes deployment.
+type KubernetesDeploymentInput struct {
+	// List of manifest files in the application directory used to deploy.
+	// Empty means all manifest files in the directory will be used.
+	Manifests []string `json:"manifests,omitempty"`
+
+	// The namespace where manifests will be applied.
+	Namespace string `json:"namespace,omitempty"`
+
+	// TODO: Define fields for KubernetesDeploymentInput.
+}


### PR DESCRIPTION
**What this PR does**:

- add `KubernetesApplicationSpec` with minimal fields
- decode the application config in the `DetermineVersions` method and pass values to manifest loader

**Why we need it**:

We have to load application config to treat the kubernetes resources.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
