### PR TITLE
[ECS] Support 5 missing fields in TaskDefinition

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -538,8 +538,6 @@ There are some restrictions in configuring a service definition file.
 
 There are some restrictions in configuring a task definition file.
 
-- `placementConstraints` is not supported.
-- `proxyConfiguration` is not supported.
 - `tags` is not supported.
 
 ### ECSTargetGroupInput

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -188,9 +188,15 @@ func (c *client) RegisterTaskDefinition(ctx context.Context, taskDefinition type
 		Volumes:                 taskDefinition.Volumes,
 		RuntimePlatform:         taskDefinition.RuntimePlatform,
 		EphemeralStorage:        taskDefinition.EphemeralStorage,
-		// Requires defined at task level in case Fargate is used.
+		// Cpu and Memory must be defined if Fargate is used.
 		Cpu:    taskDefinition.Cpu,
 		Memory: taskDefinition.Memory,
+
+		InferenceAccelerators: taskDefinition.InferenceAccelerators,
+		IpcMode:               taskDefinition.IpcMode,
+		PidMode:               taskDefinition.PidMode,
+		PlacementConstraints:  taskDefinition.PlacementConstraints,
+		ProxyConfiguration:    taskDefinition.ProxyConfiguration,
 		// TODO: Support tags for registering task definition.
 	}
 	output, err := c.ecsClient.RegisterTaskDefinition(ctx, input)


### PR DESCRIPTION
**What this PR does**:

Enabled to configure the following fields when registering a task definition:
- `InferenceAccelerators`
- `PidMode`
- `IpcMode`
- `PlacementConstraints`
- `ProxyConfiguration`

cf. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

**Why we need it**:

Users want to configure the missing fields. That is currently impossible.

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
