### PR TITLE
[k8s plugin] Prepare for implementing livestate apis

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
@@ -44,6 +44,7 @@ func GetLiveResources(ctx context.Context, kubectl *Kubectl, kubeconfig string, 
 	return namespacedLiveResources, clusterScopedLiveResources, nil
 }
 
+// BuildApplicationLiveState builds the live state of the application from the given manifests.
 func BuildApplicationLiveState(deploytarget string, manifests []Manifest, now time.Time) *model.ApplicationLiveState {
 	states := make([]*model.ResourceState, 0, len(manifests))
 	for _, m := range manifests {
@@ -56,6 +57,7 @@ func BuildApplicationLiveState(deploytarget string, manifests []Manifest, now ti
 	}
 }
 
+// buildResourceState builds the resource state from the given manifest.
 func buildResourceState(m Manifest, now time.Time) *model.ResourceState {
 	parents := make([]string, 0, len(m.body.GetOwnerReferences()))
 	for _, o := range m.body.GetOwnerReferences() {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetLiveResources returns all live resources that belong to the given application.
+func GetLiveResources(ctx context.Context, kubectl *Kubectl, kubeconfig string, appID string, selector ...string) (namespaceScoped []Manifest, clusterScoped []Manifest, _ error) {
+	namespacedLiveResources, err := kubectl.GetAll(ctx, kubeconfig,
+		"",
+		fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByPiped),
+		fmt.Sprintf("%s=%s", LabelApplication, appID),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed while listing all namespace-scoped resources (%v)", err)
+	}
+
+	clusterScopedLiveResources, err := kubectl.GetAllClusterScoped(ctx, kubeconfig,
+		fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByPiped),
+		fmt.Sprintf("%s=%s", LabelApplication, appID),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed while listing all cluster-scoped resources (%v)", err)
+	}
+
+	return namespacedLiveResources, clusterScopedLiveResources, nil
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources.go
@@ -17,6 +17,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 // GetLiveResources returns all live resources that belong to the given application.
@@ -39,4 +42,39 @@ func GetLiveResources(ctx context.Context, kubectl *Kubectl, kubeconfig string, 
 	}
 
 	return namespacedLiveResources, clusterScopedLiveResources, nil
+}
+
+func BuildApplicationLiveState(deploytarget string, manifests []Manifest, now time.Time) *model.ApplicationLiveState {
+	states := make([]*model.ResourceState, 0, len(manifests))
+	for _, m := range manifests {
+		states = append(states, buildResourceState(m, now))
+	}
+
+	return &model.ApplicationLiveState{
+		Resources:    states,
+		HealthStatus: model.ApplicationLiveState_UNKNOWN, // TODO: Implement health status calculation
+	}
+}
+
+func buildResourceState(m Manifest, now time.Time) *model.ResourceState {
+	parents := make([]string, 0, len(m.body.GetOwnerReferences()))
+	for _, o := range m.body.GetOwnerReferences() {
+		parents = append(parents, string(o.UID))
+	}
+
+	return &model.ResourceState{
+		Id:                string(m.body.GetUID()),
+		Name:              m.body.GetName(),
+		ParentIds:         parents,
+		HealthStatus:      model.ResourceState_UNKNOWN, // TODO: Implement health status calculation
+		HealthDescription: "",                          // TODO: Implement health status calculation
+		ResourceType:      m.body.GetKind(),
+		ResourceMetadata: map[string]string{
+			"Namespace":   m.body.GetNamespace(),
+			"API Version": m.body.GetAPIVersion(),
+			"Kind":        m.body.GetKind(),
+		},
+		CreatedAt: m.body.GetCreationTimestamp().Unix(),
+		UpdatedAt: now.Unix(),
+	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 func TestBuildApplicationLiveState(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/liveresources_test.go
@@ -1,0 +1,194 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestBuildApplicationLiveState(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		manifests []Manifest
+		want      *model.ApplicationLiveState
+	}{
+		{
+			name: "single pod",
+			manifests: []Manifest{
+				{
+					body: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod",
+								"namespace":         "default",
+								"uid":               "test-uid",
+								"creationTimestamp": now.Format(time.RFC3339),
+							},
+						},
+					},
+				},
+			},
+			want: &model.ApplicationLiveState{
+				Resources: []*model.ResourceState{
+					{
+						Id:           "test-uid",
+						Name:         "test-pod",
+						ResourceType: "Pod",
+						ResourceMetadata: map[string]string{
+							"Namespace":   "default",
+							"API Version": "v1",
+							"Kind":        "Pod",
+						},
+						CreatedAt: now.Unix(),
+						UpdatedAt: now.Unix(),
+					},
+				},
+				HealthStatus: model.ApplicationLiveState_UNKNOWN,
+			},
+		},
+		{
+			name: "single pod with owner references",
+			manifests: []Manifest{
+				{
+					body: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod",
+								"namespace":         "default",
+								"uid":               "test-uid",
+								"creationTimestamp": now.Format(time.RFC3339),
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"uid": "owner-uid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &model.ApplicationLiveState{
+				Resources: []*model.ResourceState{
+					{
+						Id:           "test-uid",
+						Name:         "test-pod",
+						ResourceType: "Pod",
+						ResourceMetadata: map[string]string{
+							"Namespace":   "default",
+							"API Version": "v1",
+							"Kind":        "Pod",
+						},
+						ParentIds: []string{"owner-uid"},
+						CreatedAt: now.Unix(),
+						UpdatedAt: now.Unix(),
+					},
+				},
+				HealthStatus: model.ApplicationLiveState_UNKNOWN,
+			},
+		},
+		{
+			name: "multiple resources with owner references",
+			manifests: []Manifest{
+				{
+					body: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod-1",
+								"namespace":         "default",
+								"uid":               "test-uid-1",
+								"creationTimestamp": now.Format(time.RFC3339),
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"uid": "owner-uid-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					body: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Service",
+							"metadata": map[string]interface{}{
+								"name":              "test-service",
+								"namespace":         "default",
+								"uid":               "test-uid-2",
+								"creationTimestamp": now.Format(time.RFC3339),
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"uid": "owner-uid-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &model.ApplicationLiveState{
+				Resources: []*model.ResourceState{
+					{
+						Id:           "test-uid-1",
+						Name:         "test-pod-1",
+						ResourceType: "Pod",
+						ResourceMetadata: map[string]string{
+							"Namespace":   "default",
+							"API Version": "v1",
+							"Kind":        "Pod",
+						},
+						ParentIds: []string{"owner-uid-1"},
+						CreatedAt: now.Unix(),
+						UpdatedAt: now.Unix(),
+					},
+					{
+						Id:           "test-uid-2",
+						Name:         "test-service",
+						ResourceType: "Service",
+						ResourceMetadata: map[string]string{
+							"Namespace":   "default",
+							"API Version": "v1",
+							"Kind":        "Service",
+						},
+						ParentIds: []string{"owner-uid-2"},
+						CreatedAt: now.Unix(),
+						UpdatedAt: now.Unix(),
+					},
+				},
+				HealthStatus: model.ApplicationLiveState_UNKNOWN,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildApplicationLiveState("test-deploytarget", tt.manifests, now)
+			assert.Equal(t, tt.want, got, "expected live state to be equal to the expected one")
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

- [refactor] Implement `GetLiveResources` in the provider package and use it from the deployment package
- [feature] initial implementation of `BuildApplicationLiveState` to implement the livestate feature

**Why we need it**:

To implement the livestate API for plugin-architectured piped.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
