### PR TITLE
docs: Fix relative links to configuration-reference of Notification

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuring-notifications.md
@@ -115,7 +115,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -135,4 +135,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.39.x/user-guide/managing-piped/configuring-notifications.md
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.40.x/user-guide/managing-piped/configuring-notifications.md
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.41.x/user-guide/managing-piped/configuring-notifications.md
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.42.x/user-guide/managing-piped/configuring-notifications.md
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.43.x/user-guide/managing-piped/configuring-notifications.md
@@ -78,7 +78,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -98,4 +98,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.44.x/user-guide/managing-piped/configuring-notifications.md
@@ -84,7 +84,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -104,4 +104,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.45.x/user-guide/managing-piped/configuring-notifications.md
@@ -97,7 +97,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -117,4 +117,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.46.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.46.x/user-guide/managing-piped/configuring-notifications.md
@@ -97,7 +97,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -117,4 +117,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.47.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.47.x/user-guide/managing-piped/configuring-notifications.md
@@ -97,7 +97,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -117,4 +117,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.48.x/user-guide/managing-piped/configuring-notifications.md
@@ -114,7 +114,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -134,4 +134,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.49.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.49.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.49.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.49.x/user-guide/managing-piped/configuring-notifications.md
@@ -114,7 +114,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -134,4 +134,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.

--- a/docs/content/en/docs-v0.50.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.50.x/user-guide/managing-piped/configuring-notifications.md
@@ -13,7 +13,7 @@ Notification configuration including:
 - a list of `Route`s which used to match events and decide where the event should be sent to
 - a list of `Receiver`s which used to know how to send events to the external service
 
-[Notification Route](../configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
+[Notification Route](configuration-reference/#notificationroute) matches events based on their metadata like `name`, `group`, `app`, `labels`.
 Below is the list of supporting event names and their groups.
 
 | Event | Group | Supported | Description |

--- a/docs/content/en/docs-v0.50.x/user-guide/managing-piped/configuring-notifications.md
+++ b/docs/content/en/docs-v0.50.x/user-guide/managing-piped/configuring-notifications.md
@@ -115,7 +115,7 @@ A piped has been started
 </p>
 
 
-For detailed configuration, please check the [configuration reference for Notifications](../configuration-reference/#notifications) section.
+For detailed configuration, please check the [configuration reference for Notifications](configuration-reference/#notifications) section.
 
 ### Sending notifications to external services via webhook
 
@@ -135,4 +135,4 @@ spec:
           signatureValue: {RANDOM_SIGNATURE_STRING}
 ```
 
-For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](../configuration-reference/#notificationreceiverwebhook) section.
+For detailed configuration, please check the [configuration reference for NotificationReceiverWebhook](configuration-reference/#notificationreceiverwebhook) section.


### PR DESCRIPTION
**What this PR does**:

as title 
Three links were wrong.


**Why we need it**:

Notifications are described in `managing-piped/configuration-reference.md`, not `user-guide/configuration-reference.md`


**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
