### PR TITLE
Remove client argument from DetermineVersions and DetermineStrategy methods

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -340,7 +340,7 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 	return sdk.StageStatusSuccess
 }
 
-func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, _ *sdk.Client, input *sdk.DetermineVersionsInput) (*sdk.DetermineVersionsResponse, error) {
+func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineVersionsInput) (*sdk.DetermineVersionsResponse, error) {
 	logger := input.Logger
 
 	cfg, err := config.DecodeYAML[*kubeconfig.KubernetesApplicationSpec](input.Request.DeploymentSource.ApplicationConfig)
@@ -361,7 +361,7 @@ func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, _ *sd
 	}, nil
 }
 
-func (p *Plugin) DetermineStrategy(ctx context.Context, _ *sdk.ConfigNone, _ *sdk.Client, input *sdk.DetermineStrategyInput) (*sdk.DetermineStrategyResponse, error) {
+func (p *Plugin) DetermineStrategy(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineStrategyInput) (*sdk.DetermineStrategyResponse, error) {
 	logger := input.Logger
 	loader := provider.NewLoader(toolregistry.NewRegistry(input.Client.ToolRegistry()))
 

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -63,9 +63,9 @@ type DeploymentPlugin[Config, DeployTargetConfig any] interface {
 	StagePlugin[Config, DeployTargetConfig]
 
 	// DetermineVersions determines the versions of the resources that will be deployed.
-	DetermineVersions(context.Context, *Config, *Client, *DetermineVersionsInput) (*DetermineVersionsResponse, error)
+	DetermineVersions(context.Context, *Config, *DetermineVersionsInput) (*DetermineVersionsResponse, error)
 	// DetermineStrategy determines the strategy to deploy the resources.
-	DetermineStrategy(context.Context, *Config, *Client, *DetermineStrategyInput) (*DetermineStrategyResponse, error)
+	DetermineStrategy(context.Context, *Config, *DetermineStrategyInput) (*DetermineStrategyResponse, error)
 	// BuildQuickSyncStages builds the stages that will be executed during the quick sync process.
 	BuildQuickSyncStages(context.Context, *Config, *BuildQuickSyncStagesInput) (*BuildQuickSyncStagesResponse, error)
 }
@@ -195,7 +195,7 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) DetermineVer
 		Logger:  s.logger,
 	}
 
-	versions, err := s.base.DetermineVersions(ctx, &s.config, client, input)
+	versions, err := s.base.DetermineVersions(ctx, &s.config, input)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to determine versions: %v", err)
 	}
@@ -218,7 +218,7 @@ func (s *DeploymentPluginServiceServer[Config, DeployTargetConfig]) DetermineStr
 		Logger:  s.logger,
 	}
 
-	response, err := s.base.DetermineStrategy(ctx, &s.config, client, input)
+	response, err := s.base.DetermineStrategy(ctx, &s.config, input)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to determine strategy: %v", err)
 	}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Because we have this client in sdk.DetermineVersionsInput and sdk.DetermineStrategyInput.

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
