### PR TITLE
Call `runningDSP.Get` when runningDSP  is not nil

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -479,16 +479,19 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		originalStatus = ps.Status
 	)
 
-	rds, err := s.runningDSP.Get(ctx, io.Discard)
-	if err != nil {
-		s.logger.Error("failed to get running deployment source", zap.String("stage-name", ps.Name), zap.Error(err))
-		return model.StageStatus_STAGE_FAILURE
-	}
-
 	tds, err := s.targetDSP.Get(ctx, io.Discard)
 	if err != nil {
 		s.logger.Error("failed to get target deployment source", zap.String("stage-name", ps.Name), zap.Error(err))
 		return model.StageStatus_STAGE_FAILURE
+	}
+
+	rds := &deploysource.DeploySource{}
+	if s.runningDSP != nil {
+		rds, err = s.runningDSP.Get(ctx, io.Discard)
+		if err != nil {
+			s.logger.Error("failed to get running deployment source", zap.String("stage-name", ps.Name), zap.Error(err))
+			return model.StageStatus_STAGE_FAILURE
+		}
 	}
 
 	// Check whether to execute the script rollback stage or not.


### PR DESCRIPTION
**What this PR does**:

I fixed to call `runningDSP.Get` when runningDSP is not nil.

**Why we need it**:

When first deploy, runningDSP is nil because previous running commit is not found.
So it led panic.

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
