### PR TITLE
Implement applier for the kubernetes plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -51,9 +51,15 @@ type KubernetesDeploymentInput struct {
 	// List of manifest files in the application directory used to deploy.
 	// Empty means all manifest files in the directory will be used.
 	Manifests []string `json:"manifests,omitempty"`
+	// Version of kubectl will be used.
+	KubectlVersion string `json:"kubectlVersion,omitempty"`
 
 	// The namespace where manifests will be applied.
 	Namespace string `json:"namespace,omitempty"`
+
+	// Automatically create a new namespace if it does not exist.
+	// Default is false.
+	AutoCreateNamespace bool `json:"autoCreateNamespace,omitempty"`
 
 	// TODO: Define fields for KubernetesDeploymentInput.
 }
@@ -71,4 +77,15 @@ type KubernetesVariantLabel struct {
 	// The label value for BASELINE variant.
 	// Default is baseline.
 	BaselineValue string `json:"baselineValue" default:"baseline"`
+}
+
+type KubernetesDeployTargetConfig struct {
+	// The master URL of the kubernetes cluster.
+	// Empty means in-cluster.
+	MasterURL string `json:"masterURL,omitempty"`
+	// The path to the kubeconfig file.
+	// Empty means in-cluster.
+	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
+	// Version of kubectl will be used.
+	KubectlVersion string `json:"kubectlVersion"`
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/applier.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/applier.go
@@ -1,0 +1,166 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+)
+
+type kubectl interface {
+	Apply(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	Create(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	Replace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	ForceReplace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	Delete(ctx context.Context, kubeconfig, namespace string, key ResourceKey) error
+	Get(ctx context.Context, kubeconfig, namespace string, key ResourceKey) (Manifest, error)
+	CreateNamespace(ctx context.Context, kubeconfig, namespace string) error
+}
+
+type Applier struct {
+	kubectl kubectl
+
+	input        config.KubernetesDeploymentInput
+	deployTarget config.KubernetesDeployTargetConfig
+	logger       *zap.Logger
+}
+
+func NewApplier(kubectl kubectl, input config.KubernetesDeploymentInput, cp config.KubernetesDeployTargetConfig, logger *zap.Logger) *Applier {
+	return &Applier{
+		kubectl:      kubectl,
+		input:        input,
+		deployTarget: cp,
+		logger:       logger.Named("kubernetes-applier"),
+	}
+}
+
+// ApplyManifest does applying the given manifest.
+func (a *Applier) ApplyManifest(ctx context.Context, manifest Manifest) error {
+	if a.input.AutoCreateNamespace {
+		err := a.kubectl.CreateNamespace(
+			ctx,
+			a.deployTarget.KubeConfigPath,
+			a.getNamespaceToRun(manifest.Key),
+		)
+		if err != nil && !errors.Is(err, errResourceAlreadyExists) {
+			return err
+		}
+	}
+
+	return a.kubectl.Apply(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(manifest.Key),
+		manifest,
+	)
+}
+
+// CreateManifest uses kubectl to create the given manifests.
+func (a *Applier) CreateManifest(ctx context.Context, manifest Manifest) error {
+	if a.input.AutoCreateNamespace {
+		err := a.kubectl.CreateNamespace(
+			ctx,
+			a.deployTarget.KubeConfigPath,
+			a.getNamespaceToRun(manifest.Key),
+		)
+		if err != nil && !errors.Is(err, errResourceAlreadyExists) {
+			return err
+		}
+	}
+
+	return a.kubectl.Create(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(manifest.Key),
+		manifest,
+	)
+}
+
+// ReplaceManifest uses kubectl to replace the given manifests.
+func (a *Applier) ReplaceManifest(ctx context.Context, manifest Manifest) error {
+	err := a.kubectl.Replace(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(manifest.Key),
+		manifest,
+	)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, errorReplaceNotFound) {
+		return ErrNotFound
+	}
+
+	return err
+}
+
+// ForceReplaceManifest uses kubectl to forcefully replace the given manifests.
+func (a *Applier) ForceReplaceManifest(ctx context.Context, manifest Manifest) error {
+	err := a.kubectl.ForceReplace(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(manifest.Key),
+		manifest,
+	)
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, errorReplaceNotFound) {
+		return ErrNotFound
+	}
+
+	return err
+}
+
+// Delete deletes the given resource from Kubernetes cluster.
+// If the resource key is different, this returns ErrNotFound.
+func (a *Applier) Delete(ctx context.Context, k ResourceKey) (err error) {
+	m, err := a.kubectl.Get(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(k),
+		k,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	if k.String() != m.Body.GetAnnotations()[LabelResourceKey] {
+		return ErrNotFound
+	}
+
+	return a.kubectl.Delete(
+		ctx,
+		a.deployTarget.KubeConfigPath,
+		a.getNamespaceToRun(k),
+		k,
+	)
+}
+
+// getNamespaceToRun returns namespace used on kubectl apply/delete commands.
+// priority: config.KubernetesDeploymentInput > kubernetes.ResourceKey
+func (a *Applier) getNamespaceToRun(k ResourceKey) string {
+	if a.input.Namespace != "" {
+		return a.input.Namespace
+	}
+	return k.Namespace
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
@@ -537,3 +537,57 @@ metadata:
 		})
 	}
 }
