### PR TITLE
Add application livestate version in livestatereporter for pipedv1

### DIFF
--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -241,6 +241,9 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 		ApplicationLiveState: &model.ApplicationLiveState{
 			Resources: resourceStates,
 		},
+		Version: &model.ApplicationLiveStateVersion{
+			Timestamp: time.Now().Unix(),
+		},
 	}
 	snapshot.DetermineApplicationHealthStatus()
 


### PR DESCRIPTION
**What this PR does**:

as title.
It is required for the pipedv0, especially k8s. It is used to update livestate by using the diff from an older version.
Currently, the logic is used only for k8s livestate, and the others are not considered it.

https://github.com/pipe-cd/pipecd/blob/7a07070328e3d36a70c303f3f0c6a9b1f6076cfc/pkg/app/server/applicationlivestatestore/store.go#L93C1-L130C2

**Why we need it**:

Currently, we don't use it after pipedv1, but we use it in the Control Plane to update k8s livestate for apps managed by pipedv0.
So just added to pass the validation.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
