### PR TITLE
Using backoff Do instead of WaitNext function to avoid potential panic

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -505,23 +505,10 @@ func (p *planner) buildPipelineSyncStages(ctx context.Context, cfg *config.Gener
 }
 
 func (p *planner) reportDeploymentPlanned(ctx context.Context, out *plannerOutput) error {
-	var (
-		err   error
-		retry = pipedservice.NewRetry(10)
-		req   = &pipedservice.ReportDeploymentPlannedRequest{
-			DeploymentId:              p.deployment.Id,
-			Summary:                   out.Summary,
-			StatusReason:              "The deployment has been planned",
-			RunningCommitHash:         p.lastSuccessfulCommitHash,
-			RunningConfigFilename:     p.lastSuccessfulConfigFilename,
-			Versions:                  out.Versions,
-			Stages:                    out.Stages,
-			DeploymentChainId:         p.deployment.DeploymentChainId,
-			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
-		}
-	)
-
 	users, groups, err := p.getApplicationNotificationMentions(model.NotificationEventType_EVENT_DEPLOYMENT_PLANNED)
+	if err != nil {
+		p.logger.Error("failed to get the list of users or groups", zap.Error(err))
+	}
 
 	defer func() {
 		p.notifier.Notify(model.NotificationEvent{
@@ -535,13 +522,25 @@ func (p *planner) reportDeploymentPlanned(ctx context.Context, out *plannerOutpu
 		})
 	}()
 
-	for retry.WaitNext(ctx) {
-		if _, err = p.apiClient.ReportDeploymentPlanned(ctx, req); err == nil {
-			return nil
-		}
-		err = fmt.Errorf("failed to report deployment status to control-plane: %v", err)
+	req := &pipedservice.ReportDeploymentPlannedRequest{
+		DeploymentId:              p.deployment.Id,
+		Summary:                   out.Summary,
+		StatusReason:              "The deployment has been planned",
+		RunningCommitHash:         p.lastSuccessfulCommitHash,
+		RunningConfigFilename:     p.lastSuccessfulConfigFilename,
+		Versions:                  out.Versions,
+		Stages:                    out.Stages,
+		DeploymentChainId:         p.deployment.DeploymentChainId,
+		DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
 	}
 
+	_, err = pipedservice.NewRetry(10).Do(ctx, func() (interface{}, error) {
+		_, err := p.apiClient.ReportDeploymentPlanned(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to report deployment status to control-plane: %w", err)
+		}
+		return nil, nil
+	})
 	if err != nil {
 		p.logger.Error("failed to mark deployment to be planned", zap.Error(err))
 	}
@@ -549,21 +548,6 @@ func (p *planner) reportDeploymentPlanned(ctx context.Context, out *plannerOutpu
 }
 
 func (p *planner) reportDeploymentFailed(ctx context.Context, reason string) error {
-	var (
-		err error
-		now = p.nowFunc()
-		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:              p.deployment.Id,
-			Status:                    model.DeploymentStatus_DEPLOYMENT_FAILURE,
-			StatusReason:              reason,
-			StageStatuses:             nil,
-			DeploymentChainId:         p.deployment.DeploymentChainId,
-			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
-			CompletedAt:               now.Unix(),
-		}
-		retry = pipedservice.NewRetry(10)
-	)
-
 	users, groups, err := p.getApplicationNotificationMentions(model.NotificationEventType_EVENT_DEPLOYMENT_FAILED)
 	if err != nil {
 		p.logger.Error("failed to get the list of users or groups", zap.Error(err))
@@ -581,12 +565,23 @@ func (p *planner) reportDeploymentFailed(ctx context.Context, reason string) err
 		})
 	}()
 
-	for retry.WaitNext(ctx) {
-		if _, err = p.apiClient.ReportDeploymentCompleted(ctx, req); err == nil {
-			return nil
-		}
-		err = fmt.Errorf("failed to report deployment status to control-plane: %v", err)
+	req := &pipedservice.ReportDeploymentCompletedRequest{
+		DeploymentId:              p.deployment.Id,
+		Status:                    model.DeploymentStatus_DEPLOYMENT_FAILURE,
+		StatusReason:              reason,
+		StageStatuses:             nil,
+		DeploymentChainId:         p.deployment.DeploymentChainId,
+		DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+		CompletedAt:               p.nowFunc().Unix(),
 	}
+
+	_, err = pipedservice.NewRetry(10).Do(ctx, func() (interface{}, error) {
+		_, err := p.apiClient.ReportDeploymentCompleted(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to report deployment status to control-plane: %w", err)
+		}
+		return nil, nil
+	})
 
 	if err != nil {
 		p.logger.Error("failed to mark deployment to be failed", zap.Error(err))
@@ -595,21 +590,6 @@ func (p *planner) reportDeploymentFailed(ctx context.Context, reason string) err
 }
 
 func (p *planner) reportDeploymentCancelled(ctx context.Context, commander, reason string) error {
-	var (
-		err error
-		now = p.nowFunc()
-		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:              p.deployment.Id,
-			Status:                    model.DeploymentStatus_DEPLOYMENT_CANCELLED,
-			StatusReason:              reason,
-			StageStatuses:             nil,
-			DeploymentChainId:         p.deployment.DeploymentChainId,
-			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
-			CompletedAt:               now.Unix(),
-		}
-		retry = pipedservice.NewRetry(10)
-	)
-
 	users, groups, err := p.getApplicationNotificationMentions(model.NotificationEventType_EVENT_DEPLOYMENT_CANCELLED)
 	if err != nil {
 		p.logger.Error("failed to get the list of users or groups", zap.Error(err))
@@ -627,12 +607,23 @@ func (p *planner) reportDeploymentCancelled(ctx context.Context, commander, reas
 		})
 	}()
 
-	for retry.WaitNext(ctx) {
-		if _, err = p.apiClient.ReportDeploymentCompleted(ctx, req); err == nil {
-			return nil
-		}
-		err = fmt.Errorf("failed to report deployment status to control-plane: %v", err)
+	req := &pipedservice.ReportDeploymentCompletedRequest{
+		DeploymentId:              p.deployment.Id,
+		Status:                    model.DeploymentStatus_DEPLOYMENT_CANCELLED,
+		StatusReason:              reason,
+		StageStatuses:             nil,
+		DeploymentChainId:         p.deployment.DeploymentChainId,
+		DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+		CompletedAt:               p.nowFunc().Unix(),
 	}
+
+	_, err = pipedservice.NewRetry(10).Do(ctx, func() (interface{}, error) {
+		_, err := p.apiClient.ReportDeploymentCompleted(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to report deployment status to control-plane: %w", err)
+		}
+		return nil, nil
+	})
 
 	if err != nil {
 		p.logger.Error("failed to mark deployment to be cancelled", zap.Error(err))

--- a/pkg/app/pipedv1/controller/scheduler_test.go
+++ b/pkg/app/pipedv1/controller/scheduler_test.go
@@ -295,7 +295,7 @@ func TestExecuteStage_SignalCancelled(t *testing.T) {
 					Id:     "stage-id",
 					Name:   "stage-name",
 					Index:  0,
-					Status: model.StageStatus_STAGE_RUNNING,
+					Status: model.StageStatus_STAGE_NOT_STARTED_YET,
 				},
 			},
 		},

--- a/pkg/app/pipedv1/controller/scheduler_test.go
+++ b/pkg/app/pipedv1/controller/scheduler_test.go
@@ -270,7 +270,7 @@ func TestExecuteStage_SignalTerminated(t *testing.T) {
 
 	handler.Terminate()
 	finalStatus := s.executeStage(sig, s.deployment.Stages[0])
-	assert.Equal(t, model.StageStatus_STAGE_RUNNING, finalStatus)
+	assert.Equal(t, model.StageStatus_STAGE_FAILURE, finalStatus)
 }
 
 func TestExecuteStage_SignalCancelled(t *testing.T) {
@@ -295,7 +295,7 @@ func TestExecuteStage_SignalCancelled(t *testing.T) {
 					Id:     "stage-id",
 					Name:   "stage-name",
 					Index:  0,
-					Status: model.StageStatus_STAGE_NOT_STARTED_YET,
+					Status: model.StageStatus_STAGE_RUNNING,
 				},
 			},
 		},
