### PR TITLE
[SDK] Implement DetermineVersions RPC for DeploymentPlugin

### DIFF
--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -726,3 +726,55 @@ func newStageCommand(c *model.Command) (StageCommand, error) {
 		return StageCommand{}, fmt.Errorf("invalid command type: %d", c.Type)
 	}
 }
+
+// DetermineVersionsInput is the input for the DetermineVersions method.
+type DetermineVersionsInput struct {
+	// Request is the request to determine versions.
+	Request DetermineVersionsRequest
+	// Client is the client to interact with the piped.
+	Client *Client
+	// Logger is the logger to log the events.
+	Logger *zap.Logger
+}
+
+// DetermineVersionsRequest is the request to determine versions.
+type DetermineVersionsRequest struct {
+	// Deloyment is the deployment that the versions will be determined.
+	Deployment Deployment
+	// DeploymentSource is the source of the deployment.
+	DeploymentSource DeploymentSource
+}
+
+// DetermineVersionsResponse is the response of the request to determine versions.
+type DetermineVersionsResponse struct {
+	// Versions contains the versions of the resources.
+	Versions []ArtifactVersion
+}
+
+// ArtifactVersion represents the version of an artifact.
+type ArtifactVersion struct {
+	// Kind is the kind of the artifact.
+	Kind ArtifactKind
+	// Version is the version of the artifact.
+	Version string
+	// Name is the name of the artifact.
+	Name string
+	// URL is the URL of the artifact.
+	URL string
+}
+
+// ArtifactKind represents the kind of the artifact.
+type ArtifactKind int
+
+const (
+	// ArtifactKindUnknown indicates that the kind of the artifact is unknown.
+	ArtifactKindUnknown ArtifactKind = iota
+	// ArtifactKindContainerImage indicates that the artifact is a container image.
+	ArtifactKindContainerImage
+	// ArtifactKindS3Object indicates that the artifact is an S3 object.
+	ArtifactKindS3Object
+	// ArtifactKindGitSource indicates that the artifact is a git source.
+	ArtifactKindGitSource
+	// ArtifactKindTerraformModule indicates that the artifact is a terraform module.
+	ArtifactKindTerraformModule
+)

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -745,10 +745,27 @@ type DetermineVersionsRequest struct {
 	DeploymentSource DeploymentSource
 }
 
+// newDetermineVersionsRequest converts the common.DetermineVersionsRequest to the internal representation.
+func newDetermineVersionsRequest(request *deployment.DetermineVersionsRequest) DetermineVersionsRequest {
+	return DetermineVersionsRequest{
+		Deployment:       newDeployment(request.GetInput().GetDeployment()),
+		DeploymentSource: newDeploymentSource(request.GetInput().GetTargetDeploymentSource()),
+	}
+}
+
 // DetermineVersionsResponse is the response of the request to determine versions.
 type DetermineVersionsResponse struct {
 	// Versions contains the versions of the resources.
 	Versions []ArtifactVersion
+}
+
+// toModel converts the DetermineVersionsResponse to the model.ArtifactVersion.
+func (r *DetermineVersionsResponse) toModel() []*model.ArtifactVersion {
+	versions := make([]*model.ArtifactVersion, 0, len(r.Versions))
+	for _, v := range r.Versions {
+		versions = append(versions, v.toModel())
+	}
+	return versions
 }
 
 // ArtifactVersion represents the version of an artifact.
@@ -761,6 +778,16 @@ type ArtifactVersion struct {
 	Name string
 	// URL is the URL of the artifact.
 	URL string
+}
+
+// toModel converts the ArtifactVersion to the model.ArtifactVersion.
+func (v *ArtifactVersion) toModel() *model.ArtifactVersion {
+	return &model.ArtifactVersion{
+		Kind:    v.Kind.toModelEnum(),
+		Version: v.Version,
+		Name:    v.Name,
+		Url:     v.URL,
+	}
 }
 
 // ArtifactKind represents the kind of the artifact.
