### PR TITLE
Update make build/plugin command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,10 @@ else
 endif
 
 .PHONY: build/plugin
-build/plugin: PLUGINS ?= $(shell find ./pkg/app/pipedv1/plugin -mindepth 1 -maxdepth 1 -type d | while read -r dir; do basename "$$dir"; done | paste -sd, -) # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
 build/plugin: PLUGINS_BIN_DIR ?= ~/.piped/plugins
 build/plugin: PLUGINS_SRC_DIR ?= ./pkg/app/pipedv1/plugin
 build/plugin: PLUGINS_OUT_DIR ?= ./.artifacts/plugins
+build/plugin: PLUGINS ?= $(shell find $(PLUGINS_SRC_DIR) -mindepth 1 -maxdepth 1 -type d | while read -r dir; do basename "$$dir"; done | paste -sd, -) # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
 build/plugin:
 	mkdir -p $(PLUGINS_BIN_DIR)
 	@echo "Building plugins..."

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ else
 endif
 
 .PHONY: build/plugin
-build/plugin: PLUGINS ?= "" # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
+build/plugin: PLUGINS ?= $(shell find ./pkg/app/pipedv1/plugin -mindepth 1 -maxdepth 1 -type d | while read -r dir; do basename "$$dir"; done | paste -sd, -) # comma separated list of plugins. eg: PLUGINS=kubernetes,ecs,lambda
 build/plugin: PLUGINS_BIN_DIR ?= ~/.piped/plugins
 build/plugin: PLUGINS_SRC_DIR ?= ./pkg/app/pipedv1/plugin
 build/plugin: PLUGINS_OUT_DIR ?= ./.artifacts/plugins


### PR DESCRIPTION
**What this PR does**:

Better `make build/plugin` exp by auto-detecting plugins under the `pkg/app/pipedv1/plugin` directory.

**Why we need it**:

**Which issue(s) this PR fixes**:

Follow #5402 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
