### PR TITLE
Temporarily disable v1 add application form on UI

### DIFF
--- a/web/src/components/application-form/index.tsx
+++ b/web/src/components/application-form/index.tsx
@@ -94,11 +94,11 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
             }
             {...tabProps(TabKeys.V0)}
           />
-          <Tab
+          {/* <Tab
             className={classes.tabLabel}
             label="PIPED V1 ADD FROM SUGGESTIONS"
             {...tabProps(TabKeys.V1)}
-          />
+          /> */}
           <Tab
             className={classes.tabLabel}
             label="ADD MANUALLY"


### PR DESCRIPTION
**What this PR does**:

Temporarily disable v1 add application form on UI

**Why we need it**:

We don't want to show the v1 add application form in release v0.51.0

**Which issue(s) this PR fixes**:

NONE

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
