### PR TITLE
Enhanced EventWatcher logs

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -458,7 +458,7 @@ func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eve
 	var responseError error
 	retry := backoff.NewRetry(retryPushNum, backoff.NewConstant(retryPushInterval))
 	for branch, events := range branchHandledEvents {
-		var eventIDs []string
+		eventIDs := make([]string, 0, len(events))
 		for _, e := range events {
 			eventIDs = append(eventIDs, e.Id)
 		}
@@ -614,7 +614,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		return nil
 	}
 
-	var eventIDs []string
+	eventIDs := make([]string, 0, len(handledEvents))
 	for _, e := range handledEvents {
 		eventIDs = append(eventIDs, e.Id)
 	}

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -603,7 +603,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 	retry := backoff.NewRetry(retryPushNum, backoff.NewConstant(retryPushInterval))
 	_, err = retry.Do(ctx, func() (interface{}, error) {
 		if err := tmpRepo.Push(ctx, tmpRepo.GetClonedBranch()); err != nil {
-			w.logger.Error("failed to push commits", zap.String("repo-id", repoID), zap.String("branch", tmpRepo.GetClonedBranch()), zap.Error(err))
+			w.logger.Warn("failed to push commits", zap.String("repo-id", repoID), zap.String("branch", tmpRepo.GetClonedBranch()), zap.Error(err))
 			return nil, err
 		}
 		return nil, nil

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -623,6 +623,8 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		return nil
 	}
 
+	w.logger.Error("failed to push commits", zap.Error(err))
+
 	// If push fails because of the other reason, re-set all statuses to FAILURE.
 	for i := range handledEvents {
 		if handledEvents[i].Status == model.EventStatus_EVENT_FAILURE {
@@ -636,7 +638,6 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 		return err
 	}
 	w.milestoneMap.Store(repoID, maxTimestamp)
-	w.logger.Error("failed to push commits", zap.Error(err))
 	return err
 }
 

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -603,7 +603,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 	retry := backoff.NewRetry(retryPushNum, backoff.NewConstant(retryPushInterval))
 	_, err = retry.Do(ctx, func() (interface{}, error) {
 		if err := tmpRepo.Push(ctx, tmpRepo.GetClonedBranch()); err != nil {
-			w.logger.Warn("failed to push commits", zap.String("repo-id", repoID), zap.String("branch", tmpRepo.GetClonedBranch()), zap.Error(err))
+			w.logger.Warn(fmt.Sprintf("failed to push commits. Retry attempt %d/%d", retry.Calls(), retryPushNum), zap.String("repo-id", repoID), zap.String("branch", tmpRepo.GetClonedBranch()), zap.Error(err))
 			return nil, err
 		}
 		return nil, nil
@@ -619,7 +619,7 @@ func (w *watcher) updateValues(ctx context.Context, repo git.Repo, repoID string
 
 	// If push fails because the local branch was not fresh, exit to retry again in the next interval.
 	if err == git.ErrBranchNotFresh {
-		w.logger.Warn("failed to push commits", zap.Error(err))
+		w.logger.Warn("failed to push commits: local branch was not up-to-date; will retry in the next cycle", zap.Error(err))
 		return nil
 	}
 

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -147,3 +147,15 @@ func TestDo(t *testing.T) {
 		})
 	}
 }
+
+func TestDoCalls(t *testing.T) {
+	r := NewRetry(3, NewConstant(time.Millisecond))
+	assert.Equal(t, 0, r.Calls())
+	cnt := 0
+	r.Do(context.TODO(), func() (interface{}, error) {
+		cnt++
+		assert.Equal(t, cnt, r.Calls()) // Calls should be 1,2,3
+		return nil, errors.New("error-to-retry")
+	})
+	assert.Equal(t, 4, r.Calls())
+}

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -147,15 +147,3 @@ func TestDo(t *testing.T) {
 		})
 	}
 }
-
-func TestDoCalls(t *testing.T) {
-	r := NewRetry(3, NewConstant(time.Millisecond))
-	assert.Equal(t, 0, r.Calls())
-	cnt := 0
-	r.Do(context.TODO(), func() (interface{}, error) {
-		cnt++
-		assert.Equal(t, cnt, r.Calls()) // Calls should be 1,2,3
-		return nil, errors.New("error-to-retry")
-	})
-	assert.Equal(t, 4, r.Calls())
-}


### PR DESCRIPTION
**What this PR does**:

Mainly: 
- add messages about "will retry in the next loop" and retry counts 
- convert log lever from Error to Warn in `retry.Do()`
   - After failing for the max count, ErrorLog will be shown
- add event-ids field 

**Why we need it**:

- To clarify that some errors can be solved in the next loop or retry
- To suppress too many logs while retry
- To enable to track which events failed

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
