### PR TITLE
[docs] Update status of ECS deployments to Beta

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -75,8 +75,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 
 | Feature | Phase |
 |-|-|
-| Quick sync deployment | Alpha |
-| Deployment with a defined pipeline (e.g. canary, analysis) | Alpha |
+| Quick sync deployment | Beta |
+| Deployment with a defined pipeline (e.g. canary, analysis) | Beta |
 | [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
 | [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Alpha *1 |
 | [Application live state](../user-guide/managing-application/application-live-state/) | Alpha *1 |

--- a/docs/content/en/docs-v0.50.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.50.x/feature-status/_index.md
@@ -75,8 +75,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 
 | Feature | Phase |
 |-|-|
-| Quick sync deployment | Alpha |
-| Deployment with a defined pipeline (e.g. canary, analysis) | Alpha |
+| Quick sync deployment | Beta |
+| Deployment with a defined pipeline (e.g. canary, analysis) | Beta |
 | [Automated rollback](../user-guide/managing-application/rolling-back-a-deployment/) | Beta |
 | [Automated configuration drift detection](../user-guide/managing-application/configuration-drift-detection/) | Alpha *1 |
 | [Application live state](../user-guide/managing-application/application-live-state/) | Alpha *1 |


### PR DESCRIPTION
**What this PR does**:

Update feature statuses of ECS QuickSync and PipelineSync to Beta from Alpha.

**Why we need it**:

They're already available in production.
Maybe we've forgotten to update them... 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
