### PR TITLE
Fix docs:  remote config other than Git is already available

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/remote-upgrade-remote-config.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/remote-upgrade-remote-config.md
@@ -30,7 +30,7 @@ Although the remote-upgrade allows you remotely restart your Pipeds to run any n
 
 Remote-config is the ability to load Piped config data from a remote location such as a Git repository. Not only that, but it also watches the config periodically to detect any changes on that config and restarts Piped to reflect the new configuration automatically.
 
-This feature requires the remote-upgrade feature to be enabled simultaneously. Currently, we only support remote config from a Git repository, but other remote locations could be supported in the future. Please check the [installation](../../../installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
+This feature requires the remote-upgrade feature to be enabled simultaneously. Please check [Runtime Options](runtime-options.md) and the [installation](../../../installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
 
 
 ## Summary

--- a/docs/content/en/docs-v0.50.x/user-guide/managing-piped/remote-upgrade-remote-config.md
+++ b/docs/content/en/docs-v0.50.x/user-guide/managing-piped/remote-upgrade-remote-config.md
@@ -30,7 +30,7 @@ Although the remote-upgrade allows you remotely restart your Pipeds to run any n
 
 Remote-config is the ability to load Piped config data from a remote location such as a Git repository. Not only that, but it also watches the config periodically to detect any changes on that config and restarts Piped to reflect the new configuration automatically.
 
-This feature requires the remote-upgrade feature to be enabled simultaneously. Currently, we only support remote config from a Git repository, but other remote locations could be supported in the future. Please check the [installation](../../../installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
+This feature requires the remote-upgrade feature to be enabled simultaneously. Please check [Runtime Options](runtime-options.md) and the [installation](../../../installation/install-piped/) guide on each environment to know how to configure Piped to load a remote config file.
 
 
 ## Summary


### PR DESCRIPTION
**What this PR does**:

Remove the following sentence.

> Currently, we only support remote config from a Git repository, but other remote locations could be supported in the future. Please check

And added the link to RuntimeOptions.

**Why we need it**:

Remote config other than Git repo is already available.

(e.g. GCP Secret Manager, AWS Secrets Manager, AWS SSM Parameter Store.)

Available locations are described on the RuntimeOptions page.

https://pipecd.dev/docs-v0.50.x/user-guide/managing-piped/runtime-options/#options-for-launcher


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
