### PR TITLE
Fix the piped to correct invoking the k8s plugin

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -649,7 +649,7 @@ func (p *piped) runPlugins(ctx context.Context, pluginsCfg []config.PipedPlugin,
 
 		// Build plugin's args.
 		args := make([]string, 0, 0)
-		args = append(args, "--piped-plugin-service", net.JoinHostPort("localhost", strconv.Itoa(p.pluginServicePort)))
+		args = append(args, "start", "--piped-plugin-service", net.JoinHostPort("localhost", strconv.Itoa(p.pluginServicePort)))
 		b, err := json.Marshal(pCfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare plugin %s config: %w", pCfg.Name, err)

--- a/pkg/app/pipedv1/plugin/kubernetes/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/server.go
@@ -80,7 +80,7 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	group, ctx := errgroup.WithContext(ctx)
 
-	pipedapiClient, err := pipedapi.NewClient(ctx, s.pipedPluginService, nil)
+	pipedapiClient, err := pipedapi.NewClient(ctx, s.pipedPluginService)
 	if err != nil {
 		input.Logger.Error("failed to create piped plugin service client", zap.Error(err))
 		return err


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Without this PR, the pipedv1 cannot invoke the k8s plugin.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
