### PR TITLE
Update application form add for piped v1 with deployment targets config

### DIFF
--- a/web/src/__fixtures__/dummy-piped.ts
+++ b/web/src/__fixtures__/dummy-piped.ts
@@ -17,7 +17,16 @@ export const dummyPiped: Piped.AsObject = {
     },
   ],
   platformProvidersList: [],
-  pluginsList: [],
+  pluginsList: [
+    {
+      name: "kubernetes",
+      deployTargetsList: ["local"],
+    },
+    {
+      name: "wait",
+      deployTargetsList: ["local"],
+    },
+  ],
   desc: randomText(1),
   disabled: false,
   id: randomUUID(),

--- a/web/src/api/applications.ts
+++ b/web/src/api/applications.ts
@@ -24,6 +24,7 @@ import {
 import { ApplicationGitPath } from "pipecd/web/model/common_pb";
 import { ApplicationGitRepository } from "pipecd/web/model/common_pb";
 import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wrappers_pb";
+import { DeployTargets } from "~~/model/deployment_pb";
 
 export const getApplicationLiveState = ({
   applicationId,
@@ -77,9 +78,18 @@ export const addApplication = async ({
   kind,
   gitPath,
   labelsMap,
-}: Required<Omit<AddApplicationRequest.AsObject, "platformProvider" | "kind">> &
+  deployTargetsByPluginMap,
+}: Required<
+  Omit<
+    AddApplicationRequest.AsObject,
+    "platformProvider" | "kind" | "deployTargetsByPluginMap"
+  >
+> &
   Partial<
-    Pick<AddApplicationRequest.AsObject, "platformProvider" | "kind">
+    Pick<
+      AddApplicationRequest.AsObject,
+      "platformProvider" | "kind" | "deployTargetsByPluginMap"
+    >
   >): Promise<AddApplicationResponse.AsObject> => {
   const req = new AddApplicationRequest();
   req.setName(name);
@@ -106,6 +116,13 @@ export const addApplication = async ({
   labelsMap.forEach((label) => {
     req.getLabelsMap().set(label[0], label[1]);
   });
+  if (deployTargetsByPluginMap) {
+    deployTargetsByPluginMap.forEach(([pluginName, deployTarget]) => {
+      const newDeployTarget = new DeployTargets();
+      newDeployTarget.setDeployTargetsList(deployTarget.deployTargetsList);
+      req.getDeployTargetsByPluginMap().set(pluginName, newDeployTarget);
+    });
+  }
   return apiRequest(req, apiClient.addApplication);
 };
 

--- a/web/src/api/applications.ts
+++ b/web/src/api/applications.ts
@@ -165,6 +165,7 @@ export const updateApplication = async ({
   name,
   pipedId,
   configFilename,
+  deployTargetsByPluginMap,
 }: Required<
   Omit<UpdateApplicationRequest.AsObject, "platformProvider" | "kind">
 > &
@@ -180,6 +181,13 @@ export const updateApplication = async ({
   }
   if (kind !== undefined) {
     req.setKind(kind);
+  }
+  if (deployTargetsByPluginMap) {
+    deployTargetsByPluginMap.forEach(([pluginName, deployTarget]) => {
+      const newDeployTarget = new DeployTargets();
+      newDeployTarget.setDeployTargetsList(deployTarget.deployTargetsList);
+      req.getDeployTargetsByPluginMap().set(pluginName, newDeployTarget);
+    });
   }
   req.setConfigFilename(configFilename);
   return apiRequest(req, apiClient.updateApplication);

--- a/web/src/components/application-form/application-form-manual-v0/index.tsx
+++ b/web/src/components/application-form/application-form-manual-v0/index.tsx
@@ -13,7 +13,7 @@ import { UI_TEXT_CANCEL, UI_TEXT_SAVE } from "~/constants/ui-text";
 import { ApplicationKind } from "~/modules/applications";
 import { Piped, selectAllPipeds, selectPipedById } from "~/modules/pipeds";
 import { sortFunc } from "~/utils/common";
-import { ApplicationFormProps, ApplicationFormValue } from "..";
+import { ApplicationFormProps } from "..";
 import { useFormik } from "formik";
 import * as yup from "yup";
 
@@ -22,7 +22,22 @@ import { addApplication } from "~/modules/applications";
 import FormSelectInput from "../../form-select-input";
 import { updateApplication } from "~/modules/update-application";
 
-export const emptyFormValues: ApplicationFormValue = {
+type FormValues = {
+  name: string;
+  kind: ApplicationKind;
+  pipedId: string;
+  repoPath: string;
+  configFilename: string;
+  platformProvider: string;
+  repo: {
+    id: string;
+    remote: string;
+    branch: string;
+  };
+  labels: Array<[string, string]>;
+};
+
+export const emptyFormValues: FormValues = {
   name: "",
   kind: ApplicationKind.KUBERNETES,
   pipedId: "",
@@ -135,7 +150,7 @@ const ApplicationFormManualV0: FC<ApplicationFormProps> = ({
   detailApp: detailApp,
 }) => {
   const dispatch = useAppDispatch();
-  const formik = useFormik<ApplicationFormValue>({
+  const formik = useFormik<FormValues>({
     initialValues: detailApp
       ? {
           name: detailApp.name,

--- a/web/src/components/application-form/application-form-v1/index.test.tsx
+++ b/web/src/components/application-form/application-form-v1/index.test.tsx
@@ -93,7 +93,7 @@ describe("ApplicationFormV1", () => {
     });
 
     it("Form should have 3 step", () => {
-      const step1 = screen.getByText("Select piped");
+      const step1 = screen.getByText("Select piped and deploy targets");
       const step2 = screen.getByText("Select application to add");
       const step3 = screen.getByText("Confirm information before adding");
       expect(step1).toBeInTheDocument();
@@ -106,6 +106,11 @@ describe("ApplicationFormV1", () => {
       userEvent.click(screen.getByRole("button", { name: /piped/i }));
       const optionName = `${dummyPiped.name} (${dummyPiped.id})`;
       userEvent.click(screen.getByRole("option", { name: optionName }));
+
+      // select deploy target
+      userEvent.click(screen.getByRole("textbox", { name: /deploy target/i }));
+      const optionDeployTarget = `${dummyPiped.pluginsList[0].deployTargetsList[0]} - ${dummyPiped.pluginsList[0].name}`;
+      userEvent.click(screen.getByRole("option", { name: optionDeployTarget }));
 
       // select Application
       userEvent.click(screen.getByRole("textbox", { name: "Application" }));

--- a/web/src/components/application-form/application-form-v1/index.tsx
+++ b/web/src/components/application-form/application-form-v1/index.tsx
@@ -74,7 +74,7 @@ enum STEP {
 type DeployTargetOption = {
   pluginName: string;
   deployTarget: string;
-  disabled?: boolean;
+  value: string;
 };
 
 type Props = {
@@ -129,7 +129,11 @@ const ApplicationFormSuggestionV1: FC<Props> = ({
 
     return selectedPiped.pluginsList.reduce((all, plugin) => {
       plugin.deployTargetsList.forEach((deployTarget) => {
-        all.push({ deployTarget, pluginName: plugin.name });
+        all.push({
+          deployTarget,
+          pluginName: plugin.name,
+          value: `${deployTarget} - ${plugin.name}`,
+        });
       });
       return all;
     }, [] as DeployTargetOption[]);
@@ -144,9 +148,7 @@ const ApplicationFormSuggestionV1: FC<Props> = ({
   );
 
   const pipeds = useMemo(() => {
-    return ps
-      .filter((piped) => !piped.disabled)
-      .sort((a, b) => sortFunc(a.name, b.name));
+    return ps.sort((a, b) => sortFunc(a.name, b.name));
   }, [ps]);
 
   /**
@@ -204,7 +206,7 @@ const ApplicationFormSuggestionV1: FC<Props> = ({
       repoPath: selectedApp.path,
       configFilename: selectedApp.configFilename,
       labels: selectedApp.labelsMap,
-      deployTargets: selectedDeployTargets.filter((item) => !item.disabled),
+      deployTargets: selectedDeployTargets,
     });
     setShowConfirm(true);
   };
@@ -257,16 +259,15 @@ const ApplicationFormSuggestionV1: FC<Props> = ({
                 <FormControl className={classes.formItem} variant="outlined">
                   <Autocomplete
                     id="deploy-targets"
-                    options={deployTargetOptions}
-                    getOptionLabel={(item) =>
-                      `${item.deployTarget} - ${item.pluginName}`
-                    }
+                    options={deployTargetOptions.map(({ value }) => value)}
                     multiple={true}
-                    value={selectedDeployTargets}
-                    getOptionDisabled={(option) => !!option?.disabled}
+                    value={selectedDeployTargets.map((item) => item.value)}
                     disabled={!selectedPipedId}
                     onChange={(_e, value) => {
-                      onSelectDeployTargets(value);
+                      const selected = deployTargetOptions.filter((item) =>
+                        value.includes(item.value)
+                      );
+                      onSelectDeployTargets(selected);
                     }}
                     openOnFocus
                     autoComplete={false}

--- a/web/src/components/application-form/index.tsx
+++ b/web/src/components/application-form/index.tsx
@@ -1,7 +1,7 @@
 import { Box, makeStyles, Tabs, Tab, IconButton } from "@material-ui/core";
 import { Help } from "@material-ui/icons";
 import { useState } from "react";
-import { Application, ApplicationKind } from "~/modules/applications";
+import { Application } from "~/modules/applications";
 import ApplicationFormV1 from "./application-form-v1";
 import ApplicationFormV0 from "./application-form-v0";
 import ApplicationFormManualV0 from "./application-form-manual-v0";
@@ -38,21 +38,6 @@ const tabPanelProps = (
     "aria-labelledby": `tab-${tabKey}`,
   };
 };
-
-export interface ApplicationFormValue {
-  name: string;
-  kind: ApplicationKind;
-  pipedId: string;
-  repoPath: string;
-  configFilename: string;
-  platformProvider: string;
-  repo: {
-    id: string;
-    remote: string;
-    branch: string;
-  };
-  labels: Array<[string, string]>;
-}
 
 const FORM_SUGGESTION_DOC_URL =
   "https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/#picking-from-a-list-of-unused-apps-suggested-by-pipeds";

--- a/web/src/modules/applications/index.ts
+++ b/web/src/modules/applications/index.ts
@@ -103,8 +103,25 @@ export const addApplication = createAsyncThunk<
     kind?: ApplicationKind;
     platformProvider?: string;
     labels: Array<[string, string]>;
+    deployTargets?: Array<{ pluginName: string; deployTarget: string }>;
   }
 >(`${MODULE_NAME}/add`, async (props) => {
+  const deployTargetsMap =
+    props.deployTargets?.reduce((all, { pluginName, deployTarget }) => {
+      if (!all[pluginName]) all[pluginName] = [];
+      all[pluginName].push(deployTarget);
+      return all;
+    }, {} as Record<string, string[]>) || {};
+
+  const deployTargetsByPluginMap = Object.entries(deployTargetsMap).map(
+    ([pluginName, deployTargetsList]) => {
+      return [pluginName, { deployTargetsList }] as [
+        string,
+        { deployTargetsList: string[] }
+      ];
+    }
+  );
+
   const { applicationId } = await applicationsAPI.addApplication({
     name: props.name,
     pipedId: props.pipedId,
@@ -116,7 +133,7 @@ export const addApplication = createAsyncThunk<
     },
     platformProvider: props.platformProvider,
     kind: props.kind,
-    deployTargetsByPluginMap: [], // TODO: pass this from form
+    deployTargetsByPluginMap,
     description: "",
     labelsMap: props.labels,
   });

--- a/web/src/modules/update-application/index.ts
+++ b/web/src/modules/update-application/index.ts
@@ -26,15 +26,32 @@ export const updateApplication = createAsyncThunk<
     configFilename?: string;
     kind?: ApplicationKind;
     platformProvider?: string;
+    deployTargets?: Array<{ pluginName: string; deployTarget: string }>;
   }
 >(`${MODULE_NAME}/update`, async (values) => {
+  const deployTargetsMap =
+    values.deployTargets?.reduce((all, { pluginName, deployTarget }) => {
+      if (!all[pluginName]) all[pluginName] = [];
+      all[pluginName].push(deployTarget);
+      return all;
+    }, {} as Record<string, string[]>) || {};
+
+  const deployTargetsByPluginMap = Object.entries(deployTargetsMap).map(
+    ([pluginName, deployTargetsList]) => {
+      return [pluginName, { deployTargetsList }] as [
+        string,
+        { deployTargetsList: string[] }
+      ];
+    }
+  );
+
   await applicationAPI.updateApplication({
     applicationId: values.applicationId,
     name: values.name,
     pipedId: values.pipedId,
     platformProvider: values.platformProvider,
     kind: values.kind,
-    deployTargetsByPluginMap: [], // TODO: pass this from form
+    deployTargetsByPluginMap,
     configFilename: values.configFilename || "",
   });
 });


### PR DESCRIPTION
**What this PR does**:
- Update applicaiton form UI  for piped v1 with deployment target Select input

<img src="https://github.com/user-attachments/assets/35a2f926-0eeb-4c95-ab54-74d46a5b1dda" alt="add-form-screen-shot" width="350" />

<img src="https://github.com/user-attachments/assets/8bbad44f-1ba8-4b40-b155-e43debbd2aee" alt="edit-form-screen-shot" width="1024" />


**Why we need it**:
- For adapting API add|edit applicaiton with deployment target config for Piped v1

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5252

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
