### PR TITLE
Remove git option to do partial clone

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -166,7 +166,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 				return nil, err
 			}
 			out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
-				args := []string{"clone", "--mirror", "--filter=blob:none", remote, repoCachePath}
+				args := []string{"clone", "--mirror", remote, repoCachePath}
 				args = append(authArgs, args...)
 				return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
 			})


### PR DESCRIPTION
**What this PR does**:

This PR removes `--filter=blob:none` from the git clone operation to create a locally cached repository.

**Why we need it**:

The piped does the local clone from the cached repository to prepare the event watcher's GIT_UPDATE handler. The repository must be fully cloned when doing the local clone. When doing the local clone from a partially cloned repository, we will sometimes get an error like `missing blob object.`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
