### PR TITLE
[Quickstart] chore: update to `minio/minio:RELEASE.2024-12-13T22-19-12Z`

### DIFF
--- a/quickstart/manifests/control-plane.yaml
+++ b/quickstart/manifests/control-plane.yaml
@@ -793,7 +793,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio:RELEASE.2020-08-26T00-00-49Z
+          image: minio/minio:RELEASE.2024-12-13T22-19-12Z
           args:
           - server
           - /data


### PR DESCRIPTION
**What this PR does**: update to minio/minio:RELEASE.2024-12-13T22-19-12Z

**Why we need it**: An error occurred when use `minio/minio:RELEASE.2020-08-26T00-00-49Z` on linux/arm64.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/pipe-cd/pipecd/issues/4896

**Does this PR introduce a user-facing change?**: No

I checked working correctly on linux/arm64 cluster when applied below patch to master branch.
```diff
diff --git a/master.yaml b/patch.yaml
index 7cd4e00..19c5a62 100644
--- a/master.yaml
+++ b/patch.yaml
@@ -551,7 +551,7 @@ spec:
               done;
       containers:
         - name: server
-          image: "ghcr.io/pipe-cd/pipecd:v0.50.0"
+          image: "ghcr.io/pipe-cd/pipecd:v0.50.0-40-g149078a"
           imagePullPolicy: IfNotPresent
           args:
           - server
@@ -684,7 +684,7 @@ spec:
               done;
       containers:
         - name: ops
-          image: "ghcr.io/pipe-cd/pipecd:v0.50.0"
+          image: "ghcr.io/pipe-cd/pipecd:v0.50.0-40-g149078a"
           imagePullPolicy: IfNotPresent
           args:
           - ops
@@ -793,7 +793,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio:RELEASE.2020-08-26T00-00-49Z
+          image: minio/minio:RELEASE.2024-12-13T22-19-12Z
           args:
           - server
           - /data
```

```console
$ kubectl get pod -n pipecd
NAME                             READY   STATUS    RESTARTS   AGE
pipecd-cache-56c7c65ddc-bl5kt    1/1     Running   0          15m
pipecd-gateway-6df67f5b6-sjfdp   1/1     Running   0          15m
pipecd-minio-c6cdc7c55-5v7jm     1/1     Running   0          14m
pipecd-mysql-6fff49fbc7-mrg6v    1/1     Running   0          15m
pipecd-ops-6f667bf646-6tvhz      1/1     Running   0          13m
pipecd-server-cd7f57776-hslt6    1/1     Running   0          14m
```