### PR TITLE
Add plugins build command to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 .PHONY: build/plugin
 build/plugin: PLUGINS ?= "" # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
-build/plugin: PLUGINS_BIN_DIR ?= ~/.pipecd/plugins
+build/plugin: PLUGINS_BIN_DIR ?= ~/.piped/plugins
 build/plugin: PLUGINS_SRC_DIR ?= ./pkg/app/pipedv1/plugin
 build/plugin: PLUGINS_OUT_DIR ?= ./.artifacts/plugins
 build/plugin:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,21 @@ else
 	helm package manifests/$(MOD) --version $(VERSION) --app-version $(VERSION) --dependency-update --destination .artifacts
 endif
 
+.PHONY: build/plugin
+build/plugin: PLUGINS ?= "" # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
+build/plugin: PLUGINS_BIN_DIR ?= ~/.pipecd/plugins
+build/plugin: PLUGINS_SRC_DIR ?= ./pkg/app/pipedv1/plugin
+build/plugin: PLUGINS_OUT_DIR ?= ./.artifacts/plugins
+build/plugin:
+	mkdir -p $(PLUGINS_BIN_DIR)
+	@echo "Building plugins..."
+	@for plugin in $(shell echo $(PLUGINS) | tr ',' ' '); do \
+		echo "Building plugin: $$plugin"; \
+		go build -o $(PLUGINS_OUT_DIR)/$$plugin $(PLUGINS_SRC_DIR)/$$plugin \
+			&& cp $(PLUGINS_OUT_DIR)/$$plugin $(PLUGINS_BIN_DIR)/$$plugin; \
+	done
+	@echo "Plugins are built and copied to $(PLUGINS_BIN_DIR)"
+
 .PHONY: push
 push/chart: BUCKET ?= charts.pipecd.dev
 push/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)


### PR DESCRIPTION
**What this PR does**:

as title. Sample output
```
❯ make build/plugin PLUGINS=kubernetes
mkdir -p ~/.pipecd/plugins
Building plugins...
Building plugin: kubernetes
Plugins are built and copied to ~/.pipecd/plugins
```

**Why we need it**:

This command is needed while testing plugins with pipedv1

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
