### PR TITLE
Remove Name and Version methods from plugins

### DIFF
--- a/pkg/app/pipedv1/plugin/example/plugin.go
+++ b/pkg/app/pipedv1/plugin/example/plugin.go
@@ -24,18 +24,6 @@ type plugin struct{}
 
 type config struct{}
 
-// Name implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Name() string {
-	return "example"
-}
-
-// Version implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Version() string {
-	return "0.0.1"
-}
-
 // BuildPipelineSyncStages implements sdk.StagePlugin.
 func (p *plugin) BuildPipelineSyncStages(context.Context, *config, *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	return &sdk.BuildPipelineSyncStagesResponse{}, nil

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -44,18 +44,6 @@ type toolRegistry interface {
 
 var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig] = (*Plugin)(nil)
 
-// Name returns the name of this plugin.
-// TODO: remove this method after changing the sdk.DeploymentPlugin interface.
-func (p *Plugin) Name() string {
-	return "kubernetes"
-}
-
-// Version returns the version of this plugin.
-// TODO: remove this method after changing the sdk.DeploymentPlugin interface.
-func (p *Plugin) Version() string {
-	return "0.0.1" // TODO
-}
-
 // FetchDefinedStages returns the defined stages for this plugin.
 func (p *Plugin) FetchDefinedStages() []string {
 	return allStages

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -149,18 +149,6 @@ func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.
 	}
 }
 
-// Name implements sdk.LivestatePlugin.
-// TODO: remove this method after changing the sdk.LivestatePlugin interface.
-func (p Plugin) Name() string {
-	return "kubernetes" // TODO: make this constant to share with deployment plugin
-}
-
-// Version implements sdk.LivestatePlugin.
-// TODO: remove this method after changing the sdk.LivestatePlugin interface.
-func (p Plugin) Version() string {
-	return "0.0.1" // TODO: make this constant to share with deployment plugin
-}
-
 type loader interface {
 	// LoadManifests renders and loads all manifests for application.
 	LoadManifests(ctx context.Context, input provider.LoaderInput) ([]provider.Manifest, error)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/plugin.go
@@ -29,18 +29,6 @@ type deployTargetConfig struct{}
 
 var _ sdk.StagePlugin[config, deployTargetConfig] = (*plugin)(nil)
 
-// Name implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Name() string {
-	return "kubernetes_multicluster"
-}
-
-// Version implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Version() string {
-	return "0.0.1"
-}
-
 // BuildPipelineSyncStages implements sdk.StagePlugin.
 func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ *config, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	return &sdk.BuildPipelineSyncStagesResponse{

--- a/pkg/app/pipedv1/plugin/wait/plugin.go
+++ b/pkg/app/pipedv1/plugin/wait/plugin.go
@@ -26,18 +26,6 @@ const (
 
 type plugin struct{}
 
-// Name implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Name() string {
-	return "wait"
-}
-
-// Version implements sdk.Plugin.
-// TODO: remove this method after changing the sdk.StagePlugin interface.
-func (p *plugin) Version() string {
-	return "0.0.1" // TODO
-}
-
 // BuildPipelineSyncStages implements sdk.StagePlugin.
 func (p *plugin) BuildPipelineSyncStages(ctx context.Context, _ sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	stages := make([]sdk.PipelineStage, 0, len(input.Request.Stages))


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

These are requirements of the old SDK interfaces so that we can delete them.

**Which issue(s) this PR fixes**:

Follows #5703 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
