### PR TITLE
Update Go to 1.24.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ on:
       - 'release-v*'
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.24.1
   NODE_VERSION: 18.12.0
   HELM_VERSION: 3.8.2
 

--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Generate code
       # NOTE: Keep this container image as same as defined in Makefile
-      uses: docker://ghcr.io/pipe-cd/codegen@sha256:fcb600d82cc4acc76f532c292445f868dfa176d6db116b6c5b18b81a1b1c5fa9 #v0.50.0-51-gb98a963
+      uses: docker://ghcr.io/pipe-cd/codegen@sha256:831f2dda2f56b1d12e90f88c0cb4168f51aa4eb5907b468e74bc42670939fff2 #v0.50.0-215-g3f6a738
       with:
         entrypoint: ./tool/codegen/codegen.sh
         args: /github/workspace

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ on:
       - 'release-v*'
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.24.1
   NODE_VERSION: 18.12.0
   GOLANGCI_LINT_VERSION: v1.62.2
 

--- a/.github/workflows/publish_binary.yaml
+++ b/.github/workflows/publish_binary.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.24.1
 
 jobs:
   gh_release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ on:
       - 'release-v*'
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.24.1
   NODE_VERSION: 18.12.0
 
 jobs:

--- a/.github/workflows/test_tool.yaml
+++ b/.github/workflows/test_tool.yaml
@@ -14,7 +14,7 @@ on:
       - tool/**
 
 env:
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.24.1
   NODE_VERSION: 18.12.0
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -218,8 +218,8 @@ update/copyright:
 
 .PHONY: gen/code
 gen/code:
-	# NOTE: Keep this container image as same as defined in .github/workflows/codegen.yml
-	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh ghcr.io/pipe-cd/codegen@sha256:fcb600d82cc4acc76f532c292445f868dfa176d6db116b6c5b18b81a1b1c5fa9 /repo # v0.50.0-51-gb98a963
+	# NOTE: Keep this container image as same as defined in .github/workflows/gen.yml
+	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh ghcr.io/pipe-cd/codegen@sha256:831f2dda2f56b1d12e90f88c0cb4168f51aa4eb5907b468e74bc42670939fff2 /repo # v0.50.0-215-g3f6a738
 
 .PHONY: gen/test-tls
 gen/test-tls:

--- a/cmd/helloworld/Dockerfile
+++ b/cmd/helloworld/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/launcher/Dockerfile
+++ b/cmd/launcher/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/launcher/Dockerfile-okd
+++ b/cmd/launcher/Dockerfile-okd
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -13,7 +13,7 @@ RUN make update/web-deps
 RUN make build/web
 
 # pipecd builder
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/pipecd/README.md
+++ b/cmd/pipecd/README.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-- [Go 1.22 or later](https://go.dev/)
+- [Go 1.24 or later](https://go.dev/)
 - [NodeJS v20 or later](https://nodejs.org/en/)
 - [Docker](https://www.docker.com/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (If you want to run Control Plane locally)

--- a/cmd/pipectl/Dockerfile
+++ b/cmd/pipectl/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/piped/Dockerfile
+++ b/cmd/piped/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/piped/Dockerfile-okd
+++ b/cmd/piped/Dockerfile-okd
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-- [Go 1.22 or later](https://go.dev/)
+- [Go 1.24 or later](https://go.dev/)
 
 ## Repositories
 - [pipecd](https://github.com/pipe-cd/pipecd): contains all source code and documentation of PipeCD project.

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.4-alpine3.20 AS builder
+FROM golang:1.24.1-alpine3.21 AS builder
 COPY main.go .
 RUN go build -o /server main.go
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pipe-cd/pipecd
 
-go 1.22.4
+go 1.24.1
 
 require (
 	cloud.google.com/go/firestore v1.14.0

--- a/tool/actions-gh-release/Dockerfile
+++ b/tool/actions-gh-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.3-alpine3.20
+FROM golang:1.24.1-alpine3.21
 
 RUN apk update && apk add git
 

--- a/tool/actions-gh-release/comment.go
+++ b/tool/actions-gh-release/comment.go
@@ -46,7 +46,7 @@ func makeCommentBody(proposals []ReleaseProposal, exists []ReleaseProposal) stri
 	b.WriteString(fmt.Sprintf("The following %d GitHub releases will be created once this pull request got merged.\n", len(proposals)))
 	for _, p := range proposals {
 		fmt.Fprintf(&b, "\n")
-		fmt.Fprintf(&b, p.ReleaseNote)
+		fmt.Fprint(&b, p.ReleaseNote)
 		fmt.Fprintf(&b, "\n")
 	}
 

--- a/tool/actions-gh-release/go.mod
+++ b/tool/actions-gh-release/go.mod
@@ -1,6 +1,6 @@
 module github.com/pipe-cd/actions-gh-release
 
-go 1.23.3
+go 1.24.1
 
 require (
 	github.com/creasty/defaults v1.5.2

--- a/tool/actions-plan-preview/Dockerfile
+++ b/tool/actions-plan-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.4-alpine3.20 AS builder
+FROM golang:1.24.1-alpine3.21 AS builder
 WORKDIR /app
 COPY go.mod go.sum  ./
 RUN go mod download

--- a/tool/actions-plan-preview/go.mod
+++ b/tool/actions-plan-preview/go.mod
@@ -1,6 +1,6 @@
 module github.com/pipe-cd/actions-plan-preview
 
-go 1.22.4
+go 1.24.1
 
 require (
 	github.com/google/go-github/v36 v36.0.0

--- a/tool/codegen/Dockerfile
+++ b/tool/codegen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image to build go program.
-FROM golang:1.23 AS builder
+FROM golang:1.24.1 AS builder
 
 COPY protoc-gen-auth /protoc-gen-auth
 RUN cd /protoc-gen-auth \
@@ -7,7 +7,7 @@ RUN cd /protoc-gen-auth \
   && chmod +x /usr/local/bin/protoc-gen-auth
 
 # Codegen image which is actually being used.
-FROM golang:1.23
+FROM golang:1.24.1
 
 # This is version of protobuf installed in the image.
 # See https://pkgs.alpinelinux.org/packages?name=protobuf&branch=v3.16

--- a/tool/codegen/protoc-gen-auth/go.mod
+++ b/tool/codegen/protoc-gen-auth/go.mod
@@ -1,5 +1,5 @@
 module github.com/pipe-cd/pipecd/tool/codegen/protoc-gen-auth
 
-go 1.22.4
+go 1.24.1
 
 require google.golang.org/protobuf v1.33.0


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

because 1.22 is EOL

**Which issue(s) this PR fixes**:

Fixes #5640 
~~After merging this PR, I'll update the codegen image in the Makefile~~
I'll send another PR to update the codegen's go version to pass the CI.
→ DONE

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
