### PR TITLE
[WIP] Implement multi cluster k8s sync for non template

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -75,6 +75,19 @@ type KubernetesDeploymentInput struct {
 	AutoCreateNamespace bool `json:"autoCreateNamespace,omitempty"`
 
 	// TODO: Define fields for KubernetesDeploymentInput.
+	MultiTargets []KubernetesMultiTarget `json:"multiTargets,omitempty"`
+}
+
+type KubernetesMultiTarget struct {
+	Target         KubernetesMultiTargetDeployTarget `json:"target"`
+	Manifests      []string                          `json:"manifests,omitempty"`
+	KubectlVersion string                            `json:"kubectlVersion,omitempty"`
+	KustomizeDir   string                            `json:"kustomizeDir,omitempty"`
+}
+
+type KubernetesMultiTargetDeployTarget struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
 }
 
 type KubernetesVariantLabel struct {
@@ -93,6 +106,7 @@ type KubernetesVariantLabel struct {
 }
 
 type KubernetesDeployTargetConfig struct {
+	Name string `json:"-"`
 	// The master URL of the kubernetes cluster.
 	// Empty means in-cluster.
 	MasterURL string `json:"masterURL,omitempty"`
@@ -132,5 +146,6 @@ func FindDeployTarget(cfg *config.PipedPlugin, name string) (KubernetesDeployTar
 		return KubernetesDeployTargetConfig{}, fmt.Errorf("failed to set default values for deploy target configuration: %w", err)
 	}
 
+	targetCfg.Name = deployTarget.Name
 	return targetCfg, nil
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
@@ -63,6 +63,7 @@ func TestFindDeployTarget(t *testing.T) {
 			},
 			targetName: "target",
 			expected: KubernetesDeployTargetConfig{
+				Name:           "target",
 				MasterURL:      "https://example.com",
 				KubeConfigPath: "/path/to/kubeconfig",
 				KubectlVersion: "v1.20.0",

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -43,7 +43,7 @@ func (a *DeploymentService) executeK8sRollbackStage(ctx context.Context, lp logp
 	lp.Infof("Loading manifests at commit %s for handling", input.GetDeployment().GetRunningCommitHash())
 
 	// TODO: consider multiple multiTargets
-	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
+	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource(), &kubeconfig.KubernetesMultiTarget{})
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -43,7 +43,7 @@ func (a *DeploymentService) executeK8sRollbackStage(ctx context.Context, lp logp
 	lp.Infof("Loading manifests at commit %s for handling", input.GetDeployment().GetRunningCommitHash())
 
 	// TODO: consider multiple multiTargets
-	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource(), kubeconfig.KubernetesDeployTargetConfig{})
+	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -41,7 +41,9 @@ func (a *DeploymentService) executeK8sRollbackStage(ctx context.Context, lp logp
 	}
 
 	lp.Infof("Loading manifests at commit %s for handling", input.GetDeployment().GetRunningCommitHash())
-	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource())
+
+	// TODO: consider multiple multiTargets
+	manifests, err := a.loadManifests(ctx, input.GetDeployment(), cfg.Spec, input.GetRunningDeploymentSource(), kubeconfig.KubernetesDeployTargetConfig{})
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -112,13 +112,13 @@ func (a *DeploymentService) DetermineStrategy(ctx context.Context, request *depl
 	}
 
 	// TODO: consider multiple multiTargets
-	runnings, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetRunningDeploymentSource(), kubeconfig.KubernetesDeployTargetConfig{})
+	runnings, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetRunningDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	targets, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesDeployTargetConfig{})
+	targets, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -141,7 +141,7 @@ func (a *DeploymentService) DetermineVersions(ctx context.Context, request *depl
 	}
 
 	// TODO: consider multiple multiTargets
-	manifests, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesDeployTargetConfig{})
+	manifests, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -187,15 +187,7 @@ func (a *DeploymentService) FetchDefinedStages(context.Context, *deployment.Fetc
 	}, nil
 }
 
