### PR TITLE
Do not remove resources which is not managed by piped

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/resource.go
@@ -95,6 +95,7 @@ func makeResourceKey(obj *unstructured.Unstructured) ResourceKey {
 }
 
 // FindRemoveResources identifies resources that are present in the live state but not in the desired manifests.
+// It doesn't return the resources that are not managed by Piped.
 func FindRemoveResources(manifests, namespacedLiveResources, clusterScopedLiveResources []Manifest) []ResourceKey {
 	var (
 		removeKeys = make([]ResourceKey, 0, len(namespacedLiveResources)+len(clusterScopedLiveResources))
@@ -107,7 +108,7 @@ func FindRemoveResources(manifests, namespacedLiveResources, clusterScopedLiveRe
 		}
 
 		for _, r := range namespacedLiveResources {
-			if _, ok := normalizedKeys[r.Key().normalize()]; !ok {
+			if _, ok := normalizedKeys[r.Key().normalize()]; !ok && r.IsManagedByPiped() {
 				removeKeys = append(removeKeys, r.Key())
 			}
 		}
@@ -121,7 +122,7 @@ func FindRemoveResources(manifests, namespacedLiveResources, clusterScopedLiveRe
 		}
 		for _, r := range clusterScopedLiveResources {
 			// We don't care about the namespace of the cluster-scoped resources.
-			if _, ok := normalizedKeys[r.Key().normalize().withoutNamespace()]; !ok {
+			if _, ok := normalizedKeys[r.Key().normalize().withoutNamespace()]; !ok && r.IsManagedByPiped() {
 				removeKeys = append(removeKeys, r.Key())
 			}
 		}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/resource_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/resource_test.go
@@ -136,6 +136,64 @@ metadata:
 				},
 			},
 		},
+		{
+			name: "resources not managed by piped",
+			manifestsYAML: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: default
+`,
+			namespacedLiveResourcesYAML: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: default
+`,
+			clusterScopedLiveResourcesYAML: `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+`,
+			expectedRemoveKeys: []ResourceKey{},
+		},
+		{
+			name: "mixed managed and unmanaged resources",
+			manifestsYAML: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: default
+  annotations:
+    "pipecd.dev/managed-by": "piped"
+`,
+			namespacedLiveResourcesYAML: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: default
+  annotations:
+    "pipecd.dev/managed-by": "piped"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unmanaged-secret
+  namespace: default
+`,
+			clusterScopedLiveResourcesYAML: `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unmanaged-namespace
+`,
+			expectedRemoveKeys: []ResourceKey{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Without this PR, the k8s plugin tries to remove the resources that are not directly managed by piped.
For example, when the piped manages a deployment, the deployment creates replica sets. The replica sets should not be removed by piped, but they will be removed without this PR.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
