### PR TITLE
Update copyright year format in golangci configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,12 @@ linters-settings:
   goimports:
     local-prefixes: github.com/pipe-cd/pipecd
   goheader:
+    values:
+      regexp:
+        any-year: \d{4} # the year of copyright means the first published year, so it can be any year.
     # template does not contains the comment indicator '//' or '/*' '*/'
     template: |-
-      Copyright {{mod-year-range}} The PipeCD Authors.
+      Copyright {{any-year}} The PipeCD Authors.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

I learned the year of copyright notice means the first published year, so that it can be any year.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