-func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Deployment, spec *kubeconfig.KubernetesApplicationSpec, deploymentSource *common.DeploymentSource, deployTargetConfig kubeconfig.KubernetesDeployTargetConfig) ([]provider.Manifest, error) {
-	multiTarget := kubeconfig.KubernetesMultiTarget{}
-	for _, target := range spec.Input.MultiTargets {
-		if target.Target.Name == deployTargetConfig.Name {
-			multiTarget = target
-			break
-		}
-	}
-
+func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Deployment, spec *kubeconfig.KubernetesApplicationSpec, deploymentSource *common.DeploymentSource, multiTarget kubeconfig.KubernetesMultiTarget) ([]provider.Manifest, error) {
 	// override values if multiTarget has value.
 	manifestPathes := spec.Input.Manifests
 	if len(multiTarget.Manifests) > 0 {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -112,13 +112,13 @@ func (a *DeploymentService) DetermineStrategy(ctx context.Context, request *depl
 	}
 
 	// TODO: consider multiple multiTargets
-	runnings, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetRunningDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
+	runnings, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetRunningDeploymentSource(), &kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	targets, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
+	targets, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), &kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -141,7 +141,7 @@ func (a *DeploymentService) DetermineVersions(ctx context.Context, request *depl
 	}
 
 	// TODO: consider multiple multiTargets
-	manifests, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), kubeconfig.KubernetesMultiTarget{})
+	manifests, err := a.loadManifests(ctx, request.GetInput().GetDeployment(), cfg.Spec, request.GetInput().GetTargetDeploymentSource(), &kubeconfig.KubernetesMultiTarget{})
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -187,11 +187,13 @@ func (a *DeploymentService) FetchDefinedStages(context.Context, *deployment.Fetc
 	}, nil
 }
 
