### PR TITLE
[SDK] Refine StageLogPersister handling in SDK

### DIFF
--- a/pkg/app/pipedv1/plugin/wait/wait.go
+++ b/pkg/app/pipedv1/plugin/wait/wait.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/pipe-cd/pipecd/pkg/app/piped/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
@@ -35,7 +34,7 @@ const (
 func (p *plugin) executeWait(ctx context.Context, in *sdk.ExecuteStageInput) sdk.StageStatus {
 	opts, err := decode(in.Request.StageConfig)
 	if err != nil {
-		in.Client.LogPersister.Errorf("failed to decode the stage config: %v", err)
+		in.Client.LogPersister().Errorf("failed to decode the stage config: %v", err)
 		return sdk.StageStatusFailure
 	}
 
@@ -49,10 +48,10 @@ func (p *plugin) executeWait(ctx context.Context, in *sdk.ExecuteStageInput) sdk
 	}
 	p.saveStartTime(ctx, in.Client, initialStart, in.Logger)
 
-	return wait(ctx, duration, initialStart, in.Client.LogPersister)
+	return wait(ctx, duration, initialStart, in.Client.LogPersister())
 }
 
-func wait(ctx context.Context, duration time.Duration, initialStart time.Time, slp logpersister.StageLogPersister) sdk.StageStatus {
+func wait(ctx context.Context, duration time.Duration, initialStart time.Time, slp sdk.StageLogPersister) sdk.StageStatus {
 	remaining := duration - time.Since(initialStart)
 	if remaining <= 0 {
 		// When this stage restarted and the duration has already passed.

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"github.com/pipe-cd/pipecd/pkg/plugin/signalhandler"
 )
 
 var (
@@ -170,14 +171,24 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) BuildPipelin
 func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
 }
-func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {
+	lp := s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId())
+	defer func() {
+		// When termination signal received and the stage is not completed yet, we should not mark the log persister as completed.
+		// This can occur when the piped is shutting down while the stage is still running.
+		if !response.GetStatus().IsCompleted() && signalhandler.Terminated() {
+			return
+		}
+		lp.Complete(time.Minute)
+	}()
+
 	client := &Client{
 		base:          s.client,
 		pluginName:    s.Name(),
 		applicationID: request.GetInput().GetDeployment().GetApplicationId(),
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
-		logPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
+		logPersister:  lp,
 	}
 	return executeStage(ctx, s.base, &s.config, nil, client, request, s.logger) // TODO: pass the deployTargets
 }
@@ -240,15 +251,26 @@ func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) BuildPipel
 func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
 }
-func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (*deployment.ExecuteStageResponse, error) {
+func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {
+	lp := s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId())
+	defer func() {
+		// When termination signal received and the stage is not completed yet, we should not mark the log persister as completed.
+		// This can occur when the piped is shutting down while the stage is still running.
+		if !response.GetStatus().IsCompleted() && signalhandler.Terminated() {
+			return
+		}
+		lp.Complete(time.Minute)
+	}()
+
 	client := &Client{
 		base:          s.client,
 		pluginName:    s.Name(),
 		applicationID: request.GetInput().GetDeployment().GetApplicationId(),
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
-		logPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
+		logPersister:  lp,
 	}
+
 	return executeStage(ctx, s.base, &s.config, nil, client, request, s.logger) // TODO: pass the deployTargets
 }
 

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -177,7 +177,7 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage
 		applicationID: request.GetInput().GetDeployment().GetApplicationId(),
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
-		LogPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
+		logPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
 	}
 	return executeStage(ctx, s.base, &s.config, nil, client, request, s.logger) // TODO: pass the deployTargets
 }
@@ -247,7 +247,7 @@ func (s *PipelineSyncPluginServiceServer[Config, DeployTargetConfig]) ExecuteSta
 		applicationID: request.GetInput().GetDeployment().GetApplicationId(),
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
-		LogPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
+		logPersister:  s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId()),
 	}
 	return executeStage(ctx, s.base, &s.config, nil, client, request, s.logger) // TODO: pass the deployTargets
 }


### PR DESCRIPTION
**What this PR does**:

- define type `sdk.StageLogPersister` and replace `logpersister.StageLogPersister` with it.
- Add graceful shutdown handling in ExecuteStage

**Why we need it**:

- The `Complete` method of StageLogPersister is called only in SDK, so hide it from SDK users.
- We have to handle graceful shutdown to implement plugins correctly, but it's difficult for users who don't know the piped behavior. So, I want to do it in SDK.

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
