### PR TITLE
Correct notification route handling for stage events

### DIFF
--- a/pkg/app/piped/notifier/matcher_test.go
+++ b/pkg/app/piped/notifier/matcher_test.go
@@ -164,6 +164,86 @@ func TestMatch(t *testing.T) {
 						},
 					},
 				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_STARTED,
+					Metadata: &model.NotificationEventStageStarted{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_STARTED,
+					Metadata: &model.NotificationEventStageStarted{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SKIPPED,
+					Metadata: &model.NotificationEventStageSkipped{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SKIPPED,
+					Metadata: &model.NotificationEventStageSkipped{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SUCCEEDED,
+					Metadata: &model.NotificationEventStageSucceeded{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SUCCEEDED,
+					Metadata: &model.NotificationEventStageSucceeded{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_FAILED,
+					Metadata: &model.NotificationEventStageFailed{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_FAILED,
+					Metadata: &model.NotificationEventStageFailed{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_CANCELLED,
+					Metadata: &model.NotificationEventStageCancelled{
+						Deployment: &model.Deployment{
+							ApplicationName: "canary",
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_CANCELLED,
+					Metadata: &model.NotificationEventStageCancelled{
+						Deployment: &model.Deployment{
+							ApplicationName: "bluegreen",
+						},
+					},
+				}: false,
 			},
 		},
 		{
@@ -291,6 +371,116 @@ func TestMatch(t *testing.T) {
 				{
 					Type: model.NotificationEventType_EVENT_DEPLOYMENT_STARTED,
 					Metadata: &model.NotificationEventDeploymentStarted{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_STARTED,
+					Metadata: &model.NotificationEventStageStarted{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_STARTED,
+					Metadata: &model.NotificationEventStageStarted{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SKIPPED,
+					Metadata: &model.NotificationEventStageSkipped{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SKIPPED,
+					Metadata: &model.NotificationEventStageSkipped{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SUCCEEDED,
+					Metadata: &model.NotificationEventStageSucceeded{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_SUCCEEDED,
+					Metadata: &model.NotificationEventStageSucceeded{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_FAILED,
+					Metadata: &model.NotificationEventStageFailed{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_FAILED,
+					Metadata: &model.NotificationEventStageFailed{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "dev",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: true,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_CANCELLED,
+					Metadata: &model.NotificationEventStageCancelled{
+						Deployment: &model.Deployment{
+							Labels: map[string]string{
+								"env":  "stg",
+								"team": "pipecd",
+							},
+						},
+					},
+				}: false,
+				{
+					Type: model.NotificationEventType_EVENT_STAGE_CANCELLED,
+					Metadata: &model.NotificationEventStageCancelled{
 						Deployment: &model.Deployment{
 							Labels: map[string]string{
 								"env":  "dev",

--- a/pkg/model/notificationevent.go
+++ b/pkg/model/notificationevent.go
@@ -131,3 +131,43 @@ func (e *NotificationEventApplicationOutOfSync) GetAppName() string {
 func (e *NotificationEventApplicationOutOfSync) GetLabels() map[string]string {
 	return e.Application.Labels
 }
+
+func (e *NotificationEventStageStarted) GetAppName() string {
+	return e.GetDeployment().GetApplicationName()
+}
+
+func (e *NotificationEventStageStarted) GetLabels() map[string]string {
+	return e.GetDeployment().GetLabels()
+}
+
+func (e *NotificationEventStageSkipped) GetAppName() string {
+	return e.GetDeployment().GetApplicationName()
+}
+
+func (e *NotificationEventStageSkipped) GetLabels() map[string]string {
+	return e.GetDeployment().GetLabels()
+}
+
+func (e *NotificationEventStageSucceeded) GetAppName() string {
+	return e.GetDeployment().GetApplicationName()
+}
+
+func (e *NotificationEventStageSucceeded) GetLabels() map[string]string {
+	return e.GetDeployment().GetLabels()
+}
+
+func (e *NotificationEventStageFailed) GetAppName() string {
+	return e.GetDeployment().GetApplicationName()
+}
+
+func (e *NotificationEventStageFailed) GetLabels() map[string]string {
+	return e.GetDeployment().GetLabels()
+}
+
+func (e *NotificationEventStageCancelled) GetAppName() string {
+	return e.GetDeployment().GetApplicationName()
+}
+
+func (e *NotificationEventStageCancelled) GetLabels() map[string]string {
+	return e.GetDeployment().GetLabels()
+}


### PR DESCRIPTION
**What this PR does**:

This PR corrects notification route handling for stage execution events.

Follows #5440
Related to #5523

**Why we need it**:

Without this PR, users cannot control notifications for stage execution events.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No, because the feature for stage execution events has not been released yet.

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
