### PR TITLE
Update pipe-cd/actions-gh-release to version v2.6.0

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pipe-cd/actions-gh-release@v2.4.0
+      - uses: pipe-cd/actions-gh-release@v2.6.0
         with:
           release_file: 'RELEASE'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Suspend the 'set-output' warning in the actions log.
ref: https://github.com/pipe-cd/pipecd/actions/runs/12130911992

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
