### PR TITLE
Prepare Plugin SDK

### DIFF
--- a/pkg/plugin/pipedsdk/client.go
+++ b/pkg/plugin/pipedsdk/client.go
@@ -20,5 +20,14 @@ import "github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
 // It provides methods to call the piped service APIs.
 // It's a wrapper around the raw piped service client.
 type Client struct {
-	raw pipedapi.PipedServiceClient
+	base *pipedapi.PipedServiceClient
+
+	// applicationID is used to identify the application that the client is working with.
+	applicationID string
+	// deploymentID is used to identify the deployment that the client is working with.
+	// This field exists only when the client is working with a specific deployment; for example, when this client is passed as the deployoment plugin's argument.
+	deploymentID string
+	// stageID is used to identify the stage that the client is working with.
+	// This field exists only when the client is working with a specific stage; for example, when this client is passed as the ExecuteStage method's argument.
+	stageID string
 }

--- a/pkg/plugin/pipedsdk/client.go
+++ b/pkg/plugin/pipedsdk/client.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/plugin/pipedsdk/client.go
+++ b/pkg/plugin/pipedsdk/client.go
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package pipedsdk provides software development kits for building PipeCD piped plugins.
 package pipedsdk
 
-// TODO is a placeholder for the real type.
-// This type will be replaced by the real type when implementing the sdk.
-type TODO struct{}
+import "github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
 
