### PR TITLE
Fix unable to load manifest for PlanPreview in case of ECS standalone tasks

### DIFF
--- a/pkg/app/piped/planpreview/ecsdiff.go
+++ b/pkg/app/piped/planpreview/ecsdiff.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/pipe-cd/pipecd/pkg/app/piped/deploysource"
 	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/ecs"
 	"github.com/pipe-cd/pipecd/pkg/diff"
@@ -118,9 +119,13 @@ func (b *builder) loadECSManifests(ctx context.Context, app model.Application, d
 	if err != nil {
 		return provider.ECSManifests{}, err
 	}
-	serviceDef, err := provider.LoadServiceDefinition(ds.AppDir, appCfg.Input.ServiceDefinitionFile)
-	if err != nil {
-		return provider.ECSManifests{}, err
+
+	serviceDef := types.Service{}
+	if !appCfg.Input.IsStandaloneTask() {
+		serviceDef, err = provider.LoadServiceDefinition(ds.AppDir, appCfg.Input.ServiceDefinitionFile)
+		if err != nil {
+			return provider.ECSManifests{}, err
+		}
 	}
 
 	manifests = provider.ECSManifests{


### PR DESCRIPTION
**What this PR does**:

Skip load `serviceDef` on the ECS standalone task since there is no `serviceDef` file while running planpreview logic

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #5370

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
