### PR TITLE
Update Go version of codegen to 1.24.1

### DIFF
--- a/tool/codegen/Dockerfile
+++ b/tool/codegen/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image to build go program.
-FROM golang:1.23 AS builder
+FROM golang:1.24.1 AS builder
 
 COPY protoc-gen-auth /protoc-gen-auth
 RUN cd /protoc-gen-auth \
@@ -7,7 +7,7 @@ RUN cd /protoc-gen-auth \
   && chmod +x /usr/local/bin/protoc-gen-auth
 
 # Codegen image which is actually being used.
-FROM golang:1.23
+FROM golang:1.24.1
 
 # This is version of protobuf installed in the image.
 # See https://pkgs.alpinelinux.org/packages?name=protobuf&branch=v3.16

--- a/tool/codegen/protoc-gen-auth/go.mod
+++ b/tool/codegen/protoc-gen-auth/go.mod
@@ -1,5 +1,5 @@
 module github.com/pipe-cd/pipecd/tool/codegen/protoc-gen-auth
 
-go 1.22.4
+go 1.24.1
 
 require google.golang.org/protobuf v1.33.0


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We have to update codegen's Go version to pass CI.
ref; https://github.com/pipe-cd/pipecd/actions/runs/13756842699/job/38465545575?pr=5641

after merging this PR, I'll update codegen image hash in #5641.

**Which issue(s) this PR fixes**:

Part of #5640 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
