### PR TITLE
Refactor launcher package to lifecycle

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/cli"
 	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/pipe-cd/pipecd/pkg/git"
+	"github.com/pipe-cd/pipecd/pkg/lifecycle"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcclient"
 	"github.com/pipe-cd/pipecd/pkg/version"
@@ -271,7 +272,7 @@ func (l *launcher) run(ctx context.Context, input cli.Input) error {
 	}
 
 	var (
-		runningPiped *command
+		runningPiped *lifecycle.Command
 		workingDir   = filepath.Join(l.homeDir, "piped")
 		ticker       = time.NewTicker(l.checkInterval)
 	)
@@ -384,7 +385,7 @@ func (l *launcher) shouldRelaunch(ctx context.Context, logger *zap.Logger) (vers
 	return
 }
 
-func (l *launcher) cleanOldPiped(cmd *command, workingDir string, logger *zap.Logger) error {
+func (l *launcher) cleanOldPiped(cmd *lifecycle.Command, workingDir string, logger *zap.Logger) error {
 	// Stop running Piped gracefully.
 	if cmd != nil {
 		if err := cmd.GracefulStop(l.gracePeriod); err != nil {
@@ -403,7 +404,7 @@ func (l *launcher) cleanOldPiped(cmd *command, workingDir string, logger *zap.Lo
 	return nil
 }
 
-func (l *launcher) launchNewPiped(version string, config []byte, workingDir string, logger *zap.Logger) (*command, error) {
+func (l *launcher) launchNewPiped(version string, config []byte, workingDir string, logger *zap.Logger) (*lifecycle.Command, error) {
 	if err := os.MkdirAll(workingDir, 0755); err != nil {
 		return nil, fmt.Errorf("could not create working directory %s (%w)", workingDir, err)
 	}
@@ -413,7 +414,7 @@ func (l *launcher) launchNewPiped(version string, config []byte, workingDir stri
 		binaryDir   = filepath.Join(workingDir, "bin")
 		downloadURL = makeDownloadURL(version)
 	)
-	pipedPath, err := downloadBinary(downloadURL, binaryDir, pipedBinaryFileName, logger)
+	pipedPath, err := lifecycle.DownloadBinary(downloadURL, binaryDir, pipedBinaryFileName, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download Piped from %s to %s (%w)", downloadURL, binaryDir, err)
 	}
@@ -435,7 +436,7 @@ func (l *launcher) launchNewPiped(version string, config []byte, workingDir stri
 	args := makePipedArgs(os.Args[2:], configFilePath)
 	logger.Info(fmt.Sprintf("LAUNCHER: start running Piped %s with args %v", version, args))
 
-	return runBinary(pipedPath, args)
+	return lifecycle.RunBinary(pipedPath, args)
 }
 
 func (l *launcher) loadConfigData(ctx context.Context) ([]byte, error) {

--- a/pkg/lifecycle/binary.go
+++ b/pkg/lifecycle/binary.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package launcher
+package lifecycle
 
 import (
 	"fmt"
@@ -28,13 +28,13 @@ import (
 	"go.uber.org/zap"
 )
 
-type command struct {
+type Command struct {
 	cmd       *exec.Cmd
 	stoppedCh chan struct{}
 	result    atomic.Pointer[error]
 }
 
-func (c *command) IsRunning() bool {
+func (c *Command) IsRunning() bool {
 	select {
 	case _, notClosed := <-c.stoppedCh:
 		return notClosed
@@ -43,7 +43,7 @@ func (c *command) IsRunning() bool {
 	}
 }
 
-func (c *command) GracefulStop(period time.Duration) error {
+func (c *Command) GracefulStop(period time.Duration) error {
 	// For graceful shutdown, we send SIGTERM signal to old Piped process
 	// and wait grace-period of time before force killing it.
 	c.cmd.Process.Signal(syscall.SIGTERM)
@@ -65,7 +65,7 @@ func (c *command) GracefulStop(period time.Duration) error {
 	}
 }
 
-func runBinary(execPath string, args []string) (*command, error) {
+func RunBinary(execPath string, args []string) (*Command, error) {
 	cmd := exec.Command(execPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -75,7 +75,7 @@ func runBinary(execPath string, args []string) (*command, error) {
 		return nil, err
 	}
 
-	c := &command{
+	c := &Command{
 		cmd:       cmd,
 		stoppedCh: make(chan struct{}),
 		result:    atomic.Pointer[error]{},
@@ -89,9 +89,9 @@ func runBinary(execPath string, args []string) (*command, error) {
 	return c, nil
 }
 
-// downloadBinary downloads a file from the given URL into the specified path
+// DownloadBinary downloads a file from the given URL into the specified path
 // this also marks it executable and returns its full path.
-func downloadBinary(url, destDir, destFile string, logger *zap.Logger) (string, error) {
+func DownloadBinary(url, destDir, destFile string, logger *zap.Logger) (string, error) {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return "", fmt.Errorf("could not create directory %s (%w)", destDir, err)
 	}
@@ -119,7 +119,7 @@ func downloadBinary(url, destDir, destFile string, logger *zap.Logger) (string, 
 		}
 	}()
 
-	logger.Info(fmt.Sprintf("LAUNCHER: downloading %s...", url))
+	logger.Info("downloading binary", zap.String("url", url))
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/lifecycle/binary_test.go
+++ b/pkg/lifecycle/binary_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package launcher
+package lifecycle
 
 import (
 	"strconv"
@@ -40,7 +40,7 @@ func TestGracefulStopCommand(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, err := runBinary("sh", []string{"sleep", "1m"})
+			cmd, err := RunBinary("sh", []string{"sleep", "1m"})
 			require.NoError(t, err)
 			require.NotNil(t, cmd)
 
@@ -71,7 +71,7 @@ func TestGracefulStopCommandResult(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, err := runBinary("sh", []string{"-c", "exit " + strconv.Itoa(tc.exitCode)})
+			cmd, err := RunBinary("sh", []string{"-c", "exit " + strconv.Itoa(tc.exitCode)})
 			require.NoError(t, err)
 			require.NotNil(t, cmd)
 


### PR DESCRIPTION
**What this PR does**:

This PR adds the package "lifecycle".
The "lifecycle" package is from launcher codes, and the launcher codes become using this package.

**Why we need it**:

We want to maintain the plugin lifecycle with these codes.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