-// Run runs the registered plugins.
-// It will listen the gRPC server and handle all requests from piped.
-func Run() error {
-	panic("implement me")
+// Client is a toolkit for interacting with the piped service.
+// It provides methods to call the piped service APIs.
+// It's a wrapper around the raw piped service client.
+type Client struct {
+	raw pipedapi.PipedServiceClient
 }

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -17,12 +17,13 @@ package pipedsdk
 import (
 	"context"
 
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -81,10 +82,10 @@ type logPersister interface {
 }
 
 type commonFields struct {
-	config *config.PipedPlugin
-	logger *zap.Logger
+	config       *config.PipedPlugin
+	logger       *zap.Logger
 	logPersister logPersister
-	client *pipedapi.PipedServiceClient
+	client       *pipedapi.PipedServiceClient
 }
 
 // DeploymentPluginServiceServer is the gRPC server that handles requests from the piped.

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -52,7 +52,7 @@ type DeploymentPlugin[Config any] interface {
 	BuildQuickSyncStages(context.Context, *Config, *Client, TODO) (TODO, error)
 }
 
-// PipelineSyncPlugin is the interface that be implemented by a pipeline sync plugin.
+// PipelineSyncPlugin is the interface implemented by a pipeline sync plugin.
 // This kind of plugin may not implement quick sync stages, and will not manage resources like deployment plugin.
 // It only focuses on executing stages which is generic for all kinds of pipeline sync plugins.
 type PipelineSyncPlugin[Config any] interface {

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipedsdk
+
+import (
+	"context"
+
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
+	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"google.golang.org/grpc"
+)
+
+var (
+	deploymentServiceServer interface {
+		Register(server *grpc.Server)
+		deployment.DeploymentServiceServer
+	}
+)
+
+// DeploymentPlugin is the interface that be implemented by a full-spec deployment plugin.
+// This kind of plugin should implement all methods to manage resources and execute stages.
+type DeploymentPlugin[Config any] interface {
+	PipelineSyncPlugin[Config]
+
+	// DetermineVersions determines the versions of the resources that will be deployed.
+	DetermineVersions(context.Context, Config, Client, TODO) (TODO, error)
+	// DetermineStrategy determines the strategy to deploy the resources.
+	DetermineStrategy(context.Context, Config, Client, TODO) (TODO, error)
+	// BuildQuickSyncStages builds the stages that will be executed during the quick sync process.
+	BuildQuickSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+}
+
+// PipelineSyncPlugin is the interface that be implemented by a pipeline sync plugin.
+// This kind of plugin may not implement quick sync stages, and will not manage resources like deployment plugin.
+// It only focuses on executing stages which is generic for all kinds of pipeline sync plugins.
+type PipelineSyncPlugin[Config any] interface {
+	// Name returns the name of the plugin.
+	Name() string
+	// FetchDefinedStages returns the list of stages that the plugin can execute.
+	FetchDefinedStages() []string
+	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
+	BuildPipelineSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+	// ExecuteStage executes the given stage.
+	ExecuteStage(context.Context, Config, Client, TODO) (TODO, error)
+}
+
+// RegisterDeploymentPlugin registers the given deployment plugin.
+// It will be used when running the piped.
+func RegisterDeploymentPlugin[Config any](plugin DeploymentPlugin[Config]) {
+	deploymentServiceServer = &DeploymentPluginServiceServer[Config]{base: plugin}
+}
+
+// RegisterPipelineSyncPlugin registers the given pipeline sync plugin.
+// It will be used when running the piped.
+func RegisterPipelineSyncPlugin[Config any](plugin PipelineSyncPlugin[Config]) {
+	deploymentServiceServer = &PipelineSyncPluginServiceServer[Config]{base: plugin}
+}
+
+// DeploymentPluginServiceServer is the gRPC server that handles requests from the piped.
+type DeploymentPluginServiceServer[Config any] struct {
+	deployment.UnimplementedDeploymentServiceServer
+
+	base DeploymentPlugin[Config]
+	config *config.PipedPlugin
+	logPersister logpersister.Persister
+	client pipedapi.PipedServiceClient
+}
+
+// Register registers the server to the given gRPC server.
+func (s *DeploymentPluginServiceServer[Config]) Register(server *grpc.Server) {
+	deployment.RegisterDeploymentServiceServer(server, s)
+}
+
+// PipelineSyncPluginServiceServer is the gRPC server that handles requests from the piped.
+type PipelineSyncPluginServiceServer[Config any] struct {
+	deployment.UnimplementedDeploymentServiceServer
+
+	base PipelineSyncPlugin[Config]
+	config *config.PipedPlugin
+	logPersister logpersister.Persister
+	client pipedapi.PipedServiceClient
+}
+
+// Register registers the server to the given gRPC server.
+func (s *PipelineSyncPluginServiceServer[Config]) Register(server *grpc.Server) {
+	deployment.RegisterDeploymentServiceServer(server, s)
+}

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -40,6 +40,7 @@ var (
 
 // DeploymentPlugin is the interface that be implemented by a full-spec deployment plugin.
 // This kind of plugin should implement all methods to manage resources and execute stages.
+// The Config parameter is the plugin's config defined in piped's config.
 type DeploymentPlugin[Config any] interface {
 	PipelineSyncPlugin[Config]
 

--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -19,6 +19,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
@@ -42,27 +44,25 @@ type DeploymentPlugin[Config any] interface {
 	PipelineSyncPlugin[Config]
 
 	// DetermineVersions determines the versions of the resources that will be deployed.
-	DetermineVersions(context.Context, Config, Client, TODO) (TODO, error)
+	DetermineVersions(context.Context, *Config, *Client, TODO) (TODO, error)
 	// DetermineStrategy determines the strategy to deploy the resources.
-	DetermineStrategy(context.Context, Config, Client, TODO) (TODO, error)
+	DetermineStrategy(context.Context, *Config, *Client, TODO) (TODO, error)
 	// BuildQuickSyncStages builds the stages that will be executed during the quick sync process.
-	BuildQuickSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+	BuildQuickSyncStages(context.Context, *Config, *Client, TODO) (TODO, error)
 }
 
 // PipelineSyncPlugin is the interface that be implemented by a pipeline sync plugin.
 // This kind of plugin may not implement quick sync stages, and will not manage resources like deployment plugin.
 // It only focuses on executing stages which is generic for all kinds of pipeline sync plugins.
 type PipelineSyncPlugin[Config any] interface {
-	// Name returns the name of the plugin.
-	Name() string
-	// Version returns the version of the plugin.
-	Version() string
+	Plugin
+
 	// FetchDefinedStages returns the list of stages that the plugin can execute.
 	FetchDefinedStages() []string
 	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
-	BuildPipelineSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+	BuildPipelineSyncStages(context.Context, *Config, *Client, TODO) (TODO, error)
 	// ExecuteStage executes the given stage.
-	ExecuteStage(context.Context, Config, Client, TODO) (TODO, error)
+	ExecuteStage(context.Context, *Config, *Client, logpersister.StageLogPersister, TODO) (TODO, error)
 }
 
 // RegisterDeploymentPlugin registers the given deployment plugin.
@@ -114,6 +114,25 @@ func (s *DeploymentPluginServiceServer[Config]) setCommonFields(fields commonFie
 	s.commonFields = fields
 }
 
+func (s *DeploymentPluginServiceServer[Config]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
+	return &deployment.FetchDefinedStagesResponse{Stages: s.base.FetchDefinedStages()}, nil
+}
+func (s *DeploymentPluginServiceServer[Config]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DetermineVersions not implemented")
+}
+func (s *DeploymentPluginServiceServer[Config]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DetermineStrategy not implemented")
+}
+func (s *DeploymentPluginServiceServer[Config]) BuildPipelineSyncStages(context.Context, *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BuildPipelineSyncStages not implemented")
+}
+func (s *DeploymentPluginServiceServer[Config]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
+}
+func (s *DeploymentPluginServiceServer[Config]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ExecuteStage not implemented")
+}
+
 // PipelineSyncPluginServiceServer is the gRPC server that handles requests from the piped.
 type PipelineSyncPluginServiceServer[Config any] struct {
 	deployment.UnimplementedDeploymentServiceServer
@@ -139,4 +158,23 @@ func (s *PipelineSyncPluginServiceServer[Config]) Register(server *grpc.Server) 
 
 func (s *PipelineSyncPluginServiceServer[Config]) setCommonFields(fields commonFields) {
 	s.commonFields = fields
+}
+
+func (s *PipelineSyncPluginServiceServer[Config]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
+	return &deployment.FetchDefinedStagesResponse{Stages: s.base.FetchDefinedStages()}, nil
+}
+func (s *PipelineSyncPluginServiceServer[Config]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DetermineVersions not implemented")
+}
+func (s *PipelineSyncPluginServiceServer[Config]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DetermineStrategy not implemented")
+}
+func (s *PipelineSyncPluginServiceServer[Config]) BuildPipelineSyncStages(context.Context, *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BuildPipelineSyncStages not implemented")
+}
+func (s *PipelineSyncPluginServiceServer[Config]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
+}
+func (s *PipelineSyncPluginServiceServer[Config]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ExecuteStage not implemented")
 }

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -1,0 +1,63 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package pipedsdk provides software development kits for building PipeCD piped plugins.
+package pipedsdk
+
+import "context"
+
+// TODO is a placeholder for the real type.
+// This type will be replaced by the real type when implementing the sdk.
+type TODO struct{}
+
+// Client is a placeholder for the real client.
+// This type will be replaced by the real client to gRPC piped-plugin-service when implementing the sdk.
+type Client struct{}
+
+// DeploymentPlugin is the interface that be implemented by a full-spec deployment plugin.
+// This kind of plugin should implement all methods to manage resources and execute stages.
+type DeploymentPlugin[Config any] interface {
+	PipelineSyncPlugin[Config]
+
+	DetermineVersions(context.Context, Config, Client, TODO) (TODO, error)
+	DetermineStrategy(context.Context, Config, Client, TODO) (TODO, error)
+	BuildQuickSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+}
+
+// PipelineSyncPlugin is the interface that be implemented by a pipeline sync plugin.
+// This kind of plugin may not implement quick sync stages, and will not manage resources like deployment plugin.
+// It only focuses on executing stages which is generic for all kinds of pipeline sync plugins.
+type PipelineSyncPlugin[Config any] interface {
+	FetchDefinedStages() []string
+	BuildPipelineSyncStages(context.Context, Config, Client, TODO) (TODO, error)
+	ExecuteStage(context.Context, Config, Client, TODO) (TODO, error)
+}
+
+// RegisterDeploymentPlugin registers the given deployment plugin.
+// It will be used when running the piped.
+func RegisterDeploymentPlugin[Config any](plugin DeploymentPlugin[Config]) {
+	panic("implement me")
+}
+
+// RegisterPipelineSyncPlugin registers the given pipeline sync plugin.
+// It will be used when running the piped.
+func RegisterPipelineSyncPlugin[Config any](plugin PipelineSyncPlugin[Config]) {
+	panic("implement me")
+}
+
+// Run runs the registered plugins.
+// It will listen the gRPC server and handle all requests from piped.
+func Run() error {
+	panic("implement me")
+}

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -89,7 +89,7 @@ func NewPluginCommand() *cobra.Command {
 		RunE:  cli.WithContext(s.run),
 	}
 
-	cmd.Flags().StringVar(&s.pipedPluginService, "piped-plugin-service", s.pipedPluginService, "The port number used to connect to the piped plugin service.") // TODO: we should discuss about the name of this flag, or we should use environment variable instead.
+	cmd.Flags().StringVar(&s.pipedPluginService, "piped-plugin-service", s.pipedPluginService, "The address used to connect to the piped plugin service.")
 	cmd.Flags().StringVar(&s.config, "config", s.config, "The configuration for the plugin.")
 	cmd.Flags().DurationVar(&s.gracePeriod, "grace-period", s.gracePeriod, "How long to wait for graceful shutdown.")
 

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -22,15 +22,16 @@ import (
 	"net/http/pprof"
 	"time"
 
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/pipe-cd/pipecd/pkg/admin"
 	"github.com/pipe-cd/pipecd/pkg/cli"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
 	"github.com/pipe-cd/pipecd/pkg/rpc"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 type Plugin interface {
@@ -59,6 +60,8 @@ func Run() error {
 	if err := app.Run(); err != nil {
 		return err
 	}
+
+	return nil
 }
 
 type plugin struct {
@@ -123,7 +126,7 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 	// Start running admin server.
 	{
 		var (
-			ver   = []byte(deploymentServiceServer.Version())                  // TODO: not use the deploymentServiceServer directly
+			ver   = []byte(deploymentServiceServer.Version())      // TODO: not use the deploymentServiceServer directly
 			admin = admin.NewAdmin(0, s.gracePeriod, input.Logger) // TODO: add config for admin port
 		)
 

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -85,7 +85,7 @@ func NewPluginCommand() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: fmt.Sprintf("Start running a %s plugin.", deploymentServiceServer.Name())
+		Short: fmt.Sprintf("Start running a %s plugin.", deploymentServiceServer.Name()),
 		RunE:  cli.WithContext(s.run),
 	}
 

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -34,8 +34,11 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/rpc"
 )
 
+// Plugin is the interface that must be implemented by a piped plugin.
 type Plugin interface {
+	// Name returns the name of the plugin.
 	Name() string
+	// Version returns the version of the plugin.
 	Version() string
 }
 

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -85,7 +85,7 @@ func NewPluginCommand() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start running the kubernetes-plugin.",
+		Short: fmt.Sprintf("Start running a %s plugin.", deploymentServiceServer.Name())
 		RunE:  cli.WithContext(s.run),
 	}
 


### PR DESCRIPTION
**What this PR does**:

This PR adds an SDK for plugin implementation.
The implementation is partial, and I'll send other PRs to implement the rest.

**Why we need it**:

There are many boilerplates for implementing plugins.

**What I want to be reviewed**:

The API designs.

The users of this SDK will write codes like the one below.
```go
package main

import (
  ...
)

func main() {
  pipedsdk.RegisterDeploymentPlugin(&pluginImpl{})
  if err := pipedsdk.Run(); err != nil {
     log.Fatal(err) // or some error handling
  }
}
```

**Which issue(s) this PR fixes**:

Part of #5530

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
