### PR TITLE
Turn off future flag react-router-dom, update test

### DIFF
--- a/web/src/components/application-detail-page/application-detail/index.test.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.test.tsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
 import { server } from "~/mocks/server";
 import {
   Application,
@@ -11,7 +10,13 @@ import type { AppState } from "~/store";
 import { dummyApplication } from "~/__fixtures__/dummy-application";
 import { dummyApplicationLiveState } from "~/__fixtures__/dummy-application-live-state";
 import { dummyPiped } from "~/__fixtures__/dummy-piped";
-import { createStore, render, screen, waitFor } from "~~/test-utils";
+import {
+  createStore,
+  render,
+  screen,
+  waitFor,
+  MemoryRouter,
+} from "~~/test-utils";
 import { ApplicationDetail } from ".";
 
 beforeAll(() => {

--- a/web/src/components/application-detail-page/index.test.tsx
+++ b/web/src/components/application-detail-page/index.test.tsx
@@ -1,7 +1,7 @@
-import { MemoryRouter, Route, Routes as ReactRoutes } from "react-router-dom";
+import { Route, Routes as ReactRoutes } from "react-router-dom";
 import { PAGE_PATH_APPLICATIONS } from "~/constants/path";
 import { fetchApplication } from "~/modules/applications";
-import { createStore, render } from "~~/test-utils";
+import { createStore, MemoryRouter, render } from "~~/test-utils";
 import { ApplicationDetailPage } from ".";
 
 describe("ApplicationDetailPage", () => {

--- a/web/src/components/applications-page/application-list/application-list-item/index.test.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.test.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
 import { dummyApplication } from "~/__fixtures__/dummy-application";
-import { createStore, render, screen } from "~~/test-utils";
+import { createStore, render, screen, MemoryRouter } from "~~/test-utils";
 import { ApplicationListItem } from ".";
 
 const state = {

--- a/web/src/components/applications-page/application-list/index.test.tsx
+++ b/web/src/components/applications-page/application-list/index.test.tsx
@@ -1,12 +1,17 @@
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
 import { server } from "~/mocks/server";
 import { disableApplication, enableApplication } from "~/modules/applications";
 import { setDeletingAppId } from "~/modules/delete-application";
 import { generateSealedSecret } from "~/modules/sealed-secret";
 import { setUpdateTargetId } from "~/modules/update-application";
 import { dummyApplication } from "~/__fixtures__/dummy-application";
-import { createStore, render, screen, waitFor } from "~~/test-utils";
+import {
+  createStore,
+  render,
+  screen,
+  waitFor,
+  MemoryRouter,
+} from "~~/test-utils";
 import { ApplicationList } from ".";
 
 beforeAll(() => {

--- a/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
@@ -1,9 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
 import { cancelDeployment, DeploymentStatus } from "~/modules/deployments";
 import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
 import { dummyPiped } from "~/__fixtures__/dummy-piped";
-import { createStore, render, screen } from "~~/test-utils";
+import { createStore, render, screen, MemoryRouter } from "~~/test-utils";
 import { DeploymentDetail } from ".";
 
 const baseState = {

--- a/web/src/components/deployments-detail-page/index.test.tsx
+++ b/web/src/components/deployments-detail-page/index.test.tsx
@@ -1,8 +1,8 @@
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { server } from "~/mocks/server";
 import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
 import { dummyPiped } from "~/__fixtures__/dummy-piped";
-import { createReduxStore, render, waitFor } from "~~/test-utils";
+import { createReduxStore, render, waitFor, MemoryRouter } from "~~/test-utils";
 import { DeploymentDetailPage } from ".";
 
 Element.prototype.scrollIntoView = jest.fn();

--- a/web/src/components/header/index.test.tsx
+++ b/web/src/components/header/index.test.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "~~/test-utils";
+import { MemoryRouter, render, screen } from "~~/test-utils";
 import { Header } from "./";
 
 it("shows login link if user state is not exists", () => {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -46,7 +46,12 @@ Happy PipeCD-ing 🙌
   render(
     <Provider store={store}>
       <ThemeProvider theme={theme}>
-        <BrowserRouter>
+        <BrowserRouter
+          future={{
+            v7_startTransition: false,
+            v7_relativeSplatPath: false,
+          }}
+        >
           <CssBaseline />
           <Routes />
         </BrowserRouter>

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -1,9 +1,8 @@
 import { waitFor } from "@testing-library/react";
 import { setupServer } from "msw/node";
 import { GetMeResponse } from "pipecd/web/api_client/service_pb";
-import { MemoryRouter } from "react-router-dom";
 import { createHandler } from "~/mocks/create-handler";
-import { render, screen } from "~~/test-utils";
+import { MemoryRouter, render, screen } from "~~/test-utils";
 import { Routes } from "./routes";
 
 const server = setupServer(

--- a/web/test-utils/MemoryRouterTest.tsx
+++ b/web/test-utils/MemoryRouterTest.tsx
@@ -1,0 +1,20 @@
+import { MemoryRouter, MemoryRouterProps } from "react-router-dom";
+import React from "react";
+
+type Props = MemoryRouterProps;
+
+const MemoryRouterTest = (props: Props): React.ReactElement => {
+  return (
+    <MemoryRouter
+      {...props}
+      future={{
+        v7_startTransition: false,
+        v7_relativeSplatPath: false,
+      }}
+    >
+      {props.children}
+    </MemoryRouter>
+  );
+};
+
+export default MemoryRouterTest;

--- a/web/test-utils/index.tsx
+++ b/web/test-utils/index.tsx
@@ -15,6 +15,7 @@ import { thunkErrorHandler } from "~/middlewares/thunk-error-handler";
 import { reducers } from "~/modules";
 import type { AppState } from "~/store";
 import { theme } from "~/theme";
+import MemoryRouterTest from "./MemoryRouterTest";
 
 const middlewares = getDefaultMiddleware({
   immutableCheck: false,
@@ -72,3 +73,5 @@ const customRender = (
 export * from "@testing-library/react";
 // override render method
 export { customRender as render };
+
+export { MemoryRouterTest as MemoryRouter };


### PR DESCRIPTION
**What this PR does**:
- Turn off warning future flag of react-router-dom 6
- Update test case

**Why we need it**:
- There are too many warnings of future-flag to feature of react-router-dom v7. 
![CleanShot 2025-02-06 at 21 03 05](https://github.com/user-attachments/assets/4731fe40-1d7e-44ec-854b-ca2c6d0aa456)

- We currently don't plan to upgrade react-router-dom to version 7. So this PR is disabe future-flag followed by https://github.com/remix-run/react-router/pull/12441 to suppress warning

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: None

- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
