### PR TITLE
Add empty methods which need for implementing the k8s plugin with the SDK

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -17,7 +17,9 @@ package main
 import (
 	"log"
 
+	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/cli"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
 func main() {
@@ -30,5 +32,13 @@ func main() {
 	)
 	if err := app.Run(); err != nil {
 		log.Fatal(err)
+	}
+}
+
+// TODO: use this after rewriting the plugin with the sdk
+func _main() {
+	sdk.RegisterDeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig](&plugin{})
+	if err := sdk.Run(); err != nil {
+		log.Fatalln(err)
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -37,7 +37,7 @@ func main() {
 
 // TODO: use this after rewriting the plugin with the sdk
 func _main() {
-	sdk.RegisterDeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig](&plugin{})
+	sdk.RegisterDeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig](&sdkPlugin{})
 	if err := sdk.Run(); err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/plugin.go
@@ -25,11 +25,13 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pipe-cd/pipecd/pkg/admin"
+	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/deployment"
 	"github.com/pipe-cd/pipecd/pkg/cli"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
 	"github.com/pipe-cd/pipecd/pkg/rpc"
 	"github.com/pipe-cd/pipecd/pkg/version"
@@ -161,4 +163,44 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 		return err
 	}
 	return nil
+}
+
+var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*plugin)(nil)
+
+func (p *plugin) Name() string {
+	return "kubernetes"
+}
+
+func (p *plugin) Version() string {
+	return "0.0.1" // TODO
+}
+
+// FIXME
+func (p *plugin) FetchDefinedStages() []string {
+	return nil
+}
+
+// FIXME
+func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	return nil, nil
+}
+
+// FIXME
+func (p *plugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
+	return nil, nil
+}
+
+// FIXME
+func (p *plugin) DetermineVersions(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+// FIXME
+func (p *plugin) DetermineStrategy(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+// FIXME
+func (p *plugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
+	return nil, nil
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/plugin.go
@@ -165,42 +165,46 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 	return nil
 }
 
-var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*plugin)(nil)
+// sdkPlugin implements the sdk.DeploymentPlugin interface.
+// TODO: Rename to 'plugin' after rewriting the current plugin logic with sdk.
+type sdkPlugin struct{}
 
-func (p *plugin) Name() string {
+var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*sdkPlugin)(nil)
+
+func (p *sdkPlugin) Name() string {
 	return "kubernetes"
 }
 
-func (p *plugin) Version() string {
+func (p *sdkPlugin) Version() string {
 	return "0.0.1" // TODO
 }
 
 // FIXME
-func (p *plugin) FetchDefinedStages() []string {
+func (p *sdkPlugin) FetchDefinedStages() []string {
 	return nil
 }
 
 // FIXME
-func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+func (p *sdkPlugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	return nil, nil
 }
 
 // FIXME
-func (p *plugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
+func (p *sdkPlugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
 	return nil, nil
 }
 
 // FIXME
-func (p *plugin) DetermineVersions(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+func (p *sdkPlugin) DetermineVersions(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
 	return sdk.TODO{}, nil
 }
 
 // FIXME
-func (p *plugin) DetermineStrategy(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+func (p *sdkPlugin) DetermineStrategy(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
 	return sdk.TODO{}, nil
 }
 
 // FIXME
-func (p *plugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
+func (p *sdkPlugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does**:

as title.
I plan to rewrite it with SDK as follow.
- implement the current logic with SDK into struct `sdkPlugin`.
- Replace current struct `plugin` after implementing all methods which need for the interface `DeploymentPlugin`.

**Why we need it**:

We want to rewrite plugin by using SDK while keeping the current k8s plugin work. 
Also, I want to rewrite it before implementing multi cluster plugin.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4980  https://github.com/pipe-cd/pipecd/issues/5006

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
