### PR TITLE
Rename PipedServiceClient to PluginServiceClient

### DIFF
--- a/pkg/plugin/pipedapi/client.go
+++ b/pkg/plugin/pipedapi/client.go
@@ -24,12 +24,12 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcclient"
 )
 
-type PipedServiceClient struct {
+type PluginServiceClient struct {
 	service.PluginServiceClient
 	conn *grpc.ClientConn
 }
 
-func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption) (*PipedServiceClient, error) {
+func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption) (*PluginServiceClient, error) {
 	// Clone the opts to avoid modifying the original opts slice.
 	opts = slices.Clone(opts)
 
@@ -44,12 +44,12 @@ func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption
 		return nil, err
 	}
 
-	return &PipedServiceClient{
+	return &PluginServiceClient{
 		PluginServiceClient: service.NewPluginServiceClient(conn),
 		conn:                conn,
 	}, nil
 }
 
-func (c *PipedServiceClient) Close() error {
+func (c *PluginServiceClient) Close() error {
 	return c.conn.Close()
 }

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -26,7 +26,7 @@ import (
 // It provides methods to call the piped service APIs.
 // It's a wrapper around the raw piped service client.
 type Client struct {
-	base *pipedapi.PipedServiceClient
+	base *pipedapi.PluginServiceClient
 
 	// pluginName is used to identify which plugin sends requests to piped.
 	pluginName string
@@ -52,7 +52,7 @@ type Client struct {
 // NewClient creates a new client.
 // DO NOT USE this function except in tests.
 // FIXME: Remove this function and make a better way for tests.
-func NewClient(base *pipedapi.PipedServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister, tr *toolregistry.ToolRegistry) *Client {
+func NewClient(base *pipedapi.PluginServiceClient, pluginName, applicationID, stageID string, lp StageLogPersister, tr *toolregistry.ToolRegistry) *Client {
 	return &Client{
 		base:          base,
 		pluginName:    pluginName,

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -114,7 +114,7 @@ type commonFields struct {
 	config       *config.PipedPlugin
 	logger       *zap.Logger
 	logPersister logPersister
-	client       *pipedapi.PipedServiceClient
+	client       *pipedapi.PluginServiceClient
 	toolRegistry *toolregistry.ToolRegistry
 }
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

just for clarification.

If we also want to rename the package `pipedservice` & `pipedapi`, let's do it in another PR.

**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
