### PR TITLE
Fix error deprecate overlap in badge component - setting/piped

### DIFF
--- a/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -191,6 +191,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
             >
               <Badge
                 variant="dot"
+                overlap="rectangular"
                 className={clsx({
                   [classes.onlineStatus]:
                     piped.status === Piped.ConnectionStatus.ONLINE,


### PR DESCRIPTION
**What this PR does**:
- Add `overlap="rectangular"` to suppress warning "deprecated"

**Why we need it**:
- Clean error console 
```
Warning: Failed prop type: Material-UI: `overlap="rectangle"` was deprecated. Use `overlap="rectangular"` instead.
```
![image](https://github.com/user-attachments/assets/76b1b2c8-faed-41f6-8d98-fa675172ed65)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: None

- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
