### PR TITLE
Implement K8S_SYNC without prune feature by using plugin SDK

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -1,0 +1,56 @@
+package deployment
+
+import (
+	"context"
+
+	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+// Plugin implements the sdk.DeploymentPlugin interface.
+type Plugin struct{}
+
+var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*Plugin)(nil)
+
+func (p *Plugin) Name() string {
+	return "kubernetes"
+}
+
+func (p *Plugin) Version() string {
+	return "0.0.1" // TODO
+}
+
+func (p *Plugin) FetchDefinedStages() []string {
+	stages := make([]string, 0, len(AllStages))
+	for _, s := range AllStages {
+		stages = append(stages, string(s))
+	}
+
+	return stages
+}
+
+// FIXME
+func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	return nil, nil
+}
+
+// FIXME
+func (p *Plugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
+	return nil, nil
+}
+
+// FIXME
+func (p *Plugin) DetermineVersions(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+// FIXME
+func (p *Plugin) DetermineStrategy(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
+	return sdk.TODO{}, nil
+}
+
+func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
+	return &sdk.BuildQuickSyncStagesResponse{
+		Stages: BuildQuickSyncPipeline(input.Request.Rollback),
+	}, nil
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -110,6 +110,11 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 		})
 	}
 
+	if err := annotateConfigHash(manifests); err != nil {
+		lp.Errorf("Unable to set %q annotation into the workload manifest (%v)", provider.AnnotationConfigHash, err)
+		return sdk.StageStatusFailure
+	}
+
 	return sdk.StageStatusFailure
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployment
 
 import (
@@ -5,12 +19,13 @@ import (
 	"context"
 	"errors"
 
+	"go.uber.org/zap"
+
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
-	"go.uber.org/zap"
 )
 
 const (

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -49,11 +49,11 @@ func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk
 	switch input.Request.StageName {
 	case StageK8sSync.String():
 		return &sdk.ExecuteStageResponse{
-			Status: p.executeK8sSyncStage(ctx, input),
+			Status: p.executeK8sSyncStage(ctx, input, dts),
 		}, nil
 	case StageK8sRollback.String():
 		return &sdk.ExecuteStageResponse{
-			Status: p.executeK8sRollbackStage(ctx, input),
+			Status: p.executeK8sRollbackStage(ctx, input, dts),
 		}, nil
 	default:
 		return nil, errors.New("unimplemented or unsupported stage")
@@ -61,7 +61,7 @@ func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk
 }
 
 // FIXME
-func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput) sdk.StageStatus {
+func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
 
@@ -115,6 +115,13 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 		return sdk.StageStatusFailure
 	}
 
+	// Get the deploy target config.
+	if len(dts) == 0 {
+		lp.Error("No deploy target was found")
+		return sdk.StageStatusFailure
+	}
+	deployTargetConfig := dts[0].Config
+
 	return sdk.StageStatusFailure
 }
 
@@ -141,7 +148,7 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 }
 
 // FIXME
-func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput) sdk.StageStatus {
+func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	return sdk.StageStatusFailure
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"go.uber.org/zap"
@@ -18,9 +19,23 @@ const (
 
 // Plugin implements the sdk.DeploymentPlugin interface.
 type Plugin struct {
-	loader       loader
-	toolRegistry toolRegistry
 	logger       *zap.Logger
+	toolRegistry toolRegistry
+	loader       loader
+}
+
+// NewPlugin creates a new Plugin.
+func NewPlugin(
+	logger *zap.Logger,
+	toolClient toolClient,
+	logPersister logPersister,
+) *Plugin {
+	toolRegistry := toolregistry.NewRegistry(toolClient)
+	return &Plugin{
+		logger:       logger.Named("deployment-plugin"),
+		toolRegistry: toolRegistry,
+		loader:       provider.NewLoader(toolRegistry),
+	}
 }
 
 type loader interface {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"errors"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
@@ -35,8 +36,29 @@ func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone,
 }
 
 // FIXME
-func (p *Plugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
-	return nil, nil
+func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
+	switch input.Request.StageName {
+	case StageK8sSync.String():
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeK8sSyncStage(ctx, input),
+		}, nil
+	case StageK8sRollback.String():
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeK8sRollbackStage(ctx, input),
+		}, nil
+	default:
+		return nil, errors.New("unimplemented or unsupported stage")
+	}
+}
+
+// FIXME
+func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput) sdk.StageStatus {
+	return sdk.StageStatusFailure
+}
+
+// FIXME
+func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput) sdk.StageStatus {
+	return sdk.StageStatusFailure
 }
 
 // FIXME

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -85,7 +85,7 @@ func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk
 	}
 }
 
