### PR TITLE
Fixed to certainly store the metadata in graceful shutdown

### DIFF
--- a/pkg/app/piped/executor/wait/wait.go
+++ b/pkg/app/piped/executor/wait/wait.go
@@ -74,7 +74,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	} else {
 		startTime = time.Now()
 	}
-	defer e.saveStartTime(sig.Context(), startTime)
+	e.saveStartTime(sig.Context(), startTime)
 
 	timer := time.NewTimer(duration)
 	defer timer.Stop()


### PR DESCRIPTION
**What this PR does**:

as title.

**Why we need it**:

Currently, the Wait stage waits for the whole duration AGAIN after graceful shutdown.
That's because graceful shutdown cannot store `startTime` to Control Plane.

Before fix (wait 1m again after restarting): 
![image](https://github.com/user-attachments/assets/07c3d31a-7ab6-4e0e-9b6a-f34e3d83589e)

After fix (wait ends soon after restarting): 
![image](https://github.com/user-attachments/assets/18e0500b-5e80-48c2-8117-9e497b03fc6d)




**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
