### PR TITLE
Update workflow running containers to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -29,7 +29,7 @@ jobs:
         run: make build/go
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -51,7 +51,7 @@ jobs:
         run: make build/web
 
   chart:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         image:

--- a/.github/workflows/cherry_pick.yaml
+++ b/.github/workflows/cherry_pick.yaml
@@ -13,7 +13,7 @@ on:
         type: string
 jobs:
   tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/code-butler.yaml
+++ b/.github/workflows/code-butler.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   review:
     if: startsWith(github.event.comment.body, '/review')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: ca-dp/code-butler@v1
         with:
@@ -21,7 +21,7 @@ jobs:
           model: gpt-4-1106-preview
   chat:
     if: startsWith(github.event.comment.body, '/chat')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: ca-dp/code-butler@v1
         with:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   code:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/labeler@v4
       with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
@@ -27,7 +27,7 @@ jobs:
           fail_on_error: true # this option is deprecated on v2.7.0, but we use v2.1.3, so it's still available
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   gh-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -10,12 +10,12 @@ env:
 
 jobs:
   gh_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "not implemented"
 
   binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: gh_release
     permissions:
       contents: write

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -119,7 +119,7 @@ jobs:
           data: ${{ env.PIPECD_VERSION }}
 
   release-quickstart-manifests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: artifacts
     # ignore release candidates
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-rc')

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   site:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -32,7 +32,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -54,7 +54,7 @@ jobs:
         run: make test/web
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   updateContributors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - run: |


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
