### PR TITLE
Add increase operation to calc Total triggered deploys

### DIFF
--- a/manifests/pipecd/grafana-dashboards/control-plane/overview.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/overview.json
@@ -466,7 +466,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(grpcapi_create_deployment_total{project=~\"$project\"})",
+          "expr": "sum(increase(grpcapi_create_deployment_total{project=~\"$project\"}[24h]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/manifests/pipecd/grafana-dashboards/control-plane/overview.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/overview.json
@@ -531,7 +531,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (project) (grpcapi_create_deployment_total)",
+          "expr": "sum by (project) (increase(grpcapi_create_deployment_total[24h]))",
           "interval": "",
           "legendFormat": "{{project}}",
           "refId": "A"

--- a/manifests/pipecd/grafana-dashboards/control-plane/overview.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/overview.json
@@ -466,7 +466,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(grpcapi_create_deployment_total{project=~\"$project\"}[24h]))",
+          "expr": "sum(round(increase(grpcapi_create_deployment_total{project=~\"$project\"}[24h])))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -531,7 +531,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (project) (increase(grpcapi_create_deployment_total[24h]))",
+          "expr": "sum by (project) (round(increase(grpcapi_create_deployment_total[24h])))",
           "interval": "",
           "legendFormat": "{{project}}",
           "refId": "A"


### PR DESCRIPTION
**What this PR does**:

This PR fixes the Grafana dashboard to use the `increase` operation when calculating the total triggered deployments in the last 24 hours.

**Why we need it**:

The metric `grpcapi_create_deployment_total` is a counter metric, so we have to use the `increase` operation to view it correctly.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
The control plane managers who use the monitoring feature.

- **Is this breaking change**:
- **How to migrate (if breaking change)**:
