### PR TITLE
Use git partial clone and worktree to reduce network/file io

### DIFF
--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -211,6 +211,13 @@ func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 		return nil, err
 	}
 
+	// To avoid the git operation on copied source.
+	// TODO: do not copy the .git directory to improve the performance.
+	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
+		fmt.Fprintf(lw, "Unable to remove the .git directory from the copied deploy source (%v)\n", err)
+		return nil, err
+	}
+
 	return &DeploySource{
 		RepoDir:                  dest,
 		AppDir:                   filepath.Join(dest, p.appGitPath.Path),

--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -203,18 +203,20 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 	p.copyNum++
 
+	src := p.source.RepoDir
 	dest := fmt.Sprintf("%s-%d", p.source.RepoDir, p.copyNum)
-	cmd := exec.Command("cp", "-rf", p.source.RepoDir, dest)
+
+	// use tar to exclude the .git directory
+	// the tar command does not create the destination directory if it does not exist.
+	// so we need to create it before running the command.
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		fmt.Fprintf(lw, "Unable to create the directory to store the copied deploy source (%v)\n", err)
+		return nil, err
+	}
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("tar c -f - -C '%s' --exclude='.git' . | tar x -f - -C '%s'", src, dest))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(lw, "Unable to copy deploy source data (%v, %s)\n", err, string(out))
-		return nil, err
-	}
-
-	// To avoid the git operation on copied source.
-	// TODO: do not copy the .git directory to improve the performance.
-	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
-		fmt.Fprintf(lw, "Unable to remove the .git directory from the copied deploy source (%v)\n", err)
 		return nil, err
 	}
 

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -263,6 +263,8 @@ func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo
 			if err != nil {
 				return provider.ServiceManifest{}, fmt.Errorf("failed to copy the cloned git repository (%w)", err)
 			}
+			defer repo.Clean()
+
 			repoDir := repo.GetPath()
 			appDir = filepath.Join(repoDir, app.GitPath.Path)
 		}

--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -221,7 +221,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 	return d.reporter.ReportApplicationSyncState(ctx, app.Id, state)
 }
 
