### PR TITLE
Implement the sync state calculation for the kubernetes livestate plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
@@ -75,13 +77,75 @@ func (p Plugin) GetLivestate(ctx context.Context, _ sdk.ConfigNone, deployTarget
 		resourceStates = append(resourceStates, m.ToResourceState(deployTarget.Name))
 	}
 
+	manifests, err := p.loadManifests(ctx, input, cfg.Spec, provider.NewLoader(toolRegistry))
+	if err != nil {
+		input.Logger.Error("Failed to load manifests", zap.Error(err))
+		return nil, err
+	}
+
+	liveManifests := make([]provider.Manifest, 0, len(namespacedLiveResources)+len(clusterScopedLiveResources))
+	for _, m := range namespacedLiveResources {
+		liveManifests = append(liveManifests, m)
+	}
+	for _, m := range clusterScopedLiveResources {
+		liveManifests = append(liveManifests, m)
+	}
+
+	// Calculate SyncState by comparing live manifests with desired manifests
+	diffResult, err := provider.DiffList(liveManifests, manifests, input.Logger,
+		diff.WithEquateEmpty(),
+		diff.WithIgnoreAddingMapKeys(),
+		diff.WithCompareNumberAndNumericString(),
+	)
+	if err != nil {
+		input.Logger.Error("Failed to calculate diff", zap.Error(err))
+		return nil, err
+	}
+
+	syncState := calculateSyncState(diffResult, len(manifests))
+
 	return &sdk.GetLivestateResponse{
 		LiveState: sdk.ApplicationLiveState{
 			Resources:    resourceStates,
 			HealthStatus: sdk.ApplicationHealthStateUnknown, // TODO: Implement health status calculation
 		},
-		SyncState: sdk.ApplicationSyncState{}, // TODO: Implement sync state calculation
+		SyncState: syncState,
 	}, nil
+}
+
+func calculateSyncState(diffResult *provider.DiffListResult, totalResources int) sdk.ApplicationSyncState {
+	if diffResult.NoChanges() {
+		return sdk.ApplicationSyncState{
+			Status:      sdk.ApplicationSyncStateSynced,
+			ShortReason: "",
+			Reason:      "",
+		}
+	}
+
+	total := len(diffResult.Adds) + len(diffResult.Deletes) + len(diffResult.Changes)
+	shortReason := fmt.Sprintf("There are %d manifests not synced (%d adds, %d deletes, %d changes)",
+		total,
+		len(diffResult.Adds),
+		len(diffResult.Deletes),
+		len(diffResult.Changes),
+	)
+
+	var b strings.Builder
+	b.WriteString("Diff between the actual state in cluster and expected state:\n\n")
+	b.WriteString("--- Actual   (LiveState)\n+++ Expected (Desired)\n\n")
+
+	details := diffResult.Render(provider.DiffRenderOptions{
+		MaskSecret:          true,
+		MaskConfigMap:       true,
+		MaxChangedManifests: 3,
+	})
+	b.WriteString(details)
+
+	return sdk.ApplicationSyncState{
+		Status:      sdk.ApplicationSyncStateOutOfSync,
+		ShortReason: shortReason,
+		Reason:      b.String(),
+	}
 }
 
 // Name implements sdk.LivestatePlugin.
