### PR TITLE
Correct notification routing for `DEPLOYMENT_STARTED`

### DIFF
--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -152,6 +152,14 @@ func TestMatch(t *testing.T) {
 					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
 					Metadata: &model.NotificationEventDeploymentStarted{
 						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
+					Metadata: &model.NotificationEventDeploymentStarted{
+						Deployment: &model.Deployment{
 							ApplicationName: "canary",
 						},
 					},

--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -148,6 +148,14 @@ func TestMatch(t *testing.T) {
 						},
 					},
 				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
+					Metadata: &model.NotificationEventDeploymentStarted{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
 			},
 		},
 		{
@@ -254,6 +262,28 @@ func TestMatch(t *testing.T) {
 					Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
 					Metadata: &model.NotificationEventDeploymentTriggerFailed{
 						Application: &model.Application{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
+					Metadata: &model.NotificationEventDeploymentStarted{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
+					Metadata: &model.NotificationEventDeploymentStarted{
+						Deployment: &model.Deployment{
 							Labels: map[string]string{
 								"env":  "dev",
 								"team": "pipecd",

--- a/pkg/model/notificationevent.go
+++ b/pkg/model/notificationevent.go
@@ -108,6 +108,14 @@ func (e *NotificationEventDeploymentTriggerFailed) GetLabels() map[string]string
 	return e.Application.Labels
 }
 
+func (e *NotificationEventDeploymentStarted) GetAppName() string {
+	return e.Deployment.ApplicationName
+}
+
+func (e *NotificationEventDeploymentStarted) GetLabels() map[string]string {
+	return e.Deployment.Labels
+}
+
 func (e *NotificationEventApplicationSynced) GetAppName() string {
 	return e.Application.Name
 }


### PR DESCRIPTION
**What this PR does**:

This fixes the issue the `DEPLOYMENT_STARTED` event notification is routed unconditionally.

**Why we need it**:

Without this, users would receive that event notification even if they don't want.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**: Users can control the notification correctly.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
