### PR TITLE
Add calling annotateConfigHash and refactor unmarshaling deploy target

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -100,6 +100,7 @@ type KubernetesDeployTargetConfig struct {
 	KubectlVersion string `json:"kubectlVersion"`
 }
 
+// FindDeployTarget finds the deploy target configuration by the given name.
 func FindDeployTarget(cfg *config.PipedPlugin, name string) (KubernetesDeployTargetConfig, error) {
 	if cfg == nil {
 		return KubernetesDeployTargetConfig{}, errors.New("missing plugin configuration")

--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/creasty/defaults"
+
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 )
 

--- a/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
+)
+
+func TestFindDeployTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.PipedPlugin
+		targetName  string
+		expected    KubernetesDeployTargetConfig
+		expectedErr bool
+	}{
+		{
+			name:        "nil config",
+			cfg:         nil,
+			targetName:  "target",
+			expected:    KubernetesDeployTargetConfig{},
+			expectedErr: true,
+		},
+		{
+			name: "missing deploy target",
+			cfg: &config.PipedPlugin{
+				DeployTargets: []config.PipedDeployTarget{},
+			},
+			targetName:  "target",
+			expected:    KubernetesDeployTargetConfig{},
+			expectedErr: true,
+		},
+		{
+			name: "valid deploy target",
+			cfg: &config.PipedPlugin{
+				DeployTargets: []config.PipedDeployTarget{
+					{
+						Name: "target",
+						Config: json.RawMessage(`{
+							"masterURL": "https://example.com",
+							"kubeConfigPath": "/path/to/kubeconfig",
+							"kubectlVersion": "v1.20.0"
+						}`),
+					},
+				},
+			},
+			targetName: "target",
+			expected: KubernetesDeployTargetConfig{
+				MasterURL:      "https://example.com",
+				KubeConfigPath: "/path/to/kubeconfig",
+				KubectlVersion: "v1.20.0",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid deploy target config",
+			cfg: &config.PipedPlugin{
+				DeployTargets: []config.PipedDeployTarget{
+					{
+						Name:   "target",
+						Config: json.RawMessage(`invalid`),
+					},
+				},
+			},
+			targetName:  "target",
+			expected:    KubernetesDeployTargetConfig{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FindDeployTarget(tt.cfg, tt.targetName)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -17,7 +17,6 @@ package deployment
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"time"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
@@ -278,9 +277,8 @@ func (a *DeploymentService) executeK8sSyncStage(ctx context.Context, lp logpersi
 	}
 
 	// Get the deploy target config.
-	var deployTargetConfig kubeconfig.KubernetesDeployTargetConfig
-	deployTarget := a.pluginConfig.FindDeployTarget(input.GetDeployment().GetDeployTargets()[0]) // TODO: check if there is a deploy target
-	if err := json.Unmarshal(deployTarget.Config, &deployTargetConfig); err != nil {             // TODO: do not unmarshal the config here, but in the initialization of the plugin
+	deployTargetConfig, err := kubeconfig.FindDeployTarget(a.pluginConfig, input.GetDeployment().GetDeployTargets()[0]) // TODO: check if there is a deploy target
+	if err != nil {
 		lp.Errorf("Failed while unmarshalling deploy target config (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
@@ -353,9 +351,8 @@ func (a *DeploymentService) executeK8sRollbackStage(ctx context.Context, lp logp
 	}
 
 	// Get the deploy target config.
-	var deployTargetConfig kubeconfig.KubernetesDeployTargetConfig
-	deployTarget := a.pluginConfig.FindDeployTarget(input.GetDeployment().GetDeployTargets()[0]) // TODO: check if there is a deploy target
-	if err := json.Unmarshal(deployTarget.Config, &deployTargetConfig); err != nil {             // TODO: do not unmarshal the config here, but in the initialization of the plugin
+	deployTargetConfig, err := kubeconfig.FindDeployTarget(a.pluginConfig, input.GetDeployment().GetDeployTargets()[0]) // TODO: check if there is a deploy target
+	if err != nil {
 		lp.Errorf("Failed while unmarshalling deploy target config (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -272,7 +272,10 @@ func (a *DeploymentService) executeK8sSyncStage(ctx context.Context, lp logpersi
 		})
 	}
 
-	// TODO: implement annotateConfigHash to ensure restart of workloads when config changes
+	if err := annotateConfigHash(manifests); err != nil {
+		lp.Errorf("Unable to set %q annotation into the workload manifest (%v)", provider.AnnotationConfigHash, err)
+		return model.StageStatus_STAGE_FAILURE
+	}
 
 	// Get the deploy target config.
 	var deployTargetConfig kubeconfig.KubernetesDeployTargetConfig
@@ -344,7 +347,10 @@ func (a *DeploymentService) executeK8sRollbackStage(ctx context.Context, lp logp
 		})
 	}
 
-	// TODO: implement annotateConfigHash to ensure restart of workloads when config changes
+	if err := annotateConfigHash(manifests); err != nil {
+		lp.Errorf("Unable to set %q annotation into the workload manifest (%v)", provider.AnnotationConfigHash, err)
+		return model.StageStatus_STAGE_FAILURE
+	}
 
 	// Get the deploy target config.
 	var deployTargetConfig kubeconfig.KubernetesDeployTargetConfig


### PR DESCRIPTION
**What this PR does**:

1. add calling annotateConfigHash
2. refactor the unmarshaling of the deploy target config

**Why we need it**:

1. we want to refresh workloads when the config changes

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
