### PR TITLE
Fix possible nil error on commit hash assign in case the contexts of event is nil

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -716,9 +716,12 @@ func (w *watcher) commitFiles(ctx context.Context, latestEvent *model.Event, eve
 	}
 	commitMsg = parseCommitMsg(commitMsg, args)
 	branch := makeBranchName(newBranch, eventName, repo.GetClonedBranch())
-	trailers := maps.Clone(latestEvent.Contexts)
+	trailers := make(map[string]string)
+	maps.Copy(trailers, latestEvent.Contexts)
 	// Store the commit hash of the commit that trigger this event as trailer of the manifest commit.
-	trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
+	if latestEvent.TriggerCommitHash != "" {
+		trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
+	}
 	if err := repo.CommitChanges(ctx, branch, commitMsg, newBranch, changes, trailers); err != nil {
 		w.logger.Error("failed to perform git commit",
 			zap.String("branch", branch),

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -650,9 +650,12 @@ func (w *watcher) commitFiles(ctx context.Context, latestEvent *model.Event, eve
 	}
 	commitMsg = parseCommitMsg(commitMsg, args)
 	branch := makeBranchName(newBranch, eventName, repo.GetClonedBranch())
-	trailers := maps.Clone(latestEvent.Contexts)
+	trailers := make(map[string]string)
+	maps.Copy(trailers, latestEvent.Contexts)
 	// Store the commit hash of the commit that trigger this event as trailer of the manifest commit.
-	trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
+	if latestEvent.TriggerCommitHash != "" {
+		trailers[model.TraceTriggerCommitHashKey] = latestEvent.TriggerCommitHash
+	}
 	if err := repo.CommitChanges(ctx, branch, commitMsg, newBranch, changes, trailers); err != nil {
 		return "", fmt.Errorf("failed to perform git commit: %w", err)
 	}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

If the event's context is nil, the trailers value will be nil, and leads to nil assignment when we try to add value to TraceTriggerCommitHashKey

**Which issue(s) this PR fixes**:

Follow #5625 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
