### PR TITLE
Add MigrateDatabase RPC to APIService for database migration

### DIFF
--- a/pkg/app/server/service/apiservice/service.pb.go
+++ b/pkg/app/server/service/apiservice/service.pb.go
@@ -2424,6 +2424,158 @@ func (x *ListStageLogsResponse) GetStageLogs() map[string]*StageLog {
 	return nil
 }
 
+type MigrateDatabaseRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Types that are assignable to Target:
+	//
+	//	*MigrateDatabaseRequest_Application_
+	Target isMigrateDatabaseRequest_Target `protobuf_oneof:"target"`
+}
+
+func (x *MigrateDatabaseRequest) Reset() {
+	*x = MigrateDatabaseRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[45]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MigrateDatabaseRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrateDatabaseRequest) ProtoMessage() {}
+
+func (x *MigrateDatabaseRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[45]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrateDatabaseRequest.ProtoReflect.Descriptor instead.
+func (*MigrateDatabaseRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_app_server_service_apiservice_service_proto_rawDescGZIP(), []int{45}
+}
+
+func (m *MigrateDatabaseRequest) GetTarget() isMigrateDatabaseRequest_Target {
+	if m != nil {
+		return m.Target
+	}
+	return nil
+}
+
+func (x *MigrateDatabaseRequest) GetApplication() *MigrateDatabaseRequest_Application {
+	if x, ok := x.GetTarget().(*MigrateDatabaseRequest_Application_); ok {
+		return x.Application
+	}
+	return nil
+}
+
+type isMigrateDatabaseRequest_Target interface {
+	isMigrateDatabaseRequest_Target()
+}
+
+type MigrateDatabaseRequest_Application_ struct {
+	Application *MigrateDatabaseRequest_Application `protobuf:"bytes,1,opt,name=application,proto3,oneof"` // Add more migration targets here. for example, Piped, Project, etc.
+}
+
+func (*MigrateDatabaseRequest_Application_) isMigrateDatabaseRequest_Target() {}
+
+type MigrateDatabaseResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *MigrateDatabaseResponse) Reset() {
+	*x = MigrateDatabaseResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[46]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MigrateDatabaseResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrateDatabaseResponse) ProtoMessage() {}
+
+func (x *MigrateDatabaseResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[46]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrateDatabaseResponse.ProtoReflect.Descriptor instead.
+func (*MigrateDatabaseResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_app_server_service_apiservice_service_proto_rawDescGZIP(), []int{46}
+}
+
+type MigrateDatabaseRequest_Application struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ApplicationId string `protobuf:"bytes,1,opt,name=application_id,json=applicationId,proto3" json:"application_id,omitempty"`
+}
+
+func (x *MigrateDatabaseRequest_Application) Reset() {
+	*x = MigrateDatabaseRequest_Application{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[52]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MigrateDatabaseRequest_Application) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MigrateDatabaseRequest_Application) ProtoMessage() {}
+
+func (x *MigrateDatabaseRequest_Application) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_app_server_service_apiservice_service_proto_msgTypes[52]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MigrateDatabaseRequest_Application.ProtoReflect.Descriptor instead.
+func (*MigrateDatabaseRequest_Application) Descriptor() ([]byte, []int) {
+	return file_pkg_app_server_service_apiservice_service_proto_rawDescGZIP(), []int{45, 0}
+}
+
+func (x *MigrateDatabaseRequest_Application) GetApplicationId() string {
+	if x != nil {
+		return x.ApplicationId
+	}
+	return ""
+}
+
 var File_pkg_app_server_service_apiservice_service_proto protoreflect.FileDescriptor
 
 var file_pkg_app_server_service_apiservice_service_proto_rawDesc = []byte{
@@ -2750,8 +2902,22 @@ var file_pkg_app_server_service_apiservice_service_proto_rawDesc = []byte{
 	0x65, 0x79, 0x12, 0x37, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28,
 	0x0b, 0x32, 0x21, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
 	0x2e, 0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x53, 0x74, 0x61, 0x67,
-	0x65, 0x4c, 0x6f, 0x67, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x32,
-	0xc0, 0x14, 0x0a, 0x0a, 0x41, 0x50, 0x49, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x73,
+	0x65, 0x4c, 0x6f, 0x67, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22,
+	0xc2, 0x01, 0x0a, 0x16, 0x4d, 0x69, 0x67, 0x72, 0x61, 0x74, 0x65, 0x44, 0x61, 0x74, 0x61, 0x62,
+	0x61, 0x73, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x5f, 0x0a, 0x0b, 0x61, 0x70,
+	0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x3b, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x61,
+	0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x4d, 0x69, 0x67, 0x72, 0x61, 0x74,
+	0x65, 0x44, 0x61, 0x74, 0x61, 0x62, 0x61, 0x73, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x2e, 0x41, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x48, 0x00, 0x52, 0x0b,
+	0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0x3d, 0x0a, 0x0b, 0x41,
+	0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x2e, 0x0a, 0x0e, 0x61, 0x70,
+	0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x42, 0x07, 0xfa, 0x42, 0x04, 0x72, 0x02, 0x10, 0x01, 0x52, 0x0d, 0x61, 0x70, 0x70,
+	0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x42, 0x08, 0x0a, 0x06, 0x74, 0x61,
+	0x72, 0x67, 0x65, 0x74, 0x22, 0x19, 0x0a, 0x17, 0x4d, 0x69, 0x67, 0x72, 0x61, 0x74, 0x65, 0x44,
+	0x61, 0x74, 0x61, 0x62, 0x61, 0x73, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x32,
+	0xb8, 0x15, 0x0a, 0x0a, 0x41, 0x50, 0x49, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x73,
 	0x0a, 0x0e, 0x41, 0x64, 0x64, 0x41, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
 	0x12, 0x2e, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
 	0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x41, 0x64, 0x64, 0x41, 0x70,
@@ -2915,11 +3081,19 @@ var file_pkg_app_server_service_apiservice_service_proto_rawDesc = []byte{
 	0x1a, 0x2e, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
 	0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53,
 	0x74, 0x61, 0x67, 0x65, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x22, 0x00, 0x42, 0x3d, 0x5a, 0x3b, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d,
-	0x2f, 0x70, 0x69, 0x70, 0x65, 0x2d, 0x63, 0x64, 0x2f, 0x70, 0x69, 0x70, 0x65, 0x63, 0x64, 0x2f,
-	0x70, 0x6b, 0x67, 0x2f, 0x61, 0x70, 0x70, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2f, 0x73,
-	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63,
-	0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x22, 0x00, 0x12, 0x76, 0x0a, 0x0f, 0x4d, 0x69, 0x67, 0x72, 0x61, 0x74, 0x65, 0x44, 0x61, 0x74,
+	0x61, 0x62, 0x61, 0x73, 0x65, 0x12, 0x2f, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65, 0x72,
+	0x76, 0x69, 0x63, 0x65, 0x2e, 0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2e,
+	0x4d, 0x69, 0x67, 0x72, 0x61, 0x74, 0x65, 0x44, 0x61, 0x74, 0x61, 0x62, 0x61, 0x73, 0x65, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x30, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x73, 0x65,
+	0x72, 0x76, 0x69, 0x63, 0x65, 0x2e, 0x61, 0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x2e, 0x4d, 0x69, 0x67, 0x72, 0x61, 0x74, 0x65, 0x44, 0x61, 0x74, 0x61, 0x62, 0x61, 0x73, 0x65,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x3d, 0x5a, 0x3b, 0x67, 0x69,
+	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x69, 0x70, 0x65, 0x2d, 0x63, 0x64,
+	0x2f, 0x70, 0x69, 0x70, 0x65, 0x63, 0x64, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61, 0x70, 0x70, 0x2f,
+	0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x2f, 0x61,
+	0x70, 0x69, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x33,
 }
 
 var (
@@ -2934,7 +3108,7 @@ func file_pkg_app_server_service_apiservice_service_proto_rawDescGZIP() []byte {
 	return file_pkg_app_server_service_apiservice_service_proto_rawDescData
 }
 
-var file_pkg_app_server_service_apiservice_service_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
+var file_pkg_app_server_service_apiservice_service_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_pkg_app_server_service_apiservice_service_proto_goTypes = []interface{}{
 	(*AddApplicationRequest)(nil),               // 0: grpc.service.apiservice.AddApplicationRequest
 	(*AddApplicationResponse)(nil),              // 1: grpc.service.apiservice.AddApplicationResponse
@@ -2981,87 +3155,93 @@ var file_pkg_app_server_service_apiservice_service_proto_goTypes = []interface{}
 	(*StageLog)(nil),                            // 42: grpc.service.apiservice.StageLog
 	(*ListStageLogsRequest)(nil),                // 43: grpc.service.apiservice.ListStageLogsRequest
 	(*ListStageLogsResponse)(nil),               // 44: grpc.service.apiservice.ListStageLogsResponse
-	nil,                                         // 45: grpc.service.apiservice.ListApplicationsRequest.LabelsEntry
-	nil,                                         // 46: grpc.service.apiservice.ListDeploymentsRequest.LabelsEntry
-	nil,                                         // 47: grpc.service.apiservice.RegisterEventRequest.LabelsEntry
-	nil,                                         // 48: grpc.service.apiservice.RegisterEventRequest.ContextsEntry
-	nil,                                         // 49: grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry
-	(*model.ApplicationGitPath)(nil),            // 50: model.ApplicationGitPath
-	(model.ApplicationKind)(0),                  // 51: model.ApplicationKind
-	(*model.Application)(nil),                   // 52: model.Application
-	(*model.Piped)(nil),                         // 53: model.Piped
-	(*model.Deployment)(nil),                    // 54: model.Deployment
-	(*model.Command)(nil),                       // 55: model.Command
-	(*model.PlanPreviewCommandResult)(nil),      // 56: model.PlanPreviewCommandResult
-	(*model.LogBlock)(nil),                      // 57: model.LogBlock
+	(*MigrateDatabaseRequest)(nil),              // 45: grpc.service.apiservice.MigrateDatabaseRequest
+	(*MigrateDatabaseResponse)(nil),             // 46: grpc.service.apiservice.MigrateDatabaseResponse
+	nil,                                         // 47: grpc.service.apiservice.ListApplicationsRequest.LabelsEntry
+	nil,                                         // 48: grpc.service.apiservice.ListDeploymentsRequest.LabelsEntry
+	nil,                                         // 49: grpc.service.apiservice.RegisterEventRequest.LabelsEntry
+	nil,                                         // 50: grpc.service.apiservice.RegisterEventRequest.ContextsEntry
+	nil,                                         // 51: grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry
+	(*MigrateDatabaseRequest_Application)(nil),  // 52: grpc.service.apiservice.MigrateDatabaseRequest.Application
+	(*model.ApplicationGitPath)(nil),            // 53: model.ApplicationGitPath
+	(model.ApplicationKind)(0),                  // 54: model.ApplicationKind
+	(*model.Application)(nil),                   // 55: model.Application
+	(*model.Piped)(nil),                         // 56: model.Piped
+	(*model.Deployment)(nil),                    // 57: model.Deployment
+	(*model.Command)(nil),                       // 58: model.Command
+	(*model.PlanPreviewCommandResult)(nil),      // 59: model.PlanPreviewCommandResult
+	(*model.LogBlock)(nil),                      // 60: model.LogBlock
 }
 var file_pkg_app_server_service_apiservice_service_proto_depIdxs = []int32{
-	50, // 0: grpc.service.apiservice.AddApplicationRequest.git_path:type_name -> model.ApplicationGitPath
-	51, // 1: grpc.service.apiservice.AddApplicationRequest.kind:type_name -> model.ApplicationKind
-	52, // 2: grpc.service.apiservice.GetApplicationResponse.application:type_name -> model.Application
-	45, // 3: grpc.service.apiservice.ListApplicationsRequest.labels:type_name -> grpc.service.apiservice.ListApplicationsRequest.LabelsEntry
-	52, // 4: grpc.service.apiservice.ListApplicationsResponse.applications:type_name -> model.Application
-	53, // 5: grpc.service.apiservice.GetPipedResponse.piped:type_name -> model.Piped
-	50, // 6: grpc.service.apiservice.UpdateApplicationRequest.git_path:type_name -> model.ApplicationGitPath
-	54, // 7: grpc.service.apiservice.GetDeploymentResponse.deployment:type_name -> model.Deployment
-	46, // 8: grpc.service.apiservice.ListDeploymentsRequest.labels:type_name -> grpc.service.apiservice.ListDeploymentsRequest.LabelsEntry
-	54, // 9: grpc.service.apiservice.ListDeploymentsResponse.deployments:type_name -> model.Deployment
-	55, // 10: grpc.service.apiservice.GetCommandResponse.command:type_name -> model.Command
-	47, // 11: grpc.service.apiservice.RegisterEventRequest.labels:type_name -> grpc.service.apiservice.RegisterEventRequest.LabelsEntry
-	48, // 12: grpc.service.apiservice.RegisterEventRequest.contexts:type_name -> grpc.service.apiservice.RegisterEventRequest.ContextsEntry
-	56, // 13: grpc.service.apiservice.GetPlanPreviewResultsResponse.results:type_name -> model.PlanPreviewCommandResult
-	57, // 14: grpc.service.apiservice.StageLog.blocks:type_name -> model.LogBlock
-	49, // 15: grpc.service.apiservice.ListStageLogsResponse.stage_logs:type_name -> grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry
-	42, // 16: grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry.value:type_name -> grpc.service.apiservice.StageLog
-	0,  // 17: grpc.service.apiservice.APIService.AddApplication:input_type -> grpc.service.apiservice.AddApplicationRequest
-	2,  // 18: grpc.service.apiservice.APIService.SyncApplication:input_type -> grpc.service.apiservice.SyncApplicationRequest
-	4,  // 19: grpc.service.apiservice.APIService.GetApplication:input_type -> grpc.service.apiservice.GetApplicationRequest
-	6,  // 20: grpc.service.apiservice.APIService.ListApplications:input_type -> grpc.service.apiservice.ListApplicationsRequest
-	18, // 21: grpc.service.apiservice.APIService.UpdateApplication:input_type -> grpc.service.apiservice.UpdateApplicationRequest
-	20, // 22: grpc.service.apiservice.APIService.DeleteApplication:input_type -> grpc.service.apiservice.DeleteApplicationRequest
-	14, // 23: grpc.service.apiservice.APIService.EnableApplication:input_type -> grpc.service.apiservice.EnableApplicationRequest
-	16, // 24: grpc.service.apiservice.APIService.DisableApplication:input_type -> grpc.service.apiservice.DisableApplicationRequest
-	22, // 25: grpc.service.apiservice.APIService.RenameApplicationConfigFile:input_type -> grpc.service.apiservice.RenameApplicationConfigFileRequest
-	24, // 26: grpc.service.apiservice.APIService.GetDeployment:input_type -> grpc.service.apiservice.GetDeploymentRequest
-	26, // 27: grpc.service.apiservice.APIService.ListDeployments:input_type -> grpc.service.apiservice.ListDeploymentsRequest
-	28, // 28: grpc.service.apiservice.APIService.GetCommand:input_type -> grpc.service.apiservice.GetCommandRequest
-	8,  // 29: grpc.service.apiservice.APIService.GetPiped:input_type -> grpc.service.apiservice.GetPipedRequest
-	10, // 30: grpc.service.apiservice.APIService.RegisterPiped:input_type -> grpc.service.apiservice.RegisterPipedRequest
-	12, // 31: grpc.service.apiservice.APIService.UpdatePiped:input_type -> grpc.service.apiservice.UpdatePipedRequest
-	30, // 32: grpc.service.apiservice.APIService.EnablePiped:input_type -> grpc.service.apiservice.EnablePipedRequest
-	32, // 33: grpc.service.apiservice.APIService.DisablePiped:input_type -> grpc.service.apiservice.DisablePipedRequest
-	34, // 34: grpc.service.apiservice.APIService.RegisterEvent:input_type -> grpc.service.apiservice.RegisterEventRequest
-	36, // 35: grpc.service.apiservice.APIService.RequestPlanPreview:input_type -> grpc.service.apiservice.RequestPlanPreviewRequest
-	38, // 36: grpc.service.apiservice.APIService.GetPlanPreviewResults:input_type -> grpc.service.apiservice.GetPlanPreviewResultsRequest
-	40, // 37: grpc.service.apiservice.APIService.Encrypt:input_type -> grpc.service.apiservice.EncryptRequest
-	43, // 38: grpc.service.apiservice.APIService.ListStageLogs:input_type -> grpc.service.apiservice.ListStageLogsRequest
-	1,  // 39: grpc.service.apiservice.APIService.AddApplication:output_type -> grpc.service.apiservice.AddApplicationResponse
-	3,  // 40: grpc.service.apiservice.APIService.SyncApplication:output_type -> grpc.service.apiservice.SyncApplicationResponse
-	5,  // 41: grpc.service.apiservice.APIService.GetApplication:output_type -> grpc.service.apiservice.GetApplicationResponse
-	7,  // 42: grpc.service.apiservice.APIService.ListApplications:output_type -> grpc.service.apiservice.ListApplicationsResponse
-	19, // 43: grpc.service.apiservice.APIService.UpdateApplication:output_type -> grpc.service.apiservice.UpdateApplicationResponse
-	21, // 44: grpc.service.apiservice.APIService.DeleteApplication:output_type -> grpc.service.apiservice.DeleteApplicationResponse
-	15, // 45: grpc.service.apiservice.APIService.EnableApplication:output_type -> grpc.service.apiservice.EnableApplicationResponse
-	17, // 46: grpc.service.apiservice.APIService.DisableApplication:output_type -> grpc.service.apiservice.DisableApplicationResponse
-	23, // 47: grpc.service.apiservice.APIService.RenameApplicationConfigFile:output_type -> grpc.service.apiservice.RenameApplicationConfigFileResponse
-	25, // 48: grpc.service.apiservice.APIService.GetDeployment:output_type -> grpc.service.apiservice.GetDeploymentResponse
-	27, // 49: grpc.service.apiservice.APIService.ListDeployments:output_type -> grpc.service.apiservice.ListDeploymentsResponse
-	29, // 50: grpc.service.apiservice.APIService.GetCommand:output_type -> grpc.service.apiservice.GetCommandResponse
-	9,  // 51: grpc.service.apiservice.APIService.GetPiped:output_type -> grpc.service.apiservice.GetPipedResponse
-	11, // 52: grpc.service.apiservice.APIService.RegisterPiped:output_type -> grpc.service.apiservice.RegisterPipedResponse
-	13, // 53: grpc.service.apiservice.APIService.UpdatePiped:output_type -> grpc.service.apiservice.UpdatePipedResponse
-	31, // 54: grpc.service.apiservice.APIService.EnablePiped:output_type -> grpc.service.apiservice.EnablePipedResponse
-	33, // 55: grpc.service.apiservice.APIService.DisablePiped:output_type -> grpc.service.apiservice.DisablePipedResponse
-	35, // 56: grpc.service.apiservice.APIService.RegisterEvent:output_type -> grpc.service.apiservice.RegisterEventResponse
-	37, // 57: grpc.service.apiservice.APIService.RequestPlanPreview:output_type -> grpc.service.apiservice.RequestPlanPreviewResponse
-	39, // 58: grpc.service.apiservice.APIService.GetPlanPreviewResults:output_type -> grpc.service.apiservice.GetPlanPreviewResultsResponse
-	41, // 59: grpc.service.apiservice.APIService.Encrypt:output_type -> grpc.service.apiservice.EncryptResponse
-	44, // 60: grpc.service.apiservice.APIService.ListStageLogs:output_type -> grpc.service.apiservice.ListStageLogsResponse
-	39, // [39:61] is the sub-list for method output_type
-	17, // [17:39] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	53, // 0: grpc.service.apiservice.AddApplicationRequest.git_path:type_name -> model.ApplicationGitPath
+	54, // 1: grpc.service.apiservice.AddApplicationRequest.kind:type_name -> model.ApplicationKind
+	55, // 2: grpc.service.apiservice.GetApplicationResponse.application:type_name -> model.Application
+	47, // 3: grpc.service.apiservice.ListApplicationsRequest.labels:type_name -> grpc.service.apiservice.ListApplicationsRequest.LabelsEntry
+	55, // 4: grpc.service.apiservice.ListApplicationsResponse.applications:type_name -> model.Application
+	56, // 5: grpc.service.apiservice.GetPipedResponse.piped:type_name -> model.Piped
+	53, // 6: grpc.service.apiservice.UpdateApplicationRequest.git_path:type_name -> model.ApplicationGitPath
+	57, // 7: grpc.service.apiservice.GetDeploymentResponse.deployment:type_name -> model.Deployment
+	48, // 8: grpc.service.apiservice.ListDeploymentsRequest.labels:type_name -> grpc.service.apiservice.ListDeploymentsRequest.LabelsEntry
+	57, // 9: grpc.service.apiservice.ListDeploymentsResponse.deployments:type_name -> model.Deployment
+	58, // 10: grpc.service.apiservice.GetCommandResponse.command:type_name -> model.Command
+	49, // 11: grpc.service.apiservice.RegisterEventRequest.labels:type_name -> grpc.service.apiservice.RegisterEventRequest.LabelsEntry
+	50, // 12: grpc.service.apiservice.RegisterEventRequest.contexts:type_name -> grpc.service.apiservice.RegisterEventRequest.ContextsEntry
+	59, // 13: grpc.service.apiservice.GetPlanPreviewResultsResponse.results:type_name -> model.PlanPreviewCommandResult
+	60, // 14: grpc.service.apiservice.StageLog.blocks:type_name -> model.LogBlock
+	51, // 15: grpc.service.apiservice.ListStageLogsResponse.stage_logs:type_name -> grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry
+	52, // 16: grpc.service.apiservice.MigrateDatabaseRequest.application:type_name -> grpc.service.apiservice.MigrateDatabaseRequest.Application
+	42, // 17: grpc.service.apiservice.ListStageLogsResponse.StageLogsEntry.value:type_name -> grpc.service.apiservice.StageLog
+	0,  // 18: grpc.service.apiservice.APIService.AddApplication:input_type -> grpc.service.apiservice.AddApplicationRequest
+	2,  // 19: grpc.service.apiservice.APIService.SyncApplication:input_type -> grpc.service.apiservice.SyncApplicationRequest
+	4,  // 20: grpc.service.apiservice.APIService.GetApplication:input_type -> grpc.service.apiservice.GetApplicationRequest
+	6,  // 21: grpc.service.apiservice.APIService.ListApplications:input_type -> grpc.service.apiservice.ListApplicationsRequest
+	18, // 22: grpc.service.apiservice.APIService.UpdateApplication:input_type -> grpc.service.apiservice.UpdateApplicationRequest
+	20, // 23: grpc.service.apiservice.APIService.DeleteApplication:input_type -> grpc.service.apiservice.DeleteApplicationRequest
+	14, // 24: grpc.service.apiservice.APIService.EnableApplication:input_type -> grpc.service.apiservice.EnableApplicationRequest
+	16, // 25: grpc.service.apiservice.APIService.DisableApplication:input_type -> grpc.service.apiservice.DisableApplicationRequest
+	22, // 26: grpc.service.apiservice.APIService.RenameApplicationConfigFile:input_type -> grpc.service.apiservice.RenameApplicationConfigFileRequest
+	24, // 27: grpc.service.apiservice.APIService.GetDeployment:input_type -> grpc.service.apiservice.GetDeploymentRequest
+	26, // 28: grpc.service.apiservice.APIService.ListDeployments:input_type -> grpc.service.apiservice.ListDeploymentsRequest
+	28, // 29: grpc.service.apiservice.APIService.GetCommand:input_type -> grpc.service.apiservice.GetCommandRequest
+	8,  // 30: grpc.service.apiservice.APIService.GetPiped:input_type -> grpc.service.apiservice.GetPipedRequest
+	10, // 31: grpc.service.apiservice.APIService.RegisterPiped:input_type -> grpc.service.apiservice.RegisterPipedRequest
+	12, // 32: grpc.service.apiservice.APIService.UpdatePiped:input_type -> grpc.service.apiservice.UpdatePipedRequest
+	30, // 33: grpc.service.apiservice.APIService.EnablePiped:input_type -> grpc.service.apiservice.EnablePipedRequest
+	32, // 34: grpc.service.apiservice.APIService.DisablePiped:input_type -> grpc.service.apiservice.DisablePipedRequest
+	34, // 35: grpc.service.apiservice.APIService.RegisterEvent:input_type -> grpc.service.apiservice.RegisterEventRequest
+	36, // 36: grpc.service.apiservice.APIService.RequestPlanPreview:input_type -> grpc.service.apiservice.RequestPlanPreviewRequest
+	38, // 37: grpc.service.apiservice.APIService.GetPlanPreviewResults:input_type -> grpc.service.apiservice.GetPlanPreviewResultsRequest
+	40, // 38: grpc.service.apiservice.APIService.Encrypt:input_type -> grpc.service.apiservice.EncryptRequest
+	43, // 39: grpc.service.apiservice.APIService.ListStageLogs:input_type -> grpc.service.apiservice.ListStageLogsRequest
+	45, // 40: grpc.service.apiservice.APIService.MigrateDatabase:input_type -> grpc.service.apiservice.MigrateDatabaseRequest
+	1,  // 41: grpc.service.apiservice.APIService.AddApplication:output_type -> grpc.service.apiservice.AddApplicationResponse
+	3,  // 42: grpc.service.apiservice.APIService.SyncApplication:output_type -> grpc.service.apiservice.SyncApplicationResponse
+	5,  // 43: grpc.service.apiservice.APIService.GetApplication:output_type -> grpc.service.apiservice.GetApplicationResponse
+	7,  // 44: grpc.service.apiservice.APIService.ListApplications:output_type -> grpc.service.apiservice.ListApplicationsResponse
+	19, // 45: grpc.service.apiservice.APIService.UpdateApplication:output_type -> grpc.service.apiservice.UpdateApplicationResponse
+	21, // 46: grpc.service.apiservice.APIService.DeleteApplication:output_type -> grpc.service.apiservice.DeleteApplicationResponse
+	15, // 47: grpc.service.apiservice.APIService.EnableApplication:output_type -> grpc.service.apiservice.EnableApplicationResponse
+	17, // 48: grpc.service.apiservice.APIService.DisableApplication:output_type -> grpc.service.apiservice.DisableApplicationResponse
+	23, // 49: grpc.service.apiservice.APIService.RenameApplicationConfigFile:output_type -> grpc.service.apiservice.RenameApplicationConfigFileResponse
+	25, // 50: grpc.service.apiservice.APIService.GetDeployment:output_type -> grpc.service.apiservice.GetDeploymentResponse
+	27, // 51: grpc.service.apiservice.APIService.ListDeployments:output_type -> grpc.service.apiservice.ListDeploymentsResponse
+	29, // 52: grpc.service.apiservice.APIService.GetCommand:output_type -> grpc.service.apiservice.GetCommandResponse
+	9,  // 53: grpc.service.apiservice.APIService.GetPiped:output_type -> grpc.service.apiservice.GetPipedResponse
+	11, // 54: grpc.service.apiservice.APIService.RegisterPiped:output_type -> grpc.service.apiservice.RegisterPipedResponse
+	13, // 55: grpc.service.apiservice.APIService.UpdatePiped:output_type -> grpc.service.apiservice.UpdatePipedResponse
+	31, // 56: grpc.service.apiservice.APIService.EnablePiped:output_type -> grpc.service.apiservice.EnablePipedResponse
+	33, // 57: grpc.service.apiservice.APIService.DisablePiped:output_type -> grpc.service.apiservice.DisablePipedResponse
+	35, // 58: grpc.service.apiservice.APIService.RegisterEvent:output_type -> grpc.service.apiservice.RegisterEventResponse
+	37, // 59: grpc.service.apiservice.APIService.RequestPlanPreview:output_type -> grpc.service.apiservice.RequestPlanPreviewResponse
+	39, // 60: grpc.service.apiservice.APIService.GetPlanPreviewResults:output_type -> grpc.service.apiservice.GetPlanPreviewResultsResponse
+	41, // 61: grpc.service.apiservice.APIService.Encrypt:output_type -> grpc.service.apiservice.EncryptResponse
+	44, // 62: grpc.service.apiservice.APIService.ListStageLogs:output_type -> grpc.service.apiservice.ListStageLogsResponse
+	46, // 63: grpc.service.apiservice.APIService.MigrateDatabase:output_type -> grpc.service.apiservice.MigrateDatabaseResponse
+	41, // [41:64] is the sub-list for method output_type
+	18, // [18:41] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_pkg_app_server_service_apiservice_service_proto_init() }
@@ -3610,6 +3790,45 @@ func file_pkg_app_server_service_apiservice_service_proto_init() {
 				return nil
 			}
 		}
+		file_pkg_app_server_service_apiservice_service_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MigrateDatabaseRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pkg_app_server_service_apiservice_service_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MigrateDatabaseResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pkg_app_server_service_apiservice_service_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MigrateDatabaseRequest_Application); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+	}
+	file_pkg_app_server_service_apiservice_service_proto_msgTypes[45].OneofWrappers = []interface{}{
+		(*MigrateDatabaseRequest_Application_)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3617,7 +3836,7 @@ func file_pkg_app_server_service_apiservice_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_pkg_app_server_service_apiservice_service_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   50,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/app/server/service/apiservice/service.pb.validate.go
+++ b/pkg/app/server/service/apiservice/service.pb.validate.go
@@ -5554,3 +5554,358 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = ListStageLogsResponseValidationError{}
+
+// Validate checks the field values on MigrateDatabaseRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *MigrateDatabaseRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on MigrateDatabaseRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// MigrateDatabaseRequestMultiError, or nil if none found.
+func (m *MigrateDatabaseRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *MigrateDatabaseRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	switch m.Target.(type) {
+
+	case *MigrateDatabaseRequest_Application_:
+
+		if all {
+			switch v := interface{}(m.GetApplication()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, MigrateDatabaseRequestValidationError{
+						field:  "Application",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, MigrateDatabaseRequestValidationError{
+						field:  "Application",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetApplication()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return MigrateDatabaseRequestValidationError{
+					field:  "Application",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return MigrateDatabaseRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// MigrateDatabaseRequestMultiError is an error wrapping multiple validation
+// errors returned by MigrateDatabaseRequest.ValidateAll() if the designated
+// constraints aren't met.
+type MigrateDatabaseRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m MigrateDatabaseRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m MigrateDatabaseRequestMultiError) AllErrors() []error { return m }
+
+// MigrateDatabaseRequestValidationError is the validation error returned by
+// MigrateDatabaseRequest.Validate if the designated constraints aren't met.
+type MigrateDatabaseRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e MigrateDatabaseRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e MigrateDatabaseRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e MigrateDatabaseRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e MigrateDatabaseRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e MigrateDatabaseRequestValidationError) ErrorName() string {
+	return "MigrateDatabaseRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e MigrateDatabaseRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sMigrateDatabaseRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = MigrateDatabaseRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = MigrateDatabaseRequestValidationError{}
+
+// Validate checks the field values on MigrateDatabaseResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *MigrateDatabaseResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on MigrateDatabaseResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// MigrateDatabaseResponseMultiError, or nil if none found.
+func (m *MigrateDatabaseResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *MigrateDatabaseResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return MigrateDatabaseResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// MigrateDatabaseResponseMultiError is an error wrapping multiple validation
+// errors returned by MigrateDatabaseResponse.ValidateAll() if the designated
+// constraints aren't met.
+type MigrateDatabaseResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m MigrateDatabaseResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m MigrateDatabaseResponseMultiError) AllErrors() []error { return m }
+
+// MigrateDatabaseResponseValidationError is the validation error returned by
+// MigrateDatabaseResponse.Validate if the designated constraints aren't met.
+type MigrateDatabaseResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e MigrateDatabaseResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e MigrateDatabaseResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e MigrateDatabaseResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e MigrateDatabaseResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e MigrateDatabaseResponseValidationError) ErrorName() string {
+	return "MigrateDatabaseResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e MigrateDatabaseResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sMigrateDatabaseResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = MigrateDatabaseResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = MigrateDatabaseResponseValidationError{}
+
+// Validate checks the field values on MigrateDatabaseRequest_Application with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the first error encountered is returned, or nil if there are
+// no violations.
+func (m *MigrateDatabaseRequest_Application) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on MigrateDatabaseRequest_Application
+// with the rules defined in the proto definition for this message. If any
+// rules are violated, the result is a list of violation errors wrapped in
+// MigrateDatabaseRequest_ApplicationMultiError, or nil if none found.
+func (m *MigrateDatabaseRequest_Application) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *MigrateDatabaseRequest_Application) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if utf8.RuneCountInString(m.GetApplicationId()) < 1 {
+		err := MigrateDatabaseRequest_ApplicationValidationError{
+			field:  "ApplicationId",
+			reason: "value length must be at least 1 runes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if len(errors) > 0 {
+		return MigrateDatabaseRequest_ApplicationMultiError(errors)
+	}
+
+	return nil
+}
+
+// MigrateDatabaseRequest_ApplicationMultiError is an error wrapping multiple
+// validation errors returned by
+// MigrateDatabaseRequest_Application.ValidateAll() if the designated
+// constraints aren't met.
+type MigrateDatabaseRequest_ApplicationMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m MigrateDatabaseRequest_ApplicationMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m MigrateDatabaseRequest_ApplicationMultiError) AllErrors() []error { return m }
+
+// MigrateDatabaseRequest_ApplicationValidationError is the validation error
+// returned by MigrateDatabaseRequest_Application.Validate if the designated
+// constraints aren't met.
+type MigrateDatabaseRequest_ApplicationValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e MigrateDatabaseRequest_ApplicationValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e MigrateDatabaseRequest_ApplicationValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e MigrateDatabaseRequest_ApplicationValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e MigrateDatabaseRequest_ApplicationValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e MigrateDatabaseRequest_ApplicationValidationError) ErrorName() string {
+	return "MigrateDatabaseRequest_ApplicationValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e MigrateDatabaseRequest_ApplicationValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sMigrateDatabaseRequest_Application.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = MigrateDatabaseRequest_ApplicationValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = MigrateDatabaseRequest_ApplicationValidationError{}

--- a/pkg/app/server/service/apiservice/service.proto
+++ b/pkg/app/server/service/apiservice/service.proto
@@ -58,6 +58,8 @@ service APIService {
     rpc Encrypt(EncryptRequest) returns (EncryptResponse) {}
 
     rpc ListStageLogs(ListStageLogsRequest) returns (ListStageLogsResponse) {}
+
+    rpc MigrateDatabase(MigrateDatabaseRequest) returns (MigrateDatabaseResponse) {}
 }
 
 message AddApplicationRequest {
@@ -281,4 +283,18 @@ message ListStageLogsRequest {
 
 message ListStageLogsResponse {
     map<string, StageLog> stage_logs = 1;
+}
+
+message MigrateDatabaseRequest {
+    message Application {
+        string application_id = 1 [(validate.rules).string.min_len = 1];
+    }
+    
+    oneof target {
+        Application application = 1;
+        // Add more migration targets here. for example, Piped, Project, etc.
+    }
+}
+
+message MigrateDatabaseResponse {
 }

--- a/pkg/app/server/service/apiservice/service_grpc.pb.go
+++ b/pkg/app/server/service/apiservice/service_grpc.pb.go
@@ -44,6 +44,7 @@ type APIServiceClient interface {
 	GetPlanPreviewResults(ctx context.Context, in *GetPlanPreviewResultsRequest, opts ...grpc.CallOption) (*GetPlanPreviewResultsResponse, error)
 	Encrypt(ctx context.Context, in *EncryptRequest, opts ...grpc.CallOption) (*EncryptResponse, error)
 	ListStageLogs(ctx context.Context, in *ListStageLogsRequest, opts ...grpc.CallOption) (*ListStageLogsResponse, error)
+	MigrateDatabase(ctx context.Context, in *MigrateDatabaseRequest, opts ...grpc.CallOption) (*MigrateDatabaseResponse, error)
 }
 
 type aPIServiceClient struct {
@@ -252,6 +253,15 @@ func (c *aPIServiceClient) ListStageLogs(ctx context.Context, in *ListStageLogsR
 	return out, nil
 }
 
+func (c *aPIServiceClient) MigrateDatabase(ctx context.Context, in *MigrateDatabaseRequest, opts ...grpc.CallOption) (*MigrateDatabaseResponse, error) {
+	out := new(MigrateDatabaseResponse)
+	err := c.cc.Invoke(ctx, "/grpc.service.apiservice.APIService/MigrateDatabase", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // APIServiceServer is the server API for APIService service.
 // All implementations must embed UnimplementedAPIServiceServer
 // for forward compatibility
@@ -278,6 +288,7 @@ type APIServiceServer interface {
 	GetPlanPreviewResults(context.Context, *GetPlanPreviewResultsRequest) (*GetPlanPreviewResultsResponse, error)
 	Encrypt(context.Context, *EncryptRequest) (*EncryptResponse, error)
 	ListStageLogs(context.Context, *ListStageLogsRequest) (*ListStageLogsResponse, error)
+	MigrateDatabase(context.Context, *MigrateDatabaseRequest) (*MigrateDatabaseResponse, error)
 	mustEmbedUnimplementedAPIServiceServer()
 }
 
@@ -350,6 +361,9 @@ func (UnimplementedAPIServiceServer) Encrypt(context.Context, *EncryptRequest) (
 }
 func (UnimplementedAPIServiceServer) ListStageLogs(context.Context, *ListStageLogsRequest) (*ListStageLogsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListStageLogs not implemented")
+}
+func (UnimplementedAPIServiceServer) MigrateDatabase(context.Context, *MigrateDatabaseRequest) (*MigrateDatabaseResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method MigrateDatabase not implemented")
 }
 func (UnimplementedAPIServiceServer) mustEmbedUnimplementedAPIServiceServer() {}
 
@@ -760,6 +774,24 @@ func _APIService_ListStageLogs_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _APIService_MigrateDatabase_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MigrateDatabaseRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(APIServiceServer).MigrateDatabase(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/grpc.service.apiservice.APIService/MigrateDatabase",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(APIServiceServer).MigrateDatabase(ctx, req.(*MigrateDatabaseRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // APIService_ServiceDesc is the grpc.ServiceDesc for APIService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -854,6 +886,10 @@ var APIService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListStageLogs",
 			Handler:    _APIService_ListStageLogs_Handler,
+		},
+		{
+			MethodName: "MigrateDatabase",
+			Handler:    _APIService_MigrateDatabase_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

When developing pipedv1, we have to use data with new fields, such as deploy target, or we have to patch pipedv1 temporarily to use the old field.
This PR defines the API to convert the existing data to prepare the data with new fields.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
