### PR TITLE
Add optional username and email fields to repo for commits

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -65,6 +65,11 @@ type Worktree interface {
 }
 
 type repo struct {
+	// username and email are used to commit changes.
+	// these fields are optional, and set in the `setUser` method.
+	username string
+	email    string
+
 	dir          string
 	gitPath      string
 	remote       string
@@ -174,6 +179,12 @@ func (r *repo) CopyToModify(dest string) (Repo, error) {
 		remote:       r.remote,
 		clonedBranch: r.clonedBranch,
 		gitEnvs:      r.gitEnvs,
+	}
+
+	if r.username != "" || r.email != "" {
+		if err := cloned.setUser(context.Background(), r.username, r.email); err != nil {
+			return nil, fmt.Errorf("failed to set user: %v", err)
+		}
 	}
 
 	// because we did a local cloning so set the remote url of origin
@@ -402,6 +413,9 @@ func (r repo) addCommit(ctx context.Context, message string, trailers map[string
 
 // setUser configures username and email for local user of this repo.
 func (r *repo) setUser(ctx context.Context, username, email string) error {
+	r.username = username
+	r.email = email
+
 	if out, err := r.runGitCommand(ctx, "config", "user.name", username); err != nil {
 		return formatCommandError(err, out)
 	}


### PR DESCRIPTION
**What this PR does**:

This PR adds username and email fields to the repo struct.

**Why we need it**:

We need these fields to do the git commit.
Originally, these fields are set when creating the new repo in the git client's Clone method.
When I implemented the CopyToModify method, I forgot to set these fields.

ref; https://github.com/pipe-cd/pipecd/blob/f7e3bbce415ac0db1b316bbbe64f7d5eee321240/pkg/git/client.go#L239-L244

**Which issue(s) this PR fixes**:

Without this PR, the piped cannot handle the GIT_UPDATE event successfully.

**How to reproduce the issue**

Remove global git config, run piped, and send the event with pipectl.

You will see the log like below.
```
{"severity":"ERROR","eventTime":1736988484.684635,"logger":"piped.piped.event-watcher","caller":"eventwatcher/eventwatcher.go:403","message":"failed to commit outdated files","serviceContext":{"service":"piped.piped","version":"unspecified"},"error":"failed to commit, branch: main, error: err: exit status 128, out: Author identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: unable to auto-detect email address (got 'warashi@nixos.(none)')\n","stacktrace":"github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher.(*watcher).execute\n\t/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher/eventwatcher.go:403\ngithub.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher.(*watcher).run\n\t/home/warashi/ghq/github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher/eventwatcher.go:294"}
```

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
