### PR TITLE
Update kubectl version in deployment examples to 1.32.2

### DIFF
--- a/examples/deployment-chain/simple/app.pipecd.yaml
+++ b/examples/deployment-chain/simple/app.pipecd.yaml
@@ -9,7 +9,7 @@ spec:
     manifests:
       - deployment.yaml
       - service.yaml
-    kubectlVersion: 1.18.0
+    kubectlVersion: 1.32.2
   postSync:
     chain:
       applications:

--- a/examples/kubernetes/simple/app.pipecd.yaml
+++ b/examples/kubernetes/simple/app.pipecd.yaml
@@ -9,7 +9,7 @@ spec:
     manifests:
       - deployment.yaml
       - service.yaml
-    kubectlVersion: 1.18.5
+    kubectlVersion: 1.32.2
   description: |
     This app demonstrates how to deploy a Kubernetes application with [Quick Sync](https://pipecd.dev/docs/concepts/#sync-strategy) strategy.\
     No pipeline is specified then in each deployment PipeCD will roll out the new version and switch all traffic to it immediately.\


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We use examples in the k8s plugin test, but there is no binary release for kubectl 1.18.0 for aarch64-darwin. So, the test fails on macOS with Apple Silicon.

There is no need to specify that old version, so I upgraded it to the latest.
ref; https://kubernetes.io/releases/

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:　No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
