### PR TITLE
Add trigger commit hash to deployment model

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -717,6 +717,8 @@ func (w *watcher) commitFiles(ctx context.Context, latestEvent *model.Event, eve
 	commitMsg = parseCommitMsg(commitMsg, args)
 	branch := makeBranchName(newBranch, eventName, repo.GetClonedBranch())
 	trailers := maps.Clone(latestEvent.Contexts)
+	// Store the commit hash of the commit that trigger this event as trailer of the manifest commit.
+	trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
 	if err := repo.CommitChanges(ctx, branch, commitMsg, newBranch, changes, trailers); err != nil {
 		w.logger.Error("failed to perform git commit",
 			zap.String("branch", branch),

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -104,6 +104,8 @@ func buildDeployment(
 		UpdatedAt:                 now.Unix(),
 		DeploymentChainId:         deploymentChainID,
 		DeploymentChainBlockIndex: deploymentChainBlockIndex,
+		// TODO: Add link to deployment trace design docs here.
+		DeploymentTraceCommitHash: commit.GetTrailerValueByKey(model.TraceTriggerCommitHashKey),
 	}
 
 	return deployment, nil

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -651,6 +651,8 @@ func (w *watcher) commitFiles(ctx context.Context, latestEvent *model.Event, eve
 	commitMsg = parseCommitMsg(commitMsg, args)
 	branch := makeBranchName(newBranch, eventName, repo.GetClonedBranch())
 	trailers := maps.Clone(latestEvent.Contexts)
+	// Store the commit hash of the commit that trigger this event as trailer of the manifest commit.
+	trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
 	if err := repo.CommitChanges(ctx, branch, commitMsg, newBranch, changes, trailers); err != nil {
 		return "", fmt.Errorf("failed to perform git commit: %w", err)
 	}

--- a/pkg/git/commit.go
+++ b/pkg/git/commit.go
@@ -82,3 +82,14 @@ func parseCommit(log string) (Commit, error) {
 		Body:            strings.TrimSpace(fields[6]),
 	}, nil
 }
+
+func (c *Commit) GetTrailerValueByKey(key string) string {
+	lines := strings.Split(c.Body, "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, key+":") {
+			continue
+		}
+		return strings.TrimSpace(line[len(key)+1:])
+	}
+	return ""
+}

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -78,3 +78,57 @@ This PR was merged by Kapetanios.`,
 	})
 	assert.Equal(t, expected, commits)
 }
+
+func TestGetTrailerValueByKey(t *testing.T) {
+	testcases := []struct {
+		name string
+		body string
+		key  string
+		want string
+	}{
+		{
+			name: "single line trailer",
+			body: "Some commit message\nKey: value",
+			key:  "Key",
+			want: "value",
+		},
+		{
+			name: "multiple line trailers",
+			body: "Some commit message\nKey1: value1\nKey2: value2",
+			key:  "Key2",
+			want: "value2",
+		},
+		{
+			name: "trailer with spaces",
+			body: "Some commit message\nKey:    spaced value    ",
+			key:  "Key",
+			want: "spaced value",
+		},
+		{
+			name: "no matching trailer",
+			body: "Some commit message\nOtherKey: value",
+			key:  "Key",
+			want: "",
+		},
+		{
+			name: "empty body",
+			body: "",
+			key:  "Key",
+			want: "",
+		},
+		{
+			name: "multiline value",
+			body: "Some commit message\nKey: first line\n second line",
+			key:  "Key",
+			want: "first line",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Commit{Body: tc.body}
+			got := c.GetTrailerValueByKey(tc.key)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -127,6 +127,7 @@ func TestGetTrailerValueByKey(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+                         t.Parallel()
 			c := &Commit{Body: tc.body}
 			got := c.GetTrailerValueByKey(tc.key)
 			assert.Equal(t, tc.want, got)

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -80,7 +80,7 @@ This PR was merged by Kapetanios.`,
 }
 
 func TestGetTrailerValueByKey(t *testing.T) {
-        t.Parallel()
+	t.Parallel()
 	testcases := []struct {
 		name string
 		body string
@@ -127,7 +127,7 @@ func TestGetTrailerValueByKey(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-                         t.Parallel()
+			t.Parallel()
 			c := &Commit{Body: tc.body}
 			got := c.GetTrailerValueByKey(tc.key)
 			assert.Equal(t, tc.want, got)

--- a/pkg/git/commit_test.go
+++ b/pkg/git/commit_test.go
@@ -80,6 +80,7 @@ This PR was merged by Kapetanios.`,
 }
 
 func TestGetTrailerValueByKey(t *testing.T) {
+        t.Parallel()
 	testcases := []struct {
 		name string
 		body string

--- a/pkg/model/deployment_trace.go
+++ b/pkg/model/deployment_trace.go
@@ -14,6 +14,12 @@
 
 package model
 
+const (
+	// The key to store the commit hash that triggers the event (in EventWatcher flow).
+	// It will be used as key to store the commit hash as metadata in the commit boy.
+	TraceTriggerCommitHashKey = "Trace-Trigger-Commit-Hash"
+)
+
 func (d *DeploymentTrace) SetUpdatedAt(t int64) {
 	d.UpdatedAt = t
 }

--- a/pkg/model/deployment_trace.go
+++ b/pkg/model/deployment_trace.go
@@ -16,7 +16,7 @@ package model
 
 const (
 	// The key to store the commit hash that triggers the event (in EventWatcher flow) as metadata in the commit body.
-	TraceTriggerCommitHashKey = "pipecd.dev.Trace-Trigger-Commit-Hash"
+	TraceTriggerCommitHashKey = "Pipecd-Dev-Trace-Trigger-Commit-Hash"
 )
 
 func (d *DeploymentTrace) SetUpdatedAt(t int64) {

--- a/pkg/model/deployment_trace.go
+++ b/pkg/model/deployment_trace.go
@@ -16,7 +16,7 @@ package model
 
 const (
 	// The key to store the commit hash that triggers the event (in EventWatcher flow) as metadata in the commit body.
-	TraceTriggerCommitHashKey = "Trace-Trigger-Commit-Hash"
+	TraceTriggerCommitHashKey = "pipecd.dev.Trace-Trigger-Commit-Hash"
 )
 
 func (d *DeploymentTrace) SetUpdatedAt(t int64) {

--- a/pkg/model/deployment_trace.go
+++ b/pkg/model/deployment_trace.go
@@ -15,8 +15,7 @@
 package model
 
 const (
-	// The key to store the commit hash that triggers the event (in EventWatcher flow).
-	// It will be used as key to store the commit hash as metadata in the commit boy.
+	// The key to store the commit hash that triggers the event (in EventWatcher flow) as metadata in the commit body.
 	TraceTriggerCommitHashKey = "Trace-Trigger-Commit-Hash"
 )
 


### PR DESCRIPTION
**What this PR does**:

Add value for `DeploymentTraceCommitHash` to deployment model.

**Why we need it**:

This commit will be used as the key to link between the DeploymentTrace model and the Deployment model. By referring to this key, we can query all deployments, which should be grouped under one DeploymentTrace (aka. Group deployments triggered by the same event)

**Which issue(s) this PR fixes**:

Part of #5444

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
