### PR TITLE
Update pipedv1 trigger to support adding trace commit hash to deployment model

### DIFF
--- a/pkg/app/pipedv1/trigger/deployment.go
+++ b/pkg/app/pipedv1/trigger/deployment.go
@@ -104,6 +104,8 @@ func buildDeployment(
 		UpdatedAt:                 now.Unix(),
 		DeploymentChainId:         deploymentChainID,
 		DeploymentChainBlockIndex: deploymentChainBlockIndex,
+		// TODO: Add link to deployment trace design docs here.
+		DeploymentTraceCommitHash: commit.GetTrailerValueByKey(model.TraceTriggerCommitHashKey),
 	}
 
 	return deployment, nil


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We must pass this value to the deployment model to use the Deployment Trace feature. This change is the same as we did in pipedv0 logic (ref: [pipedv0/trigger/deployment](https://github.com/pipe-cd/pipecd/pull/5625/files#diff-9c94e1765f50c81cc1e04535ec50d0f16fd6459fb06402713be9b2eb68a0e3cb))

**Which issue(s) this PR fixes**:

Follow #5625

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
