### PR TITLE
Fix publish_tool ci

### DIFF
--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -31,6 +31,10 @@ jobs:
       - name: Determine version
         run: echo "PIPECD_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
 
+      - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
       # Login to push container images.
       - name: Log in to the container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b #v2.0.0
@@ -45,4 +49,5 @@ jobs:
         with:
           context: tool/${{ matrix.image }}
           tags: ${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
+          platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -25,7 +25,7 @@ jobs:
           - piped-base-okd
           - firestore-emulator
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Determine version


### PR DESCRIPTION
**What this PR does**: I forgot to fix the CI where `docker push` is executed 😅

**Why we need it**: To publish linux/arm64 images

**Which issue(s) this PR fixes**:

related: https://github.com/pipe-cd/pipecd/pull/5395

**Does this PR introduce a user-facing change?**: No
