### PR TITLE
Improve docker build performance

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -40,3 +40,6 @@ jobs:
           context: tool/${{ matrix.image }}
           tags: ${{ env.REGISTRY }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
           platforms: linux/amd64,linux/arm64
+          # parameter to use inline cache. ref; https://docs.docker.com/build/ci/github-actions/cache/#inline-cache
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/pipe-cd/${{ matrix.image }}:latest
+          cache-to: type=inline

--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -93,6 +93,9 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ matrix.container_registry }}/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
+          # parameter to use inline cache. ref; https://docs.docker.com/build/ci/github-actions/cache/#inline-cache
+          cache-from: type=registry,ref=${{ matrix.container_registry }}/${{ matrix.image }}:latest
+          cache-to: type=inline
 
       # Building and pushing Helm charts.
       - name: Install helm

--- a/.github/workflows/publish_site.yaml
+++ b/.github/workflows/publish_site.yaml
@@ -55,6 +55,9 @@ jobs:
           context: docs
           file: docs/Dockerfile
           tags: ${{ env.GHCR }}/pipe-cd/site:${{ env.PIPECD_VERSION }}
+          # parameter to use inline cache. ref; https://docs.docker.com/build/ci/github-actions/cache/#inline-cache
+          cache-from: type=registry,ref=${{ env.GHCR }}/pipe-cd/site:latest
+          cache-to: type=inline
 
       # Building and pushing Helm charts.
       - name: Install helm

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -51,3 +51,6 @@ jobs:
           tags: ${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:${{ env.PIPECD_VERSION }}
           platforms: linux/amd64,linux/arm64
           push: true
+          # parameter to use inline cache. ref; https://docs.docker.com/build/ci/github-actions/cache/#inline-cache
+          cache-from: type=registry,ref=${{ env.GHCR }}/pipe-cd/${{ matrix.image }}:latest
+          cache-to: type=inline

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,19 +1,13 @@
 # syntax=docker/dockerfile:1
 # web builder
-# because of this issue, we choose node 18
-# https://github.com/pipe-cd/pipecd/issues/5422
-# https://github.com/nodejs/docker-node/issues/1335#issuecomment-2024344411
-FROM node:18.20.5-alpine3.21 AS web
+# because this stage builds only web assets, we can use any platform
+FROM --platform=$BUILDPLATFORM node:18.20.5-alpine3.21 AS web
 
 WORKDIR /app
 
 COPY . .
 
 RUN apk add --no-cache make git
-
-# because of this issue, we set network-timeout to 300000
-# https://github.com/pipe-cd/pipecd/issues/5422
-RUN yarn config set network-timeout 300000
 
 RUN make update/web-deps
 RUN make build/web


### PR DESCRIPTION
**What this PR does**:

- Use `--platform=$BUILDPLATFORM` flag to build web static assets in a docker multi-stage build
- Use docker build cache from the latest image in GitHub Actions Workflow

**Why we need it**:

- I want to reduce CI build time

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