+
+func TestApplier_getNamespaceToRun(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		inputNamespace string
+		resourceKey    ResourceKey
+		expected       string
+	}{
+		{
+			name:           "input namespace is used",
+			inputNamespace: "input-namespace",
+			resourceKey: ResourceKey{
+				Namespace: "resource-namespace",
+			},
+			expected: "input-namespace",
+		},
+		{
+			name:           "resource key namespace is used",
+			inputNamespace: "",
+			resourceKey: ResourceKey{
+				Namespace: "resource-namespace",
+			},
+			expected: "resource-namespace",
+		},
+		{
+			name:           "both namespaces are empty",
+			inputNamespace: "",
+			resourceKey: ResourceKey{
+				Namespace: "",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			applier := &Applier{
+				input: config.KubernetesDeploymentInput{
+					Namespace: tc.inputNamespace,
+				},
+			}
+
+			result := applier.getNamespaceToRun(tc.resourceKey)
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
@@ -33,53 +33,57 @@ type mockKubectl struct {
 	CreateNamespaceFunc func(ctx context.Context, kubeconfig, namespace string) error
 }
 
+var (
+	errUnexpectedCall = errors.New("unexpected call")
+)
+
 func (m *mockKubectl) Apply(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
 	if m.ApplyFunc != nil {
 		return m.ApplyFunc(ctx, kubeconfig, namespace, manifest)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func (m *mockKubectl) Create(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
 	if m.CreateFunc != nil {
 		return m.CreateFunc(ctx, kubeconfig, namespace, manifest)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func (m *mockKubectl) Replace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
 	if m.ReplaceFunc != nil {
 		return m.ReplaceFunc(ctx, kubeconfig, namespace, manifest)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func (m *mockKubectl) ForceReplace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
 	if m.ForceReplaceFunc != nil {
 		return m.ForceReplaceFunc(ctx, kubeconfig, namespace, manifest)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func (m *mockKubectl) Delete(ctx context.Context, kubeconfig, namespace string, key ResourceKey) error {
 	if m.DeleteFunc != nil {
 		return m.DeleteFunc(ctx, kubeconfig, namespace, key)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func (m *mockKubectl) Get(ctx context.Context, kubeconfig, namespace string, key ResourceKey) (Manifest, error) {
 	if m.GetFunc != nil {
 		return m.GetFunc(ctx, kubeconfig, namespace, key)
 	}
-	return Manifest{}, nil
+	return Manifest{}, errUnexpectedCall
 }
 
 func (m *mockKubectl) CreateNamespace(ctx context.Context, kubeconfig, namespace string) error {
 	if m.CreateNamespaceFunc != nil {
 		return m.CreateNamespaceFunc(ctx, kubeconfig, namespace)
 	}
-	return nil
+	return errUnexpectedCall
 }
 
 func TestApplier_ApplyManifest(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
@@ -151,16 +151,16 @@ func TestApplier_ApplyManifest(t *testing.T) {
 				},
 			}
 
-			applier := &Applier{
-				kubectl: mockKubectl,
-				input: config.KubernetesDeploymentInput{
+			applier := NewApplier(
+				mockKubectl,
+				config.KubernetesDeploymentInput{
 					AutoCreateNamespace: tc.autoCreateNamespace,
 				},
-				deployTarget: config.KubernetesDeployTargetConfig{
+				config.KubernetesDeployTargetConfig{
 					KubeConfigPath: "test-kubeconfig",
 				},
-				logger: zap.NewNop(),
-			}
+				zap.NewNop(),
+			)
 
 			manifest := Manifest{
 				Key: ResourceKey{

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/applier_test.go
@@ -1,0 +1,173 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"go.uber.org/zap"
+)
+
+type mockKubectl struct {
+	ApplyFunc           func(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	CreateFunc          func(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	ReplaceFunc         func(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	ForceReplaceFunc    func(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error
+	DeleteFunc          func(ctx context.Context, kubeconfig, namespace string, key ResourceKey) error
+	GetFunc             func(ctx context.Context, kubeconfig, namespace string, key ResourceKey) (Manifest, error)
+	CreateNamespaceFunc func(ctx context.Context, kubeconfig, namespace string) error
+}
+
+func (m *mockKubectl) Apply(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
+	if m.ApplyFunc != nil {
+		return m.ApplyFunc(ctx, kubeconfig, namespace, manifest)
+	}
+	return nil
+}
+
+func (m *mockKubectl) Create(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(ctx, kubeconfig, namespace, manifest)
+	}
+	return nil
+}
+
+func (m *mockKubectl) Replace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
+	if m.ReplaceFunc != nil {
+		return m.ReplaceFunc(ctx, kubeconfig, namespace, manifest)
+	}
+	return nil
+}
+
+func (m *mockKubectl) ForceReplace(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
+	if m.ForceReplaceFunc != nil {
+		return m.ForceReplaceFunc(ctx, kubeconfig, namespace, manifest)
+	}
+	return nil
+}
+
+func (m *mockKubectl) Delete(ctx context.Context, kubeconfig, namespace string, key ResourceKey) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, kubeconfig, namespace, key)
+	}
+	return nil
+}
+
+func (m *mockKubectl) Get(ctx context.Context, kubeconfig, namespace string, key ResourceKey) (Manifest, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, kubeconfig, namespace, key)
+	}
+	return Manifest{}, nil
+}
+
+func (m *mockKubectl) CreateNamespace(ctx context.Context, kubeconfig, namespace string) error {
+	if m.CreateNamespaceFunc != nil {
+		return m.CreateNamespaceFunc(ctx, kubeconfig, namespace)
+	}
+	return nil
+}
+
+func TestApplier_ApplyManifest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		errNamespaceCreation = errors.New("namespace creation error")
+		errApply             = errors.New("apply error")
+	)
+
+	testCases := []struct {
+		name                string
+		autoCreateNamespace bool
+		createNamespaceErr  error
+		applyErr            error
+		expectedErr         error
+	}{
+		{
+			name:                "successful apply without namespace creation",
+			autoCreateNamespace: false,
+			expectedErr:         nil,
+		},
+		{
+			name:                "successful apply with namespace creation",
+			autoCreateNamespace: true,
+			expectedErr:         nil,
+		},
+		{
+			name:                "namespace creation error",
+			autoCreateNamespace: true,
+			createNamespaceErr:  errNamespaceCreation,
+			expectedErr:         errNamespaceCreation,
+		},
+		{
+			name:                "apply error",
+			autoCreateNamespace: false,
+			applyErr:            errApply,
+			expectedErr:         errApply,
+		},
+		{
+			name:                "successful apply with existing namespace",
+			autoCreateNamespace: true,
+			createNamespaceErr:  errResourceAlreadyExists,
+			expectedErr:         nil,
+		},
+		{
+			name:                "apply error after successful namespace creation",
+			autoCreateNamespace: true,
+			applyErr:            errApply,
+			expectedErr:         errApply,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockKubectl := &mockKubectl{
+				CreateNamespaceFunc: func(ctx context.Context, kubeconfig, namespace string) error {
+					return tc.createNamespaceErr
+				},
+				ApplyFunc: func(ctx context.Context, kubeconfig, namespace string, manifest Manifest) error {
+					return tc.applyErr
+				},
+			}
+
+			applier := &Applier{
+				kubectl: mockKubectl,
+				input: config.KubernetesDeploymentInput{
+					AutoCreateNamespace: tc.autoCreateNamespace,
+				},
+				deployTarget: config.KubernetesDeployTargetConfig{
+					KubeConfigPath: "test-kubeconfig",
+				},
+				logger: zap.NewNop(),
+			}
+
+			manifest := Manifest{
+				Key: ResourceKey{
+					Namespace: "test-namespace",
+				},
+			}
+
+			err := applier.ApplyManifest(context.Background(), manifest)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
@@ -31,6 +31,15 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/toolregistry/toolregistrytest"
 )
 
+func mustParseManifests(t *testing.T, data string) []Manifest {
+	t.Helper()
+
+	manifests, err := ParseManifests(data)
+	require.NoError(t, err)
+
+	return manifests
+}
+
 func TestParseManifests(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
**What this PR does**:

This PR implements the Kubernetes applier functionalities.
Almost of this PR is copy of [pkg/app/piped/platformprovider/kubernetes/applier.go](https://github.com/pipe-cd/pipecd/blob/1907301ca6de307381db05bd594768d610591a6b/pkg/app/piped/platformprovider/kubernetes/applier.go).

I made the modifications below with the above file.
- make kubectl wrapper as constructor arguments
    - before, the kubectl wrapper is initialized in the first call of the applier method
- make the struct public
    - before, the Applier interface was public and the struct is private
    - ref; [Go Code Review Comments #Interfaces](https://go.dev/wiki/CodeReviewComments#interfaces).
- Add unit test for methods

**Why we need it**:

- to implement k8s stages

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
