### PR TITLE
[Stage Plugins] Implement ListStageCommands() in pipedapi

### DIFF
--- a/pkg/app/pipedv1/apistore/commandstore/store.go
+++ b/pkg/app/pipedv1/apistore/commandstore/store.go
@@ -35,7 +35,6 @@ type apiClient interface {
 type Store interface {
 	Run(ctx context.Context) error
 	Lister() Lister
-	StageCommandHandledReporter() StageCommandHandledReporter
 }
 
 // Lister helps list commands.

--- a/pkg/app/pipedv1/apistore/commandstore/store.go
+++ b/pkg/app/pipedv1/apistore/commandstore/store.go
@@ -258,12 +258,12 @@ func (s *store) reportCommandHandled(ctx context.Context, c *model.Command, stat
 }
 
 func (s *store) ListStageCommands(deploymentID, stageID string, commandType model.Command_Type) ([]*model.Command, error) {
-	var list stageCommandMap
+	var commands stageCommandMap
 	switch commandType {
 	case model.Command_APPROVE_STAGE:
-		list = s.stageApproveCommands
+		commands = s.stageApproveCommands
 	case model.Command_SKIP_STAGE:
-		list = s.stageSkipCommands
+		commands = s.stageSkipCommands
 	default:
 		s.logger.Error("invalid command type", zap.String("commandType", commandType.String()))
 		return nil, fmt.Errorf("invalid command type: %v", commandType.String())
@@ -272,7 +272,7 @@ func (s *store) ListStageCommands(deploymentID, stageID string, commandType mode
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return list[deploymentID][stageID], nil
+	return commands[deploymentID][stageID], nil
 }
 
 func (m stageCommandMap) append(c *model.Command) {

--- a/pkg/app/pipedv1/apistore/commandstore/store_test.go
+++ b/pkg/app/pipedv1/apistore/commandstore/store_test.go
@@ -1,0 +1,138 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+func TestListStageCommands(t *testing.T) {
+	t.Parallel()
+
+	store := store{
+		stageApproveCommands: stageCommandMap{
+			"deployment-1": {
+				"stage-1": []*model.Command{
+					{
+						Id:           "command-1",
+						DeploymentId: "deployment-1",
+						StageId:      "stage-1",
+						Type:         model.Command_APPROVE_STAGE,
+						Commander:    "commander-1",
+					},
+					{
+						Id:           "command-2",
+						DeploymentId: "deployment-1",
+						StageId:      "stage-1",
+						Type:         model.Command_APPROVE_STAGE,
+						Commander:    "commander-2",
+					},
+				},
+			},
+		},
+		stageSkipCommands: stageCommandMap{
+			"deployment-11": {
+				"stage-11": []*model.Command{
+					{
+						Id:           "command-11",
+						DeploymentId: "deployment-11",
+						StageId:      "stage-11",
+						Type:         model.Command_SKIP_STAGE,
+					},
+				},
+			},
+		},
+		logger: zap.NewNop(),
+	}
+
+	testcases := []struct {
+		name         string
+		deploymentID string
+		stageID      string
+		commandType  model.Command_Type
+		want         []*model.Command
+		wantErr      error
+	}{
+		{
+			name:         "valid arguments of Approve",
+			deploymentID: "deployment-1",
+			stageID:      "stage-1",
+			commandType:  model.Command_APPROVE_STAGE,
+			want: []*model.Command{
+				{
+					Id:           "command-1",
+					DeploymentId: "deployment-1",
+					StageId:      "stage-1",
+					Type:         model.Command_APPROVE_STAGE,
+					Commander:    "commander-1",
+				},
+				{
+					Id:           "command-2",
+					DeploymentId: "deployment-1",
+					StageId:      "stage-1",
+					Type:         model.Command_APPROVE_STAGE,
+					Commander:    "commander-2",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:         "valid arguments of Skip",
+			deploymentID: "deployment-11",
+			stageID:      "stage-11",
+			commandType:  model.Command_SKIP_STAGE,
+			want: []*model.Command{
+				{
+					Id:           "command-11",
+					DeploymentId: "deployment-11",
+					StageId:      "stage-11",
+					Type:         model.Command_SKIP_STAGE,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:         "stageID not exists",
+			deploymentID: "deployment-1",
+			stageID:      "stage-999",
+			commandType:  model.Command_APPROVE_STAGE,
+			want:         nil,
+			wantErr:      nil,
+		},
+		{
+			name:         "invalid commandType",
+			deploymentID: "deployment-1",
+			stageID:      "stage-1",
+			commandType:  model.Command_CANCEL_DEPLOYMENT,
+			want:         nil,
+			wantErr:      fmt.Errorf("invalid command type: CANCEL_DEPLOYMENT"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := store.ListStageCommands(tc.deploymentID, tc.stageID, tc.commandType)
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/cmd/piped/grpcapi/plugin_api.go
+++ b/pkg/app/pipedv1/cmd/piped/grpcapi/plugin_api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/metadatastore"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/model"
 	service "github.com/pipe-cd/pipecd/pkg/plugin/pipedservice"
 
 	"go.uber.org/zap"
@@ -36,6 +37,7 @@ type PluginAPI struct {
 	toolRegistry          *toolRegistry
 	Logger                *zap.Logger
 	metadataStoreRegistry *metadatastore.MetadataStoreRegistry
+	stageCommandLister    stageCommandLister
 }
 
 type apiClient interface {
@@ -43,12 +45,23 @@ type apiClient interface {
 	ReportStageLogsFromLastCheckpoint(ctx context.Context, in *pipedservice.ReportStageLogsFromLastCheckpointRequest, opts ...grpc.CallOption) (*pipedservice.ReportStageLogsFromLastCheckpointResponse, error)
 }
 
+type stageCommandLister interface {
+	ListStageCommands(deploymentID, stageID string, commandType model.Command_Type) ([]*model.Command, error)
+}
+
 // Register registers all handling of this service into the specified gRPC server.
 func (a *PluginAPI) Register(server *grpc.Server) {
 	service.RegisterPluginServiceServer(server, a)
 }
 
-func NewPluginAPI(cfg *config.PipedSpec, apiClient apiClient, toolsDir string, logger *zap.Logger, metadataStoreRegistry *metadatastore.MetadataStoreRegistry) (*PluginAPI, error) {
+func NewPluginAPI(
+	cfg *config.PipedSpec,
+	apiClient apiClient,
+	toolsDir string,
+	logger *zap.Logger,
+	metadataStoreRegistry *metadatastore.MetadataStoreRegistry,
+	stageCommandLister stageCommandLister,
+) (*PluginAPI, error) {
 	toolRegistry, err := newToolRegistry(toolsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tool registry: %w", err)
@@ -60,6 +73,7 @@ func NewPluginAPI(cfg *config.PipedSpec, apiClient apiClient, toolsDir string, l
 		toolRegistry:          toolRegistry,
 		Logger:                logger.Named("plugin-api"),
 		metadataStoreRegistry: metadataStoreRegistry,
+		stageCommandLister:    stageCommandLister,
 	}, nil
 }
 
@@ -142,4 +156,14 @@ func (a *PluginAPI) PutDeploymentPluginMetadataMulti(ctx context.Context, req *s
 
 func (a *PluginAPI) GetDeploymentSharedMetadata(ctx context.Context, req *service.GetDeploymentSharedMetadataRequest) (*service.GetDeploymentSharedMetadataResponse, error) {
 	return a.metadataStoreRegistry.GetDeploymentSharedMetadata(ctx, req)
+}
+
+func (a *PluginAPI) ListStageCommands(ctx context.Context, req *service.ListStageCommandsRequest) (*service.ListStageCommandsResponse, error) {
+	commands, err := a.stageCommandLister.ListStageCommands(req.DeploymentId, req.StageId, req.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &service.ListStageCommandsResponse{
+		Commands: commands,
+	}, nil
 }

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -302,7 +302,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	// Start running plugin service server.
 	{
 		var (
-			service, err = grpcapi.NewPluginAPI(cfg, apiClient, p.toolsDir, input.Logger, metadataStoreRegistry)
+			service, err = grpcapi.NewPluginAPI(cfg, apiClient, p.toolsDir, input.Logger, metadataStoreRegistry, commandLister)
 			opts         = []rpc.Option{
 				rpc.WithPort(p.pluginServicePort),
 				rpc.WithGracePeriod(p.gracePeriod),

--- a/pkg/app/pipedv1/controller/controller.go
+++ b/pkg/app/pipedv1/controller/controller.go
@@ -68,7 +68,6 @@ type deploymentLister interface {
 
 type commandLister interface {
 	ListDeploymentCommands() []model.ReportableCommand
-	ListStageCommands(deploymentID, stageID string) []model.ReportableCommand
 }
 
 type notifier interface {


### PR DESCRIPTION
**What this PR does**:

- Implement ListStageCommands() in pipedapi
- Implement ListStageCommands() in commandstore as backend

In the next PR, I'll implement `ReportCommandsHandled()` to report stage commands as completed in the scheduler.

**Why we need it**:



**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5367
Follows https://github.com/pipe-cd/pipecd/pull/5521

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
