### PR TITLE
Fix cancel handling in pipedv1 scheduler

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -553,7 +553,10 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 			TargetDeploymentSource:  tds.ToPluginDeploySource(),
 		},
 	})
-	if err != nil {
+	// do not return error if the context is already canceled.
+	// this occurs when the stage is canceled.
+	// otherwise, return the error.
+	if err != nil && ctx.Err() == nil {
 		s.logger.Error("failed to execute stage", zap.String("stage-name", ps.Name), zap.Error(err))
 		s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires)
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/pipedv1/plugin/wait/wait.go
+++ b/pkg/app/pipedv1/plugin/wait/wait.go
@@ -78,7 +78,10 @@ func wait(ctx context.Context, duration time.Duration, initialStart time.Time, s
 
 		case <-ctx.Done(): // on cancelled
 			slp.Info("Wait cancelled")
-			return sdk.StageStatusCancelled
+			// The piped handles this case as cancelled by the user without using the plugin's result.
+			// So we don't need to consider which status should be returned.
+			// We return the failure here.
+			return sdk.StageStatusFailure
 		}
 	}
 }

--- a/pkg/app/pipedv1/plugin/wait/wait.go
+++ b/pkg/app/pipedv1/plugin/wait/wait.go
@@ -78,9 +78,8 @@ func wait(ctx context.Context, duration time.Duration, initialStart time.Time, s
 
 		case <-ctx.Done(): // on cancelled
 			slp.Info("Wait cancelled")
-			// The piped handles this case as cancelled by the user without using the plugin's result.
-			// So we don't need to consider which status should be returned.
-			// We return the failure here.
+			// We can return any status here because the piped handles this case as cancelled by a user, 
+			// ignoring the result from a plugin.
 			return sdk.StageStatusFailure
 		}
 	}

--- a/pkg/app/pipedv1/plugin/wait/wait_test.go
+++ b/pkg/app/pipedv1/plugin/wait/wait_test.go
@@ -69,7 +69,7 @@ func TestWait_Cancel(t *testing.T) {
 
 	select {
 	case result := <-resultCh:
-		assert.Equal(t, sdk.StageStatusCancelled, result)
+		assert.Equal(t, sdk.StageStatusFailure, result)
 	case <-time.After(1 * time.Second):
 		t.Error("wait() did not ended even after the context was canceled")
 	}

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -455,9 +455,8 @@ type ExecuteStageResponse struct {
 type StageStatus int
 
 const (
-	StageStatusSuccess   StageStatus = 2
-	StageStatusFailure   StageStatus = 3
-	StageStatusCancelled StageStatus = 4
+	StageStatusSuccess StageStatus = 2
+	StageStatusFailure StageStatus = 3
 
 	// StageStatusSkipped         StageStatus = 5 // TODO: If SDK can handle whole skipping, this is unnecessary.
 
@@ -472,8 +471,6 @@ func (o StageStatus) toModelEnum() model.StageStatus {
 		return model.StageStatus_STAGE_SUCCESS
 	case StageStatusFailure:
 		return model.StageStatus_STAGE_FAILURE
-	case StageStatusCancelled:
-		return model.StageStatus_STAGE_CANCELLED
 	case StageStatusExited:
 		return model.StageStatus_STAGE_EXITED
 	default:

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -455,16 +455,19 @@ type ExecuteStageResponse struct {
 type StageStatus int
 
 const (
-	StageStatusSuccess StageStatus = 2
-	StageStatusFailure StageStatus = 3
-
-	// StageStatusSkipped         StageStatus = 5 // TODO: If SDK can handle whole skipping, this is unnecessary.
-
+	_ StageStatus = iota
+	// StageStatusSuccess indicates that the stage succeeded.
+	StageStatusSuccess
+	// StageStatusFailure indicates that the stage failed.
+	StageStatusFailure
 	// StageStatusExited can be used when the stage succeeded and exit the pipeline without executing the following stages.
-	StageStatusExited StageStatus = 6
+	StageStatusExited
+
+	// StageStatusSkipped // TODO: If SDK can handle whole skipping, this is unnecessary.
 )
 
 // toModelEnum converts the StageStatus to the model.StageStatus.
+// It returns model.StageStatus_STAGE_FAILURE if the given value is invalid.
 func (o StageStatus) toModelEnum() model.StageStatus {
 	switch o {
 	case StageStatusSuccess:


### PR DESCRIPTION
**What this PR does**:

- fix the handling of errors when the context is canceled. This occurs when the user cancels the deployment from WebUI.
- remove `StageStatusCancelled` from the SDK because cancel is handled in the piped. We don't have to handle cancel in the plugin implementations.

**Why we need it**:

- to fix cancel behavior
- to clarify what we need to implement in plugins

**Which issue(s) this PR fixes**:

Part of #4980 #5530

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
