### PR TITLE
Add context to RunBinary interface

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -306,7 +306,7 @@ func (l *launcher) run(ctx context.Context, input cli.Input) error {
 		}
 
 		// Start new piped process.
-		runningPiped, err = l.launchNewPiped(version, config, workingDir, input.Logger)
+		runningPiped, err = l.launchNewPiped(ctx, version, config, workingDir, input.Logger)
 		if err != nil {
 			input.Logger.Error("LAUNCHER: failed while launching new Piped", zap.Error(err))
 			return err
@@ -404,7 +404,7 @@ func (l *launcher) cleanOldPiped(cmd *lifecycle.Command, workingDir string, logg
 	return nil
 }
 
-func (l *launcher) launchNewPiped(version string, config []byte, workingDir string, logger *zap.Logger) (*lifecycle.Command, error) {
+func (l *launcher) launchNewPiped(ctx context.Context, version string, config []byte, workingDir string, logger *zap.Logger) (*lifecycle.Command, error) {
 	if err := os.MkdirAll(workingDir, 0755); err != nil {
 		return nil, fmt.Errorf("could not create working directory %s (%w)", workingDir, err)
 	}
@@ -436,7 +436,7 @@ func (l *launcher) launchNewPiped(version string, config []byte, workingDir stri
 	args := makePipedArgs(os.Args[2:], configFilePath)
 	logger.Info(fmt.Sprintf("LAUNCHER: start running Piped %s with args %v", version, args))
 
-	return lifecycle.RunBinary(pipedPath, args)
+	return lifecycle.RunBinary(ctx, pipedPath, args)
 }
 
 func (l *launcher) loadConfigData(ctx context.Context) ([]byte, error) {

--- a/pkg/lifecycle/binary.go
+++ b/pkg/lifecycle/binary.go
@@ -70,8 +70,8 @@ func (c *Command) GracefulStop(period time.Duration) error {
 	}
 }
 
-func RunBinary(execPath string, args []string) (*Command, error) {
-	cmd, err := backoff.NewRetry(runBinaryRetryCount, backoff.NewConstant(5*time.Second)).Do(context.Background(), func() (interface{}, error) {
+func RunBinary(ctx context.Context, execPath string, args []string) (*Command, error) {
+	cmd, err := backoff.NewRetry(runBinaryRetryCount, backoff.NewConstant(5*time.Second)).Do(ctx, func() (interface{}, error) {
 		cmd := exec.Command(execPath, args...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
**What this PR does**:

Add context to the RunBinary interface to have more control.
Also, add test for the DownloadBinary function.

**Why we need it**:

Instead of `context.Background`, use context passed by the run binary caller side would gain the caller more control on the binary lifecycle.

**Which issue(s) this PR fixes**:

Part of #4980
Follows #5361

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
