### PR TITLE
Fix missing call to cancel context in backoff test

### DIFF
--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -138,6 +138,8 @@ func TestDo(t *testing.T) {
 				cancel()
 			}
 
+			defer cancel()
+
 			data, err := r.Do(ctx, tc.operation)
 			assert.Equal(t, tc.expected, data)
 			assert.Equal(t, tc.expectedErr, err)


### PR DESCRIPTION
**What this PR does**:

Fix missing call to cancel context in backoff test

**Why we need it**:

My go lint yields this error potential context leak due to not calling context cancel in all paths

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
