### PR TITLE
Use new plugin sdk interface to build example plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/example/main.go
+++ b/pkg/app/pipedv1/plugin/example/main.go
@@ -21,9 +21,12 @@ import (
 )
 
 func main() {
-	sdk.RegisterStagePlugin(&plugin{})
+	plugin, err := sdk.NewPlugin("example", "0.0.1", sdk.WithStagePlugin(&plugin{}))
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-	if err := sdk.Run(); err != nil {
+	if err := plugin.Run(); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/pkg/app/pipedv1/plugin/example/plugin.go
+++ b/pkg/app/pipedv1/plugin/example/plugin.go
@@ -25,11 +25,13 @@ type plugin struct{}
 type config struct{}
 
 // Name implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Name() string {
 	return "example"
 }
 
 // Version implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Version() string {
 	return "0.0.1"
 }


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Because we introduced a new plugin SDK interface in #5698, I want to migrate the example.
After migrating all plugins, I'll remove and refactor old SDK interfaces.

**Which issue(s) this PR fixes**:

Follows #5698 
Part of #5530 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
