### PR TITLE
Fix for lint

### DIFF
--- a/pkg/app/pipedv1/plugin/wait/wait.go
+++ b/pkg/app/pipedv1/plugin/wait/wait.go
@@ -77,7 +77,7 @@ func wait(ctx context.Context, duration time.Duration, initialStart time.Time, s
 
 		case <-ctx.Done(): // on cancelled
 			slp.Info("Wait cancelled")
-			// We can return any status here because the piped handles this case as cancelled by a user, 
+			// We can return any status here because the piped handles this case as cancelled by a user,
 			// ignoring the result from a plugin.
 			return sdk.StageStatusFailure
 		}


### PR DESCRIPTION
**What this PR does**:

as title. I just removed unnecessary space.

**Why we need it**:

I encountered lint error on `pkg/app/pipedv1/plugin/wait/wait.go`
There is an error from goimports, but actually it derives from formatting go code. (goimport may format the target codes before analyzing)

i will consider introducing `gofmt` linter.

```bash
% make lint/go                                                                        (git)-[fix-for-lint]
docker run --rm -e GOCACHE=/repo/.cache/go-build -e GOLANGCI_LINT_CACHE=/repo/.cache/golangci-lint -v /Users/s14218/oss/pipe-cd/pipecd:/repo -w /repo -it golangci/golangci-lint@sha256:4e53bfe25ef2f1e14a95da42d694211080f40d118730541ce1513a83cf7587ec  golangci-lint run -v
INFO golangci-lint has version 1.62.2 built with go1.23.3 from 89476e7a on 2024-11-25T14:16:01Z
INFO [config_reader] Config search paths: [./ /repo / /root]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [depguard gocritic goheader goimports gosimple ineffassign misspell prealloc staticcheck stylecheck unconvert unparam]
INFO [loader] Go packages loading at mode 8767 (types_sizes|compiled_files|imports|files|name|deps|exports_file) took 14.92870643s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 67.685649ms
INFO [linters_context/goanalysis] analyzers took 2m28.513605334s with top 10 stages: goheader: 52.716132641s, buildir: 29.029748651s, goimports: 17.6757466s, unparam: 8.529713654s, gocritic: 4.777197959s, buildssa: 3.97055409s, unconvert: 3.758489316s, misspell: 2.115103867s, S1038: 2.000847241s, nilness: 1.530075685s
INFO [runner/skip_dirs] Skipped 39 issues from dir pkg/app/piped/executor/analysis/mannwhitney by pattern pkg/app/piped/executor/analysis/mannwhitney
INFO [runner] Issues before processing: 1043, after processing: 1
INFO [runner] Processors filtering stat (in/out): filename_unadjuster: 1043/1043, path_prettifier: 1043/1043, skip_dirs: 953/914, fixer: 1/1, max_per_file_from_linter: 1/1, source_code: 1/1, nolint: 5/1, uniq_by_line: 1/1, max_from_linter: 1/1, path_prefixer: 1/1, cgo: 1043/1043, autogenerated_exclude: 914/459, identifier_marker: 459/459, exclude: 459/459, sort_results: 1/1, max_same_issues: 1/1, path_shortener: 1/1, severity-rules: 1/1, invalid_issue: 1043/1043, skip_files: 1043/953, exclude-rules: 459/5, diff: 1/1
INFO [runner] processing took 42.832597ms with stages: autogenerated_exclude: 23.275007ms, exclude-rules: 5.81421ms, identifier_marker: 4.723793ms, path_prettifier: 4.417751ms, nolint: 2.227126ms, skip_dirs: 1.310917ms, skip_files: 813.875µs, cgo: 95.667µs, invalid_issue: 71.666µs, source_code: 40.917µs, filename_unadjuster: 31.792µs, uniq_by_line: 4.501µs, max_same_issues: 1.667µs, sort_results: 875ns, path_shortener: 751ns, max_per_file_from_linter: 583ns, max_from_linter: 416ns, diff: 333ns, fixer: 292ns, exclude: 291ns, severity-rules: 84ns, path_prefixer: 83ns
INFO [runner] linters took 9.333567348s with stages: goanalysis_metalinter: 9.290631791s
pkg/app/pipedv1/plugin/wait/wait.go:80: File is not `goimports`-ed with -local github.com/pipe-cd/pipecd (goimports)
                        // We can return any status here because the piped handles this case as cancelled by a user,
INFO File cache stats: 693 entries of total size 6.6MiB
INFO Memory: 244 samples, avg is 586.1MB, max is 2094.7MB
INFO Execution took 24.334864261s
make: *** [lint/go] Error 1
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
