### PR TITLE
Improve docker build performance

### DIFF
--- a/cmd/helloworld/Dockerfile
+++ b/cmd/helloworld/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.23.3 AS builder
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +11,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=helloworld
+RUN make build/go MOD=helloworld BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 FROM alpine:3.21.0
 

--- a/cmd/launcher/Dockerfile
+++ b/cmd/launcher/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +10,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=launcher
+RUN make build/go MOD=launcher BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 # https://github.com/pipe-cd/pipecd/pkgs/container/piped-base/321463679?tag=v0.50.0-26-ga8527d2
 FROM ghcr.io/pipe-cd/piped-base@sha256:9960b45a5aa822ae45ca2966056d8d2e98795b51681df25afd1fecf96360981c

--- a/cmd/launcher/Dockerfile
+++ b/cmd/launcher/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
 
 ARG TARGETOS

--- a/cmd/launcher/Dockerfile-okd
+++ b/cmd/launcher/Dockerfile-okd
@@ -1,4 +1,7 @@
-FROM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +10,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=launcher
+RUN make build/go MOD=launcher BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 # https://github.com/pipe-cd/pipecd/pkgs/container/piped-base-okd/321464518?tag=v0.50.0-26-ga8527d2
 FROM ghcr.io/pipe-cd/piped-base-okd@sha256:da9bd5a1dae3aa5c2df4baba81ff836ba4a55159d85984605549ef2d1f136895

--- a/cmd/launcher/Dockerfile-okd
+++ b/cmd/launcher/Dockerfile-okd
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
 
 ARG TARGETOS

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # web builder
 # because of this issue, we choose node 18
 # https://github.com/pipe-cd/pipecd/issues/5422
@@ -18,7 +19,10 @@ RUN make update/web-deps
 RUN make build/web
 
 # pipecd builder
-FROM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -27,7 +31,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=pipecd
+RUN make build/go MOD=pipecd BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 FROM alpine:3.21.0
 

--- a/cmd/pipectl/Dockerfile
+++ b/cmd/pipectl/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +10,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=pipectl
+RUN make build/go MOD=pipectl BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 FROM alpine:3.21.0
 

--- a/cmd/pipectl/Dockerfile
+++ b/cmd/pipectl/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
 
 ARG TARGETOS

--- a/cmd/piped/Dockerfile
+++ b/cmd/piped/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.23.3 AS builder
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +11,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=piped
+RUN make build/go MOD=piped BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 # https://github.com/pipe-cd/pipecd/pkgs/container/piped-base/321463679?tag=v0.50.0-26-ga8527d2
 FROM ghcr.io/pipe-cd/piped-base@sha256:9960b45a5aa822ae45ca2966056d8d2e98795b51681df25afd1fecf96360981c

--- a/cmd/piped/Dockerfile-okd
+++ b/cmd/piped/Dockerfile-okd
@@ -1,4 +1,8 @@
-FROM golang:1.23.3 AS builder
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +11,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make build/go MOD=piped
+RUN make build/go MOD=piped BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 
 # https://github.com/pipe-cd/pipecd/pkgs/container/piped-base-okd/321464518?tag=v0.50.0-26-ga8527d2
 FROM ghcr.io/pipe-cd/piped-base-okd@sha256:da9bd5a1dae3aa5c2df4baba81ff836ba4a55159d85984605549ef2d1f136895


### PR DESCRIPTION
**What this PR does**:

Build a Go binary with the host platform using the GOOS/GOARCH option and copy it to the target container image.
ref; https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application

**Why we need it**:

We sometimes face build failure at go build. I think this comes from QEMU and Go combination. So I changed the Dockerfile to build go binary without QEMU.
https://github.com/pipe-cd/pipecd/actions/runs/13126728528/job/36624384578#step:8:1

**Which issue(s) this PR fixes**:

Maybe fixes #5548 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
