### PR TITLE
Set fail_on_error in the lint/go workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           go_version: ${{ env.GO_VERSION }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
+          fail_on_error: true # this option is deprecated on v2.7.0, but we use v2.1.3, so it's still available
 
   web:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does**:

set `fail_on_error` option on reviewdog action.

**Why we need it**:

to notice there are errors.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
