### PR TITLE
Implement DetermineStrategy for the Kubernetes plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -26,6 +26,15 @@ type KubernetesApplicationSpec struct {
 	// Input for Kubernetes deployment such as kubectl version, helm version, manifests filter...
 	Input KubernetesDeploymentInput `json:"input"`
 
+	// Which resources should be considered as the Workload of application.
+	// Empty means all Deployments.
+	// e.g.
+	// - kind: Deployment
+	//   name: deployment-name
+	// - kind: ReplicationController
+	//   name: replication-controller-name
+	Workloads []K8sResourceReference `json:"workloads"`
+
 	// TODO: Define fields for KubernetesApplicationSpec.
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -65,8 +65,49 @@ func (a *DeploymentService) Register(server *grpc.Server) {
 }
 
 // DetermineStrategy implements deployment.DeploymentServiceServer.
-func (a *DeploymentService) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
-	panic("unimplemented")
+func (a *DeploymentService) DetermineStrategy(ctx context.Context, request *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
+	cfg, err := config.DecodeYAML[*kubeconfig.KubernetesApplicationSpec](request.GetInput().GetTargetDeploymentSource().GetApplicationConfig())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	runnings, err := a.Loader.LoadManifests(ctx, provider.LoaderInput{
+		AppName:          request.GetInput().GetDeployment().GetApplicationName(),
+		AppDir:           request.GetInput().GetRunningDeploymentSource().GetApplicationDirectory(),
+		ConfigFilename:   request.GetInput().GetRunningDeploymentSource().GetApplicationConfigFilename(),
+		Manifests:        cfg.Spec.Input.Manifests,
+		Namespace:        cfg.Spec.Input.Namespace,
+		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
+
+		// TODO: Define other fields for LoaderInput
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	targets, err := a.Loader.LoadManifests(ctx, provider.LoaderInput{
+		AppName:          request.GetInput().GetDeployment().GetApplicationName(),
+		AppDir:           request.GetInput().GetTargetDeploymentSource().GetApplicationDirectory(),
+		ConfigFilename:   request.GetInput().GetTargetDeploymentSource().GetApplicationConfigFilename(),
+		Manifests:        cfg.Spec.Input.Manifests,
+		Namespace:        cfg.Spec.Input.Namespace,
+		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
+
+		// TODO: Define other fields for LoaderInput
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	strategy, summary := determineStrategy(runnings, targets, cfg.Spec.Workloads, a.Logger)
+
+	return &deployment.DetermineStrategyResponse{
+		SyncStrategy: strategy,
+		Summary:      summary,
+	}, nil
+
 }
 
 // DetermineVersions implements deployment.DeploymentServiceServer.


### PR DESCRIPTION
**What this PR does**:

This PR adds the DetermineStrategy implementation for the k8s plugin.

**Why we need it**:

We have to support this method to deploy k8s resources.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