@@ -778,3 +805,19 @@ const (
 	// ArtifactKindTerraformModule indicates that the artifact is a terraform module.
 	ArtifactKindTerraformModule
 )
+
+// toModelEnum converts the ArtifactKind to the model.ArtifactVersion_Kind.
+func (k ArtifactKind) toModelEnum() model.ArtifactVersion_Kind {
+	switch k {
+	case ArtifactKindContainerImage:
+		return model.ArtifactVersion_CONTAINER_IMAGE
+	case ArtifactKindS3Object:
+		return model.ArtifactVersion_S3_OBJECT
+	case ArtifactKindGitSource:
+		return model.ArtifactVersion_GIT_SOURCE
+	case ArtifactKindTerraformModule:
+		return model.ArtifactVersion_TERRAFORM_MODULE
+	default:
+		return model.ArtifactVersion_UNKNOWN
+	}
+}

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -63,7 +63,7 @@ type DeploymentPlugin[Config, DeployTargetConfig any] interface {
 	StagePlugin[Config, DeployTargetConfig]
 
 	// DetermineVersions determines the versions of the resources that will be deployed.
-	DetermineVersions(context.Context, *Config, *Client, TODO) (TODO, error)
+	DetermineVersions(context.Context, *Config, *Client, *DetermineVersionsInput) (*DetermineVersionsResponse, error)
 	// DetermineStrategy determines the strategy to deploy the resources.
 	DetermineStrategy(context.Context, *Config, *Client, TODO) (TODO, error)
 	// BuildQuickSyncStages builds the stages that will be executed during the quick sync process.

--- a/pkg/plugin/sdk/deployment_test.go
+++ b/pkg/plugin/sdk/deployment_test.go
@@ -447,3 +447,94 @@ func TestNewDetermineVersionsRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestArtifactVersion_toModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  ArtifactVersion
+		expected *model.ArtifactVersion
+	}{
+		{
+			name: "container image",
+			version: ArtifactVersion{
+				Kind:    ArtifactKindContainerImage,
+				Version: "v1.0.0",
+				Name:    "nginx",
+				URL:     "https://example.com/nginx:v1.0.0",
+			},
+			expected: &model.ArtifactVersion{
+				Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+				Version: "v1.0.0",
+				Name:    "nginx",
+				Url:     "https://example.com/nginx:v1.0.0",
+			},
+		},
+		{
+			name: "s3 object",
+			version: ArtifactVersion{
+				Kind:    ArtifactKindS3Object,
+				Version: "v1.0.0",
+				Name:    "backup",
+				URL:     "s3://bucket/backup/v1.0.0",
+			},
+			expected: &model.ArtifactVersion{
+				Kind:    model.ArtifactVersion_S3_OBJECT,
+				Version: "v1.0.0",
+				Name:    "backup",
+				Url:     "s3://bucket/backup/v1.0.0",
+			},
+		},
+		{
+			name: "git source",
+			version: ArtifactVersion{
+				Kind:    ArtifactKindGitSource,
+				Version: "commit-hash",
+				Name:    "repo",
+				URL:     "https://github.com/repo/commit/commit-hash",
+			},
+			expected: &model.ArtifactVersion{
+				Kind:    model.ArtifactVersion_GIT_SOURCE,
+				Version: "commit-hash",
+				Name:    "repo",
+				Url:     "https://github.com/repo/commit/commit-hash",
+			},
+		},
+		{
+			name: "terraform module",
+			version: ArtifactVersion{
+				Kind:    ArtifactKindTerraformModule,
+				Version: "v1.0.0",
+				Name:    "module",
+				URL:     "https://registry.terraform.io/modules/module/v1.0.0",
+			},
+			expected: &model.ArtifactVersion{
+				Kind:    model.ArtifactVersion_TERRAFORM_MODULE,
+				Version: "v1.0.0",
+				Name:    "module",
+				Url:     "https://registry.terraform.io/modules/module/v1.0.0",
+			},
+		},
+		{
+			name: "unknown kind",
+			version: ArtifactVersion{
+				Kind:    ArtifactKindUnknown,
+				Version: "v1.0.0",
+				Name:    "unknown",
+				URL:     "https://example.com/unknown:v1.0.0",
+			},
+			expected: &model.ArtifactVersion{
+				Kind:    model.ArtifactVersion_UNKNOWN,
+				Version: "v1.0.0",
+				Name:    "unknown",
+				Url:     "https://example.com/unknown:v1.0.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.version.toModel()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/plugin/sdk/deployment_test.go
+++ b/pkg/plugin/sdk/deployment_test.go
@@ -581,3 +581,80 @@ func TestArtifactKind_toModelEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineVersionsResponse_toModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		response DetermineVersionsResponse
+		expected []*model.ArtifactVersion
+	}{
+		{
+			name: "single version",
+			response: DetermineVersionsResponse{
+				Versions: []ArtifactVersion{
+					{
+						Kind:    ArtifactKindContainerImage,
+						Version: "v1.0.0",
+						Name:    "nginx",
+						URL:     "https://example.com/nginx:v1.0.0",
+					},
+				},
+			},
+			expected: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "v1.0.0",
+					Name:    "nginx",
+					Url:     "https://example.com/nginx:v1.0.0",
+				},
+			},
+		},
+		{
+			name: "multiple versions",
+			response: DetermineVersionsResponse{
+				Versions: []ArtifactVersion{
+					{
+						Kind:    ArtifactKindContainerImage,
+						Version: "v1.0.0",
+						Name:    "nginx",
+						URL:     "https://example.com/nginx:v1.0.0",
+					},
+					{
+						Kind:    ArtifactKindS3Object,
+						Version: "v1.0.0",
+						Name:    "backup",
+						URL:     "s3://bucket/backup/v1.0.0",
+					},
+				},
+			},
+			expected: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "v1.0.0",
+					Name:    "nginx",
+					Url:     "https://example.com/nginx:v1.0.0",
+				},
+				{
+					Kind:    model.ArtifactVersion_S3_OBJECT,
+					Version: "v1.0.0",
+					Name:    "backup",
+					Url:     "s3://bucket/backup/v1.0.0",
+				},
+			},
+		},
+		{
+			name: "empty versions",
+			response: DetermineVersionsResponse{
+				Versions: []ArtifactVersion{},
+			},
+			expected: []*model.ArtifactVersion{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.response.toModel()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/plugin/sdk/deployment_test.go
+++ b/pkg/plugin/sdk/deployment_test.go
@@ -538,3 +538,46 @@ func TestArtifactVersion_toModel(t *testing.T) {
 		})
 	}
 }
+
+func TestArtifactKind_toModelEnum(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     ArtifactKind
+		expected model.ArtifactVersion_Kind
+	}{
+		{
+			name:     "container image",
+			kind:     ArtifactKindContainerImage,
+			expected: model.ArtifactVersion_CONTAINER_IMAGE,
+		},
+		{
+			name:     "s3 object",
+			kind:     ArtifactKindS3Object,
+			expected: model.ArtifactVersion_S3_OBJECT,
+		},
+		{
+			name:     "git source",
+			kind:     ArtifactKindGitSource,
+			expected: model.ArtifactVersion_GIT_SOURCE,
+		},
+		{
+			name:     "terraform module",
+			kind:     ArtifactKindTerraformModule,
+			expected: model.ArtifactVersion_TERRAFORM_MODULE,
+		},
+		{
+			name:     "unknown",
+			kind:     ArtifactKindUnknown,
+			expected: model.ArtifactVersion_UNKNOWN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.kind.toModelEnum()
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

This PR implements the DetermineVersions gRPC method for DeploymentPlugin.

**Why we need it**:

To implement SDK

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
