### PR TITLE
Enable livestate reporter for pipedv1

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -60,6 +60,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/controller"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/controller/controllermetrics"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/eventwatcher"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/livestatereporter"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/metadatastore"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/notifier"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin"
@@ -381,16 +382,15 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	}
 
 	// Start running application live state reporter.
-	// Currently, this feature is disabled beucause many errors are showed up if the app.pipecd.yaml is not migrated.
-	// {
-	// 	r, err := livestatereporter.NewReporter(applicationLister, apiClient, gitClient, pluginRegistry, cfg, decrypter, input.Logger)
-	// 	if err != nil {
-	// 		input.Logger.Error("failed to create live state reporter", zap.Error(err))
-	// 	}
-	// 	group.Go(func() error {
-	// 		return r.Run(ctx)
-	// 	})
-	// }
+	{
+		r, err := livestatereporter.NewReporter(applicationLister, apiClient, gitClient, pluginRegistry, cfg, decrypter, input.Logger)
+		if err != nil {
+			input.Logger.Error("failed to create live state reporter", zap.Error(err))
+		}
+		group.Go(func() error {
+			return r.Run(ctx)
+		})
+	}
 
 	// Start running deployment controller.
 	{


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We need it to send the livestate for the app managed by pipedv1.

**Which issue(s) this PR fixes**:

Part of #5363

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
