### PR TITLE
Use new plugin SDK interface to build kubernetes_multicluster plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
@@ -21,9 +21,15 @@ import (
 )
 
 func main() {
-	sdk.RegisterStagePlugin(&plugin{})
+	plugin, err := sdk.NewPlugin(
+		"kubernetes_multicluster", "0.0.1",
+		sdk.WithStagePlugin(&plugin{}),
+	)
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-	if err := sdk.Run(); err != nil {
+	if err := plugin.Run(); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
@@ -30,11 +30,13 @@ type deployTargetConfig struct{}
 var _ sdk.StagePlugin[config, deployTargetConfig] = (*plugin)(nil)
 
 // Name implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Name() string {
 	return "kubernetes_multicluster"
 }
 
 // Version implements sdk.Plugin.
+// TODO: remove this method after changing the sdk.StagePlugin interface.
 func (p *plugin) Version() string {
 	return "0.0.1"
 }


### PR DESCRIPTION
**What this PR does**:

as title
**Why we need it**:

Because we introduced a new plugin SDK interface in #5698, I want to migrate the k8s multicluster plugin.
After migrating all plugins, I'll remove and refactor old SDK interfaces.

**Which issue(s) this PR fixes**:

Follows #5698 
Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
