### PR TITLE
Fix rolling back deployments are ignored on piped restarted event

### DIFF
--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -103,13 +103,13 @@ func (s *store) Lister() Lister {
 }
 
 func (s *store) sync(ctx context.Context) error {
+	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{})
 	if err != nil {
 		s.logger.Error("failed to list unhandled deployment", zap.Error(err))
 		return err
 	}
 
-	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	var pendings, planneds, runnings []*model.Deployment
 	for _, d := range resp.Deployments {
 		switch d.Status {
@@ -117,7 +117,7 @@ func (s *store) sync(ctx context.Context) error {
 			pendings = append(pendings, d)
 		case model.DeploymentStatus_DEPLOYMENT_PLANNED:
 			planneds = append(planneds, d)
-		case model.DeploymentStatus_DEPLOYMENT_RUNNING:
+		case model.DeploymentStatus_DEPLOYMENT_RUNNING, model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK:
 			runnings = append(runnings, d)
 		}
 	}

--- a/pkg/app/pipedv1/apistore/deploymentstore/store.go
+++ b/pkg/app/pipedv1/apistore/deploymentstore/store.go
@@ -103,13 +103,13 @@ func (s *store) Lister() Lister {
 }
 
 func (s *store) sync(ctx context.Context) error {
+	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{})
 	if err != nil {
 		s.logger.Error("failed to list unhandled deployment", zap.Error(err))
 		return err
 	}
 
-	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	var pendings, planneds, runnings []*model.Deployment
 	for _, d := range resp.Deployments {
 		switch d.Status {
@@ -117,7 +117,7 @@ func (s *store) sync(ctx context.Context) error {
 			pendings = append(pendings, d)
 		case model.DeploymentStatus_DEPLOYMENT_PLANNED:
 			planneds = append(planneds, d)
-		case model.DeploymentStatus_DEPLOYMENT_RUNNING:
+		case model.DeploymentStatus_DEPLOYMENT_RUNNING, model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK:
 			runnings = append(runnings, d)
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

Add rolling back deployment as running deployment on deploymentstore sync.

**Why we need it**:

Without this change, when piped is restarted, the deployments at the ROLLING_BACK stage are not listed as running deployments in the deployment store. Thus, restarted piped will ignore these deployments.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
