### PR TITLE
fix: remove error disableBackdropClick is deprecated

### DIFF
--- a/web/src/components/applications-page/add-application-drawer/index.tsx
+++ b/web/src/components/applications-page/add-application-drawer/index.tsx
@@ -69,8 +69,10 @@ export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
         <Drawer
           anchor="right"
           open={open}
-          onClose={handleClose}
-          ModalProps={{ disableBackdropClick: formik.isSubmitting }}
+          onClose={(_, reason) => {
+            if (reason === "backdropClick" && formik.isSubmitting) return;
+            handleClose();
+          }}
         >
           <ApplicationFormTabs
             {...formik}

--- a/web/src/components/applications-page/edit-application-drawer/index.tsx
+++ b/web/src/components/applications-page/edit-application-drawer/index.tsx
@@ -63,8 +63,10 @@ export const EditApplicationDrawer: FC<EditApplicationDrawerProps> = memo(
       <Drawer
         anchor="right"
         open={Boolean(app)}
-        onClose={handleClose}
-        ModalProps={{ disableBackdropClick: formik.isSubmitting }}
+        onClose={(_, reason) => {
+          if (reason === "backdropClick" && formik.isSubmitting) return;
+          handleClose();
+        }}
       >
         <ApplicationForm
           {...formik}

--- a/web/src/components/applications-page/index.tsx
+++ b/web/src/components/applications-page/index.tsx
@@ -179,8 +179,10 @@ export const ApplicationIndexPage: FC = () => {
       <Drawer
         anchor="right"
         open={!!addedApplicationId}
-        onClose={handleCloseApplicationAddedView}
-        ModalProps={{ disableBackdropClick: isAdding }}
+        onClose={(_, reason) => {
+          if (reason === "backdropClick" && isAdding) return;
+          handleCloseApplicationAddedView();
+        }}
       >
         <ApplicationAddedView onClose={handleCloseApplicationAddedView} />
       </Drawer>


### PR DESCRIPTION
**What this PR does**:
- remove error disableBackdropClick is deprecated
![CleanShot 2025-01-21 at 16 44 07](https://github.com/user-attachments/assets/5a6385ea-28f2-44c3-a5f0-bd1700a365b6)

**Why we need it**:
- Resolve error warning in web console and prevent unwanted behavior

**Which issue(s) this PR fixes**:
- none

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: none
