### PR TITLE
Implement k8s sync pruning with SDK

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -205,6 +205,12 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 
 	lp.Successf("Successfully loaded %d live resources", len(namespacedLiveResources)+len(clusterScopedLiveResources))
 
+	removeKeys := provider.FindRemoveResources(manifests, namespacedLiveResources, clusterScopedLiveResources)
+	if len(removeKeys) == 0 {
+		lp.Info("There are no live resources should be removed")
+		return sdk.StageStatusSuccess
+	}
+
 	return sdk.StageStatusSuccess
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -200,7 +200,7 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 
 	if len(namespacedLiveResources)+len(clusterScopedLiveResources) == 0 {
 		lp.Info("There is no data about live resource so no resource will be removed")
-		return sdk.StageStatusFailure
+		return sdk.StageStatusSuccess
 	}
 
 	lp.Successf("Successfully loaded %d live resources", len(namespacedLiveResources)+len(clusterScopedLiveResources))

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -202,4 +203,250 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
 	assert.Equal(t, "apps:Deployment:test-namespace:simple", deployment.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
 	assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+}
+
+func TestPlugin_executeK8sSyncStage_withPrune(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	running := filepath.Join("./", "testdata", "prune", "running")
+
+	// read the running application config from the testdata file
+	runningCfg, err := os.ReadFile(filepath.Join(running, "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	ok := t.Run("prepare", func(t *testing.T) {
+		// prepare the input to ensure the running deployment exists
+		runningInput := &sdk.ExecuteStageInput{
+			Request: sdk.ExecuteStageRequest{
+				StageName:               "K8S_SYNC",
+				StageConfig:             []byte(``),
+				RunningDeploymentSource: sdk.DeploymentSource{},
+				TargetDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      running,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         runningCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "app-id", "stage-id", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+		status := plugin.executeK8sSyncStage(ctx, runningInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+		require.Equal(t, sdk.StageStatusSuccess, status)
+
+		service, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(context.Background(), "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, "piped", service.GetLabels()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetLabels()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetLabels()["pipecd.dev/application"])
+		require.Equal(t, "0123456789", service.GetLabels()["pipecd.dev/commit-hash"])
+
+		require.Equal(t, "simple", service.GetName())
+		require.Equal(t, "piped", service.GetAnnotations()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetAnnotations()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetAnnotations()["pipecd.dev/application"])
+		require.Equal(t, "v1", service.GetAnnotations()["pipecd.dev/original-api-version"])
+		require.Equal(t, ":Service::simple", service.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
+		require.Equal(t, "0123456789", service.GetAnnotations()["pipecd.dev/commit-hash"])
+	})
+	require.Truef(t, ok, "expected prepare to succeed")
+
+	t.Run("run with prune", func(t *testing.T) {
+		target := filepath.Join("./", "testdata", "prune", "target")
+
+		// read the running application config from the testdata file
+		targetCfg, err := os.ReadFile(filepath.Join(target, "app.pipecd.yaml"))
+		require.NoError(t, err)
+
+		// prepare the input to ensure the running deployment exists
+		targetInput := &sdk.ExecuteStageInput{
+			Request: sdk.ExecuteStageRequest{
+				StageName:   "K8S_SYNC",
+				StageConfig: []byte(``),
+				RunningDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      running,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         runningCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      target,
+					CommitHash:                "0012345678",
+					ApplicationConfig:         targetCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "app-id", "stage-id", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+		status := plugin.executeK8sSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(context.Background(), "simple", metav1.GetOptions{})
+		require.Error(t, err)
+		require.Truef(t, apierrors.IsNotFound(err), "expected error to be NotFound, but got %v", err)
+	})
+}
+
+func TestPlugin_executeK8sSyncStage_withPrune_changesNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	running := filepath.Join("./", "testdata", "prune_with_change_namespace", "running")
+
+	// read the running application config from the example file
+	runningCfg, err := os.ReadFile(filepath.Join(running, "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	ok := t.Run("prepare", func(t *testing.T) {
+		// prepare the input to ensure the running deployment exists
+		runningInput := &sdk.ExecuteStageInput{
+			Request: sdk.ExecuteStageRequest{
+				StageName:               "K8S_SYNC",
+				StageConfig:             []byte(``),
+				RunningDeploymentSource: sdk.DeploymentSource{},
+				TargetDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      running,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         runningCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "app-id", "stage-id", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+		status := plugin.executeK8sSyncStage(ctx, runningInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+		require.Equal(t, sdk.StageStatusSuccess, status)
+
+		service, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("test-1").Get(context.Background(), "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, "piped", service.GetLabels()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetLabels()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetLabels()["pipecd.dev/application"])
+		require.Equal(t, "0123456789", service.GetLabels()["pipecd.dev/commit-hash"])
+
+		require.Equal(t, "simple", service.GetName())
+		require.Equal(t, "piped", service.GetAnnotations()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetAnnotations()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetAnnotations()["pipecd.dev/application"])
+		require.Equal(t, "v1", service.GetAnnotations()["pipecd.dev/original-api-version"])
+		require.Equal(t, "0123456789", service.GetAnnotations()["pipecd.dev/commit-hash"])
+		require.Equal(t, ":Service:test-1:simple", service.GetAnnotations()["pipecd.dev/resource-key"])
+	})
+	require.Truef(t, ok, "expected prepare to succeed")
+
+	t.Run("run with prune", func(t *testing.T) {
+		target := filepath.Join("./", "testdata", "prune_with_change_namespace", "target")
+
+		// read the running application config from the example file
+		targetCfg, err := os.ReadFile(filepath.Join(target, "app.pipecd.yaml"))
+		require.NoError(t, err)
+
+		// prepare the input to ensure the running deployment exists
+		targetInput := &sdk.ExecuteStageInput{
+			Request: sdk.ExecuteStageRequest{
+				StageName:   "K8S_SYNC",
+				StageConfig: []byte(``),
+				RunningDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      running,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         runningCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource{
+					ApplicationDirectory:      target,
+					CommitHash:                "0012345678",
+					ApplicationConfig:         targetCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "app-id", "stage-id", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+		status := plugin.executeK8sSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+		require.Equal(t, sdk.StageStatusSuccess, status)
+
+		// The service should be removed from the previous namespace
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("test-1").Get(context.Background(), "simple", metav1.GetOptions{})
+		require.Error(t, err)
+		require.Truef(t, apierrors.IsNotFound(err), "expected error to be NotFound, but got %v", err)
+
+		// The service should be created in the new namespace
+		service, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("test-2").Get(context.Background(), "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, "piped", service.GetLabels()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetLabels()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetLabels()["pipecd.dev/application"])
+		require.Equal(t, "0012345678", service.GetLabels()["pipecd.dev/commit-hash"])
+
+		require.Equal(t, "simple", service.GetName())
+		require.Equal(t, "piped", service.GetAnnotations()["pipecd.dev/managed-by"])
+		require.Equal(t, "piped-id", service.GetAnnotations()["pipecd.dev/piped"])
+		require.Equal(t, "app-id", service.GetAnnotations()["pipecd.dev/application"])
+		require.Equal(t, "v1", service.GetAnnotations()["pipecd.dev/original-api-version"])
+		require.Equal(t, "0012345678", service.GetAnnotations()["pipecd.dev/commit-hash"])
+		require.Equal(t, ":Service:test-2:simple", service.GetAnnotations()["pipecd.dev/resource-key"])
+	})
 }


### PR DESCRIPTION
**What this PR does**:

I implemented k8s sync pruning feature by using SDK.

**The fix summary**
- `deployment/plugin.go`: implement the logic for pruning.
- `deployment/plugin_test.go`: Implement three tests for the pruning.

**Why we need it**:

We want to implement plugins with SDK.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/4980 https://github.com/pipe-cd/pipecd/issues/5006
Follow #5624

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
