### PR TITLE
[SDK] Add PipedID and ApplicationName fields to GetLivestateRequest

### DIFF
--- a/pkg/plugin/sdk/livestate.go
+++ b/pkg/plugin/sdk/livestate.go
@@ -132,9 +132,9 @@ func (s *LivestatePluginServer[Config, DeployTargetConfig]) GetLivestate(ctx con
 
 	response, err := s.base.GetLivestate(ctx, &s.config, deployTargets, &GetLivestateInput{
 		Request: GetLivestateRequest{
-			PipedID:          request.PipedId,
-			ApplicationID:    request.ApplicationId,
-			ApplicationName:  request.ApplicationName,
+			PipedID:          request.GetPipedId(),
+			ApplicationID:    request.GetApplicationId(),
+			ApplicationName:  request.GetApplicationName(),
 			DeploymentSource: newDeploymentSource(request.GetDeploySource()),
 		},
 		Client: client,

--- a/pkg/plugin/sdk/livestate.go
+++ b/pkg/plugin/sdk/livestate.go
@@ -132,7 +132,9 @@ func (s *LivestatePluginServer[Config, DeployTargetConfig]) GetLivestate(ctx con
 
 	response, err := s.base.GetLivestate(ctx, &s.config, deployTargets, &GetLivestateInput{
 		Request: GetLivestateRequest{
+			PipedID:          request.PipedId,
 			ApplicationID:    request.ApplicationId,
+			ApplicationName:  request.ApplicationName,
 			DeploymentSource: newDeploymentSource(request.GetDeploySource()),
 		},
 		Client: client,
@@ -157,8 +159,12 @@ type GetLivestateInput struct {
 
 // GetLivestateRequest is the request for the GetLivestate method.
 type GetLivestateRequest struct {
+	// PipedID is the ID of the piped.
+	PipedID string
 	// ApplicationID is the ID of the application.
 	ApplicationID string
+	// ApplicationName is the name of the application.
+	ApplicationName string
 	// DeploymentSource is the source of the deployment.
 	DeploymentSource DeploymentSource
 }

--- a/pkg/plugin/sdk/livestate_test.go
+++ b/pkg/plugin/sdk/livestate_test.go
@@ -81,8 +81,10 @@ func TestLivestatePluginServer_GetLivestate(t *testing.T) {
 		{
 			name: "success",
 			request: &livestate.GetLivestateRequest{
-				ApplicationId: "app1",
-				DeployTargets: []string{"target1"},
+				PipedId:         "piped1",
+				ApplicationId:   "app1",
+				ApplicationName: "app1",
+				DeployTargets:   []string{"target1"},
 			},
 			result: &GetLivestateResponse{
 				LiveState: ApplicationLiveState{
@@ -103,8 +105,10 @@ func TestLivestatePluginServer_GetLivestate(t *testing.T) {
 		{
 			name: "failure when deploy target not found",
 			request: &livestate.GetLivestateRequest{
-				ApplicationId: "app1",
-				DeployTargets: []string{"target2"},
+				PipedId:         "piped1",
+				ApplicationId:   "app1",
+				ApplicationName: "app1",
+				DeployTargets:   []string{"target2"},
 			},
 			result:         &GetLivestateResponse{},
 			expectErr:      true,


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We need these to implement livestate/driftdetection feature

**Which issue(s) this PR fixes**:

Follows https://github.com/pipe-cd/pipecd/pull/5668
Part of https://github.com/pipe-cd/pipecd/issues/4980 https://github.com/pipe-cd/pipecd/issues/5363

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
