### PR TITLE
Fix index ensurer error on alter table command run

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -82,8 +82,7 @@ ALTER TABLE Deployment MODIFY DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS 
 CREATE INDEX deployment_chain_id_updated_at_desc ON Deployment (DeploymentChainId, UpdatedAt DESC);
 
 -- index on `DeploymentTraceCommitHash` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN DeploymentTraceCommitHash VARCHAR(40) GENERATED ALWAYS AS (data->>"$.deployment_trace_commit_hash") VIRTUAL NOT NULL;
-ALTER TABLE Deployment MODIFY DeploymentTraceCommitHash VARCHAR(40) GENERATED ALWAYS AS (IFNULL(data->>"$.deployment_trace_commit_hash", "")) VIRTUAL NOT NULL;
+ALTER TABLE Deployment ADD COLUMN DeploymentTraceCommitHash VARCHAR(40) GENERATED ALWAYS AS (IFNULL(data->>"$.deployment_trace_commit_hash", "")) VIRTUAL NOT NULL;
 CREATE INDEX deployment_trace_commit_hash_updated_at_desc ON Deployment (DeploymentTraceCommitHash, UpdatedAt DESC);
 
 --
@@ -146,6 +145,5 @@ CREATE INDEX deploymentchain_status_updated_at_desc ON Deployment (Status, Updat
 CREATE INDEX deploymenttrace_project_id_updated_at_desc ON DeploymentTrace (ProjectId, UpdatedAt DESC);
 
 -- index on `CommitHash` ASC and `UpdatedAt` DESC
-ALTER TABLE DeploymentTrace ADD COLUMN CommitHash VARCHAR(40) GENERATED ALWAYS AS (data->>"$.commit_hash") VIRTUAL NOT NULL;
-ALTER TABLE DeploymentTrace MODIFY CommitHash VARCHAR(40) GENERATED ALWAYS AS (IFNULL(data->>"$.commit_hash", "")) VIRTUAL NOT NULL;
+ALTER TABLE DeploymentTrace ADD COLUMN CommitHash VARCHAR(40) GENERATED ALWAYS AS (IFNULL(data->>"$.commit_hash", "")) VIRTUAL NOT NULL;
 CREATE INDEX deploymenttrace_commit_hash_updated_at_desc ON DeploymentTrace (CommitHash, UpdatedAt DESC);


### PR DESCRIPTION
**What this PR does**:

This change fixes the error on running the alter table query.

> "failed to create required indexes on sql database: Error 1048: Column 'DeploymentTraceCommitHash' cannot be null"

**Why we need it**:

Since the previous data on Deployment model didn't have DeploymentTraceCommitHash value, the first Alter Table statement will be failed

**Which issue(s) this PR fixes**:

Follow PR #5631

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
