### PR TITLE
Add migrate command for database migration tasks

### DIFF
--- a/cmd/pipectl/main.go
+++ b/cmd/pipectl/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/encrypt"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/event"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/initialize"
+	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/migrate"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/piped"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/planpreview"
 	"github.com/pipe-cd/pipecd/pkg/cli"
@@ -41,6 +42,7 @@ func main() {
 		piped.NewCommand(),
 		encrypt.NewCommand(),
 		initialize.NewCommand(),
+		migrate.NewCommand(),
 	)
 
 	if err := app.Run(); err != nil {

--- a/pkg/app/pipectl/cmd/migrate/database.go
+++ b/pkg/app/pipectl/cmd/migrate/database.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
+	"github.com/pipe-cd/pipecd/pkg/cli"
+)
+
+type database struct {
+	root *command
+
+	applications []string
+}
+
+func newDatabaseCommand(root *command) *cobra.Command {
+	c := &database{
+		root: root,
+	}
+	cmd := &cobra.Command{
+		Use:   "database",
+		Short: "Do migration tasks for database.",
+		RunE:  cli.WithContext(c.run),
+	}
+
+	cmd.Flags().StringSliceVar(&c.applications, "applications", c.applications, "The list of application to migrate database.")
+	cmd.MarkFlagRequired("applications")
+	return cmd
+}
+
+func (c *database) run(ctx context.Context, input cli.Input) error {
+	client, err := c.root.clientOptions.NewClient(ctx)
+	if err != nil {
+		input.Logger.Error("failed to create client", zap.Error(err))
+		return err
+	}
+
+	for _, appID := range c.applications {
+		input.Logger.Info("migrating database", zap.String("application", appID))
+		if err := c.migrateApplication(ctx, client, appID); err != nil {
+			input.Logger.Error("failed to migrate database", zap.String("application", appID), zap.Error(err))
+			return err
+		}
+		input.Logger.Info("successfully migrated database", zap.String("application", appID))
+	}
+
+	return nil
+}
+
+func (c *database) migrateApplication(ctx context.Context, client apiservice.Client, appID string) error {
+	req := &apiservice.MigrateDatabaseRequest{
+		Target: &apiservice.MigrateDatabaseRequest_Application_{
+			Application: &apiservice.MigrateDatabaseRequest_Application{
+				ApplicationId: appID,
+			},
+		},
+	}
+	if _, err := client.MigrateDatabase(ctx, req); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/app/pipectl/cmd/migrate/database.go
+++ b/pkg/app/pipectl/cmd/migrate/database.go
@@ -37,6 +37,7 @@ func newDatabaseCommand(root *command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "database",
 		Short: "Do migration tasks for database.",
+		Long:  "Make existing applications compatible with plugin-architectured piped. Once you execute this command for an application, it can be deployed using plugin-architectured piped.",
 		RunE:  cli.WithContext(c.run),
 	}
 

--- a/pkg/app/pipectl/cmd/migrate/migrate.go
+++ b/pkg/app/pipectl/cmd/migrate/migrate.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipectl/client"
+)
+
+type command struct {
+	clientOptions *client.Options
+}
+
+func NewCommand() *cobra.Command {
+	c := &command{
+		clientOptions: &client.Options{},
+	}
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Do migration tasks.",
+	}
+
+	cmd.AddCommand(newDatabaseCommand(c))
+
+	c.clientOptions.RegisterPersistentFlags(cmd)
+
+	return cmd
+}


### PR DESCRIPTION
**What this PR does**:

as title

I tested with the dev control plane, and the output is below.

```
$ pipectl migrate database \
    --address=${PIPECD_HOST} \
    --api-key=${PIPECD_API_KEY} \
    --applications cbdf8d86-71b8-40d6-b7d6-c2e42d82fe33,28470795-1ef1-4629-b704-d7567f6ba972

migrating database      {"application": "cbdf8d86-71b8-40d6-b7d6-c2e42d82fe33"}
successfully migrated database  {"application": "cbdf8d86-71b8-40d6-b7d6-c2e42d82fe33"}
migrating database      {"application": "28470795-1ef1-4629-b704-d7567f6ba972"}
successfully migrated database  {"application": "28470795-1ef1-4629-b704-d7567f6ba972"}
```

**Why we need it**:

When developing pipedv1, we have to use data with new fields, such as deploy target, or we have to patch pipedv1 temporarily to use the old field.
This PR implements the server side.

Follows https://github.com/pipe-cd/pipecd/pull/5476
Follows https://github.com/pipe-cd/pipecd/pull/5497

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4980

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
