### PR TITLE
Update codeql version to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: github/codeql-action/init@v2
+    - uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-    - uses: github/codeql-action/autobuild@v2
+    - uses: github/codeql-action/autobuild@v3
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

codeql v1 and v2 are deprecated and will be removed soon, migrate to v3 instead.
ref: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
