### PR TITLE
Add DeployTargetConfig and unmarshal config json

### DIFF
--- a/pkg/plugin/pipedsdk/deployment.go
+++ b/pkg/plugin/pipedsdk/deployment.go
@@ -16,6 +16,8 @@ package pipedsdk
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -34,15 +36,22 @@ var (
 
 		Register(server *grpc.Server)
 		setCommonFields(commonFields)
+		setConfig([]byte) error
 		deployment.DeploymentServiceServer
 	}
 )
 
+// DeployTargetsNone is a type alias for a slice of pointers to DeployTarget
+// with an empty struct as the generic type parameter. It represents a case
+// where there are no deployment targets.
+// This utility is defined for plugins which has no deploy targets handling in ExecuteStage.
+type DeployTargetsNone = []*DeployTarget[struct{}]
+
 // DeploymentPlugin is the interface that be implemented by a full-spec deployment plugin.
 // This kind of plugin should implement all methods to manage resources and execute stages.
 // The Config parameter is the plugin's config defined in piped's config.
-type DeploymentPlugin[Config any] interface {
-	PipelineSyncPlugin[Config]
+type DeploymentPlugin[Config, DeployTargetConfig any] interface {
+	PipelineSyncPlugin[Config, DeployTargetConfig]
 
 	// DetermineVersions determines the versions of the resources that will be deployed.
 	DetermineVersions(context.Context, *Config, *Client, TODO) (TODO, error)
@@ -55,7 +64,8 @@ type DeploymentPlugin[Config any] interface {
 // PipelineSyncPlugin is the interface implemented by a pipeline sync plugin.
 // This kind of plugin may not implement quick sync stages, and will not manage resources like deployment plugin.
 // It only focuses on executing stages which is generic for all kinds of pipeline sync plugins.
-type PipelineSyncPlugin[Config any] interface {
+// The Config parameter is the plugin's config defined in piped's config.
+type PipelineSyncPlugin[Config, DeployTargetConfig any] interface {
 	Plugin
 
 	// FetchDefinedStages returns the list of stages that the plugin can execute.
@@ -63,19 +73,29 @@ type PipelineSyncPlugin[Config any] interface {
 	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
 	BuildPipelineSyncStages(context.Context, *Config, *Client, TODO) (TODO, error)
 	// ExecuteStage executes the given stage.
-	ExecuteStage(context.Context, *Config, *Client, logpersister.StageLogPersister, TODO) (TODO, error)
+	ExecuteStage(context.Context, *Config, []*DeployTarget[DeployTargetConfig], *Client, logpersister.StageLogPersister, TODO) (TODO, error)
+}
+
+// DeployTarget defines the deploy target configuration for the piped.
+type DeployTarget[Config any] struct {
+	// The name of the deploy target.
+	Name string `json:"name"`
+	// The labes of the deploy target.
+	Labels map[string]string `json:"labels,omitempty"`
+	// The configuration of the deploy target.
+	Config Config `json:"config"`
 }
 
 // RegisterDeploymentPlugin registers the given deployment plugin.
 // It will be used when running the piped.
-func RegisterDeploymentPlugin[Config any](plugin DeploymentPlugin[Config]) {
-	deploymentServiceServer = &DeploymentPluginServiceServer[Config]{base: plugin}
+func RegisterDeploymentPlugin[Config, DeployTargetConfig any](plugin DeploymentPlugin[Config, DeployTargetConfig]) {
+	deploymentServiceServer = &DeploymentPluginServiceServer[Config, DeployTargetConfig]{base: plugin}
 }
 
 // RegisterPipelineSyncPlugin registers the given pipeline sync plugin.
 // It will be used when running the piped.
-func RegisterPipelineSyncPlugin[Config any](plugin PipelineSyncPlugin[Config]) {
-	deploymentServiceServer = &PipelineSyncPluginServiceServer[Config]{base: plugin}
+func RegisterPipelineSyncPlugin[Config, DeployTargetConfig any](plugin PipelineSyncPlugin[Config, DeployTargetConfig]) {
+	deploymentServiceServer = &PipelineSyncPluginServiceServer[Config, DeployTargetConfig]{base: plugin}
 }
 
 type logPersister interface {
@@ -90,92 +110,108 @@ type commonFields struct {
 }
 
 // DeploymentPluginServiceServer is the gRPC server that handles requests from the piped.
-type DeploymentPluginServiceServer[Config any] struct {
+type DeploymentPluginServiceServer[Config, DeployTargetConfig any] struct {
 	deployment.UnimplementedDeploymentServiceServer
 	commonFields
 
-	base DeploymentPlugin[Config]
+	base   DeploymentPlugin[Config, DeployTargetConfig]
+	config Config
 }
 
 // Name returns the name of the plugin.
-func (s *DeploymentPluginServiceServer[Config]) Name() string {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) Name() string {
 	return s.base.Name()
 }
 
-func (s *DeploymentPluginServiceServer[Config]) Version() string {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) Version() string {
 	return s.base.Version()
 }
 
 // Register registers the server to the given gRPC server.
-func (s *DeploymentPluginServiceServer[Config]) Register(server *grpc.Server) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) Register(server *grpc.Server) {
 	deployment.RegisterDeploymentServiceServer(server, s)
 }
 
-func (s *DeploymentPluginServiceServer[Config]) setCommonFields(fields commonFields) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) setCommonFields(fields commonFields) {
 	s.commonFields = fields
 }
 
-func (s *DeploymentPluginServiceServer[Config]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) setConfig(bytes []byte) error {
+	if err := json.Unmarshal(bytes, &s.config); err != nil {
+		return fmt.Errorf("failed to unmarshal the plugin config: %v", err)
+	}
+	return nil
+}
+
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
 	return &deployment.FetchDefinedStagesResponse{Stages: s.base.FetchDefinedStages()}, nil
 }
-func (s *DeploymentPluginServiceServer[Config]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DetermineVersions not implemented")
 }
-func (s *DeploymentPluginServiceServer[Config]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DetermineStrategy not implemented")
 }
-func (s *DeploymentPluginServiceServer[Config]) BuildPipelineSyncStages(context.Context, *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) BuildPipelineSyncStages(ctx context.Context, request *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildPipelineSyncStages not implemented")
 }
-func (s *DeploymentPluginServiceServer[Config]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
 }
-func (s *DeploymentPluginServiceServer[Config]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExecuteStage not implemented")
 }
 
 // PipelineSyncPluginServiceServer is the gRPC server that handles requests from the piped.
-type PipelineSyncPluginServiceServer[Config any] struct {
+type PipelineSyncPluginServiceServer[Config, DeployTargetConfig any] struct {
 	deployment.UnimplementedDeploymentServiceServer
 	commonFields
 
-	base PipelineSyncPlugin[Config]
+	base   PipelineSyncPlugin[Config, DeployTargetConfig]
+	config Config
 }
 
 // Name returns the name of the plugin.
-func (s *PipelineSyncPluginServiceServer[Config]) Name() string {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) Name() string {
 	return s.base.Name()
 }
 
 // Version returns the version of the plugin.
-func (s *PipelineSyncPluginServiceServer[Config]) Version() string {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) Version() string {
 	return s.base.Version()
 }
 
 // Register registers the server to the given gRPC server.
-func (s *PipelineSyncPluginServiceServer[Config]) Register(server *grpc.Server) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) Register(server *grpc.Server) {
 	deployment.RegisterDeploymentServiceServer(server, s)
 }
 
-func (s *PipelineSyncPluginServiceServer[Config]) setCommonFields(fields commonFields) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) setCommonFields(fields commonFields) {
 	s.commonFields = fields
 }
 
-func (s *PipelineSyncPluginServiceServer[Config]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) setConfig(bytes []byte) error {
+	if err := json.Unmarshal(bytes, &s.config); err != nil {
+		return fmt.Errorf("failed to unmarshal the plugin config: %v", err)
+	}
+	return nil
+}
+
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) FetchDefinedStages(context.Context, *deployment.FetchDefinedStagesRequest) (*deployment.FetchDefinedStagesResponse, error) {
 	return &deployment.FetchDefinedStagesResponse{Stages: s.base.FetchDefinedStages()}, nil
 }
-func (s *PipelineSyncPluginServiceServer[Config]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DetermineVersions not implemented")
 }
-func (s *PipelineSyncPluginServiceServer[Config]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DetermineStrategy not implemented")
 }
-func (s *PipelineSyncPluginServiceServer[Config]) BuildPipelineSyncStages(context.Context, *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) BuildPipelineSyncStages(ctx context.Context, request *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildPipelineSyncStages not implemented")
 }
-func (s *PipelineSyncPluginServiceServer[Config]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
 }
-func (s *PipelineSyncPluginServiceServer[Config]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(context.Context, *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExecuteStage not implemented")
 }

--- a/pkg/plugin/pipedsdk/sdk.go
+++ b/pkg/plugin/pipedsdk/sdk.go
@@ -162,6 +162,10 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 			logPersister: persister,
 			client:       pipedapiClient,
 		})
+		if err := deploymentServiceServer.setConfig(cfg.Config); err != nil {
+			input.Logger.Error("failed to set configuration", zap.Error(err))
+			return err
+		}
 		var (
 			opts = []rpc.Option{
 				rpc.WithPort(cfg.Port),


### PR DESCRIPTION
**What this PR does**:

- Add struct `DeployTarget` to represent deploy targets for plugins.
- Implement unmarshaling of plugin config

**Why we need it**:

- I want the plugin developer to write less code, such as unmarshaling JSON to config struct.

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
