### PR TITLE
Use new plugin sdk interface to build wait plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/wait/main.go
+++ b/pkg/app/pipedv1/plugin/wait/main.go
@@ -21,9 +21,12 @@ import (
 )
 
 func main() {
-	sdk.RegisterStagePlugin(&plugin{})
+	plugin, err := sdk.NewPlugin("wait", "0.0.1", sdk.WithStagePlugin(&plugin{}))
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-	if err := sdk.Run(); err != nil {
+	if err := plugin.Run(); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/pkg/app/pipedv1/plugin/wait/plugin.go
+++ b/pkg/app/pipedv1/plugin/wait/plugin.go
@@ -27,11 +27,13 @@ const (
 type plugin struct{}
 
 // Name implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Name() string {
 	return "wait"
 }
 
 // Version implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Version() string {
 	return "0.0.1" // TODO
 }


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Because we introduced a new plugin SDK interface in #5698, I want to migrate the wait plugin.
After migrating all plugins, I'll remove and refactor old SDK interfaces.

**Which issue(s) this PR fixes**:

Follows #5698 
Part of #5530 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
