### PR TITLE
Refactor manifest loading in DeploymentService to reduce code duplication

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -170,7 +170,7 @@ func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Dep
 	})
 
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return manifests, nil


### PR DESCRIPTION
**What this PR does**:

This PR refactors loading manifests in the k8s plugin.

**Why we need it**:

I don't want to maintain the same logic in multiple codes.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
