### PR TITLE
Implement preparing manifest applier in kubernetes plugin

### DIFF
--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -1310,3 +1310,13 @@ type PipedDeployTarget struct {
 	// The configuration of the deploy target.
 	Config json.RawMessage `json:"config"`
 }
+
+// FindDeployTarget finds the deploy target by the given name.
+func (p *PipedPlugin) FindDeployTarget(name string) *PipedDeployTarget {
+	for _, dt := range p.DeployTargets {
+		if dt.Name == name {
+			return &dt
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does**:

This PR implements the preparation of a manifest applier in the Kubernetes plugin.

**Why we need it**:

Without this PR, we cannot execute the K8S_SYNC stage.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
