### PR TITLE
Add `Config` field to `PipedPlugin`

### DIFF
--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -1116,6 +1116,8 @@ type PipedPlugin struct {
 	URL string `json:"url"`
 	// The port which the plugin listens to.
 	Port int `json:"port"`
+	// Configuration for the plugin.
+	Config json.RawMessage `json:"config,omitempty"`
 	// The deploy target names.
 	DeployTargets []PipedDeployTarget `json:"deployTargets,omitempty"`
 }

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -1118,7 +1118,7 @@ type PipedPlugin struct {
 	Port int `json:"port"`
 	// Configuration for the plugin.
 	Config json.RawMessage `json:"config,omitempty"`
-	// The deploy target names.
+	// The deploy targets.
 	DeployTargets []PipedDeployTarget `json:"deployTargets,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does**:

- Add `Config` field to `PipedPlugin` for plugin configuration.
- Update comment for `DeployTargets` in `PipedPlugin`

**Why we need it**:

We want to add a plugin configuration that does not depend on deploy targets.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
