### PR TITLE
Implement rollback stage for kubernetes plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -207,7 +207,6 @@ func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Dep
 }
 
 func (a *DeploymentService) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {
-	// TODO: move this to the ExecuteStage function and pass the log persister as an argument?
 	lp := a.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId())
 	defer func() {
 		// When the piped cancelled the RPC while the stage is still runnning, we should not mark the log persister as completed.


### PR DESCRIPTION
**What this PR does**:

- Implement executeK8sRollbackStage
- refactor duplicates of executeK8sSyncStage and executeK8sRollbackStage
    - There are some duplicates remaining, but these parts has unimplemented TODOs. so I didn't refactor all of them.

**Why we need it**:

We have to support rollback of k8s stages

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
