### PR TITLE
Refactor to remove unnecessary error in the return values

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -47,7 +47,7 @@ func parseContainerImage(image string) (img containerImage) {
 
 // determineVersions decides artifact versions of an application.
 // It finds all container images that are being specified in the workload manifests then returns their names and tags.
-func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion, error) {
+func determineVersions(manifests []provider.Manifest) []*model.ArtifactVersion {
 	imageMap := map[string]struct{}{}
 	for _, m := range manifests {
 		for _, c := range provider.FindContainerImages(m) {
@@ -66,7 +66,7 @@ func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion,
 		})
 	}
 
-	return versions, nil
+	return versions
 }
 
 // findManifests returns the manifests that have the specified kind and name.

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine_test.go
@@ -100,11 +100,12 @@ func TestParseContainerImage(t *testing.T) {
 	}
 }
 func TestDetermineVersions(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		manifests []string
 		want      []*model.ArtifactVersion
-		wantErr   bool
 	}{
 		{
 			name: "single manifest with one container",
@@ -247,8 +248,7 @@ spec:
     spec: {}
 `,
 			},
-			want:    []*model.ArtifactVersion{},
-			wantErr: false,
+			want: []*model.ArtifactVersion{},
 		},
 		{
 			name: "manifest with invalid containers field -- skipped",
@@ -265,23 +265,18 @@ spec:
         - "invalid-containers-field"
 `,
 			},
-			wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var manifests []provider.Manifest
 			for _, data := range tt.manifests {
 				manifests = append(manifests, mustUnmarshalYAML[provider.Manifest](t, []byte(strings.TrimSpace(data))))
 			}
-			got, err := determineVersions(manifests)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			} else {
-				require.NoError(t, err)
-			}
+			got := determineVersions(manifests)
 			assert.ElementsMatch(t, tt.want, got)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -145,13 +145,8 @@ func (a *DeploymentService) DetermineVersions(ctx context.Context, request *depl
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	versions, err := determineVersions(manifests)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	return &deployment.DetermineVersionsResponse{
-		Versions: versions,
+		Versions: determineVersions(manifests),
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

This is the fix for lint/go

```
% make lint/go                                                       (git)-[extract-deploy-targets-in-sdk]
docker run --rm -e GOCACHE=/repo/.cache/go-build -e GOLANGCI_LINT_CACHE=/repo/.cache/golangci-lint -v /XXX/oss/pipe-cd/pipecd:/repo -w /repo -it golangci/golangci-lint@sha256:4e53bfe25ef2f1e14a95da42d694211080f40d118730541ce1513a83cf7587ec  golangci-lint run -v
INFO golangci-lint has version 1.62.2 built with go1.23.3 from 89476e7a on 2024-11-25T14:16:01Z
INFO [config_reader] Config search paths: [./ /repo / /root]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [depguard gocritic goheader goimports gosimple ineffassign misspell prealloc staticcheck stylecheck unconvert unparam]
INFO [loader] Go packages loading at mode 8767 (deps|files|types_sizes|compiled_files|exports_file|imports|name) took 17.436272239s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 85.210374ms
INFO [linters_context/goanalysis] analyzers took 3m8.309183376s with top 10 stages: goheader: 1m3.40000826s, buildir: 36.015408723s, goimports: 20.824258293s, unparam: 10.711564454s, gocritic: 5.915612973s, buildssa: 4.758022927s, unconvert: 4.622158107s, misspell: 3.093733263s, S1038: 2.380250755s, fact_deprecated: 1.764631053s
INFO [runner/skip_dirs] Skipped 39 issues from dir pkg/app/piped/executor/analysis/mannwhitney by pattern pkg/app/piped/executor/analysis/mannwhitney
INFO [runner] Issues before processing: 1045, after processing: 1
INFO [runner] Processors filtering stat (in/out): invalid_issue: 1045/1045, exclude: 459/459, max_same_issues: 1/1, path_prefixer: 1/1, sort_results: 1/1, path_prettifier: 1045/1045, identifier_marker: 459/459, fixer: 1/1, cgo: 1045/1045, filename_unadjuster: 1045/1045, skip_dirs: 955/916, exclude-rules: 459/5, uniq_by_line: 1/1, max_per_file_from_linter: 1/1, max_from_linter: 1/1, path_shortener: 1/1, skip_files: 1045/955, autogenerated_exclude: 916/459, nolint: 5/1, diff: 1/1, source_code: 1/1, severity-rules: 1/1
INFO [runner] processing took 41.978065ms with stages: autogenerated_exclude: 23.200203ms, exclude-rules: 6.019259ms, identifier_marker: 4.564675ms, path_prettifier: 3.359422ms, nolint: 2.421962ms, skip_dirs: 1.239877ms, skip_files: 793.209µs, invalid_issue: 163.25µs, filename_unadjuster: 67.917µs, source_code: 67.083µs, cgo: 60.667µs, sort_results: 13.417µs, uniq_by_line: 3.208µs, max_same_issues: 1.709µs, path_shortener: 457ns, max_from_linter: 416ns, fixer: 334ns, diff: 334ns, exclude: 250ns, max_per_file_from_linter: 208ns, path_prefixer: 125ns, severity-rules: 83ns
INFO [runner] linters took 11.887634625s with stages: goanalysis_metalinter: 11.845228681s
pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go:50:82: determineVersions - result 1 (error) is always nil (unparam)
func determineVersions(manifests []provider.Manifest) ([]*model.ArtifactVersion, error) {
                                                                                 ^
INFO File cache stats: 686 entries of total size 6.6MiB
INFO Memory: 290 samples, avg is 555.7MB, max is 1969.4MB
INFO Execution took 29.413953533s
make: *** [lint/go] Error 1
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
