### PR TITLE
Add deployment trace model encode/decode logic for MySQL datastore

### DIFF
--- a/pkg/datastore/mysql/model_wrapper.go
+++ b/pkg/datastore/mysql/model_wrapper.go
@@ -92,6 +92,14 @@ func wrapModel(entity interface{}) (interface{}, error) {
 			DeploymentChain: *e,
 			Extra:           e.Id,
 		}, nil
+	case *model.DeploymentTrace:
+		if e == nil {
+			return nil, fmt.Errorf("nil entity given")
+		}
+		return &deploymentTrace{
+			DeploymentTrace: *e,
+			Extra:           e.Id,
+		}, nil
 	default:
 		return nil, fmt.Errorf("%T is not supported", e)
 	}
@@ -150,5 +158,10 @@ type event struct {
 
 type deploymentChain struct {
 	model.DeploymentChain `json:",inline"`
+	Extra                 string `json:"_extra"`
+}
+
+type deploymentTrace struct {
+	model.DeploymentTrace `json:",inline"`
 	Extra                 string `json:"_extra"`
 }


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Without this, in case of using MySQL as the datastore of PipeCD control plane, the datastore backend doesn't understand how to encode model object to store to MySQL table 😓 

We will get the below error

```
caller: "mysql/mysql.go:159"
error: "*model.DeploymentTrace is not supported"
kind: "DeploymentTrace"
logger: "pipecd.server"
message: "failed to create entity: failed to encode json data"
```

**Which issue(s) this PR fixes**:

Follow PR #5622

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
