### PR TITLE
Refactor the k8s plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -21,6 +21,7 @@ import (
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
@@ -33,7 +34,7 @@ import (
 )
 
 type toolRegistry interface {
-	InstallTool(ctx context.Context, name, version string) (path string, err error)
+	InstallTool(ctx context.Context, name, version, script string) (string, error)
 }
 
 type loader interface {
@@ -60,7 +61,6 @@ type DeploymentService struct {
 	deployment.UnimplementedDeploymentServiceServer
 
 	logger       *zap.Logger
-	toolRegistry toolRegistry
 	loader       loader
 	logPersister logPersister
 }
@@ -68,10 +68,13 @@ type DeploymentService struct {
 // NewDeploymentService creates a new planService.
 func NewDeploymentService(
 	logger *zap.Logger,
+	toolRegistry toolRegistry,
+	logPersister logPersister,
 ) *DeploymentService {
 	return &DeploymentService{
 		logger:       logger.Named("planner"),
-		toolRegistry: nil, // TODO: set the tool registry
+		loader:       provider.NewLoader(toolregistry.NewRegistry(toolRegistry)),
+		logPersister: logPersister,
 	}
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type toolRegistry interface {
+type toolClient interface {
 	InstallTool(ctx context.Context, name, version, script string) (string, error)
 }
 
@@ -68,12 +68,12 @@ type DeploymentService struct {
 // NewDeploymentService creates a new planService.
 func NewDeploymentService(
 	logger *zap.Logger,
-	toolRegistry toolRegistry,
+	toolClient toolClient,
 	logPersister logPersister,
 ) *DeploymentService {
 	return &DeploymentService{
 		logger:       logger.Named("planner"),
-		loader:       provider.NewLoader(toolregistry.NewRegistry(toolRegistry)),
+		loader:       provider.NewLoader(toolregistry.NewRegistry(toolClient)),
 		logPersister: logPersister,
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
@@ -77,6 +77,12 @@ type ToolRegistry interface {
 	Helm(ctx context.Context, version string) (string, error)
 }
 
+func NewLoader(registry ToolRegistry) *Loader {
+	return &Loader{
+		toolRegistry: registry,
+	}
+}
+
 func (l *Loader) LoadManifests(ctx context.Context, input LoaderInput) (manifests []Manifest, err error) {
 	defer func() {
 		// Override namespace if set because ParseManifests does not parse it

--- a/pkg/app/pipedv1/plugin/kubernetes/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/server.go
@@ -68,11 +68,15 @@ func (s *server) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	group, ctx := errgroup.WithContext(ctx)
 
+	// TODO: create the piped plugin gRPC client here.
+
 	// Start a gRPC server for handling external API requests.
 	{
 		var (
 			service = deployment.NewDeploymentService(
 				input.Logger,
+				nil, // TODO: set the tool registry here.
+				nil, // TODO: set the log persister here.
 			)
 			opts = []rpc.Option{
 				rpc.WithPort(s.apiPort),

--- a/pkg/app/pipedv1/plugin/kubernetes/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/server.go
@@ -75,7 +75,7 @@ func (s *server) run(ctx context.Context, input cli.Input) (runErr error) {
 		var (
 			service = deployment.NewDeploymentService(
 				input.Logger,
-				nil, // TODO: set the tool registry here.
+				nil, // TODO: set the tool registry client here.
 				nil, // TODO: set the log persister here.
 			)
 			opts = []rpc.Option{


### PR DESCRIPTION
**What this PR does**:

1. make the DeploymentService fields private and remove unused fields.
1. add arguments of NewDeploymentService to make tool registry and log persister as arguments

**Why we need it**:

1. Making the variable scope narrow is better
1. we have to create gRPC conn for piped-side service, which may be done out of the initialization of DeploymentService. So we have to pass them as arguments.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