-func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.ServiceManifest, error) {
+func (d *detector) loadHeadServiceManifest(app *model.Application, repo git.Worktree, headCommit git.Commit) (provider.ServiceManifest, error) {
 	var (
 		manifestCache = provider.ServiceManifestCache{
 			AppID:  app.Id,

--- a/pkg/app/piped/driftdetector/ecs/detector.go
+++ b/pkg/app/piped/driftdetector/ecs/detector.go
@@ -343,7 +343,7 @@ func ignoreParameters(liveManifests provider.ECSManifests, headManifests provide
 	return live, head
 }
 
-func (d *detector) loadConfigs(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.ECSManifests, error) {
+func (d *detector) loadConfigs(app *model.Application, repo git.Worktree, headCommit git.Commit) (provider.ECSManifests, error) {
 	var (
 		manifestCache = provider.ECSManifestsCache{
 			AppID:  app.Id,

--- a/pkg/app/piped/driftdetector/ecs/detector.go
+++ b/pkg/app/piped/driftdetector/ecs/detector.go
@@ -387,6 +387,8 @@ func (d *detector) loadConfigs(app *model.Application, repo git.Repo, headCommit
 		if err != nil {
 			return provider.ECSManifests{}, fmt.Errorf("failed to copy the cloned git repository (%w)", err)
 		}
+		defer repo.Clean()
+
 		repoDir := repo.GetPath()
 		appDir = filepath.Join(repoDir, app.GitPath.Path)
 	}

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -278,6 +278,8 @@ func (d *detector) loadHeadManifests(ctx context.Context, app *model.Application
 			if err != nil {
 				return nil, fmt.Errorf("failed to copy the cloned git repository (%w)", err)
 			}
+			defer repo.Clean()
+
 			repoDir = repo.GetPath()
 			appDir = filepath.Join(repoDir, app.GitPath.Path)
 		}

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -236,7 +236,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 	return d.reporter.ReportApplicationSyncState(ctx, app.Id, state)
 }
 
-func (d *detector) loadHeadManifests(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit, watchingResourceKinds []provider.APIVersionKind) ([]provider.Manifest, error) {
+func (d *detector) loadHeadManifests(ctx context.Context, app *model.Application, repo git.Worktree, headCommit git.Commit, watchingResourceKinds []provider.APIVersionKind) ([]provider.Manifest, error) {
 	var (
 		manifestCache = provider.AppManifestsCache{
 			AppID:  app.Id,

--- a/pkg/app/piped/driftdetector/lambda/detector.go
+++ b/pkg/app/piped/driftdetector/lambda/detector.go
@@ -270,7 +270,7 @@ func ignoreAndSortParameters(headSpec provider.FunctionManifestSpec) provider.Fu
 	return cloneSpec
 }
 
-func (d *detector) loadHeadFunctionManifest(app *model.Application, repo git.Repo, headCommit git.Commit) (provider.FunctionManifest, error) {
+func (d *detector) loadHeadFunctionManifest(app *model.Application, repo git.Worktree, headCommit git.Commit) (provider.FunctionManifest, error) {
 	var (
 		manifestCache = provider.FunctionManifestCache{
 			AppID:  app.Id,

--- a/pkg/app/piped/driftdetector/lambda/detector.go
+++ b/pkg/app/piped/driftdetector/lambda/detector.go
@@ -312,6 +312,8 @@ func (d *detector) loadHeadFunctionManifest(app *model.Application, repo git.Rep
 			if err != nil {
 				return provider.FunctionManifest{}, fmt.Errorf("failed to copy the cloned git repository (%w)", err)
 			}
+			defer repo.Clean()
+
 			repoDir := repo.GetPath()
 			appDir = filepath.Join(repoDir, app.GitPath.Path)
 		}

--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -169,7 +169,7 @@ func (d *detector) check(ctx context.Context) {
 	}
 }
 
-func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Repo, headCommit git.Commit) error {
+func (d *detector) checkApplication(ctx context.Context, app *model.Application, repo git.Worktree, headCommit git.Commit) error {
 	var (
 		repoDir = repo.GetPath()
 		appDir  = filepath.Join(repoDir, app.GitPath.Path)

--- a/pkg/app/piped/driftdetector/terraform/detector.go
+++ b/pkg/app/piped/driftdetector/terraform/detector.go
@@ -206,6 +206,8 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		if err != nil {
 			return fmt.Errorf("failed to copy the cloned git repository (%w)", err)
 		}
+		defer repo.Clean()
+
 		repoDir = repo.GetPath()
 		appDir = filepath.Join(repoDir, app.GitPath.Path)
 	}

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -319,7 +319,7 @@ func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eve
 	if err != nil {
 		return fmt.Errorf("failed to create a new temporary directory: %w", err)
 	}
-	tmpRepo, err := repo.Copy(filepath.Join(tmpDir, "tmp-repo"))
+	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		return fmt.Errorf("failed to copy the repository to the temporary directory: %w", err)
 	}
@@ -495,7 +495,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 	if err != nil {
 		return fmt.Errorf("failed to create a new temporary directory: %w", err)
 	}
-	tmpRepo, err := repo.Copy(filepath.Join(tmpDir, "tmp-repo"))
+	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		return fmt.Errorf("failed to copy the repository to the temporary directory: %w", err)
 	}

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -191,6 +191,13 @@ func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 		return nil, err
 	}
 
+	// To avoid the git operation on copied source.
+	// TODO: do not copy the .git directory to improve the performance.
+	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
+		fmt.Fprintf(lw, "Unable to remove the .git directory from the copied deploy source (%v)\n", err)
+		return nil, err
+	}
+
 	return &DeploySource{
 		RepoDir:                  dest,
 		AppDir:                   filepath.Join(dest, p.appGitPath.Path),

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -183,18 +183,20 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 	p.copyNum++
 
+	src := p.source.RepoDir
 	dest := fmt.Sprintf("%s-%d", p.source.RepoDir, p.copyNum)
-	cmd := exec.Command("cp", "-rf", p.source.RepoDir, dest)
+
+	// use tar to exclude the .git directory
+	// the tar command does not create the destination directory if it does not exist.
+	// so we need to create it before running the command.
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		fmt.Fprintf(lw, "Unable to create the directory to store the copied deploy source (%v)\n", err)
+		return nil, err
+	}
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("tar c -f - -C '%s' --exclude='.git' . | tar x -f - -C '%s'", src, dest))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(lw, "Unable to copy deploy source data (%v, %s)\n", err, string(out))
-		return nil, err
-	}
-
-	// To avoid the git operation on copied source.
-	// TODO: do not copy the .git directory to improve the performance.
-	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
-		fmt.Fprintf(lw, "Unable to remove the .git directory from the copied deploy source (%v)\n", err)
 		return nil, err
 	}
 

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -317,7 +317,7 @@ func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eve
 	if err != nil {
 		return fmt.Errorf("failed to create a new temporary directory: %w", err)
 	}
-	tmpRepo, err := repo.Copy(filepath.Join(tmpDir, "tmp-repo"))
+	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		return fmt.Errorf("failed to copy the repository to the temporary directory: %w", err)
 	}
@@ -478,7 +478,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 	if err != nil {
 		return fmt.Errorf("failed to create a new temporary directory: %w", err)
 	}
-	tmpRepo, err := repo.Copy(filepath.Join(tmpDir, "tmp-repo"))
+	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		return fmt.Errorf("failed to copy the repository to the temporary directory: %w", err)
 	}

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -166,7 +166,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 				return nil, err
 			}
 			out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
-				args := []string{"clone", "--mirror", remote, repoCachePath}
+				args := []string{"clone", "--mirror", "--filter=blob:none", remote, repoCachePath}
 				args = append(authArgs, args...)
 				return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
 			})
@@ -214,11 +214,12 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 		}
 	}
 
