### PR TITLE
Add workaround for aarch64 container image build

### DIFF
--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,5 +1,8 @@
 # web builder
-FROM node:20.18.1-alpine3.21 AS web
+# because of this issue, we choose node 18
+# https://github.com/pipe-cd/pipecd/issues/5422
+# https://github.com/nodejs/docker-node/issues/1335#issuecomment-2024344411
+FROM node:18.20.5-alpine3.21 AS web
 
 WORKDIR /app
 

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -6,6 +6,11 @@ WORKDIR /app
 COPY . .
 
 RUN apk add --no-cache make git
+
+# because of this issue, we set network-timeout to 300000
+# https://github.com/pipe-cd/pipecd/issues/5422
+RUN yarn config set network-timeout 300000
+
 RUN make update/web-deps
 RUN make build/web
 


### PR DESCRIPTION
**What this PR does**:

Add workaround for building pipecd arm64 image.

**Why we need it**:

to make the publish_image_chart workflow success

**Which issue(s) this PR fixes**:

Fix #5422 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