-func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Deployment, spec *kubeconfig.KubernetesApplicationSpec, deploymentSource *common.DeploymentSource, multiTarget kubeconfig.KubernetesMultiTarget) ([]provider.Manifest, error) {
+func (a *DeploymentService) loadManifests(ctx context.Context, deploy *model.Deployment, spec *kubeconfig.KubernetesApplicationSpec, deploymentSource *common.DeploymentSource, multiTarget *kubeconfig.KubernetesMultiTarget) ([]provider.Manifest, error) {
 	// override values if multiTarget has value.
 	manifestPathes := spec.Input.Manifests
-	if len(multiTarget.Manifests) > 0 {
-		manifestPathes = multiTarget.Manifests
+	if multiTarget != nil {
+		if len(multiTarget.Manifests) > 0 {
+			manifestPathes = multiTarget.Manifests
+		}
 	}
 
 	manifests, err := a.loader.LoadManifests(ctx, provider.LoaderInput{

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
@@ -153,17 +153,6 @@ func (a *DeploymentService) sync(ctx context.Context, lp logpersister.StageLogPe
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	// Get the deploy target config.
-	targets, err := input.GetDeployment().GetDeployTargets(a.pluginConfig.Name)
-	if err != nil {
-		lp.Errorf("Failed while finding deploy target config (%v)", err)
-		return model.StageStatus_STAGE_FAILURE
-	}
-	deployTargetConfig, err = kubeconfig.FindDeployTarget(a.pluginConfig, targets[0]) // TODO: consider multiple targets
-	if err != nil {
-		lp.Errorf("Failed while unmarshalling deploy target config (%v)", err)
-		return model.StageStatus_STAGE_FAILURE
-	}
 	// Get the kubectl tool path.
 	kubectlVersions := []string{cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion, defaultKubectlVersion}
 	// If multi-target is specified, use the kubectl version specified in it.

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
@@ -42,11 +42,12 @@ func (a *DeploymentService) executeK8sSyncStage(ctx context.Context, lp logpersi
 
 	type targetConfig struct {
 		deployTarget kubeconfig.KubernetesDeployTargetConfig
-		multiTarget  kubeconfig.KubernetesMultiTarget
+		multiTarget  *kubeconfig.KubernetesMultiTarget
 	}
 	deployTargetMap := make(map[string]kubeconfig.KubernetesDeployTargetConfig, 0)
 	targetConfigs := make([]targetConfig, 0, len(input.GetDeployment().GetDeployTargets()))
 
+	// prevent the deployment when its deployTarget is not found in the piped config
 	for _, target := range input.GetDeployment().GetDeployTargets() {
 		dt, err := kubeconfig.FindDeployTarget(a.pluginConfig, target)
 		if err != nil {
@@ -57,26 +58,37 @@ func (a *DeploymentService) executeK8sSyncStage(ctx context.Context, lp logpersi
 		deployTargetMap[dt.Name] = dt
 	}
 
-	for _, multiTarget := range cfg.Spec.Input.MultiTargets {
-		dt, ok := deployTargetMap[multiTarget.Target.Name]
-		if !ok {
-			lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
-			continue
+	// If no multi-targets are specified, sync to all deploy targets.
+	if len(cfg.Spec.Input.MultiTargets) == 0 {
+		for _, dt := range deployTargetMap {
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  nil,
+			})
 		}
+	} else {
+		// Sync to the specified multi-targets.
+		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
+			dt, ok := deployTargetMap[multiTarget.Target.Name]
+			if !ok {
+				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
+				continue
+			}
 
-		targetConfigs = append(targetConfigs, targetConfig{
-			deployTarget: dt,
-			multiTarget:  multiTarget,
-		})
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  &multiTarget,
+			})
+		}
 	}
 
 	for _, tc := range targetConfigs {
 		// Start syncing the deployment to the target.
 		eg.Go(func() error {
-			lp.Infof("Start syncing the deployment to the target %s", tc.multiTarget.Target.Name)
+			lp.Infof("Start syncing the deployment to the target %s", tc.deployTarget.Name)
 			status := a.sync(ctx, lp, input, tc.deployTarget, tc.multiTarget)
 			if status != model.StageStatus_STAGE_SUCCESS {
-				return fmt.Errorf("failed to sync the deployment to the target %s", tc.multiTarget.Target.Name)
+				return fmt.Errorf("failed to sync the deployment to the target %s", tc.deployTarget.Name)
 			}
 			return nil
 		})
@@ -90,7 +102,7 @@ func (a *DeploymentService) executeK8sSyncStage(ctx context.Context, lp logpersi
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func (a *DeploymentService) sync(ctx context.Context, lp logpersister.StageLogPersister, input *deployment.ExecutePluginInput, deployTargetConfig kubeconfig.KubernetesDeployTargetConfig, multiTarget kubeconfig.KubernetesMultiTarget) model.StageStatus {
+func (a *DeploymentService) sync(ctx context.Context, lp logpersister.StageLogPersister, input *deployment.ExecutePluginInput, deployTargetConfig kubeconfig.KubernetesDeployTargetConfig, multiTarget *kubeconfig.KubernetesMultiTarget) model.StageStatus {
 	lp.Infof("Start syncing the deployment")
 
 	cfg, err := config.DecodeYAML[*kubeconfig.KubernetesApplicationSpec](input.GetTargetDeploymentSource().GetApplicationConfig())
@@ -147,7 +159,12 @@ func (a *DeploymentService) sync(ctx context.Context, lp logpersister.StageLogPe
 	}
 
 	// Get the kubectl tool path.
-	kubectlPath, err := a.toolRegistry.Kubectl(ctx, cmp.Or(multiTarget.KubectlVersion, cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion, defaultKubectlVersion))
+	kubectlVersions := []string{cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion, defaultKubectlVersion}
+	// If multi-target is specified, use the kubectl version specified in it.
+	if multiTarget != nil {
+		kubectlVersions = append([]string{multiTarget.KubectlVersion}, kubectlVersions...)
+	}
+	kubectlPath, err := a.toolRegistry.Kubectl(ctx, cmp.Or(kubectlVersions...))
 	if err != nil {
 		lp.Errorf("Failed while getting kubectl tool (%v)", err)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -644,20 +644,9 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster(t *testing.T) {
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargetsByPlugin: map[string]*structpb.ListValue{
-					"kubernetes": &structpb.ListValue{
-						Values: []*structpb.Value{
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster1",
-								},
-							},
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster2",
-								},
-							},
-						},
+				DeployTargetsByPlugin: map[string]*model.DeployTargets{
+					"kubernetes": {
+						DeployTargets: []string{"cluster1", "cluster2"},
 					},
 				},
 			},
@@ -733,20 +722,9 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_one_of_deploy_target
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargetsByPlugin: map[string]*structpb.ListValue{
-					"kubernetes": &structpb.ListValue{
-						Values: []*structpb.Value{
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster1",
-								},
-							},
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "wrong_value", // include wrong deploy target
-								},
-							},
-						},
+				DeployTargetsByPlugin: map[string]*model.DeployTargets{
+					"kubernetes": {
+						DeployTargets: []string{"cluster1", "wrong_value"}, // include wrong deploy target
 					},
 				},
 			},
@@ -804,20 +782,9 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_templateNone(t *test
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargetsByPlugin: map[string]*structpb.ListValue{
-					"kubernetes": &structpb.ListValue{
-						Values: []*structpb.Value{
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster1",
-								},
-							},
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster2",
-								},
-							},
-						},
+				DeployTargetsByPlugin: map[string]*model.DeployTargets{
+					"kubernetes": {
+						DeployTargets: []string{"cluster1", "cluster2"},
 					},
 				},
 			},
@@ -893,20 +860,9 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_failed_one_of_the_sy
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargetsByPlugin: map[string]*structpb.ListValue{
-					"kubernetes": &structpb.ListValue{
-						Values: []*structpb.Value{
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster1",
-								},
-							},
-							{
-								Kind: &structpb.Value_StringValue{
-									StringValue: "cluster2",
-								},
-							},
-						},
+				DeployTargetsByPlugin: map[string]*model.DeployTargets{
+					"kubernetes": {
+						DeployTargets: []string{"cluster1", "cluster2"},
 					},
 				},
 			},

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -644,7 +644,22 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster(t *testing.T) {
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargets: []string{"cluster1", "cluster2"},
+				DeployTargetsByPlugin: map[string]*structpb.ListValue{
+					"kubernetes": &structpb.ListValue{
+						Values: []*structpb.Value{
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster1",
+								},
+							},
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster2",
+								},
+							},
+						},
+					},
+				},
 			},
 			Stage: &model.PipelineStage{
 				Id:   "stage-id",
@@ -670,6 +685,7 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster(t *testing.T) {
 	cluster2 := setupCluster(t, "cluster2")
 
 	pluginCfg := &config.PipedPlugin{
+		Name: "kubernetes",
 		DeployTargets: []config.PipedDeployTarget{
 			cluster1.deployTarget,
 			cluster2.deployTarget,
@@ -717,7 +733,22 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_one_of_deploy_target
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargets: []string{"cluster1", "wrong_value"}, // include wrong deploy target
+				DeployTargetsByPlugin: map[string]*structpb.ListValue{
+					"kubernetes": &structpb.ListValue{
+						Values: []*structpb.Value{
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster1",
+								},
+							},
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "wrong_value", // include wrong deploy target
+								},
+							},
+						},
+					},
+				},
 			},
 			Stage: &model.PipelineStage{
 				Id:   "stage-id",
@@ -743,6 +774,7 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_one_of_deploy_target
 	cluster2 := setupCluster(t, "cluster2")
 
 	pluginCfg := &config.PipedPlugin{
+		Name: "kubernetes",
 		DeployTargets: []config.PipedDeployTarget{
 			cluster1.deployTarget,
 			cluster2.deployTarget,
@@ -772,7 +804,22 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_templateNone(t *test
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargets: []string{"cluster1", "cluster2"},
+				DeployTargetsByPlugin: map[string]*structpb.ListValue{
+					"kubernetes": &structpb.ListValue{
+						Values: []*structpb.Value{
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster1",
+								},
+							},
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster2",
+								},
+							},
+						},
+					},
+				},
 			},
 			Stage: &model.PipelineStage{
 				Id:   "stage-id",
@@ -798,6 +845,7 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_templateNone(t *test
 	cluster2 := setupCluster(t, "cluster2")
 
 	pluginCfg := &config.PipedPlugin{
+		Name: "kubernetes",
 		DeployTargets: []config.PipedDeployTarget{
 			cluster1.deployTarget,
 			cluster2.deployTarget,
@@ -845,7 +893,22 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_failed_one_of_the_sy
 			Deployment: &model.Deployment{
 				PipedId:       "piped-id",
 				ApplicationId: "app-id",
-				DeployTargets: []string{"cluster1", "cluster2"},
+				DeployTargetsByPlugin: map[string]*structpb.ListValue{
+					"kubernetes": &structpb.ListValue{
+						Values: []*structpb.Value{
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster1",
+								},
+							},
+							{
+								Kind: &structpb.Value_StringValue{
+									StringValue: "cluster2",
+								},
+							},
+						},
+					},
+				},
 			},
 			Stage: &model.PipelineStage{
 				Id:   "stage-id",
@@ -871,6 +934,7 @@ func TestDeploymentService_executeK8sSyncStage_multiCluster_failed_one_of_the_sy
 	cluster2 := setupCluster(t, "cluster2")
 
 	pluginCfg := &config.PipedPlugin{
+		Name: "kubernetes",
 		DeployTargets: []config.PipedDeployTarget{
 			cluster1.deployTarget,
 			cluster2.deployTarget,

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/app.pipecd.yaml
@@ -1,0 +1,26 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: simple
+  labels:
+    env: example
+    team: product
+  quickSync:
+    prune: true
+  input:
+    kubectlVersion: 1.31.0
+    multiTargets:
+      - target:
+          name: cluster1
+        manifests:
+          - ./cluster1/deployment.yaml
+        kubectlVersion: 1.31.0
+      - target:
+          name: cluster2
+        manifests:
+          - ./cluster_hoge/deployment.yaml # wrong path
+        kubectlVersion: 1.31.0
+  description: |
+    This app demonstrates how to deploy a Kubernetes application with [Quick Sync](https://pipecd.dev/docs/concepts/#sync-strategy) strategy.\
+    No pipeline is specified then in each deployment PipeCD will roll out the new version and switch all traffic to it immediately.\
+    References: [adding a new app](https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs/user-guide/configuration-reference/)

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster1/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster1/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster1
+  labels:
+    app: simple-cluster1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster1
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster1
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster2/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster2/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster2
+  labels:
+    app: simple-cluster2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster2
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster2
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/app.pipecd.yaml
@@ -1,0 +1,26 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: simple
+  labels:
+    env: example
+    team: product
+  quickSync:
+    prune: true
+  input:
+    kubectlVersion: 1.31.0
+    multiTargets:
+      - target:
+          name: cluster1
+        manifests:
+          - ./cluster1/deployment.yaml
+        kubectlVersion: 1.31.0
+      - target:
+          name: cluster2
+        manifests:
+          - ./cluster2/deployment.yaml
+        kubectlVersion: 1.31.0
+  description: |
+    This app demonstrates how to deploy a Kubernetes application with [Quick Sync](https://pipecd.dev/docs/concepts/#sync-strategy) strategy.\
+    No pipeline is specified then in each deployment PipeCD will roll out the new version and switch all traffic to it immediately.\
+    References: [adding a new app](https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs/user-guide/configuration-reference/)

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/cluster1/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/cluster1/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster1
+  labels:
+    app: simple-cluster1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster1
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster1
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/cluster2/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/multicluster_template_none/target/cluster2/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster2
+  labels:
+    app: simple-cluster2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster2
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster2
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085


### PR DESCRIPTION
**What this PR does**:

I fixed the K8S_SYNC to deploy an app to the multiple clusters.

**Details**
I introduced `spec.input.multiTargets` field.
We can control the settings (manifests, kubectlVersion and so on) for each deploy target.

Here is the example of the app.pipecd.yaml with it.
```yaml
apiVersion: pipecd.dev/v1beta1
kind: KubernetesApp
spec:
  name: simple
  labels:
    env: example
    team: product
  quickSync:
    prune: true
  input:
    kubectlVersion: 1.31.0
    multiTargets:
      - target:
          name: cluster1
        manifests:
          - ./cluster1/deployment.yaml
        kubectlVersion: 1.31.0
      - target:
          name: cluster2
        manifests:
          - ./cluster2/deployment.yaml
        kubectlVersion: 1.31.0
```

If multiTargets are set, the configuration for each target is applied and deployed accordingly. If multiTargets is not set, the deployment is executed for all deploy targets.

Also, each multi-target process is executed in parallel. 
K8S_SYNC is successful when all of the processes are executed successfully.

**Why we need it**:

**Which issue(s) this PR fixes**:

Part of #5006

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
