### PR TITLE
Add toolRegistry as a common field for the Client in the SDK

### DIFF
--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	logPersister StageLogPersister
 
 	// toolRegistry is used to install and get the path of the tools used in the plugin.
+	// TODO: We should consider installing the tools in other way.
 	toolRegistry *toolregistry.ToolRegistry
 }
 

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedservice"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
 )
 
 // Client is a toolkit for interacting with the piped service.
@@ -42,6 +43,9 @@ type Client struct {
 	// logPersister is used to persist the stage logs.
 	// This field exists only when the client is working with a specific stage; for example, when this client is passed as the ExecuteStage method's argument.
 	logPersister StageLogPersister
+
+	// toolRegistry is used to install and get the path of the tools used in the plugin.
+	toolRegistry *toolregistry.ToolRegistry
 }
 
 // StageLogPersister is a interface for persisting the stage logs.
@@ -138,4 +142,10 @@ func (c *Client) GetDeploymentSharedMetadata(ctx context.Context, key string) (s
 // TODO: we should consider returning an error instead of nil, or return logger which prints to stdout.
 func (c *Client) LogPersister() StageLogPersister {
 	return c.logPersister
+}
+
+// ToolRegistry returns the tool registry.
+// Use this to install and get the path of the tools used in the plugin.
+func (c *Client) ToolRegistry() *toolregistry.ToolRegistry {
+	return c.toolRegistry
 }

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
 	"github.com/pipe-cd/pipecd/pkg/plugin/signalhandler"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
 )
 
 var (
@@ -114,6 +115,7 @@ type commonFields struct {
 	logger       *zap.Logger
 	logPersister logPersister
 	client       *pipedapi.PipedServiceClient
+	toolRegistry *toolregistry.ToolRegistry
 }
 
 // DeploymentPluginServiceServer is the gRPC server that handles requests from the piped.
@@ -205,6 +207,7 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) ExecuteStage
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
 		logPersister:  lp,
+		toolRegistry:  s.toolRegistry,
 	}
 
 	// Get the deploy targets set on the deployment from the piped plugin config.
@@ -308,6 +311,7 @@ func (s *StagePluginServiceServer[Config, DeployTargetConfig]) ExecuteStage(ctx 
 		deploymentID:  request.GetInput().GetDeployment().GetId(),
 		stageID:       request.GetInput().GetStage().GetId(),
 		logPersister:  lp,
+		toolRegistry:  s.toolRegistry,
 	}
 
 	return executeStage(ctx, s.base, &s.config, nil, client, request, s.logger) // TODO: pass the deployTargets

--- a/pkg/plugin/sdk/sdk.go
+++ b/pkg/plugin/sdk/sdk.go
@@ -31,6 +31,7 @@ import (
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
 	"github.com/pipe-cd/pipecd/pkg/rpc"
 )
 
@@ -161,6 +162,7 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 			logger:       input.Logger.Named("deployment-service"),
 			logPersister: persister,
 			client:       pipedapiClient,
+			toolRegistry: toolregistry.NewToolRegistry(pipedapiClient),
 		})
 		if err := deploymentServiceServer.setConfig(cfg.Config); err != nil {
 			input.Logger.Error("failed to set configuration", zap.Error(err))


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We need it to install tools to load manifests and deploy them to the platform for the platform-specific plugin.
(e.g. k8s plugin's [DetermineStrategy](https://github.com/pipe-cd/pipecd/blob/6cf50973ea81bf963cca1f72b7efe0ad0546d875/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go#L114), [DetermineVersion](https://github.com/pipe-cd/pipecd/blob/6cf50973ea81bf963cca1f72b7efe0ad0546d875/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go#L142), [ExecuteStage](https://github.com/pipe-cd/pipecd/blob/6cf50973ea81bf963cca1f72b7efe0ad0546d875/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go#L97))

Also, we need it for the stage plugin to execute any tool on the generic stage.

It is better to set it on the SDK side because it requires a piped service client.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5530

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
