### PR TITLE
[docs] Fix links to analysisProvider config pages

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.49.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.49.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 

--- a/docs/content/en/docs-v0.50.x/user-guide/managing-piped/adding-an-analysis-provider.md
+++ b/docs/content/en/docs-v0.50.x/user-guide/managing-piped/adding-an-analysis-provider.md
@@ -28,7 +28,7 @@ spec:
       config:
         address: https://your-prometheus.dev
 ```
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderprometheusconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 Piped queries the [MetricsApi.QueryMetrics](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) endpoint to obtain metrics used to evaluate the deployment.
@@ -45,7 +45,7 @@ spec:
         applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-The full list of configurable fields are [here](../configuration-reference/#analysisproviderdatadogconfig).
+The full list of configurable fields are [here](configuration-reference/#analysisproviderdatadogconfig).
 
 If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

The current links to analysisProvider config are invalid since the directory is wrong.


Now (wrong): 
https://pipecd.dev/docs-v0.50.x/user-guide/configuration-reference/

Correct: 
https://pipecd.dev/docs-v0.50.x/user-guide/managing-piped/configuration-reference/#analysisproviderprometheusconfig


**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
