### PR TITLE
Implement MigrateDatabase RPC

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -1031,6 +1031,7 @@ func (a *API) MigrateDatabase(ctx context.Context, req *apiservice.MigrateDataba
 	switch { //nolint:gocritic // we plan to add more cases
 	case req.GetApplication() != nil:
 		if err := a.migrateApplication(ctx, req.GetApplication()); err != nil {
+			a.logger.Error("failed to migrate application", zap.Error(err))
 			return nil, err
 		}
 		return &apiservice.MigrateDatabaseResponse{}, nil

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -1047,6 +1047,7 @@ func (a *API) migrateApplication(ctx context.Context, app *apiservice.MigrateDat
 	if err := a.applicationStore.UpdateDeployTargets(ctx, app.ApplicationId, []string{application.PlatformProvider}); err != nil {
 		return gRPCStoreError(err, "update application")
 	}
+	return nil
 }
 
 // requireAPIKey checks the existence of an API key inside the given context

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -198,6 +198,7 @@ type ApplicationStore interface {
 	UpdateBasicInfo(ctx context.Context, id, name, description string, labels map[string]string) error
 	UpdateConfiguration(ctx context.Context, id, pipedID, platformProvider, configFilename string) error
 	UpdatePlatformProvider(ctx context.Context, id string, provider string) error
+	UpdateDeployTargets(ctx context.Context, id string, targets []string) error
 }
 
 type applicationStore struct {
@@ -374,6 +375,13 @@ func (s *applicationStore) UpdateConfiguration(ctx context.Context, id, pipedID,
 func (s *applicationStore) UpdatePlatformProvider(ctx context.Context, id string, provider string) error {
 	return s.update(ctx, id, func(app *model.Application) error {
 		app.PlatformProvider = provider
+		return nil
+	})
+}
+
+func (s *applicationStore) UpdateDeployTargets(ctx context.Context, id string, targets []string) error {
+	return s.update(ctx, id, func(app *model.Application) error {
+		app.DeployTargets = targets
 		return nil
 	})
 }

--- a/pkg/datastore/datastoretest/datastore.mock.go
+++ b/pkg/datastore/datastoretest/datastore.mock.go
@@ -546,6 +546,20 @@ func (mr *MockApplicationStoreMockRecorder) UpdateConfiguration(ctx, id, pipedID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfiguration", reflect.TypeOf((*MockApplicationStore)(nil).UpdateConfiguration), ctx, id, pipedID, platformProvider, configFilename)
 }
 
+// UpdateDeployTargets mocks base method.
+func (m *MockApplicationStore) UpdateDeployTargets(ctx context.Context, id string, targets []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeployTargets", ctx, id, targets)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDeployTargets indicates an expected call of UpdateDeployTargets.
+func (mr *MockApplicationStoreMockRecorder) UpdateDeployTargets(ctx, id, targets any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeployTargets", reflect.TypeOf((*MockApplicationStore)(nil).UpdateDeployTargets), ctx, id, targets)
+}
+
 // UpdateDeployingStatus mocks base method.
 func (m *MockApplicationStore) UpdateDeployingStatus(ctx context.Context, id string, deploying bool) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

When developing pipedv1, we have to use data with new fields, such as deploy target, or we have to patch pipedv1 temporarily to use the old field.
This PR implements the server side.

Follows #5476 

**Which issue(s) this PR fixes**:

Part of #4980
Part of #5252 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
