### PR TITLE
Add livestatereporter for the plugin architecture

### DIFF
--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -77,9 +77,9 @@ func (r *reporter) Run(ctx context.Context) error {
 	for _, reporter := range r.reporters {
 		// Avoid starting all reporters at the same time to reduce the API call burst.
 		time.Sleep(10 * time.Second)
-		r.logger.Info("starting app live state reporter for plugin")
 
 		group.Go(func() error {
+			reporter.logger.Info("starting app live state reporter for plugin")
 			return reporter.Run(ctx)
 		})
 	}

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -74,6 +74,8 @@ func NewReporter(appLister applicationLister, apiClient apiClient, plugins map[s
 func (r *reporter) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
+	r.logger.Info(fmt.Sprintf("starting %d live state reporters of plugins", len(r.reporters)))
+
 	for _, reporter := range r.reporters {
 		// Avoid starting all reporters at the same time to reduce the API call burst.
 		time.Sleep(10 * time.Second)

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -145,7 +145,6 @@ func (pr *pluginReporter) flushSnapshots(ctx context.Context) {
 		// TODO: Implement DetermineAppHealthStatus for the case of plugin architecture.
 		snapshot.DetermineAppHealthStatus()
 
-		// TODO: Fix ReportApplicationLiveState to store ApplicationLiveState.
 		if _, err := pr.apiClient.ReportApplicationLiveState(ctx, &pipedservice.ReportApplicationLiveStateRequest{
 			Snapshot: snapshot,
 		}); err != nil {

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
-	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	pluginapi "github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/livestate"
@@ -52,7 +51,7 @@ type reporter struct {
 }
 
 // NewReporter creates a new reporter.
-func NewReporter(appLister applicationLister, apiClient apiClient, cfg *config.PipedSpec, plugins map[string]pluginapi.PluginClient, logger *zap.Logger) Reporter {
+func NewReporter(appLister applicationLister, apiClient apiClient, plugins map[string]pluginapi.PluginClient, logger *zap.Logger) Reporter {
 	rlogger := logger.Named("live-state-reporter")
 	r := &reporter{
 		reporters: make([]pluginReporter, 0, len(plugins)),
@@ -76,7 +75,6 @@ func (r *reporter) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
 	for i, reporter := range r.reporters {
-		reporter := reporter
 		// Avoid starting all reporters at the same time to reduce the API call burst.
 		time.Sleep(time.Duration(i) * 10 * time.Second)
 		r.logger.Info("starting app live state reporter for plugin")

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -1,0 +1,173 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package livestatereporter provides a piped component
+// that reports the changes as well as full snapshot about live state of registered applications.
+package livestatereporter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/model"
+	pluginapi "github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/livestate"
+)
+
+type applicationLister interface {
+	ListByPluginName(name string) []*model.Application
+}
+
+type apiClient interface {
+	ReportApplicationLiveState(ctx context.Context, req *pipedservice.ReportApplicationLiveStateRequest, opts ...grpc.CallOption) (*pipedservice.ReportApplicationLiveStateResponse, error)
+	ReportApplicationSyncState(ctx context.Context, req *pipedservice.ReportApplicationSyncStateRequest, opts ...grpc.CallOption) (*pipedservice.ReportApplicationSyncStateResponse, error)
+}
+
+// Reporter represents a component that reports the snapshot about live state of registered applications.
+type Reporter interface {
+	Run(ctx context.Context) error
+}
+
+type reporter struct {
+	reporters []pluginReporter
+	logger    *zap.Logger
+}
+
+// NewReporter creates a new reporter.
+func NewReporter(appLister applicationLister, apiClient apiClient, cfg *config.PipedSpec, plugins map[string]pluginapi.PluginClient, logger *zap.Logger) Reporter {
+	rlogger := logger.Named("live-state-reporter")
+	r := &reporter{
+		reporters: make([]pluginReporter, 0, len(plugins)),
+		logger:    rlogger,
+	}
+
+	for name, p := range plugins {
+		r.reporters = append(r.reporters, pluginReporter{
+			pluginName:            name,
+			snapshotFlushInterval: time.Minute,
+			appLister:             appLister,
+			apiClient:             apiClient,
+			pluginClient:          p,
+			logger:                rlogger.With(zap.String("plugin-name", name)),
+		})
+	}
+	return r
+}
+
+func (r *reporter) Run(ctx context.Context) error {
+	group, ctx := errgroup.WithContext(ctx)
+
+	for i, reporter := range r.reporters {
+		reporter := reporter
+		// Avoid starting all reporters at the same time to reduce the API call burst.
+		time.Sleep(time.Duration(i) * 10 * time.Second)
+		r.logger.Info("starting app live state reporter for plugin")
+
+		group.Go(func() error {
+			return reporter.Run(ctx)
+		})
+	}
+
+	r.logger.Info(fmt.Sprintf("all live state reporters of %d plugins have been started", len(r.reporters)))
+
+	if err := group.Wait(); err != nil {
+		r.logger.Error("failed while running", zap.Error(err))
+		return err
+	}
+
+	r.logger.Info(fmt.Sprintf("all live state reporters of %d plugins have been stopped", len(r.reporters)))
+	return nil
+}
+
+type pluginReporter struct {
+	pluginName            string
+	snapshotFlushInterval time.Duration
+	appLister             applicationLister
+	apiClient             apiClient
+	pluginClient          pluginapi.PluginClient
+	logger                *zap.Logger
+}
+
+func (pr *pluginReporter) Run(ctx context.Context) error {
+	pr.logger.Info("start running app live state reporter", zap.Duration("snapshot-flush-interval", pr.snapshotFlushInterval))
+
+	snapshotTicker := time.NewTicker(pr.snapshotFlushInterval)
+	defer snapshotTicker.Stop()
+
+	for {
+		select {
+		case <-snapshotTicker.C:
+			pr.flushSnapshots(ctx)
+
+		case <-ctx.Done():
+			pr.logger.Info("app live state reporter has been stopped")
+			return nil
+		}
+	}
+}
+
+func (pr *pluginReporter) flushSnapshots(ctx context.Context) {
+	// TODO: Implement appLister.ListByPluginName.
+	apps := pr.appLister.ListByPluginName(pr.pluginName)
+	for _, app := range apps {
+		res, err := pr.pluginClient.GetLivestate(ctx, &livestate.GetLivestateRequest{ApplicationId: app.Id})
+		if err != nil {
+			pr.logger.Info(fmt.Sprintf("no app state of application %s to report", app.Id))
+			continue
+		}
+
+		// Report the application live state to the control plane.
+		snapshot := &model.ApplicationLiveStateSnapshot{
+			ApplicationId:        app.Id,
+			PipedId:              app.PipedId,
+			ProjectId:            app.ProjectId,
+			Kind:                 app.Kind,
+			ApplicationLiveState: res.GetApplicationLiveState(),
+		}
+		// TODO: Implement DetermineAppHealthStatus for the case of plugin architecture.
+		snapshot.DetermineAppHealthStatus()
+
+		// TODO: Fix ReportApplicationLiveState to store ApplicationLiveState.
+		if _, err := pr.apiClient.ReportApplicationLiveState(ctx, &pipedservice.ReportApplicationLiveStateRequest{
+			Snapshot: snapshot,
+		}); err != nil {
+			pr.logger.Error("failed to report application live state",
+				zap.String("application-id", app.Id),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// Report the application sync state to the control plane.
+		if _, err := pr.apiClient.ReportApplicationSyncState(ctx, &pipedservice.ReportApplicationSyncStateRequest{
+			ApplicationId: app.Id,
+			State:         res.GetSyncState(),
+		}); err != nil {
+			pr.logger.Error("failed to report application live state",
+				zap.String("application-id", app.Id),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		pr.logger.Info(fmt.Sprintf("successfully reported application live state for application: %s", app.Id))
+	}
+}

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -74,9 +74,9 @@ func NewReporter(appLister applicationLister, apiClient apiClient, plugins map[s
 func (r *reporter) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
-	for i, reporter := range r.reporters {
+	for _, reporter := range r.reporters {
 		// Avoid starting all reporters at the same time to reduce the API call burst.
-		time.Sleep(time.Duration(i) * 10 * time.Second)
+		time.Sleep(10 * time.Second)
 		r.logger.Info("starting app live state reporter for plugin")
 
 		group.Go(func() error {

--- a/pkg/plugin/api/v1alpha1/client.go
+++ b/pkg/plugin/api/v1alpha1/client.go
@@ -25,16 +25,19 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/livestate"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcclient"
 )
 
 type PluginClient interface {
 	deployment.DeploymentServiceClient
+	livestate.LivestateServiceClient
 	Close() error
 }
 
 type client struct {
 	deployment.DeploymentServiceClient
+	livestate.LivestateServiceClient
 	conn *grpc.ClientConn
 }
 
@@ -46,6 +49,7 @@ func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption
 
 	return &client{
 		DeploymentServiceClient: deployment.NewDeploymentServiceClient(conn),
+		LivestateServiceClient:  livestate.NewLivestateServiceClient(conn),
 		conn:                    conn,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does**:

Implement livestatereporter for the plugin architecture.

It reports the application's live state and the sync state for every registered apps by the interval of 1 minute.

**Why we need it**:

We need to support livestate features on the pipedv1

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5363

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
