### PR TITLE
Update softprops/action-gh-release to version v2.2.1

### DIFF
--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -42,7 +42,7 @@ jobs:
           make build/go MOD=pipectl BUILD_OS=darwin BUILD_ARCH=arm64 BIN_SUFFIX=_${{ env.PIPECD_VERSION }}_darwin_arm64
 
       - name: Publish binary artifacts
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 #v0.1.14
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Suspend warning 'set-output' is deprecated on actions log

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
