### PR TITLE
Implement BuildPipelineSyncStages for k8s multi sync 

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -17,53 +17,20 @@ package deployment
 import (
 	"slices"
 
-	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
-
-type Stage string
 
 const (
 	// StageK8sSync represents the state where
 	// all resources should be synced with the Git state.
-	StageK8sMultiSync Stage = "K8S_MULTI_SYNC"
+	StageK8sMultiSync string = "K8S_MULTI_SYNC"
 	// StageK8sRollback represents the state where all deployed resources should be rollbacked.
-	StageK8sMultiRollback Stage = "K8S_MULTI_ROLLBACK"
+	StageK8sMultiRollback string = "K8S_MULTI_ROLLBACK"
 )
 
-var AllStages = []Stage{
+var AllStages = []string{
 	StageK8sMultiSync,
 	StageK8sMultiRollback,
-}
-
-func (s Stage) String() string {
-	return string(s)
-}
-
-const (
-	PredefinedStageK8sMultiSync     = "K8sMultiSync"
-	PredefinedStageK8sMultiRollback = "K8sMultiRollback"
-)
-
-var predefinedStages = map[string]*model.PipelineStage{
-	PredefinedStageK8sMultiSync: {
-		Id:       PredefinedStageK8sMultiSync,
-		Name:     string(StageK8sMultiSync),
-		Desc:     "Sync by applying all manifests",
-		Rollback: false,
-	},
-	PredefinedStageK8sMultiRollback: {
-		Id:       PredefinedStageK8sMultiRollback,
-		Name:     string(StageK8sMultiRollback),
-		Desc:     "Rollback the deployment",
-		Rollback: true,
-	},
-}
-
-// GetPredefinedStage finds and returns the predefined stage for the given id.
-func GetPredefinedStage(id string) (*model.PipelineStage, bool) {
-	stage, ok := predefinedStages[id]
-	return stage, ok
 }
 
 func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.PipelineStage {
@@ -86,11 +53,10 @@ func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 			return a.Index - b.Index
 		}).Index
 
-		s, _ := GetPredefinedStage(PredefinedStageK8sMultiRollback)
 		// we copy the predefined stage to avoid modifying the original one.
 		out = append(out, sdk.PipelineStage{
 			Index:              minIndex,
-			Name:               s.Name,
+			Name:               StageK8sMultiRollback,
 			Rollback:           true,
 			Metadata:           make(map[string]string, 0),
 			AvailableOperation: sdk.ManualOperationNone,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -27,36 +27,12 @@ const (
 	// StageK8sSync represents the state where
 	// all resources should be synced with the Git state.
 	StageK8sSync Stage = "K8S_SYNC"
-	// StageK8sPrimaryRollout represents the state where
-	// the PRIMARY variant resources has been updated to the new version/configuration.
-	StageK8sPrimaryRollout Stage = "K8S_PRIMARY_ROLLOUT"
-	// StageK8sCanaryRollout represents the state where
-	// the CANARY variant resources has been rolled out with the new version/configuration.
-	StageK8sCanaryRollout Stage = "K8S_CANARY_ROLLOUT"
-	// StageK8sCanaryClean represents the state where
-	// the CANARY variant resources has been cleaned.
-	StageK8sCanaryClean Stage = "K8S_CANARY_CLEAN"
-	// StageK8sBaselineRollout represents the state where
-	// the BASELINE variant resources has been rolled out.
-	StageK8sBaselineRollout Stage = "K8S_BASELINE_ROLLOUT"
-	// StageK8sBaselineClean represents the state where
-	// the BASELINE variant resources has been cleaned.
-	StageK8sBaselineClean Stage = "K8S_BASELINE_CLEAN"
-	// StageK8sTrafficRouting represents the state where the traffic to application
-	// should be splitted as the specified percentage to PRIMARY, CANARY, BASELINE variants.
-	StageK8sTrafficRouting Stage = "K8S_TRAFFIC_ROUTING"
 	// StageK8sRollback represents the state where all deployed resources should be rollbacked.
 	StageK8sRollback Stage = "K8S_ROLLBACK"
 )
 
 var AllStages = []Stage{
 	StageK8sSync,
-	StageK8sPrimaryRollout,
-	StageK8sCanaryRollout,
-	StageK8sCanaryClean,
-	StageK8sBaselineRollout,
-	StageK8sBaselineClean,
-	StageK8sTrafficRouting,
 	StageK8sRollback,
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -26,14 +26,14 @@ type Stage string
 const (
 	// StageK8sSync represents the state where
 	// all resources should be synced with the Git state.
-	StageK8sSync Stage = "K8S_SYNC"
+	StageK8sMultiSync Stage = "K8S_MULTI_SYNC"
 	// StageK8sRollback represents the state where all deployed resources should be rollbacked.
-	StageK8sRollback Stage = "K8S_ROLLBACK"
+	StageK8sMultiRollback Stage = "K8S_MULTI_ROLLBACK"
 )
 
 var AllStages = []Stage{
-	StageK8sSync,
-	StageK8sRollback,
+	StageK8sMultiSync,
+	StageK8sMultiRollback,
 }
 
 func (s Stage) String() string {
@@ -41,20 +41,20 @@ func (s Stage) String() string {
 }
 
 const (
-	PredefinedStageK8sSync  = "K8sSync"
-	PredefinedStageRollback = "K8sRollback"
+	PredefinedStageK8sMultiSync     = "K8sMultiSync"
+	PredefinedStageK8sMultiRollback = "K8sMultiRollback"
 )
 
 var predefinedStages = map[string]*model.PipelineStage{
-	PredefinedStageK8sSync: {
-		Id:       PredefinedStageK8sSync,
-		Name:     string(StageK8sSync),
+	PredefinedStageK8sMultiSync: {
+		Id:       PredefinedStageK8sMultiSync,
+		Name:     string(StageK8sMultiSync),
 		Desc:     "Sync by applying all manifests",
 		Rollback: false,
 	},
-	PredefinedStageRollback: {
-		Id:       PredefinedStageRollback,
-		Name:     string(StageK8sRollback),
+	PredefinedStageK8sMultiRollback: {
+		Id:       PredefinedStageK8sMultiRollback,
+		Name:     string(StageK8sMultiRollback),
 		Desc:     "Rollback the deployment",
 		Rollback: true,
 	},
@@ -86,7 +86,7 @@ func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 			return a.Index - b.Index
 		}).Index
 
-		s, _ := GetPredefinedStage(PredefinedStageRollback)
+		s, _ := GetPredefinedStage(PredefinedStageK8sMultiRollback)
 		// we copy the predefined stage to avoid modifying the original one.
 		out = append(out, sdk.PipelineStage{
 			Index:              minIndex,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	// StageK8sSync represents the state where
+	// StageK8sMultiSync represents the state where
 	// all resources should be synced with the Git state.
 	StageK8sMultiSync string = "K8S_MULTI_SYNC"
-	// StageK8sRollback represents the state where all deployed resources should be rollbacked.
+	// StageK8sMultiRollback represents the state where all deployed resources should be rollbacked.
 	StageK8sMultiRollback string = "K8S_MULTI_ROLLBACK"
 )
 
@@ -53,7 +53,6 @@ func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 			return a.Index - b.Index
 		}).Index
 
-		// we copy the predefined stage to avoid modifying the original one.
 		out = append(out, sdk.PipelineStage{
 			Index:              minIndex,
 			Name:               StageK8sMultiRollback,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -1,4 +1,4 @@
-// Copyright 202 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 	if input.Request.Rollback {
 		// we set the index of the rollback stage to the minimum index of all stages.
 		minIndex := slices.MinFunc(out, func(a, b sdk.PipelineStage) int {
-			return int(a.Index - b.Index)
+			return a.Index - b.Index
 		}).Index
 
 		s, _ := GetPredefinedStage(PredefinedStageRollback)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -1,0 +1,125 @@
+// Copyright 202 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"slices"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+type Stage string
+
+const (
+	// StageK8sSync represents the state where
+	// all resources should be synced with the Git state.
+	StageK8sSync Stage = "K8S_SYNC"
+	// StageK8sPrimaryRollout represents the state where
+	// the PRIMARY variant resources has been updated to the new version/configuration.
+	StageK8sPrimaryRollout Stage = "K8S_PRIMARY_ROLLOUT"
+	// StageK8sCanaryRollout represents the state where
+	// the CANARY variant resources has been rolled out with the new version/configuration.
+	StageK8sCanaryRollout Stage = "K8S_CANARY_ROLLOUT"
+	// StageK8sCanaryClean represents the state where
+	// the CANARY variant resources has been cleaned.
+	StageK8sCanaryClean Stage = "K8S_CANARY_CLEAN"
+	// StageK8sBaselineRollout represents the state where
+	// the BASELINE variant resources has been rolled out.
+	StageK8sBaselineRollout Stage = "K8S_BASELINE_ROLLOUT"
+	// StageK8sBaselineClean represents the state where
+	// the BASELINE variant resources has been cleaned.
+	StageK8sBaselineClean Stage = "K8S_BASELINE_CLEAN"
+	// StageK8sTrafficRouting represents the state where the traffic to application
+	// should be splitted as the specified percentage to PRIMARY, CANARY, BASELINE variants.
+	StageK8sTrafficRouting Stage = "K8S_TRAFFIC_ROUTING"
+	// StageK8sRollback represents the state where all deployed resources should be rollbacked.
+	StageK8sRollback Stage = "K8S_ROLLBACK"
+)
+
+var AllStages = []Stage{
+	StageK8sSync,
+	StageK8sPrimaryRollout,
+	StageK8sCanaryRollout,
+	StageK8sCanaryClean,
+	StageK8sBaselineRollout,
+	StageK8sBaselineClean,
+	StageK8sTrafficRouting,
+	StageK8sRollback,
+}
+
+func (s Stage) String() string {
+	return string(s)
+}
+
+const (
+	PredefinedStageK8sSync  = "K8sSync"
+	PredefinedStageRollback = "K8sRollback"
+)
+
+var predefinedStages = map[string]*model.PipelineStage{
+	PredefinedStageK8sSync: {
+		Id:       PredefinedStageK8sSync,
+		Name:     string(StageK8sSync),
+		Desc:     "Sync by applying all manifests",
+		Rollback: false,
+	},
+	PredefinedStageRollback: {
+		Id:       PredefinedStageRollback,
+		Name:     string(StageK8sRollback),
+		Desc:     "Rollback the deployment",
+		Rollback: true,
+	},
+}
+
+// GetPredefinedStage finds and returns the predefined stage for the given id.
+func GetPredefinedStage(id string) (*model.PipelineStage, bool) {
+	stage, ok := predefinedStages[id]
+	return stage, ok
+}
+
+func BuildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.PipelineStage {
+	out := make([]sdk.PipelineStage, 0, len(input.Request.Stages)+1)
+
+	for _, s := range input.Request.Stages {
+		stage := sdk.PipelineStage{
+			Index:              s.Index,
+			Name:               s.Name,
+			Rollback:           false,
+			Metadata:           make(map[string]string, 0),
+			AvailableOperation: sdk.ManualOperationNone,
+		}
+		out = append(out, stage)
+	}
+
+	if input.Request.Rollback {
+		// we set the index of the rollback stage to the minimum index of all stages.
+		minIndex := slices.MinFunc(out, func(a, b sdk.PipelineStage) int {
+			return int(a.Index - b.Index)
+		}).Index
+
+		s, _ := GetPredefinedStage(PredefinedStageRollback)
+		// we copy the predefined stage to avoid modifying the original one.
+		out = append(out, sdk.PipelineStage{
+			Index:              minIndex,
+			Name:               s.Name,
+			Rollback:           true,
+			Metadata:           make(map[string]string, 0),
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+
+	return out
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
@@ -113,6 +113,8 @@ func TestBuildPipelineStages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := BuildPipelineStages(tt.input)
 			assert.Equal(t, tt.expected, actual)
 		})

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
@@ -102,7 +102,7 @@ func TestBuildPipelineStages(t *testing.T) {
 				},
 				{
 					Index:              0,
-					Name:               string(StageK8sMultiRollback),
+					Name:               StageK8sMultiRollback,
 					Rollback:           true,
 					Metadata:           make(map[string]string, 0),
 					AvailableOperation: sdk.ManualOperationNone,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func TestBuildPipelineStages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *sdk.BuildPipelineSyncStagesInput
+		expected []sdk.PipelineStage
+	}{
+		{
+			name: "without auto rollback",
+			input: &sdk.BuildPipelineSyncStagesInput{
+				Request: sdk.BuildPipelineSyncStagesRequest{
+					Rollback: false,
+					Stages: []sdk.StageConfig{
+						{
+							Index:  0,
+							Name:   "Stage 1",
+							Config: []byte(""),
+						},
+						{
+							Index:  1,
+							Name:   "Stage 2",
+							Config: []byte(""),
+						},
+					},
+				},
+			},
+			expected: []sdk.PipelineStage{
+				{
+					Index:              0,
+					Name:               "Stage 1",
+					Rollback:           false,
+					Metadata:           make(map[string]string, 0),
+					AvailableOperation: sdk.ManualOperationNone,
+				},
+				{
+					Index:              1,
+					Name:               "Stage 2",
+					Rollback:           false,
+					Metadata:           make(map[string]string, 0),
+					AvailableOperation: sdk.ManualOperationNone,
+				},
+			},
+		},
+		{
+			name: "with auto rollback",
+			input: &sdk.BuildPipelineSyncStagesInput{
+				Request: sdk.BuildPipelineSyncStagesRequest{
+					Rollback: true,
+					Stages: []sdk.StageConfig{
+						{
+							Index:  0,
+							Name:   "Stage 1",
+							Config: []byte(""),
+						},
+						{
+							Index:  1,
+							Name:   "Stage 2",
+							Config: []byte(""),
+						},
+					},
+				},
+			},
+			expected: []sdk.PipelineStage{
+				{
+					Index:              0,
+					Name:               "Stage 1",
+					Rollback:           false,
+					Metadata:           make(map[string]string, 0),
+					AvailableOperation: sdk.ManualOperationNone,
+				},
+				{
+					Index:              1,
+					Name:               "Stage 2",
+					Rollback:           false,
+					Metadata:           make(map[string]string, 0),
+					AvailableOperation: sdk.ManualOperationNone,
+				},
+				{
+					Index:              0,
+					Name:               string(StageK8sRollback),
+					Rollback:           true,
+					Metadata:           make(map[string]string, 0),
+					AvailableOperation: sdk.ManualOperationNone,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := BuildPipelineStages(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
@@ -102,7 +102,7 @@ func TestBuildPipelineStages(t *testing.T) {
 				},
 				{
 					Index:              0,
-					Name:               string(StageK8sRollback),
+					Name:               string(StageK8sMultiRollback),
 					Rollback:           true,
 					Metadata:           make(map[string]string, 0),
 					AvailableOperation: sdk.ManualOperationNone,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
@@ -39,8 +40,12 @@ func (p *plugin) Version() string {
 }
 
 // BuildPipelineSyncStages implements sdk.StagePlugin.
-func (p *plugin) BuildPipelineSyncStages(context.Context, *config, *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
-	return &sdk.BuildPipelineSyncStagesResponse{}, nil
+func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ *config, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages := deployment.BuildPipelineStages(input)
+
+	return &sdk.BuildPipelineSyncStagesResponse{
+		Stages: stages,
+	}, nil
 }
 
 // ExecuteStage implements sdk.StagePlugin.

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
@@ -41,10 +41,8 @@ func (p *plugin) Version() string {
 
 // BuildPipelineSyncStages implements sdk.StagePlugin.
 func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ *config, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
-	stages := deployment.BuildPipelineStages(input)
-
 	return &sdk.BuildPipelineSyncStagesResponse{
-		Stages: stages,
+		Stages: deployment.BuildPipelineStages(input),
 	}, nil
 }
 
@@ -55,5 +53,5 @@ func (p *plugin) ExecuteStage(context.Context, *config, []*sdk.DeployTarget[depl
 
 // FetchDefinedStages implements sdk.StagePlugin.
 func (p *plugin) FetchDefinedStages() []string {
-	return []string{"K8S_SYNC"}
+	return deployment.AllStages
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
@@ -24,6 +24,10 @@ type plugin struct{}
 
 type config struct{}
 
+type deployTargetConfig struct{}
+
+var _ sdk.StagePlugin[config, deployTargetConfig] = (*plugin)(nil)
+
 // Name implements sdk.Plugin.
 func (p *plugin) Name() string {
 	return "kubernetes_multicluster"
@@ -40,7 +44,7 @@ func (p *plugin) BuildPipelineSyncStages(context.Context, *config, *sdk.BuildPip
 }
 
 // ExecuteStage implements sdk.StagePlugin.
-func (p *plugin) ExecuteStage(context.Context, *config, sdk.DeployTargetsNone, *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
+func (p *plugin) ExecuteStage(context.Context, *config, []*sdk.DeployTarget[deployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
 	return &sdk.ExecuteStageResponse{}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:

as title.

I checked the behavior with planning pipeline sync. It is ok to fail the execution because I don't implement its logic.

```
apiVersion: pipecd.dev/v1beta1
kind: Application
spec:
  name: multicluster-plugin
  labels:
    env: example
    team: product
  planner:
    alwaysUsePipeline: true
  quickSync:
    prune: true
  pipeline:
    stages:
        - name: K8S_SYNC
  input:
    kubectlVersion: 1.31.0
  description: |
    try multi cluster plugin
  plugins:
    - kubernetes_multicluster
```

<img width="1721" alt="PipeCD" src="https://github.com/user-attachments/assets/4c518410-9637-4bf2-9240-c8344bf165d5" />


**Why we need it**:

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5006

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
