### PR TITLE
Change kubectl DL host to dl.k8s.io

### DIFF
--- a/pkg/app/piped/toolregistry/tool_darwin.go
+++ b/pkg/app/piped/toolregistry/tool_darwin.go
@@ -16,7 +16,7 @@ package toolregistry
 
 var kubectlInstallScript = `
 cd {{ .WorkingDir }}
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v{{ .Version }}/bin/darwin/amd64/kubectl
+curl -LO https://dl.k8s.io/release/v{{ .Version }}/bin/darwin/amd64/kubectl
 mv kubectl {{ .BinDir }}/kubectl-{{ .Version }}
 chmod +x {{ .BinDir }}/kubectl-{{ .Version }}
 {{ if .AsDefault }}

--- a/pkg/app/piped/toolregistry/tool_linux.go
+++ b/pkg/app/piped/toolregistry/tool_linux.go
@@ -16,7 +16,7 @@ package toolregistry
 
 var kubectlInstallScript = `
 cd {{ .WorkingDir }}
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v{{ .Version }}/bin/linux/amd64/kubectl
+curl -LO https://dl.k8s.io/release/v{{ .Version }}/bin/linux/amd64/kubectl
 mv kubectl {{ .BinDir }}/kubectl-{{ .Version }}
 chmod +x {{ .BinDir }}/kubectl-{{ .Version }}
 {{ if .AsDefault }}


### PR DESCRIPTION
**What this PR does**:

Changed the URL for installing the kubectl. It seems that some versions are not hosted on the older URL. ( e.g. v1.30.5

I tested whether to use kubectl 1.30.5 and it works well.
```
...
  platformProviders:
    - name: kubernetes-dev
      type: KUBERNETES
      labels:
        env: local
      config:
        masterURL: https://127.0.0.1:56247
        kubeConfigPath: kubeconfig
        kubectlVersion: 1.30.5
```

**Why we need it**:

We should use https://dl.k8s.io/ instead of https://storage.googleapis.com/kubernetes-release because the old one is deprecated.

ref: https://github.com/kubernetes/kubernetes/issues/127796#issuecomment-2392019607

**Which issue(s) this PR fixes**:

Fixes #5369

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
