### PR TITLE
Copy .git in deploysource provider

### DIFF
--- a/pkg/app/piped/deploysource/deploysource.go
+++ b/pkg/app/piped/deploysource/deploysource.go
@@ -203,17 +203,8 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 	p.copyNum++
 
-	src := p.source.RepoDir
 	dest := fmt.Sprintf("%s-%d", p.source.RepoDir, p.copyNum)
-
-	// use tar to exclude the .git directory
-	// the tar command does not create the destination directory if it does not exist.
-	// so we need to create it before running the command.
-	if err := os.MkdirAll(dest, 0700); err != nil {
-		fmt.Fprintf(lw, "Unable to create the directory to store the copied deploy source (%v)\n", err)
-		return nil, err
-	}
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("tar c -f - -C '%s' --exclude='.git' . | tar x -f - -C '%s'", src, dest))
+	cmd := exec.Command("cp", "-rf", p.source.RepoDir, dest)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(lw, "Unable to copy deploy source data (%v, %s)\n", err, string(out))

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -196,17 +196,8 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 	p.copyNum++
 
-	src := p.source.RepoDir
 	dest := fmt.Sprintf("%s-%d", p.source.RepoDir, p.copyNum)
-
-	// use tar to exclude the .git directory
-	// the tar command does not create the destination directory if it does not exist.
-	// so we need to create it before running the command.
-	if err := os.MkdirAll(dest, 0700); err != nil {
-		fmt.Fprintf(lw, "Unable to create the directory to store the copied deploy source (%v)\n", err)
-		return nil, err
-	}
-	cmd := exec.Command("sh", "-c", fmt.Sprintf("tar c -f - -C '%s' --exclude='.git' . | tar x -f - -C '%s'", src, dest))
+	cmd := exec.Command("cp", "-rf", p.source.RepoDir, dest)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(lw, "Unable to copy deploy source data (%v, %s)\n", err, string(out))


### PR DESCRIPTION
**What this PR does**:

This PR partially reverts https://github.com/pipe-cd/pipecd/pull/5412.

**Why we need it**:

In #5412, I implemented that the piped does not copy `.git` in the deploysource provider's `copy` method.
This made a breaking change on the SCRIPT_RUN stage.
Before #5412, we can use the `git` command to retrieve manifest repository information.
After #5412, we cannot do that because there is not `.git`.
In #5412, I implemented the git client to use `git worktree` to clone from the locally cached git repository, so it's a small cost to copy the `.git` because it's a small text file.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