-	args := []string{"clone"}
+	// git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]
+	//                   [--orphan] [(-b | -B) <new-branch>] <path> [<commit-ish>]
+	args := []string{"-C", repoCachePath, "worktree", "add", "--detach", destination}
 	if branch != "" {
-		args = append(args, "-b", branch)
+		args = append(args, branch)
 	}
-	args = append(args, repoCachePath, destination)
 
 	logger.Info("cloning a repo from cached one in local",
 		zap.String("src", repoCachePath),

--- a/pkg/git/gittest/git.mock.go
+++ b/pkg/git/gittest/git.mock.go
@@ -135,6 +135,21 @@ func (mr *MockRepoMockRecorder) Copy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockRepo)(nil).Copy), arg0)
 }
 
+// CopyToModify mocks base method.
+func (m *MockRepo) CopyToModify(arg0 string) (git.Repo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyToModify", arg0)
+	ret0, _ := ret[0].(git.Repo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CopyToModify indicates an expected call of CopyToModify.
+func (mr *MockRepoMockRecorder) CopyToModify(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyToModify", reflect.TypeOf((*MockRepo)(nil).CopyToModify), arg0)
+}
+
 // GetClonedBranch mocks base method.
 func (m *MockRepo) GetClonedBranch() string {
 	m.ctrl.T.Helper()

--- a/pkg/git/gittest/git.mock.go
+++ b/pkg/git/gittest/git.mock.go
@@ -121,10 +121,10 @@ func (mr *MockRepoMockRecorder) CommitChanges(arg0, arg1, arg2, arg3, arg4, arg5
 }
 
 // Copy mocks base method.
-func (m *MockRepo) Copy(arg0 string) (git.Repo, error) {
+func (m *MockRepo) Copy(arg0 string) (git.Worktree, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy", arg0)
-	ret0, _ := ret[0].(git.Repo)
+	ret0, _ := ret[0].(git.Worktree)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -185,6 +185,11 @@ func (r *repo) CopyToModify(dest string) (Repo, error) {
 		return nil, err
 	}
 
+	// fetch the latest changes which doesn't exist in the local repository
+	if out, err := cloned.runGitCommand(context.Background(), "fetch"); err != nil {
+		return nil, formatCommandError(err, out)
+	}
+
 	return cloned, nil
 }
 

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -180,7 +180,7 @@ func (r *repo) CopyToModify(dest string) (Repo, error) {
 		gitEnvs:      r.gitEnvs,
 	}
 
-	// because we did a local cloning so the remote url of origin
+	// because we did a local cloning so set the remote url of origin
 	if err := cloned.setRemote(context.Background(), r.remote); err != nil {
 		return nil, err
 	}

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -266,16 +266,11 @@ func TestCopy(t *testing.T) {
 	assert.Equal(t, 1, len(commits))
 
 	tmpDir := filepath.Join(faker.dir, "tmp-repo")
-	newRepo, err := r.CopyToModify(tmpDir)
+	newRepo, err := r.Copy(tmpDir)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, r, newRepo)
 
-	newRepoCommits, err := newRepo.ListCommits(ctx, "")
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(newRepoCommits))
-
-	assert.Equal(t, commits, newRepoCommits)
 	assert.NoError(t, newRepo.Clean())
 }
 

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -269,6 +269,11 @@ func TestCopy(t *testing.T) {
 	newRepo, err := r.Copy(tmpDir)
 	require.NoError(t, err)
 
+	// we can copy the repo to another directory multiple times
+	tmpDir2 := filepath.Join(faker.dir, "tmp-repo2")
+	newRepo2, err := r.Copy(tmpDir2)
+	require.NoError(t, err)
+
 	assert.NotEqual(t, r, newRepo)
 
 	newRepoCommits, err := newRepo.ListCommits(ctx, "")
@@ -276,6 +281,50 @@ func TestCopy(t *testing.T) {
 	assert.Equal(t, 1, len(newRepoCommits))
 
 	assert.Equal(t, commits, newRepoCommits)
+	assert.NoError(t, newRepo.Clean())
+	assert.NoError(t, newRepo2.Clean())
+}
+
+func TestCopyToModify(t *testing.T) {
+	faker, err := newFaker()
+	require.NoError(t, err)
+	defer faker.clean()
+
+	var (
+		org      = "test-repo-org"
+		repoName = "repo-copy"
+		ctx      = context.Background()
+	)
+
+	err = faker.makeRepo(org, repoName)
+	require.NoError(t, err)
+	r := &repo{
+		dir:     faker.repoDir(org, repoName),
+		gitPath: faker.gitPath,
+	}
+
+	commits, err := r.ListCommits(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(commits))
+
+	tmpDir := filepath.Join(faker.dir, "tmp-repo")
+	newRepo, err := r.CopyToModify(tmpDir)
+	require.NoError(t, err)
+
+	// we can copy the repo to another directory multiple times
+	tmpDir2 := filepath.Join(faker.dir, "tmp-repo2")
+	newRepo2, err := r.CopyToModify(tmpDir2)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, r, newRepo)
+
+	newRepoCommits, err := newRepo.ListCommits(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(newRepoCommits))
+
+	assert.Equal(t, commits, newRepoCommits)
+	assert.NoError(t, newRepo.Clean())
+	assert.NoError(t, newRepo2.Clean())
 }
 
 func TestGetCommitForRev(t *testing.T) {

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -266,12 +266,7 @@ func TestCopy(t *testing.T) {
 	assert.Equal(t, 1, len(commits))
 
 	tmpDir := filepath.Join(faker.dir, "tmp-repo")
-	newRepo, err := r.Copy(tmpDir)
-	require.NoError(t, err)
-
-	// we can copy the repo to another directory multiple times
-	tmpDir2 := filepath.Join(faker.dir, "tmp-repo2")
-	newRepo2, err := r.Copy(tmpDir2)
+	newRepo, err := r.CopyToModify(tmpDir)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, r, newRepo)
@@ -282,7 +277,6 @@ func TestCopy(t *testing.T) {
 
 	assert.Equal(t, commits, newRepoCommits)
 	assert.NoError(t, newRepo.Clean())
-	assert.NoError(t, newRepo2.Clean())
 }
 
 func TestCopyToModify(t *testing.T) {

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -290,6 +290,7 @@ func TestCopyToModify(t *testing.T) {
 	r := &repo{
 		dir:     faker.repoDir(org, repoName),
 		gitPath: faker.gitPath,
+		remote:  faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
 	}
 
 	commits, err := r.ListCommits(ctx, "")


### PR DESCRIPTION
**What this PR does**:

- Use not `cp -rf` but `git worktree add` to Copy the git.Repo
- Use git partial clone to reduce network io

**Why we need it**:

I want to reduce network/file io

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
