### PR TITLE
Show kind="APPLICATION" for item using pipedv1 in App and Deploy List page

### DIFF
--- a/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -62,6 +62,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+enum PipedVersion {
+  V0 = "v0",
+  V1 = "v1",
+}
+
 const EmptyDeploymentData: FC<{ displayAllProperties: boolean }> = ({
   displayAllProperties,
 }) =>
@@ -136,6 +141,11 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
 
     const recentlyDeployment = app.mostRecentlySuccessfulDeployment;
 
+    const pipedVersion =
+      !app.platformProvider || app?.deployTargetsByPluginMap?.length > 0
+        ? PipedVersion.V1
+        : PipedVersion.V0;
+
     return (
       <>
         <TableRow className={clsx({ [classes.disabled]: app.disabled })}>
@@ -155,7 +165,11 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
               {app.name}
             </Link>
           </TableCell>
-          <TableCell>{APPLICATION_KIND_TEXT[app.kind]}</TableCell>
+          <TableCell>
+            {pipedVersion === PipedVersion.V0 &&
+              APPLICATION_KIND_TEXT[app.kind]}
+            {pipedVersion === PipedVersion.V1 && "APPLICATION"}
+          </TableCell>
           <TableCell>
             <div className={classes.labels}>
               {app.labelsMap.length !== 0

--- a/web/src/components/deployments-page/deployment-item/index.tsx
+++ b/web/src/components/deployments-page/deployment-item/index.tsx
@@ -44,6 +44,11 @@ export interface DeploymentItemProps {
   id: string;
 }
 
+enum PipedVersion {
+  V0 = "v0",
+  V1 = "v1",
+}
+
 const NO_DESCRIPTION = "No description.";
 
 export const DeploymentItem: FC<DeploymentItemProps> = memo(
@@ -56,6 +61,12 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
     if (!deployment) {
       return null;
     }
+
+    const pipedVersion =
+      !deployment.platformProvider ||
+      deployment?.deployTargetsByPluginMap?.length > 0
+        ? PipedVersion.V1
+        : PipedVersion.V0;
 
     return (
       <ListItem
@@ -92,7 +103,9 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
               color="textSecondary"
               className={classes.info}
             >
-              {APPLICATION_KIND_TEXT[deployment.kind]}
+              {pipedVersion === PipedVersion.V0 &&
+                APPLICATION_KIND_TEXT[deployment.kind]}
+              {pipedVersion === PipedVersion.V1 && "APPLICATION"}
               {deployment?.labelsMap.map(([key, value], i) => (
                 <Chip
                   label={key + ": " + value}


### PR DESCRIPTION
**What this PR does**:
- Show kind = "APPLICATION" for item using pipedv1 in Application List Page
- Show kind = "APPLICATION" for item using pipedv1 in Deployment List Page

**Why we need it**:
- Currently application list item and deployment list item using pipedv1 show Kind = KUBERNETES, it should be APPLICATION

**Which issue(s) this PR fixes**:

Part of #5252  #5509

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: none