-// FIXME
+// TODO: implement pruing feature
 func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
@@ -96,6 +96,8 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 		return sdk.StageStatusFailure
 	}
 
+	// TODO: find the way to hold the tool registry and loader in the plugin.
+	// Currently, we create them every time the stage is executed beucause we can't pass input.Client.toolRegistry to the plugin when starting the plugin.
 	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
 	loader := provider.NewLoader(toolRegistry)
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+
+	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+)
+
+func setupTestDeployTargetConfig(t *testing.T, kubeCfg *rest.Config) *kubeConfigPkg.KubernetesDeployTargetConfig {
+	t.Helper()
+
+	kubeconfig, err := kubeconfigFromRestConfig(kubeCfg)
+	require.NoError(t, err)
+
+	workDir := t.TempDir()
+	kubeconfigPath := path.Join(workDir, "kubeconfig")
+	err = os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0755)
+	require.NoError(t, err)
+
+	return &kubeConfigPkg.KubernetesDeployTargetConfig{
+		KubeConfigPath: kubeconfigPath,
+	}
+}
+
+func setupTestDeployTargetConfigAndDynamicClient(t *testing.T) (*kubeConfigPkg.KubernetesDeployTargetConfig, dynamic.Interface) {
+	t.Helper()
+
+	kubeCfg := setupEnvTest(t)
+	deployTargetCfg := setupTestDeployTargetConfig(t, kubeCfg)
+
+	dynamicClient, err := dynamic.NewForConfig(kubeCfg)
+	require.NoError(t, err)
+
+	return deployTargetCfg, dynamicClient
+}
+
+func TestPlugin_executeK8sSyncStage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// read the application config from the example file
+	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName:               "K8S_SYNC",
+			StageConfig:             []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t)),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	// initialize tool registry
+	testRegistry, err := toolregistrytest.NewToolRegistry(t)
+	require.NoError(t, err)
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	plugin := NewPlugin(zaptest.NewLogger(t), testRegistry, logpersistertest.NewTestLogPersister(t))
+
+	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	deployment, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(context.Background(), "simple", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "simple", deployment.GetName())
+	assert.Equal(t, "simple", deployment.GetLabels()["app"])
+
+	assert.Equal(t, "piped", deployment.GetLabels()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetLabels()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetLabels()["pipecd.dev/application"])
+	assert.Equal(t, "0123456789", deployment.GetLabels()["pipecd.dev/commit-hash"])
+
+	assert.Equal(t, "piped", deployment.GetAnnotations()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetAnnotations()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
+	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
+	assert.Equal(t, "apps:Deployment::simple", deployment.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
+	assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+}
+
+func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// read the application config from the example file
+	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// decode and override the autoCreateNamespace and namespace
+	spec, err := config.DecodeYAML[*kubeConfigPkg.KubernetesApplicationSpec](cfg)
+	require.NoError(t, err)
+	spec.Spec.Input.AutoCreateNamespace = true
+	spec.Spec.Input.Namespace = "test-namespace"
+	cfg, err = yaml.Marshal(spec)
+	require.NoError(t, err)
+
+	// prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName:               "K8S_SYNC",
+			StageConfig:             []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t)),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	// initialize tool registry
+	testRegistry, err := toolregistrytest.NewToolRegistry(t)
+	require.NoError(t, err)
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	plugin := NewPlugin(zaptest.NewLogger(t), testRegistry, logpersistertest.NewTestLogPersister(t))
+
+	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	deployment, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("test-namespace").Get(context.Background(), "simple", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "piped", deployment.GetLabels()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetLabels()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetLabels()["pipecd.dev/application"])
+	assert.Equal(t, "0123456789", deployment.GetLabels()["pipecd.dev/commit-hash"])
+
+	assert.Equal(t, "simple", deployment.GetName())
+	assert.Equal(t, "simple", deployment.GetLabels()["app"])
+	assert.Equal(t, "piped", deployment.GetAnnotations()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetAnnotations()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
+	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
+	assert.Equal(t, "apps:Deployment:test-namespace:simple", deployment.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
+	assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
@@ -74,6 +74,9 @@ func TestPlugin_executeK8sSyncStage(t *testing.T) {
 	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
 	require.NoError(t, err)
 
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
 	// prepare the input
 	input := &sdk.ExecuteStageInput{
 		Request: sdk.ExecuteStageRequest{
@@ -91,18 +94,14 @@ func TestPlugin_executeK8sSyncStage(t *testing.T) {
 				ApplicationID: "app-id",
 			},
 		},
-		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t)),
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
 		Logger: zaptest.NewLogger(t),
 	}
-
-	// initialize tool registry
-	testRegistry, err := toolregistrytest.NewToolRegistry(t)
-	require.NoError(t, err)
 
 	// initialize deploy target config and dynamic client for assertions with envtest
 	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
 
-	plugin := NewPlugin(zaptest.NewLogger(t), testRegistry, logpersistertest.NewTestLogPersister(t))
+	plugin := &Plugin{}
 
 	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
@@ -149,6 +148,9 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	cfg, err = yaml.Marshal(spec)
 	require.NoError(t, err)
 
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
 	// prepare the input
 	input := &sdk.ExecuteStageInput{
 		Request: sdk.ExecuteStageRequest{
@@ -166,18 +168,14 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 				ApplicationID: "app-id",
 			},
 		},
-		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t)),
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
 		Logger: zaptest.NewLogger(t),
 	}
