### PR TITLE
Add DeployTargets when building a deployment

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -95,6 +95,7 @@ func buildDeployment(
 		GitPath:                   app.GitPath,
 		CloudProvider:             app.CloudProvider,
 		PlatformProvider:          app.PlatformProvider,
+		DeployTargets:             app.DeployTargets,
 		Labels:                    app.Labels,
 		Status:                    model.DeploymentStatus_DEPLOYMENT_PENDING,
 		StatusReason:              "The deployment is waiting to be planned",

--- a/pkg/app/pipedv1/trigger/deployment.go
+++ b/pkg/app/pipedv1/trigger/deployment.go
@@ -95,6 +95,7 @@ func buildDeployment(
 		GitPath:                   app.GitPath,
 		CloudProvider:             app.CloudProvider,
 		PlatformProvider:          app.PlatformProvider,
+		DeployTargets:             app.DeployTargets,
 		Labels:                    app.Labels,
 		Status:                    model.DeploymentStatus_DEPLOYMENT_PENDING,
 		StatusReason:              "The deployment is waiting to be planned",


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We use the DeployTargets field in the Deployment model when executing the deployment.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
