### PR TITLE
Add example plugin implementation using SDK

### DIFF
--- a/pkg/app/pipedv1/plugin/example/main.go
+++ b/pkg/app/pipedv1/plugin/example/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func main() {
+	sdk.RegisterPipelineSyncPlugin(&plugin{})
+
+	if err := sdk.Run(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/pkg/app/pipedv1/plugin/example/main.go
+++ b/pkg/app/pipedv1/plugin/example/main.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/app/pipedv1/plugin/example/plugin.go
+++ b/pkg/app/pipedv1/plugin/example/plugin.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+type plugin struct{}
+
+type config struct{}
+
+// Name implements sdk.Plugin.
+func (p *plugin) Name() string {
+	return "example"
+}
+
+// Version implements sdk.Plugin.
+func (p *plugin) Version() string {
+	return "0.0.1"
+}
+
+// BuildPipelineSyncStages implements sdk.PipelineSyncPlugin.
+func (p *plugin) BuildPipelineSyncStages(context.Context, *config, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+// ExecuteStage implements sdk.PipelineSyncPlugin.
+func (p *plugin) ExecuteStage(context.Context, *config, sdk.DeployTargetsNone, *sdk.Client, logpersister.StageLogPersister, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+// FetchDefinedStages implements sdk.PipelineSyncPlugin.
+func (p *plugin) FetchDefinedStages() []string {
+	return []string{"EXAMPLE_PLAN", "EXAMPLE_APPLY"}
+}

--- a/pkg/app/pipedv1/plugin/example/plugin.go
+++ b/pkg/app/pipedv1/plugin/example/plugin.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pipedsdk
+package sdk
 
 import (
 	"context"

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pipedsdk
+package sdk
 
 import (
 	"context"

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -137,6 +137,9 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) setCommonFie
 }
 
 func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) setConfig(bytes []byte) error {
+	if bytes == nil {
+		return nil
+	}
 	if err := json.Unmarshal(bytes, &s.config); err != nil {
 		return fmt.Errorf("failed to unmarshal the plugin config: %v", err)
 	}
@@ -191,6 +194,9 @@ func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) setCommonF
 }
 
 func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) setConfig(bytes []byte) error {
+	if bytes == nil {
+		return nil
+	}
 	if err := json.Unmarshal(bytes, &s.config); err != nil {
 		return fmt.Errorf("failed to unmarshal the plugin config: %v", err)
 	}

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -207,10 +207,10 @@ func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) FetchDefin
 	return &deployment.FetchDefinedStagesResponse{Stages: s.base.FetchDefinedStages()}, nil
 }
 func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) DetermineVersions(context.Context, *deployment.DetermineVersionsRequest) (*deployment.DetermineVersionsResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DetermineVersions not implemented")
+	return &deployment.DetermineVersionsResponse{}, nil
 }
 func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) DetermineStrategy(context.Context, *deployment.DetermineStrategyRequest) (*deployment.DetermineStrategyResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DetermineStrategy not implemented")
+	return &deployment.DetermineStrategyResponse{Unsupported: true}, nil
 }
 func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) BuildPipelineSyncStages(ctx context.Context, request *deployment.BuildPipelineSyncStagesRequest) (*deployment.BuildPipelineSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildPipelineSyncStages not implemented")

--- a/pkg/plugin/sdk/sdk.go
+++ b/pkg/plugin/sdk/sdk.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // package pipedsdk provides software development kits for building PipeCD piped plugins.
-package pipedsdk
+package sdk
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does**:

- rename pipedsdk to SDK
    - the name `pipedsdk` is confusing because it's SDK for plugin not piped.
- add example plugin
- fix error in config unmarshal
- implement some methods for PipelineSyncPlugin

**Why we need it**:

It's nice that we have example implementation

**Which issue(s) this PR fixes**:

Part of #5529 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
