### PR TITLE
[Plugin SDK] Implement another way to create plugin

### DIFF
--- a/pkg/plugin/sdk/plugin.go
+++ b/pkg/plugin/sdk/plugin.go
@@ -1,0 +1,314 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pipe-cd/pipecd/pkg/admin"
+	"github.com/pipe-cd/pipecd/pkg/cli"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister"
+	"github.com/pipe-cd/pipecd/pkg/plugin/pipedapi"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry"
+	"github.com/pipe-cd/pipecd/pkg/rpc"
+)
+
+// PluginOption is a function that configures the plugin.
+type PluginOption[Config, DeployTargetConfig any] func(*Plugin_[Config, DeployTargetConfig])
+
+// WithStagePlugin is a function that sets the stage plugin.
+// This is mutually exclusive with WithDeploymentPlugin.
+func WithStagePlugin[Config, DeployTargetConfig any](stagePlugin StagePlugin[Config, DeployTargetConfig]) PluginOption[Config, DeployTargetConfig] {
+	return func(plugin *Plugin_[Config, DeployTargetConfig]) {
+		plugin.stagePlugin = stagePlugin
+	}
+}
+
+// WithDeploymentPlugin is a function that sets the deployment plugin.
+// This is mutually exclusive with WithStagePlugin.
+func WithDeploymentPlugin[Config, DeployTargetConfig any](deploymentPlugin DeploymentPlugin[Config, DeployTargetConfig]) PluginOption[Config, DeployTargetConfig] {
+	return func(plugin *Plugin_[Config, DeployTargetConfig]) {
+		plugin.deploymentPlugin = deploymentPlugin
+	}
+}
+
+// WithLivestatePlugin is a function that sets the livestate plugin.
+func WithLivestatePlugin[Config, DeployTargetConfig any](livestatePlugin LivestatePlugin[Config, DeployTargetConfig]) PluginOption[Config, DeployTargetConfig] {
+	return func(plugin *Plugin_[Config, DeployTargetConfig]) {
+		plugin.livestatePlugin = livestatePlugin
+	}
+}
+
+// Plugin_ is a wrapper for the plugin.
+// It provides a way to run the plugin with the given config and deploy target config.
+// TODO: This type name will be changed to Plugin.
+type Plugin_[Config, DeployTargetConfig any] struct {
+	// plugin info
+	name    string
+	version string
+
+	// plugin implementations
+	stagePlugin      StagePlugin[Config, DeployTargetConfig]
+	deploymentPlugin DeploymentPlugin[Config, DeployTargetConfig]
+	livestatePlugin  LivestatePlugin[Config, DeployTargetConfig]
+
+	// command line options
+	pipedPluginService   string
+	gracePeriod          time.Duration
+	tls                  bool
+	certFile             string
+	keyFile              string
+	config               string
+	enableGRPCReflection bool
+}
+
+// NewPlugin creates a new plugin.
+func NewPlugin[Config, DeployTargetConfig any](name, version string, options ...PluginOption[Config, DeployTargetConfig]) (*Plugin_[Config, DeployTargetConfig], error) {
+	plugin := &Plugin_[Config, DeployTargetConfig]{
+		name:    name,
+		version: version,
+
+		// Default values of command line options
+		gracePeriod: 30 * time.Second,
+	}
+
+	for _, option := range options {
+		option(plugin)
+	}
+
+	if plugin.stagePlugin == nil && plugin.deploymentPlugin == nil && plugin.livestatePlugin == nil {
+		return nil, fmt.Errorf("at least one plugin must be registered")
+	}
+
+	if _, ok := plugin.stagePlugin.(DeploymentPlugin[Config, DeployTargetConfig]); ok {
+		return nil, fmt.Errorf("stage plugin cannot be a deployment plugin, you must use WithDeploymentPlugin instead")
+	}
+
+	if plugin.stagePlugin != nil && plugin.deploymentPlugin != nil {
+		return nil, fmt.Errorf("stage plugin and deployment plugin cannot be registered at the same time")
+	}
+
+	return plugin, nil
+}
+
+// Run runs the plugin.
+func (p *Plugin_[Config, DeployTargetConfig]) Run() error {
+	app := cli.NewApp(
+		fmt.Sprintf("pipecd-plugin-%s", p.name),
+		"Plugin component for Piped.",
+	)
+
+	app.AddCommands(
+		p.command(),
+	)
+
+	if err := app.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// command returns the cobra command for the plugin.
+func (p *Plugin_[Config, DeployTargetConfig]) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: fmt.Sprintf("Start running a %s plugin.", p.name),
+		RunE:  cli.WithContext(p.run),
+	}
+
+	cmd.Flags().StringVar(&p.pipedPluginService, "piped-plugin-service", p.pipedPluginService, "The address used to connect to the piped plugin service.")
+	cmd.Flags().StringVar(&p.config, "config", p.config, "The configuration for the plugin.")
+	cmd.Flags().DurationVar(&p.gracePeriod, "grace-period", p.gracePeriod, "How long to wait for graceful shutdown.")
+
+	cmd.Flags().BoolVar(&p.tls, "tls", p.tls, "Whether running the gRPC server with TLS or not.")
+	cmd.Flags().StringVar(&p.certFile, "cert-file", p.certFile, "The path to the TLS certificate file.")
+	cmd.Flags().StringVar(&p.keyFile, "key-file", p.keyFile, "The path to the TLS key file.")
+
+	// For debugging early in development
+	cmd.Flags().BoolVar(&p.enableGRPCReflection, "enable-grpc-reflection", p.enableGRPCReflection, "Whether to enable the reflection service or not.")
+
+	cmd.MarkFlagRequired("piped-plugin-service")
+	cmd.MarkFlagRequired("config")
+
+	return cmd
+}
+
+// run is the entrypoint of the plugin.
+func (p *Plugin_[Config, DeployTargetConfig]) run(ctx context.Context, input cli.Input) error {
+	var (
+		stagePluginServiceServer      *StagePluginServiceServer[Config, DeployTargetConfig]
+		deploymentPluginServiceServer *DeploymentPluginServiceServer[Config, DeployTargetConfig]
+		livestatePluginServiceServer  *LivestatePluginServer[Config, DeployTargetConfig]
+	)
+
+	if p.stagePlugin != nil && p.deploymentPlugin != nil {
+		return fmt.Errorf("stage plugin and deployment plugin cannot be registered at the same time")
+	}
+
+	if p.stagePlugin != nil {
+		stagePluginServiceServer = &StagePluginServiceServer[Config, DeployTargetConfig]{base: p.stagePlugin}
+	}
+
+	if p.deploymentPlugin != nil {
+		deploymentPluginServiceServer = &DeploymentPluginServiceServer[Config, DeployTargetConfig]{base: p.deploymentPlugin}
+	}
+
+	if p.livestatePlugin != nil {
+		livestatePluginServiceServer = &LivestatePluginServer[Config, DeployTargetConfig]{base: p.livestatePlugin}
+	}
+
+	// Make a cancellable context.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	pipedapiClient, err := pipedapi.NewClient(ctx, p.pipedPluginService)
+	if err != nil {
+		input.Logger.Error("failed to create piped plugin service client", zap.Error(err))
+		return err
+	}
+
+	// Load the configuration.
+	cfg, err := config.ParsePluginConfig(p.config)
+	if err != nil {
+		input.Logger.Error("failed to parse the configuration", zap.Error(err))
+		return err
+	}
+
+	// Start running admin server.
+	{
+		var (
+			ver   = []byte(p.version)
+			admin = admin.NewAdmin(0, p.gracePeriod, input.Logger) // TODO: add config for admin port
+		)
+
+		admin.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+			w.Write(ver)
+		})
+		admin.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		})
+		admin.HandleFunc("/debug/pprof/", pprof.Index)
+		admin.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		admin.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		group.Go(func() error {
+			return admin.Run(ctx)
+		})
+	}
+
+	// Start log persister
+	persister := logpersister.NewPersister(pipedapiClient, input.Logger)
+	group.Go(func() error {
+		return persister.Run(ctx)
+	})
+
+	// Start a gRPC server for handling external API requests.
+	{
+		commonFields := commonFields{
+			config:       cfg,
+			logPersister: persister,
+			client:       pipedapiClient,
+			toolRegistry: toolregistry.NewToolRegistry(pipedapiClient),
+		}
+
+		var services []rpc.Service
+
+		if p.stagePlugin != nil {
+			if err := stagePluginServiceServer.setFields(
+				commonFields.withLogger(input.Logger.Named("stage-service")),
+			); err != nil {
+				input.Logger.Error("failed to set fields", zap.Error(err))
+				return err
+			}
+			services = append(services, stagePluginServiceServer)
+		}
+
+		if p.deploymentPlugin != nil {
+			if err := deploymentPluginServiceServer.setFields(
+				commonFields.withLogger(input.Logger.Named("deployment-service")),
+			); err != nil {
+				input.Logger.Error("failed to set fields", zap.Error(err))
+				return err
+			}
+			services = append(services, deploymentPluginServiceServer)
+		}
+
+		if p.livestatePlugin != nil {
+			if err := livestatePluginServiceServer.setFields(
+				commonFields.withLogger(input.Logger.Named("livestate-service")),
+			); err != nil {
+				input.Logger.Error("failed to set fields", zap.Error(err))
+				return err
+			}
+			services = append(services, livestatePluginServiceServer)
+		}
+
+		if len(services) == 0 {
+			// This is promised in the NewPlugin function.
+			// When this happens, it means that *Plugin was initialized without using NewPlugin.
+			return fmt.Errorf("no plugin is registered, you must use NewPlugin to initialize the plugin")
+		}
+
+		var (
+			opts = []rpc.Option{
+				rpc.WithPort(cfg.Port),
+				rpc.WithGracePeriod(p.gracePeriod),
+				rpc.WithLogger(input.Logger),
+				rpc.WithLogUnaryInterceptor(input.Logger),
+				rpc.WithRequestValidationUnaryInterceptor(),
+				rpc.WithSignalHandlingUnaryInterceptor(),
+			}
+		)
+		if p.tls {
+			opts = append(opts, rpc.WithTLS(p.certFile, p.keyFile))
+		}
+		if p.enableGRPCReflection {
+			opts = append(opts, rpc.WithGRPCReflection())
+		}
+		if input.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
+		}
+		if len(services) > 1 {
+			for _, service := range services[1:] {
+				opts = append(opts, rpc.WithService(service))
+			}
+		}
+
+		server := rpc.NewServer(services[0], opts...)
+
+		group.Go(func() error {
+			return server.Run(ctx)
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		input.Logger.Error("failed while running", zap.Error(err))
+		return err
+	}
+	return nil
+
+}

