### PR TITLE
[WAIT] Implement server plan methods of Wait plugin

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -378,10 +378,11 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *deployment
 			p.logger.Warn("Unable to determine strategy using current plugin", zap.Error(err))
 			continue
 		}
-		strategy = res.SyncStrategy
-		if res.Summary != "" {
-			summary = res.Summary
+		if res.Unsupported {
+			continue
 		}
+		strategy = res.SyncStrategy
+		summary = res.Summary
 		// If one of plugins returns PIPELINE_SYNC, use that as strategy intermediately
 		if strategy == model.SyncStrategy_PIPELINE {
 			break

--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -379,7 +379,9 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *deployment
 			continue
 		}
 		strategy = res.SyncStrategy
-		summary = res.Summary
+		if res.Summary != "" {
+			summary = res.Summary
+		}
 		// If one of plugins returns PIPELINE_SYNC, use that as strategy intermediately
 		if strategy == model.SyncStrategy_PIPELINE {
 			break

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -87,8 +87,10 @@ func (s *deploymentServiceServer) FetchDefinedStages(ctx context.Context, reques
 
 // DetermineVersions implements deployment.DeploymentServiceServer.
 func (s *deploymentServiceServer) DetermineVersions(ctx context.Context, request *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
-	// TODO: Implement this func
-	return &deployment.DetermineVersionsResponse{}, nil
+	// Wait Stage does not have any versioned resources.
+	return &deployment.DetermineVersionsResponse{
+		Versions: []*model.ArtifactVersion{},
+	}, nil
 }
 
 // DetermineStrategy implements deployment.DeploymentServiceServer.

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -95,11 +95,7 @@ func (s *deploymentServiceServer) DetermineVersions(ctx context.Context, request
 
 // DetermineStrategy implements deployment.DeploymentServiceServer.
 func (s *deploymentServiceServer) DetermineStrategy(ctx context.Context, request *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
-	// Delegate other plugins to determine strategy and summary.
-	return &deployment.DetermineStrategyResponse{
-		SyncStrategy: model.SyncStrategy_QUICK_SYNC,
-		Summary:      "",
-	}, nil
+	return &deployment.DetermineStrategyResponse{Unsupported: true}, nil
 }
 
 // BuildPipelineSyncStages implements deployment.BuildPipelineSyncStages.

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -93,8 +93,11 @@ func (s *deploymentServiceServer) DetermineVersions(ctx context.Context, request
 
 // DetermineStrategy implements deployment.DeploymentServiceServer.
 func (s *deploymentServiceServer) DetermineStrategy(ctx context.Context, request *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
-	// TODO: Implement this func
-	return &deployment.DetermineStrategyResponse{}, nil
+	// Delegate other plugins to determine strategy and summary.
+	return &deployment.DetermineStrategyResponse{
+		SyncStrategy: model.SyncStrategy_QUICK_SYNC,
+		Summary:      "",
+	}, nil
 }
 
 // BuildPipelineSyncStages implements deployment.BuildPipelineSyncStages.

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -29,6 +29,12 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/signalhandler"
 )
 
+type Stage string
+
+const (
+	stageWait Stage = "WAIT"
+)
+
 type deploymentServiceServer struct {
 	deployment.UnimplementedDeploymentServiceServer
 

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -125,7 +125,7 @@ func (s *deploymentServiceServer) BuildPipelineSyncStages(ctx context.Context, r
 // BuildQuickSyncStages implements deployment.BuildQuickSyncStages.
 func (s *deploymentServiceServer) BuildQuickSyncStages(ctx context.Context, request *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
 	return &deployment.BuildQuickSyncStagesResponse{
-		Stages: []*model.PipelineStage{newWaitStage()},
+		Stages: []*model.PipelineStage{},
 	}, nil
 }
 

--- a/pkg/app/pipedv1/plugin/wait/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server.go
@@ -108,12 +108,12 @@ func (s *deploymentServiceServer) DetermineStrategy(ctx context.Context, request
 func (s *deploymentServiceServer) BuildPipelineSyncStages(ctx context.Context, request *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
 	stages := make([]*model.PipelineStage, 0, len(request.GetStages()))
 	for _, stage := range request.GetStages() {
+		waitStage := newWaitStage()
+
 		id := stage.GetId()
 		if id == "" {
 			id = fmt.Sprintf("stage-%d", stage.GetIndex())
 		}
-
-		waitStage := newWaitStage()
 		waitStage.Id = id
 		waitStage.Index = stage.GetIndex()
 		stages = append(stages, waitStage)

--- a/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetchDefinedStages(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
@@ -56,15 +56,7 @@ func TestBuildQuickSyncStages(t *testing.T) {
 	t.Parallel()
 
 	expected := &deployment.BuildQuickSyncStagesResponse{
-		Stages: []*model.PipelineStage{
-			{
-				Id:       "WAIT",
-				Name:     "WAIT",
-				Desc:     "Wait for the specified duration",
-				Rollback: false,
-				Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
-			},
-		},
+		Stages: []*model.PipelineStage{},
 	}
 
 	server := NewDeploymentService(nil, zap.NewNop(), nil)
@@ -73,17 +65,6 @@ func TestBuildQuickSyncStages(t *testing.T) {
 		Rollback: false,
 	})
 	assert.NoError(t, err)
-	resp.Stages[0].CreatedAt = 0 // Ignore timestamps
-	resp.Stages[0].UpdatedAt = 0
-	assert.Equal(t, resp, expected)
-
-	// The response will be the same even if Rollback is true.
-	resp, err = server.BuildQuickSyncStages(context.Background(), &deployment.BuildQuickSyncStagesRequest{
-		Rollback: true,
-	})
-	assert.NoError(t, err)
-	resp.Stages[0].CreatedAt = 0 // Ignore timestamps
-	resp.Stages[0].UpdatedAt = 0
 	assert.Equal(t, resp, expected)
 }
 

--- a/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestFetchDefinedStages(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/server_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestFetchDefinedStages(t *testing.T) {
+	t.Parallel()
+
+	server := NewDeploymentService(nil, zap.NewNop(), nil)
+	resp, err := server.FetchDefinedStages(context.Background(), &deployment.FetchDefinedStagesRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Stages, []string{"WAIT"})
+}
+
+func TestDetermineVersions(t *testing.T) {
+	t.Parallel()
+
+	server := NewDeploymentService(nil, zap.NewNop(), nil)
+	resp, err := server.DetermineVersions(context.Background(), &deployment.DetermineVersionsRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Versions, []*model.ArtifactVersion{}) // Empty
+}
+
+func TestDetermineStrategy(t *testing.T) {
+	t.Parallel()
+
+	server := NewDeploymentService(nil, zap.NewNop(), nil)
+	resp, err := server.DetermineStrategy(context.Background(), &deployment.DetermineStrategyRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Unsupported, true)
+}
+
+func TestBuildQuickSyncStages(t *testing.T) {
+	t.Parallel()
+
+	expected := &deployment.BuildQuickSyncStagesResponse{
+		Stages: []*model.PipelineStage{
+			{
+				Id:       "WAIT",
+				Name:     "WAIT",
+				Desc:     "Wait for the specified duration",
+				Rollback: false,
+				Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
+			},
+		},
+	}
+
+	server := NewDeploymentService(nil, zap.NewNop(), nil)
+
+	resp, err := server.BuildQuickSyncStages(context.Background(), &deployment.BuildQuickSyncStagesRequest{
+		Rollback: false,
+	})
+	assert.NoError(t, err)
+	resp.Stages[0].CreatedAt = 0 // Ignore timestamps
+	resp.Stages[0].UpdatedAt = 0
+	assert.Equal(t, resp, expected)
+
+	// The response will be the same even if Rollback is true.
+	resp, err = server.BuildQuickSyncStages(context.Background(), &deployment.BuildQuickSyncStagesRequest{
+		Rollback: true,
+	})
+	assert.NoError(t, err)
+	resp.Stages[0].CreatedAt = 0 // Ignore timestamps
+	resp.Stages[0].UpdatedAt = 0
+	assert.Equal(t, resp, expected)
+}
+
+func TestBuildPipelineSyncStages(t *testing.T) {
+	t.Parallel()
+
+	req := &deployment.BuildPipelineSyncStagesRequest{
+		Stages: []*deployment.BuildPipelineSyncStagesRequest_StageConfig{
+			{
+				// ID is empty.
+				Name:  "WAIT",
+				Index: 0,
+			},
+			{
+				Id:    "stage-2",
+				Name:  "WAIT",
+				Index: 2,
+			},
+		},
+		Rollback: true,
+	}
+
+	expected := &deployment.BuildPipelineSyncStagesResponse{
+		Stages: []*model.PipelineStage{
+			{
+				Id:       "stage-0",
+				Name:     "WAIT",
+				Desc:     "Wait for the specified duration",
+				Index:    0,
+				Rollback: false,
+				Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
+			},
+			{
+				Id:       "stage-2",
+				Name:     "WAIT",
+				Desc:     "Wait for the specified duration",
+				Index:    2,
+				Rollback: false,
+				Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
+			},
+		},
+	}
+
+	server := NewDeploymentService(nil, zap.NewNop(), nil)
+	resp, err := server.BuildPipelineSyncStages(context.Background(), req)
+	assert.NoError(t, err)
+	resp.Stages[0].CreatedAt = 0 // Ignore timestamps
+	resp.Stages[0].UpdatedAt = 0
+	resp.Stages[1].CreatedAt = 0
+	resp.Stages[1].UpdatedAt = 0
+	assert.Equal(t, resp, expected)
+}

--- a/pkg/app/pipedv1/plugin/wait/deployment/wait.go
+++ b/pkg/app/pipedv1/plugin/wait/deployment/wait.go
@@ -24,12 +24,9 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 )
 
-type Stage string
-
 const (
-	logInterval        = 10 * time.Second
-	startTimeKey       = "startTime"
-	stageWait    Stage = "WAIT"
+	logInterval  = 10 * time.Second
+	startTimeKey = "startTime"
 )
 
 // Execute starts waiting for the specified duration.


### PR DESCRIPTION
**What this PR does**:

Implemented the following methods:

- DetermineVersions()
- DetermineStrategy()
- BuildQuickSyncStages()
- BuildPipelineSyncStages()

**Why we need it**:

to plan wait stages

**Note**

[IMO] It'd be better to set values of the following variables of BuildQuick(or Pipeline)SyncStagesResponse on piped planner side:

- `Status`
- `CreatedAt`
- `UpdatedAt`

That's because plugins should not set wrong values and they're not related to plugin behavior.


**Which issue(s) this PR fixes**:

Part of #5367

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**: