### PR TITLE
nit: Remove old 'planner' comments

### DIFF
--- a/pkg/plugin/api/v1alpha1/client.go
+++ b/pkg/plugin/api/v1alpha1/client.go
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package planner provides a piped component
-// that decides the deployment pipeline of a deployment.
-// The planner bases on the changes from git commits
-// then builds the deployment manifests to know the behavior of the deployment.
-// From that behavior the planner can decides which pipeline should be applied.
 package pluginapi
 
 import (

--- a/pkg/plugin/pipedapi/client.go
+++ b/pkg/plugin/pipedapi/client.go
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package planner provides a piped component
-// that decides the deployment pipeline of a deployment.
-// The planner bases on the changes from git commits
-// then builds the deployment manifests to know the behavior of the deployment.
-// From that behavior the planner can decides which pipeline should be applied.
-
 package pipedapi
 
 import (

--- a/pkg/plugin/signalhandler/handler.go
+++ b/pkg/plugin/signalhandler/handler.go
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package planner provides a piped component
-// that decides the deployment pipeline of a deployment.
-// The planner bases on the changes from git commits
-// then builds the deployment manifests to know the behavior of the deployment.
-// From that behavior the planner can decides which pipeline should be applied.
-
 package signalhandler
 
 import (


### PR DESCRIPTION
**What this PR does**:

Removed `Package planner provides a piped component...` comments from pkg/plugin/.* files.

**Why we need it**:

They are not planner packages. (migrated from planner)

**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