@@ -306,5 +306,5 @@ func TestExecuteStage_SignalCancelled(t *testing.T) {
 
 	handler.Cancel()
 	finalStatus := s.executeStage(sig, s.deployment.Stages[0])
-	assert.Equal(t, model.StageStatus_STAGE_CANCELLED, finalStatus)
+	assert.Equal(t, model.StageStatus_STAGE_FAILURE, finalStatus)
 }

--- a/pkg/app/pipedv1/trigger/deployment.go
+++ b/pkg/app/pipedv1/trigger/deployment.go
@@ -109,29 +109,26 @@ func buildDeployment(
 }
 
 func reportMostRecentlyTriggeredDeployment(ctx context.Context, client apiClient, d *model.Deployment) error {
-	var (
-		err error
-		req = &pipedservice.ReportApplicationMostRecentDeploymentRequest{
-			ApplicationId: d.ApplicationId,
-			Status:        model.DeploymentStatus_DEPLOYMENT_PENDING,
-			Deployment: &model.ApplicationDeploymentReference{
-				DeploymentId: d.Id,
-				Trigger:      d.Trigger,
-				Summary:      d.Summary,
-				Version:      d.Version,
-				Versions:     d.Versions,
-				StartedAt:    d.CreatedAt,
-				CompletedAt:  d.CompletedAt,
-			},
-		}
-		retry = pipedservice.NewRetry(10)
-	)
-
-	for retry.WaitNext(ctx) {
-		if _, err = client.ReportApplicationMostRecentDeployment(ctx, req); err == nil {
-			return nil
-		}
-		err = fmt.Errorf("failed to report most recent successful deployment: %w", err)
+	req := &pipedservice.ReportApplicationMostRecentDeploymentRequest{
+		ApplicationId: d.ApplicationId,
+		Status:        model.DeploymentStatus_DEPLOYMENT_PENDING,
+		Deployment: &model.ApplicationDeploymentReference{
+			DeploymentId: d.Id,
+			Trigger:      d.Trigger,
+			Summary:      d.Summary,
+			Version:      d.Version,
+			Versions:     d.Versions,
+			StartedAt:    d.CreatedAt,
+			CompletedAt:  d.CompletedAt,
+		},
 	}
+	_, err := pipedservice.NewRetry(10).Do(ctx, func() (interface{}, error) {
+		_, err := client.ReportApplicationMostRecentDeployment(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to report most recent successful deployment: %w", err)
+		}
+		return nil, nil
+	})
+
 	return err
 }

--- a/pkg/app/server/service/pipedservice/service.go
+++ b/pkg/app/server/service/pipedservice/service.go
@@ -47,6 +47,12 @@ func Retriable(err error) bool {
 	}
 }
 
+// NewRetriableErr returns a new backoff.Error for the given error.
+// Based on the error code, it determines whether the error is retriable or not.
+func NewRetriableErr(err error) *backoff.Error {
+	return backoff.NewError(err, Retriable(err))
+}
+
 // NewRetry returns a new backoff.Retry for piped API caller.
 // 0s 997.867435ms 2.015381172s 3.485134345s 4.389600179s 18.118099328s 48.73058264s
 func NewRetry(maxRetries int) backoff.Retry {


### PR DESCRIPTION
**What this PR does**:

Using backoff.Do in pipedv1 codebase instead of backoff.WaitNext

**Why we need it**:

In the backoff package, we have two functions that handle retry logic: WaitNext and Do. The main difference between them (aside from the interface) is that WaitNext does not raise an error in case the context is canceled/stopped, while Do does. So if using WaitNext and the returned value of the caller are used as a check for further logic, it may cause panic due to no error returned while the value is nil either.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
