### PR TITLE
Do treeless clone for git clone to improve performance

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -166,7 +166,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 				return nil, err
 			}
 			out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
-				args := []string{"clone", "--mirror", remote, repoCachePath}
+				args := []string{"clone", "--mirror", "--filter=tree:0", remote, repoCachePath}
 				args = append(authArgs, args...)
 				return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
 			})

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -288,9 +288,12 @@ func TestCopyToModify(t *testing.T) {
 	err = faker.makeRepo(org, repoName)
 	require.NoError(t, err)
 	r := &repo{
-		dir:     faker.repoDir(org, repoName),
-		gitPath: faker.gitPath,
-		remote:  faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
+		dir:          faker.repoDir(org, repoName),
+		gitPath:      faker.gitPath,
+		remote:       faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
+		username:     "test-user",
+		email:        "test-email",
+		clonedBranch: "master",
 	}
 
 	commits, err := r.ListCommits(ctx, "")


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

I want to reduce file/network IO.

As before, I implemented git partial cloning in #5412.
This is reverted due to a failure in the event watcher, caused by a failure of git repository cloning from the local cached repository.
This cloning failure occurs because the local cached repository doesn't have the necessary git object because it's cloned "partially."
So, I modified the `CopyToModify` method to clone directly from the original remote repository, such as GitHub, and retry the partial cloning performance tuning.
I tested normal deployment and event watcher behavior on my local, and these ran successfully.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
