### PR TITLE
Add selector handling in k8s plugin sync and rollback stage

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+
+func ensureVariantSelectorInWorkload(m provider.Manifest, variantLabel, variant string) error {
+	variantMap := map[string]string{
+		variantLabel: variant,
+	}
+	if err := m.AddStringMapValues(variantMap, "spec", "selector", "matchLabels"); err != nil {
+		return err
+	}
+	return m.AddStringMapValues(variantMap, "spec", "template", "metadata", "labels")
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+)
+
+func TestCheckVariantSelectorInWorkload(t *testing.T) {
+	t.Parallel()
+
+	const (
+		variantLabel   = "pipecd.dev/variant"
+		primaryVariant = "primary"
+	)
+	testcases := []struct {
+		name     string
+		manifest string
+	}{
+		{
+			name: "missing variant in selector",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+		},
+		{
+			name: "missing variant in template labels",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+		},
+		{
+			name: "wrong variant in selector",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: canary
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+		},
+		{
+			name: "wrong variant in temlate labels",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: canary
+`,
+		},
+		{
+			name: "ok",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+`,
+		},
+	}
+
+	expected := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+`
+	generatedManifests, err := provider.ParseManifests(expected)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(generatedManifests))
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifests, err := provider.ParseManifests(tc.manifest)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(manifests))
+
+			err = ensureVariantSelectorInWorkload(manifests[0], variantLabel, primaryVariant)
+			assert.NoError(t, err)
+			assert.Equal(t, generatedManifests[0], manifests[0])
+		})
+	}
+
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does**:

This PR partially resolves TODO in K8S_SYNC and K8S_ROLLBACK implementation of the Kubernetes plugin.

**Why we need it**:

To make the k8s plugin behave the same as the current piped's Kubernetes deployment feature.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
