### PR TITLE
Update application-detail-page, deployment-detail-page with deployment target info row

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -90,8 +90,6 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
     const deployment = useAppSelector<Deployment.AsObject | undefined>(
       (state) => selectDeploymentById(state.deployments, deploymentId)
     );
-
-    // console.log("❌ ~ DeploymentDetail ~ deployment:", deployment);
     const activeStage = useAppSelector((state) => state.activeStage);
     const piped = useAppSelector(selectPipedById(deployment?.pipedId));
     const isCanceling = useAppSelector(

--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -10,7 +10,7 @@ import {
 import CancelIcon from "@material-ui/icons/Cancel";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import dayjs from "dayjs";
-import { FC, memo } from "react";
+import { FC, memo, useMemo } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { CopyIconButton } from "~/components/copy-icon-button";
 import { DeploymentStatusIcon } from "~/components/deployment-status-icon";
@@ -66,6 +66,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+enum PIPED_VERSION {
+  V0 = "v0",
+  V1 = "v1",
+}
+
 export interface DeploymentDetailProps {
   deploymentId: string;
 }
@@ -85,6 +90,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
     const deployment = useAppSelector<Deployment.AsObject | undefined>(
       (state) => selectDeploymentById(state.deployments, deploymentId)
     );
+
+    // console.log("❌ ~ DeploymentDetail ~ deployment:", deployment);
     const activeStage = useAppSelector((state) => state.activeStage);
     const piped = useAppSelector(selectPipedById(deployment?.pipedId));
     const isCanceling = useAppSelector(
@@ -108,6 +115,12 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
         ? LOG_FETCH_INTERVAL
         : null
     );
+
+    const pipedVersion = useMemo(() => {
+      if (deployment?.deployTargetsByPluginMap?.length) return PIPED_VERSION.V1;
+
+      return PIPED_VERSION.V0;
+    }, [deployment?.deployTargetsByPluginMap?.length]);
 
     if (!deployment || !piped) {
       return (
@@ -181,10 +194,24 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                     }
                   />
                   <DetailTableRow label="Piped" value={piped.name} />
-                  <DetailTableRow
-                    label="Platform Provider"
-                    value={deployment.platformProvider}
-                  />
+                  {pipedVersion === PIPED_VERSION.V0 && (
+                    <DetailTableRow
+                      label="Platform Provider"
+                      value={deployment.platformProvider}
+                    />
+                  )}
+                  {pipedVersion === PIPED_VERSION.V1 && (
+                    <DetailTableRow
+                      label="Deploy Targets"
+                      value={deployment?.deployTargetsByPluginMap
+                        ?.map(([pluginName, { deployTargetsList }]) =>
+                          deployTargetsList.map(
+                            (deployTarget) => `${deployTarget} - ${pluginName}`
+                          )
+                        )
+                        .join(", ")}
+                    />
+                  )}
                   <DetailTableRow label="Summary" value={deployment.summary} />
                 </tbody>
               </table>


### PR DESCRIPTION
**What this PR does**:
As titile

**Why we need it**:
For pages application-detail and deployment-target that using piped v1,
- there is no platformProvider and kind information
- there are new data deployment Targets

**Which issue(s) this PR fixes**:

Fixes #5561

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
