### PR TITLE
Fix kubectl download URL in install script

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/toolregistry/scripts.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/toolregistry/scripts.go
@@ -16,7 +16,7 @@ package toolregistry
 
 const kubectlInstallScript = `
 cd {{ .TmpDir }}
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v{{ .Version }}/bin/{{ .Os }}/{{ .Arch }}/kubectl
+curl -LO https://dl.k8s.io/release/v{{ .Version }}/bin/{{ .Os }}/{{ .Arch }}/kubectl
 mv kubectl {{ .OutPath }}
 `
 


### PR DESCRIPTION
**What this PR does**:

This PR does the same as #5379 at the k8s plugin implementation.

**Why we need it**:

Not to use deprecated download URLs.

**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
