### PR TITLE
Add metrics_generator_processors config to manifest

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -271,7 +271,7 @@ tempo:
       remoteWriteUrl: http://{{ .Release.Name }}-prometheus-server/api/v1/write # we cannot use pipecd.fullname because it returns tempo's fullname
 
   # -- Tempo configuration file contents
-  # modified by @pipecd, to expand template remoteWriteUrl
+  # modified by @pipecd to add metrics_generator_processors and remote_write
   # @default -- Dynamically generated tempo configmap
   config: |
     memberlist:
@@ -301,11 +301,18 @@ tempo:
           metrics_generator_processors:
           - 'service-graphs'
           - 'span-metrics'
-    metrics_generator:
-          storage:
-            path: "/tmp/tempo"
-            remote_write:
-              - url: {{ tpl .Values.tempo.metricsGenerator.remoteWriteUrl . }} # modified line is here
+          - 'local-blocks' # this line is added by @pipecd
+    metrics_generator: # this block is modified by @pipecd
+      traces_storage:
+        path: "/tmp/tempo/generator/traces"
+      storage:
+        path: "/tmp/tempo/generator/wal"
+        remote_write:
+          - url: {{ tpl .Values.tempo.metricsGenerator.remoteWriteUrl . }}
+      processor: # this block is added by @pipecd
+        local_blocks:
+          filter_server_spans: false
+          flush_to_storage: true
       {{- end }}
 
 opentelemetry-collector:


### PR DESCRIPTION
**What this PR does**:

Add config to Grafana Tempo's manifest to enable TraceQL metrics.

**Why we need it**:

I want to add this to get more verbose metrics about traces.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