@@ -92,4 +156,32 @@ func (p Plugin) Name() string {
 // Version implements sdk.LivestatePlugin.
 func (p Plugin) Version() string {
 	return "0.0.1" // TODO: make this constant to share with deployment plugin
+}
+
+type loader interface {
+	// LoadManifests renders and loads all manifests for application.
+	LoadManifests(ctx context.Context, input provider.LoaderInput) ([]provider.Manifest, error)
+}
+
+// TODO: share this implementation with the deployment plugin
+func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput, spec *kubeconfig.KubernetesApplicationSpec, loader loader) ([]provider.Manifest, error) {
+	manifests, err := loader.LoadManifests(ctx, provider.LoaderInput{
+		PipedID:          input.Request.PipedID,
+		AppID:            input.Request.ApplicationID,
+		CommitHash:       input.Request.DeploymentSource.CommitHash,
+		AppName:          input.Request.ApplicationName,
+		AppDir:           input.Request.DeploymentSource.ApplicationDirectory,
+		ConfigFilename:   input.Request.DeploymentSource.ApplicationConfigFilename,
+		Manifests:        spec.Input.Manifests,
+		Namespace:        spec.Input.Namespace,
+		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
+
+		// TODO: Define other fields for LoaderInput
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return manifests, nil
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin_test.go
@@ -1,0 +1,373 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livestate
+
+import (
+	"testing"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeTestManifest(t *testing.T, yaml string) provider.Manifest {
+	t.Helper()
+	manifests, err := provider.ParseManifests(yaml)
+	require.NoError(t, err)
+	require.Len(t, manifests, 1)
+	return manifests[0]
+}
+
+func makeTestDiffChange(t *testing.T, oldYAML, newYAML string) provider.DiffListChange {
+	t.Helper()
+	old := makeTestManifest(t, oldYAML)
+	new := makeTestManifest(t, newYAML)
+
+	oldData, err := old.MarshalJSON()
+	require.NoError(t, err)
+	oldUnstructured := unstructured.Unstructured{}
+	err = oldUnstructured.UnmarshalJSON(oldData)
+	require.NoError(t, err)
+
+	newData, err := new.MarshalJSON()
+	require.NoError(t, err)
+	newUnstructured := unstructured.Unstructured{}
+	err = newUnstructured.UnmarshalJSON(newData)
+	require.NoError(t, err)
+
+	result, err := diff.DiffUnstructureds(oldUnstructured, newUnstructured, old.Key().String(),
+		diff.WithEquateEmpty(),
+		diff.WithIgnoreAddingMapKeys(),
+		diff.WithCompareNumberAndNumericString(),
+	)
+	require.NoError(t, err)
+
+	return provider.DiffListChange{
+		Old:  old,
+		New:  new,
+		Diff: result,
+	}
+}
+
+func TestCalculateSyncState(t *testing.T) {
+	tests := []struct {
+		name           string
+		diffResult     *provider.DiffListResult
+		totalResources int
+		want           sdk.ApplicationSyncState
+	}{
+		{
+			name: "all resources are in sync",
+			diffResult: &provider.DiffListResult{
+				Adds:    []provider.Manifest{},
+				Deletes: []provider.Manifest{},
+				Changes: []provider.DiffListChange{},
+			},
+			totalResources: 3,
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateSynced,
+				ShortReason: "",
+				Reason:      "",
+			},
+		},
+		{
+			name: "deployment spec changes",
+			diffResult: &provider.DiffListResult{
+				Changes: []provider.DiffListChange{
+					makeTestDiffChange(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.19
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.20
+`),
+				},
+			},
+			totalResources: 1,
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateOutOfSync,
+				ShortReason: "There are 1 manifests not synced (0 adds, 0 deletes, 1 changes)",
+				Reason: `Diff between the actual state in cluster and expected state:
+
+--- Actual   (LiveState)
++++ Expected (Desired)
+
+# 1. name="test-deployment", kind="Deployment", namespace="default", apiGroup="apps"
+
+  spec:
+    #spec.replicas
+-   replicas: 1
++   replicas: 3
+
+    template:
+      spec:
+        containers:
+          -
+            #spec.template.spec.containers.0.image
+-           image: nginx:1.19
++           image: nginx:1.20
+
+
+`,
+			},
+		},
+		{
+			name: "service and ingress changes",
+			diffResult: &provider.DiffListResult{
+				Changes: []provider.DiffListChange{
+					makeTestDiffChange(t, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: test
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: default
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    app: test
+`),
+					makeTestDiffChange(t, `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: old.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: test-service
+            port:
+              number: 80
+`, `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: new.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: test-service
+            port:
+              number: 443
+`),
+				},
+			},
+			totalResources: 2,
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateOutOfSync,
+				ShortReason: "There are 2 manifests not synced (0 adds, 0 deletes, 2 changes)",
+				Reason: `Diff between the actual state in cluster and expected state:
+
+--- Actual   (LiveState)
++++ Expected (Desired)
+
+# 1. name="test-service", kind="Service", namespace="default", apiGroup=""
+
+  spec:
+    ports:
+      -
+        #spec.ports.0.port
+-       port: 80
++       port: 443
+
+        #spec.ports.0.targetPort
+-       targetPort: 8080
++       targetPort: 8443
+
+
+# 2. name="test-ingress", kind="Ingress", namespace="default", apiGroup="networking.k8s.io"
+
+  spec:
+    rules:
+      -
+        #spec.rules.0.host
+-       host: old.example.com
++       host: new.example.com
+
+        http:
+          paths:
+            - backend:
+                service:
+                  port:
+                    #spec.rules.0.http.paths.0.backend.service.port.number
+-                   number: 80
++                   number: 443
+
+
+`,
+			},
+		},
+		{
+			name: "resource deletion and addition",
+			diffResult: &provider.DiffListResult{
+				Adds: []provider.Manifest{
+					makeTestManifest(t, `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+`),
+				},
+				Deletes: []provider.Manifest{
+					makeTestManifest(t, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: nginx:1.19
+`),
+				},
+			},
+			totalResources: 2,
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateOutOfSync,
+				ShortReason: "There are 2 manifests not synced (1 adds, 1 deletes, 0 changes)",
+				Reason: `Diff between the actual state in cluster and expected state:
+
+--- Actual   (LiveState)
++++ Expected (Desired)
+
+- 1. name="test-pod", kind="Pod", namespace="default", apiGroup=""
+
++ 2. name="test-pvc", kind="PersistentVolumeClaim", namespace="default", apiGroup=""
+
+`,
+			},
+		},
+		{
+			name: "some resources are out of sync",
+			diffResult: &provider.DiffListResult{
+				Changes: []provider.DiffListChange{
+					makeTestDiffChange(t, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: old-value
+`, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: new-value
+`),
+				},
+			},
+			totalResources: 3,
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateOutOfSync,
+				ShortReason: "There are 1 manifests not synced (0 adds, 0 deletes, 1 changes)",
+				Reason: `Diff between the actual state in cluster and expected state:
+
+--- Actual   (LiveState)
++++ Expected (Desired)
+
+# 1. name="test-config", kind="ConfigMap", namespace="default", apiGroup=""
+
+  data:
+    #data.key
+-   key: *****
++   key: *****
+
+
+`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateSyncState(tt.diffResult, tt.totalResources)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We want to support DriftDetection feature with k8s plugin

**Which issue(s) this PR fixes**:

Part of #5363 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