-
-	// initialize tool registry
-	testRegistry, err := toolregistrytest.NewToolRegistry(t)
-	require.NoError(t, err)
 
 	// initialize deploy target config and dynamic client for assertions with envtest
 	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
 
-	plugin := NewPlugin(zaptest.NewLogger(t), testRegistry, logpersistertest.NewTestLogPersister(t))
+	plugin := &Plugin{}
 
 	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -34,18 +34,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	defaultKubectlVersion = "1.18.2"
-)
-
 type toolClient interface {
 	InstallTool(ctx context.Context, name, version, script string) (string, error)
-}
-
-type toolRegistry interface {
-	Kubectl(ctx context.Context, version string) (string, error)
-	Kustomize(ctx context.Context, version string) (string, error)
-	Helm(ctx context.Context, version string) (string, error)
 }
 
 type applier interface {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -48,11 +48,6 @@ type toolRegistry interface {
 	Helm(ctx context.Context, version string) (string, error)
 }
 
-type loader interface {
-	// LoadManifests renders and loads all manifests for application.
-	LoadManifests(ctx context.Context, input provider.LoaderInput) ([]provider.Manifest, error)
-}
-
 type applier interface {
 	// ApplyManifest does applying the given manifest.
 	ApplyManifest(ctx context.Context, manifest provider.Manifest) error

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/server.go
@@ -38,17 +38,6 @@ type toolClient interface {
 	InstallTool(ctx context.Context, name, version, script string) (string, error)
 }
 
-type applier interface {
-	// ApplyManifest does applying the given manifest.
-	ApplyManifest(ctx context.Context, manifest provider.Manifest) error
-	// CreateManifest does creating resource from given manifest.
-	CreateManifest(ctx context.Context, manifest provider.Manifest) error
-	// ReplaceManifest does replacing resource from given manifest.
-	ReplaceManifest(ctx context.Context, manifest provider.Manifest) error
-	// ForceReplaceManifest does force replacing resource from given manifest.
-	ForceReplaceManifest(ctx context.Context, manifest provider.Manifest) error
-}
-
 type logPersister interface {
 	StageLogPersister(deploymentID, stageID string) logpersister.StageLogPersister
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -18,6 +18,7 @@ import (
 	"log"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/deployment"
 	"github.com/pipe-cd/pipecd/pkg/cli"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
@@ -37,7 +38,7 @@ func main() {
 
 // TODO: use this after rewriting the plugin with the sdk
 func _main() {
-	sdk.RegisterDeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig](&sdkPlugin{})
+	sdk.RegisterDeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig](&deployment.Plugin{})
 	if err := sdk.Run(); err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/plugin.go
@@ -25,13 +25,11 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pipe-cd/pipecd/pkg/admin"
-	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/deployment"
 	"github.com/pipe-cd/pipecd/pkg/cli"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
-	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
 	"github.com/pipe-cd/pipecd/pkg/rpc"
 	"github.com/pipe-cd/pipecd/pkg/version"
@@ -163,53 +161,4 @@ func (s *plugin) run(ctx context.Context, input cli.Input) (runErr error) {
 		return err
 	}
 	return nil
-}
-
-// sdkPlugin implements the sdk.DeploymentPlugin interface.
-// TODO: Rename to 'plugin' after rewriting the current plugin logic with sdk.
-type sdkPlugin struct{}
-
-var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*sdkPlugin)(nil)
-
-func (p *sdkPlugin) Name() string {
-	return "kubernetes"
-}
-
-func (p *sdkPlugin) Version() string {
-	return "0.0.1" // TODO
-}
-
-func (p *sdkPlugin) FetchDefinedStages() []string {
-	stages := make([]string, 0, len(deployment.AllStages))
-	for _, s := range deployment.AllStages {
-		stages = append(stages, string(s))
-	}
-
-	return stages
-}
-
-// FIXME
-func (p *sdkPlugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
-	return nil, nil
-}
-
-// FIXME
-func (p *sdkPlugin) ExecuteStage(context.Context, *sdk.ConfigNone, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], *sdk.ExecuteStageInput) (*sdk.ExecuteStageResponse, error) {
-	return nil, nil
-}
-
-// FIXME
-func (p *sdkPlugin) DetermineVersions(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
-	return sdk.TODO{}, nil
-}
-
-// FIXME
-func (p *sdkPlugin) DetermineStrategy(context.Context, *sdk.ConfigNone, *sdk.Client, sdk.TODO) (sdk.TODO, error) {
-	return sdk.TODO{}, nil
-}
-
-func (p *sdkPlugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
-	return &sdk.BuildQuickSyncStagesResponse{
-		Stages: deployment.BuildQuickSyncPipeline(input.Request.Rollback),
-	}, nil
 }

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -49,6 +49,16 @@ type Client struct {
 	toolRegistry *toolregistry.ToolRegistry
 }
 
+func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister) *Client {
+	return &Client{
+		base:          base,
+		pluginName:    pluginName,
+		applicationID: applicationID,
+		stageID:       stageID,
+		logPersister:  lp,
+	}
+}
+
 // StageLogPersister is a interface for persisting the stage logs.
 // Use this to persist the stage logs and make it viewable on the UI.
 type StageLogPersister interface {

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -50,7 +50,8 @@ type Client struct {
 }
 
 // NewClient creates a new client.
-// Currently, this is used to create the Client in the test for the plugin made by the SDK.
+// DO NOT USE this function except in tests.
+// FIXME: Remove this function and make a better way for tests.
 func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister, tr *toolregistry.ToolRegistry) *Client {
 	return &Client{
 		base:          base,

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -49,13 +49,14 @@ type Client struct {
 	toolRegistry *toolregistry.ToolRegistry
 }
 
-func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister) *Client {
+func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister, tr *toolregistry.ToolRegistry) *Client {
 	return &Client{
 		base:          base,
 		pluginName:    pluginName,
 		applicationID: applicationID,
 		stageID:       stageID,
 		logPersister:  lp,
+		toolRegistry:  tr,
 	}
 }
 

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -49,6 +49,8 @@ type Client struct {
 	toolRegistry *toolregistry.ToolRegistry
 }
 
+// NewClient creates a new client.
+// Currently, this is used to create the Client in the test for the plugin made by the SDK.
 func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister, tr *toolregistry.ToolRegistry) *Client {
 	return &Client{
 		base:          base,


### PR DESCRIPTION
**What this PR does**:

I implemented k8s sync without prune feature by using SDK.

**The fix summary**
- `deployment/plugin.go`: Implement `deployment.Plugin`, similar to the `deployment.DeploymentService` to keep the current implementation working until finishing the re-implementation.
- `deployment/plugin_test.go`: Implement two tests for the quick sync features without pruning.

**Why we need it**:

We want to implement plugins with SDK.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4980 https://github.com/pipe-cd/pipecd/issues/5006

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
