### PR TITLE
Refactor the plugin SDK to set common fields and configs in a single method

### DIFF
--- a/pkg/plugin/sdk/sdk.go
+++ b/pkg/plugin/sdk/sdk.go
@@ -156,14 +156,13 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	// Start a gRPC server for handling external API requests.
 	{
-		deploymentServiceServer.setCommonFields(commonFields{
+		if err := deploymentServiceServer.setFields(commonFields{
 			config:       cfg,
 			logger:       input.Logger.Named("deployment-service"),
 			logPersister: persister,
 			client:       pipedapiClient,
-		})
-		if err := deploymentServiceServer.setConfig(cfg.Config); err != nil {
-			input.Logger.Error("failed to set configuration", zap.Error(err))
+		}); err != nil {
+			input.Logger.Error("failed to set fields", zap.Error(err))
 			return err
 		}
 		var (


### PR DESCRIPTION
**What this PR does**:

- merge `setCommonFields` and `setConfig` as `setFields`
- parse `DeployTargets` in `setFields` method and store it as a `DeploymentPluginServiceServer.deployTargets`

**Why we need it**:

- I don't want to make/call multiple methods to initialize gRPC server
- resolve `TODO: cache the unmarshaled config to avoid unmarshaling it multiple times.`

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
