### PR TITLE
Update Grafana Tempo helm chart

### DIFF
--- a/manifests/pipecd/Chart.lock
+++ b/manifests/pipecd/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.93.3
 - name: tempo
   repository: https://grafana.github.io/helm-charts
-  version: 1.10.2
-digest: sha256:2fa3e0df6d19e699e8ae52b415bed1a56f9890701eaa04cd48f4419eb4da01cc
-generated: "2024-08-08T10:45:50.558122029+09:00"
+  version: 1.14.0
+digest: sha256:c6d00e5535f3d61210cca8a16521f2186ddaf5d9cf6f2da68cdfa9eba08473f0
+generated: "2024-12-09T09:56:27.110590328+09:00"

--- a/manifests/pipecd/Chart.yaml
+++ b/manifests/pipecd/Chart.yaml
@@ -32,6 +32,6 @@ dependencies:
   repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
   condition: monitoring.enabled
 - name: tempo
-  version: "1.10.2"
+  version: "1.14.0"
   repository: "https://grafana.github.io/helm-charts"
   condition: monitoring.enabled

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -274,6 +274,8 @@ tempo:
   # modified by @pipecd, to expand template remoteWriteUrl
   # @default -- Dynamically generated tempo configmap
   config: |
+    memberlist:
+      cluster_label: "{{ .Release.Name }}.{{ .Release.Namespace }}"
     multitenancy_enabled: {{ .Values.tempo.multitenancyEnabled }}
     usage_report:
       reporting_enabled: {{ .Values.tempo.reportingEnabled }}


### PR DESCRIPTION
**What this PR does**:

upgrade tempo chart

**Why we need it**:

I want to use the config below, introduced at Tempo v2.6.
The helm chart v1.10.2 points to Tempo v2.5.0, so I want to upgrade the chart.

```yaml
metrics_generator:
  processor:
    local_blocks:
      flush_to_storage: true
```

ref; https://grafana.com/docs/tempo/latest/release-notes/v2-6/#operational-change-for-traceql-metrics

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
