### PR TITLE
[K8s Plugin] Add e2e tests for K8S_ROLLBACK stage and fix the bug

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -72,8 +72,11 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 		}
 	}
 
-	// Add variant annotations to all manifests.
+	// Add variant labels and annotations to all manifests.
 	for i := range manifests {
+		manifests[i].AddLabels(map[string]string{
+			variantLabel: primaryVariant,
+		})
 		manifests[i].AddAnnotations(map[string]string{
 			variantLabel: primaryVariant,
 		})

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+)
+
+func TestPlugin_executeK8sRollbackStage_NoPreviousDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// Initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, _ := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	// Read the application config from the example file
+	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// Prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName:   "K8S_ROLLBACK",
+			StageConfig: []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{
+				CommitHash: "", // Empty commit hash indicates no previous deployment
+			},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	plugin := &Plugin{}
+	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusFailure, status)
+}
+
+func TestPlugin_executeK8sRollbackStage_SuccessfulRollback(t *testing.T) {
+	t.Parallel()
+
+	// Initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// Initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	// Read the application config from the example file
+	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// Prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName:   "K8S_ROLLBACK",
+			StageConfig: []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "previous-hash",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	plugin := &Plugin{}
+	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	// Verify the deployment was rolled back
+	deployment, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(t.Context(), "simple", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify labels and annotations
+	assert.Equal(t, "piped", deployment.GetLabels()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetLabels()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetLabels()["pipecd.dev/application"])
+	assert.Equal(t, "previous-hash", deployment.GetLabels()["pipecd.dev/commit-hash"])
+
+	assert.Equal(t, "piped", deployment.GetAnnotations()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetAnnotations()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
+	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
+	assert.Equal(t, "apps:Deployment::simple", deployment.GetAnnotations()["pipecd.dev/resource-key"])
+	assert.Equal(t, "previous-hash", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+}
+
+func TestPlugin_executeK8sRollbackStage_WithVariantLabels(t *testing.T) {
+	t.Parallel()
+
+	// Initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// Initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	// Read the application config and modify it to include variant labels
+	cfg, err := os.ReadFile(filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// Prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName:   "K8S_ROLLBACK",
+			StageConfig: []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "previous-hash",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	plugin := &Plugin{}
+	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	// Verify the deployment was rolled back with variant labels
+	deployment, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(t.Context(), "simple", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify labels and annotations
+	assert.Equal(t, "piped", deployment.GetLabels()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetLabels()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetLabels()["pipecd.dev/application"])
+	assert.Equal(t, "previous-hash", deployment.GetLabels()["pipecd.dev/commit-hash"])
+	assert.Equal(t, "primary", deployment.GetLabels()["pipecd.dev/variant"])
+
+	assert.Equal(t, "piped", deployment.GetAnnotations()["pipecd.dev/managed-by"])
+	assert.Equal(t, "piped-id", deployment.GetAnnotations()["pipecd.dev/piped"])
+	assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
+	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
+	assert.Equal(t, "apps:Deployment::simple", deployment.GetAnnotations()["pipecd.dev/resource-key"])
+	assert.Equal(t, "previous-hash", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+	assert.Equal(t, "primary", deployment.GetAnnotations()["pipecd.dev/variant"])
+}


### PR DESCRIPTION
**What this PR does**:

- add simple E2E test for K8S_ROLLBACK stage
- add a variant label to manifests when executing the K8S_ROLLBACK stage
    - to make consistent with the K8S_SYNC stage

**Why we need it**:

- to check and keep the k8s plugin's behavior as the test

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
