### PR TITLE
Use new plugin sdk interface to build kubernetes plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -45,11 +45,13 @@ type toolRegistry interface {
 var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*Plugin)(nil)
 
 // Name returns the name of this plugin.
+// TODO: remove this method after changing the sdk.DeploymentPlugin interface.
 func (p *Plugin) Name() string {
 	return "kubernetes"
 }
 
 // Version returns the version of this plugin.
+// TODO: remove this method after changing the sdk.DeploymentPlugin interface.
 func (p *Plugin) Version() string {
 	return "0.0.1" // TODO
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -33,7 +33,7 @@ import (
 type Plugin struct{}
 
 // GetLivestate implements sdk.LivestatePlugin.
-func (p Plugin) GetLivestate(ctx context.Context, _ sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput) (*sdk.GetLivestateResponse, error) {
+func (p Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput) (*sdk.GetLivestateResponse, error) {
 	if len(deployTargets) != 1 {
 		return nil, fmt.Errorf("only 1 deploy target is allowed but got %d", len(deployTargets))
 	}
@@ -150,11 +150,13 @@ func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.
 }
 
 // Name implements sdk.LivestatePlugin.
+// TODO: remove this method after changing the sdk.LivestatePlugin interface.
 func (p Plugin) Name() string {
 	return "kubernetes" // TODO: make this constant to share with deployment plugin
 }
 
 // Version implements sdk.LivestatePlugin.
+// TODO: remove this method after changing the sdk.LivestatePlugin interface.
 func (p Plugin) Version() string {
 	return "0.0.1" // TODO: make this constant to share with deployment plugin
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -23,9 +23,15 @@ import (
 )
 
 func main() {
-	sdk.RegisterDeploymentPlugin(&deployment.Plugin{})
-	sdk.RegisterLivestatePlugin(livestate.Plugin{})
-	if err := sdk.Run(); err != nil {
+	plugin, err := sdk.NewPlugin(
+		"kubernetes", "0.0.1",
+		sdk.WithDeploymentPlugin(&deployment.Plugin{}),
+		sdk.WithLivestatePlugin(&livestate.Plugin{}),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if err := plugin.Run(); err != nil {
 		log.Fatalln(err)
 	}
 }


### PR DESCRIPTION
**What this PR does**:

- as title
- change the livestate plugin signature to match the deployment plugin

**Why we need it**:

Because we introduced a new plugin SDK interface in #5698, I want to migrate the k8s plugin.
After migrating all plugins, I'll remove and refactor old SDK interfaces.

**Which issue(s) this PR fixes**:

Follows #5698 
Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
