### PR TITLE
Update setup-helm version to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install helm
-        uses: Azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: ${{ env.HELM_VERSION }}
       - name: Package helm charts

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -96,7 +96,7 @@ jobs:
 
       # Building and pushing Helm charts.
       - name: Install helm
-        uses: Azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: ${{ env.HELM_VERSION }}
       - name: Login to OCI using Helm
@@ -129,7 +129,7 @@ jobs:
     steps:
       # setup tools and repositories
       - name: Install helm
-        uses: Azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: ${{ env.HELM_VERSION }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -58,7 +58,7 @@ jobs:
 
       # Building and pushing Helm charts.
       - name: Install helm
-        uses: Azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: ${{ env.HELM_VERSION }}
       - name: Login to OCI using Helm


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Internally, setup-helm using set-output, which is deprecated and will be soon removed by GitHub, using azure/setup-helm version > v3.5 to avoid this error
ref: https://github.com/Azure/setup-helm/issues/103

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
