### PR TITLE
[sdk] Add 7 metadataStore methods to Client

### DIFF
--- a/pkg/plugin/pipedsdk/client.go
+++ b/pkg/plugin/pipedsdk/client.go
@@ -14,13 +14,21 @@
 
 package pipedsdk
 
-import "github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+import (
+	"context"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"github.com/pipe-cd/pipecd/pkg/plugin/pipedservice"
+)
 
 // Client is a toolkit for interacting with the piped service.
 // It provides methods to call the piped service APIs.
 // It's a wrapper around the raw piped service client.
 type Client struct {
 	base *pipedapi.PipedServiceClient
+
+	// pluginName is used to identify which plugin sends requests to piped.
+	pluginName string
 
 	// applicationID is used to identify the application that the client is working with.
 	applicationID string
@@ -30,4 +38,79 @@ type Client struct {
 	// stageID is used to identify the stage that the client is working with.
 	// This field exists only when the client is working with a specific stage; for example, when this client is passed as the ExecuteStage method's argument.
 	stageID string
+}
+
+// GetStageMetadata gets the metadata of the current stage.
+func (c *Client) GetStageMetadata(ctx context.Context, key string) (string, error) {
+	resp, err := c.base.GetStageMetadata(ctx, &pipedservice.GetStageMetadataRequest{
+		DeploymentId: c.deploymentID,
+		StageId:      c.stageID,
+		Key:          key,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Value, nil
+}
+
+// PutStageMetadata stores the metadata of the current stage.
+func (c *Client) PutStageMetadata(ctx context.Context, key, value string) error {
+	_, err := c.base.PutStageMetadata(ctx, &pipedservice.PutStageMetadataRequest{
+		DeploymentId: c.deploymentID,
+		StageId:      c.stageID,
+		Key:          key,
+		Value:        value,
+	})
+	return err
+}
+
+// PutStageMetadataMulti stores the multiple metadata of the current stage.
+func (c *Client) PutStageMetadataMulti(ctx context.Context, metadata map[string]string) error {
+	_, err := c.base.PutStageMetadataMulti(ctx, &pipedservice.PutStageMetadataMultiRequest{
+		DeploymentId: c.deploymentID,
+		StageId:      c.stageID,
+		Metadata:     metadata,
+	})
+	return err
+}
+
+// GetDeploymentPluginMetadata gets the metadata of the current deployment and plugin.
+func (c *Client) GetDeploymentPluginMetadata(ctx context.Context, key string) (string, error) {
+	resp, err := c.base.GetDeploymentPluginMetadata(ctx, &pipedservice.GetDeploymentPluginMetadataRequest{
+		DeploymentId: c.deploymentID,
+		PluginName:   c.pluginName,
+		Key:          key,
+	})
+	return resp.Value, err
+}
+
+// PutDeploymentPluginMetadata stores the metadata of the current deployment and plugin.
+func (c *Client) PutDeploymentPluginMetadata(ctx context.Context, key, value string) error {
+	_, err := c.base.PutDeploymentPluginMetadata(ctx, &pipedservice.PutDeploymentPluginMetadataRequest{
+		DeploymentId: c.deploymentID,
+		PluginName:   c.pluginName,
+		Key:          key,
+		Value:        value,
+	})
+	return err
+}
+
+// PutDeploymentPluginMetadataMulti stores the multiple metadata of the current deployment and plugin.
+func (c *Client) PutDeploymentPluginMetadataMulti(ctx context.Context, metadata map[string]string) error {
+	_, err := c.base.PutDeploymentPluginMetadataMulti(ctx, &pipedservice.PutDeploymentPluginMetadataMultiRequest{
+		DeploymentId: c.deploymentID,
+		PluginName:   c.pluginName,
+		Metadata:     metadata,
+	})
+	return err
+}
+
+// GetDeploymentSharedMetadata gets the metadata of the current deployment
+// which is shared among piped and plugins.
+func (c *Client) GetDeploymentSharedMetadata(ctx context.Context, key string) (string, error) {
+	resp, err := c.base.GetDeploymentSharedMetadata(ctx, &pipedservice.GetDeploymentSharedMetadataRequest{
+		DeploymentId: c.deploymentID,
+		Key:          key,
+	})
+	return resp.Value, err
 }


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

To make it easier for plugin developers to call methods of metadataStore.

**Which issue(s) this PR fixes**:

Part of #5530

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