--- a/pkg/plugin/sdk/plugin_test.go
+++ b/pkg/plugin/sdk/plugin_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"log"
+)
+
+var (
+	_ StagePlugin[ExampleConfig, ExampleDeployTargetConfig]      = ExampleStagePlugin{}
+	_ DeploymentPlugin[ExampleConfig, ExampleDeployTargetConfig] = ExampleDeploymentPlugin{}
+	_ LivestatePlugin[ExampleConfig, ExampleDeployTargetConfig]  = ExampleLivestatePlugin{}
+)
+
+type (
+	ExampleStagePlugin        struct{}
+	ExampleDeploymentPlugin   struct{}
+	ExampleLivestatePlugin    struct{}
+	ExampleConfig             struct{}
+	ExampleDeployTargetConfig struct{}
+)
+
+// BuildPipelineSyncStages implements StagePlugin.
+func (e ExampleStagePlugin) BuildPipelineSyncStages(context.Context, *ExampleConfig, *BuildPipelineSyncStagesInput) (*BuildPipelineSyncStagesResponse, error) {
+	panic("unimplemented")
+}
+
+// ExecuteStage implements StagePlugin.
+func (e ExampleStagePlugin) ExecuteStage(context.Context, *ExampleConfig, []*DeployTarget[ExampleDeployTargetConfig], *ExecuteStageInput) (*ExecuteStageResponse, error) {
+	panic("unimplemented")
+}
+
+// FetchDefinedStages implements StagePlugin.
+func (e ExampleStagePlugin) FetchDefinedStages() []string {
+	panic("unimplemented")
+}
+
+// Name implements StagePlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleStagePlugin) Name() string {
+	panic("unimplemented")
+}
+
+// Version implements StagePlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleStagePlugin) Version() string {
+	panic("unimplemented")
+}
+
+// BuildPipelineSyncStages implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) BuildPipelineSyncStages(context.Context, *ExampleConfig, *BuildPipelineSyncStagesInput) (*BuildPipelineSyncStagesResponse, error) {
+	panic("unimplemented")
+}
+
+// BuildQuickSyncStages implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) BuildQuickSyncStages(context.Context, *ExampleConfig, *BuildQuickSyncStagesInput) (*BuildQuickSyncStagesResponse, error) {
+	panic("unimplemented")
+}
+
+// DetermineStrategy implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) DetermineStrategy(context.Context, *ExampleConfig, *DetermineStrategyInput) (*DetermineStrategyResponse, error) {
+	panic("unimplemented")
+}
+
+// DetermineVersions implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) DetermineVersions(context.Context, *ExampleConfig, *DetermineVersionsInput) (*DetermineVersionsResponse, error) {
+	panic("unimplemented")
+}
+
+// ExecuteStage implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) ExecuteStage(context.Context, *ExampleConfig, []*DeployTarget[ExampleDeployTargetConfig], *ExecuteStageInput) (*ExecuteStageResponse, error) {
+	panic("unimplemented")
+}
+
+// FetchDefinedStages implements DeploymentPlugin.
+func (e ExampleDeploymentPlugin) FetchDefinedStages() []string {
+	panic("unimplemented")
+}
+
+// Name implements DeploymentPlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleDeploymentPlugin) Name() string {
+	panic("unimplemented")
+}
+
+// Version implements DeploymentPlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleDeploymentPlugin) Version() string {
+	panic("unimplemented")
+}
+
+// GetLivestate implements LivestatePlugin.
+func (e ExampleLivestatePlugin) GetLivestate(context.Context, *ExampleConfig, []*DeployTarget[ExampleDeployTargetConfig], *GetLivestateInput) (*GetLivestateResponse, error) {
+	panic("unimplemented")
+}
+
+// Name implements LivestatePlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleLivestatePlugin) Name() string {
+	panic("unimplemented")
+}
+
+// Version implements LivestatePlugin.
+// TODO: This function will be removed in the future.
+func (e ExampleLivestatePlugin) Version() string {
+	panic("unimplemented")
+}
+
+func ExampleNewPlugin() {
+	plugin, err := NewPlugin("test", "1.0.0",
+		WithDeploymentPlugin(ExampleDeploymentPlugin{}),
+		WithLivestatePlugin(ExampleLivestatePlugin{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Run runs the plugin and blocks until the signal is received.
+	// So you can use it like this:
+	/*
+		if err := plugin.Run(); err != nil {
+			log.Fatal(err)
+		}
+	*/
+
+	_ = plugin
+}
+
+func ExampleWithStagePlugin() {
+	plugin, err := NewPlugin("test", "1.0.0",
+		WithStagePlugin(ExampleStagePlugin{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// plugin.Run()
+	_ = plugin
+}
+
+func ExampleWithDeploymentPlugin() {
+	plugin, err := NewPlugin("test", "1.0.0",
+		WithDeploymentPlugin(ExampleDeploymentPlugin{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// plugin.Run()
+	_ = plugin
+}
+
+func ExampleWithLivestatePlugin() {
+	plugin, err := NewPlugin("test", "1.0.0",
+		WithLivestatePlugin(ExampleLivestatePlugin{}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// plugin.Run()
+	_ = plugin
+}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

In #5693, I wanted to remove the duplicated `Name()` and `Version()` definitions in the Kubernetes plugin.
It's easy to remove the duplication in the k8s plugin only, but it's better to provide a way to implement plugins without requiring the `Name()` and `Version()` methods in multiple interfaces.
I noticed that we can provide the way that requires name and version as positional arguments when creating a plugin.
In this way, the plugin implementations are passed as the Functional Options Pattern to the plugin constructor function.
Additionally, we can implement assertions to the constructor function to provide helpful errors.

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
