### PR TITLE
Update docs index weight

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -1,7 +1,7 @@
 ---
 title: "Command-line tool: pipectl"
 linkTitle: "Command-line tool: pipectl"
-weight: 9
+weight: 996
 description: >
   This page describes how to install and use pipectl to manage PipeCD's resources.
 ---

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration reference"
 linkTitle: "Configuration reference"
-weight: 11
+weight: 998
 description: >
   This page describes all configurable fields in the application configuration and analysis template.
 ---

--- a/docs/content/en/docs-dev/user-guide/event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/event-watcher.md
@@ -1,7 +1,7 @@
 ---
 title: "Connect between CI and CD with event watcher"
 linkTitle: "Event watcher"
-weight: 5
+weight: 992
 description: >
   A helper facility to automatically update files when it finds out a new event.
 ---

--- a/docs/content/en/docs-dev/user-guide/examples/_index.md
+++ b/docs/content/en/docs-dev/user-guide/examples/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Examples"
 linkTitle: "Examples"
-weight: 12
+weight: 999
 description: >
   Some examples of PipeCD in action!
 ---

--- a/docs/content/en/docs-dev/user-guide/insights.md
+++ b/docs/content/en/docs-dev/user-guide/insights.md
@@ -1,7 +1,7 @@
 ---
 title: "Insights"
 linkTitle: "Insights"
-weight: 7
+weight: 994
 description: >
   This page describes how to see delivery performance.
 ---

--- a/docs/content/en/docs-dev/user-guide/metrics.md
+++ b/docs/content/en/docs-dev/user-guide/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: "Metrics"
 linkTitle: "Metrics"
-weight: 8
+weight: 995
 description: >
   This page describes how to enable monitoring system for collecting PipeCD' metrics.
 ---

--- a/docs/content/en/docs-dev/user-guide/plan-preview.md
+++ b/docs/content/en/docs-dev/user-guide/plan-preview.md
@@ -1,7 +1,7 @@
 ---
 title: "Confidently review your changes with Plan Preview"
 linkTitle: "Plan preview"
-weight: 6
+weight: 993
 description: >
   Enables the ability to preview the deployment plan against a given commit before merging.
 ---

--- a/docs/content/en/docs-dev/user-guide/terraform-provider-pipecd.md
+++ b/docs/content/en/docs-dev/user-guide/terraform-provider-pipecd.md
@@ -1,7 +1,7 @@
 ---
 title: "PipeCD Terraform provider"
 linkTitle: "PipeCD Terraform provider"
-weight: 10
+weight: 997
 description: >
   This page describes how to manage PipeCD resources with Terraform using terraform-provider-pipecd.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/command-line-tool.md
@@ -1,7 +1,7 @@
 ---
 title: "Command-line tool: pipectl"
 linkTitle: "Command-line tool: pipectl"
-weight: 9
+weight: 996
 description: >
   This page describes how to install and use pipectl to manage PipeCD's resources.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/configuration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration reference"
 linkTitle: "Configuration reference"
-weight: 11
+weight: 998
 description: >
   This page describes all configurable fields in the application configuration and analysis template.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/event-watcher.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/event-watcher.md
@@ -1,7 +1,7 @@
 ---
 title: "Connect between CI and CD with event watcher"
 linkTitle: "Event watcher"
-weight: 5
+weight: 992
 description: >
   A helper facility to automatically update files when it finds out a new event.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/examples/_index.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/examples/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Examples"
 linkTitle: "Examples"
-weight: 12
+weight: 999
 description: >
   Some examples of PipeCD in action!
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/insights.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/insights.md
@@ -1,7 +1,7 @@
 ---
 title: "Insights"
 linkTitle: "Insights"
-weight: 7
+weight: 994
 description: >
   This page describes how to see delivery performance.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/metrics.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: "Metrics"
 linkTitle: "Metrics"
-weight: 8
+weight: 995
 description: >
   This page describes how to enable monitoring system for collecting PipeCD' metrics.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/plan-preview.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/plan-preview.md
@@ -1,7 +1,7 @@
 ---
 title: "Confidently review your changes with Plan Preview"
 linkTitle: "Plan preview"
-weight: 6
+weight: 993
 description: >
   Enables the ability to preview the deployment plan against a given commit before merging.
 ---

--- a/docs/content/en/docs-v0.51.x/user-guide/terraform-provider-pipecd.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/terraform-provider-pipecd.md
@@ -1,7 +1,7 @@
 ---
 title: "PipeCD Terraform provider"
 linkTitle: "PipeCD Terraform provider"
-weight: 10
+weight: 997
 description: >
   This page describes how to manage PipeCD resources with Terraform using terraform-provider-pipecd.
 ---


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

When we want to add a new docs page, the current docs weight indexes require us to change many different page indexes in order to keep the order of old pages. Indexing docs page like this could fix the problem

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
