### PR TITLE
Embed k8s deployment and livestate plugins into one structure in main

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
@@ -21,12 +21,12 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sBaselineRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sBaselineRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Baseline rollout is not yet implemented")
 	return sdk.StageStatusFailure
 }
 
-func (p *Plugin) executeK8sBaselineCleanStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sBaselineCleanStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Baseline clean is not yet implemented")
 	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/canary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/canary.go
@@ -21,12 +21,12 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sCanaryRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sCanaryRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Canary rollout is not yet implemented")
 	return sdk.StageStatusFailure
 }
 
-func (p *Plugin) executeK8sCanaryCleanStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sCanaryCleanStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Canary clean is not yet implemented")
 	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sPrimaryRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sPrimaryRolloutStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Primary rollout is not yet implemented")
 	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 
 	if input.Request.RunningDeploymentSource.CommitHash == "" {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
@@ -67,7 +67,7 @@ func TestPlugin_executeK8sRollbackStage_NoPreviousDeployment(t *testing.T) {
 		Logger: zaptest.NewLogger(t),
 	}
 
-	plugin := &Plugin{}
+	plugin := &DeploymentPlugin{}
 	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
 			Name:   "default",
@@ -117,7 +117,7 @@ func TestPlugin_executeK8sRollbackStage_SuccessfulRollback(t *testing.T) {
 		Logger: zaptest.NewLogger(t),
 	}
 
-	plugin := &Plugin{}
+	plugin := &DeploymentPlugin{}
 	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
 			Name:   "default",
@@ -184,7 +184,7 @@ func TestPlugin_executeK8sRollbackStage_WithVariantLabels(t *testing.T) {
 		Logger: zaptest.NewLogger(t),
 	}
 
-	plugin := &Plugin{}
+	plugin := &DeploymentPlugin{}
 	status := plugin.executeK8sRollbackStage(t.Context(), input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
 			Name:   "default",

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStageInput, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -71,7 +71,7 @@ func TestPlugin_executeK8sSyncStage(t *testing.T) {
 	// initialize deploy target config and dynamic client for assertions with envtest
 	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
 
-	plugin := &Plugin{}
+	plugin := &DeploymentPlugin{}
 
 	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
@@ -145,7 +145,7 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	// initialize deploy target config and dynamic client for assertions with envtest
 	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
 
-	plugin := &Plugin{}
+	plugin := &DeploymentPlugin{}
 
 	status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 		{
@@ -213,7 +213,7 @@ func TestPlugin_executeK8sSyncStage_withPrune(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, runningInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -273,7 +273,7 @@ func TestPlugin_executeK8sSyncStage_withPrune(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -327,7 +327,7 @@ func TestPlugin_executeK8sSyncStage_withPrune_changesNamespace(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, runningInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -387,7 +387,7 @@ func TestPlugin_executeK8sSyncStage_withPrune_changesNamespace(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -459,7 +459,7 @@ func TestPlugin_executeK8sSyncStage_withPrune_clusterScoped(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, prepareInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -495,7 +495,7 @@ func TestPlugin_executeK8sSyncStage_withPrune_clusterScoped(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, runningInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
@@ -544,7 +544,7 @@ func TestPlugin_executeK8sSyncStage_withPrune_clusterScoped(t *testing.T) {
 			Logger: zaptest.NewLogger(t),
 		}
 
-		plugin := &Plugin{}
+		plugin := &DeploymentPlugin{}
 		status := plugin.executeK8sSyncStage(ctx, &targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/traffic.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/traffic.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sTrafficRoutingStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *DeploymentPlugin) executeK8sTrafficRoutingStage(_ context.Context, input *sdk.ExecuteStageInput, _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Traffic routing is not yet implemented")
 	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -30,10 +30,10 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-type Plugin struct{}
+type LivestatePlugin struct{}
 
-// GetLivestate implements sdk.LivestatePlugin.
-func (p Plugin) GetLivestate(ctx context.Context, _ sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput) (*sdk.GetLivestateResponse, error) {
+// GetLivestate implements sdk.LivestatePlugin without Name and Version.
+func (p LivestatePlugin) GetLivestate(ctx context.Context, _ sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput) (*sdk.GetLivestateResponse, error) {
 	if len(deployTargets) != 1 {
 		return nil, fmt.Errorf("only 1 deploy target is allowed but got %d", len(deployTargets))
 	}
@@ -149,23 +149,13 @@ func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.
 	}
 }
 
-// Name implements sdk.LivestatePlugin.
-func (p Plugin) Name() string {
-	return "kubernetes" // TODO: make this constant to share with deployment plugin
-}
-
-// Version implements sdk.LivestatePlugin.
-func (p Plugin) Version() string {
-	return "0.0.1" // TODO: make this constant to share with deployment plugin
-}
-
 type loader interface {
 	// LoadManifests renders and loads all manifests for application.
 	LoadManifests(ctx context.Context, input provider.LoaderInput) ([]provider.Manifest, error)
 }
 
 // TODO: share this implementation with the deployment plugin
-func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput, spec *kubeconfig.KubernetesApplicationSpec, loader loader) ([]provider.Manifest, error) {
+func (p LivestatePlugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput, spec *kubeconfig.KubernetesApplicationSpec, loader loader) ([]provider.Manifest, error) {
 	manifests, err := loader.LoadManifests(ctx, provider.LoaderInput{
 		PipedID:          input.Request.PipedID,
 		AppID:            input.Request.ApplicationID,

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -22,9 +22,23 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
+type Plugin struct {
+	deployment.DeploymentPlugin
+	livestate.LivestatePlugin
+}
+
+func (p *Plugin) Name() string {
+	return "kubernetes"
+}
+
+func (p *Plugin) Version() string {
+	return "0.0.1" // TODO: update this value
+}
+
 func main() {
-	sdk.RegisterDeploymentPlugin(&deployment.Plugin{})
-	sdk.RegisterLivestatePlugin(livestate.Plugin{})
+	plugin := new(Plugin)
+	sdk.RegisterDeploymentPlugin(plugin)
+	sdk.RegisterLivestatePlugin(plugin)
 	if err := sdk.Run(); err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We don't want to define the same Name and Version method in both the deployment and livestate packages.

**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
