### PR TITLE
Move plugin registry under the pkg/app/pipedv1/plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/registry.go
+++ b/pkg/app/pipedv1/plugin/registry.go
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package planner provides a piped component
-// that decides the deployment pipeline of a deployment.
-// The planner bases on the changes from git commits
-// then builds the deployment manifests to know the behavior of the deployment.
-// From that behavior the planner can decides which pipeline should be applied.
-package registry
+package plugin
 
 import (
 	"context"

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package planner provides a piped component
-// that decides the deployment pipeline of a deployment.
-// The planner bases on the changes from git commits
-// then builds the deployment manifests to know the behavior of the deployment.
-// From that behavior the planner can decides which pipeline should be applied.
-package registry
+package plugin
 
 import (
 	"testing"


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We have two plugin packages for different purposes.
- `pkg/app/pipedv1/plugin`: This is used in the piped side.
- `pkg/plugin`: This is used for the plugin developer.

The plugin registry is used in the piped side. So I moved it under the `pkg/app/pipedv1/plugin`

**Which issue(s) this PR fixes**:

Part of #4980
Related #5467

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
