### PR TITLE
Change resource name for piped helm chart

### DIFF
--- a/manifests/piped/templates/_helpers.tpl
+++ b/manifests/piped/templates/_helpers.tpl
@@ -77,10 +77,10 @@ Name of Secret containing sensitive data
 Name of Temporary Volume containing piped configuration
 */}}
 {{- define "piped.temporaryVolumeName" -}}
-{{- if .Values.temporaryVolume.create }}
-{{- include "piped.fullname" . }}
-{{- else }}
+{{- if .Values.temporaryVolume.name }}
 {{- .Values.temporaryVolume.name }}
+{{- else }}
+{{- include "piped.fullname" . }}
 {{- end }}
 {{- end }}
 

--- a/manifests/piped/templates/_helpers.tpl
+++ b/manifests/piped/templates/_helpers.tpl
@@ -66,10 +66,10 @@ Name of ConfigMap containing piped configuration
 Name of Secret containing sensitive data
 */}}
 {{- define "piped.secretName" -}}
-{{- if .Values.secret.create }}
-{{- include "piped.fullname" . }}
-{{- else }}
+{{- if .Values.secret.name }}
 {{- .Values.secret.name }}
+{{- else }}
+{{- include "piped.fullname" . }}
 {{- end }}
 {{- end }}
 

--- a/manifests/piped/templates/_helpers.tpl
+++ b/manifests/piped/templates/_helpers.tpl
@@ -88,10 +88,10 @@ Name of Temporary Volume containing piped configuration
 Name of ServiceAccount
 */}}
 {{- define "piped.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-{{ include "piped.fullname" . }}
-{{- else }}
+{{- if .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
+{{- else }}
+{{- include "piped.fullname" . }}
 {{- end }}
 {{- end }}
 

--- a/manifests/piped/templates/_helpers.tpl
+++ b/manifests/piped/templates/_helpers.tpl
@@ -55,10 +55,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Name of ConfigMap containing piped configuration
 */}}
 {{- define "piped.configMapName" -}}
-{{- if .Values.config.create }}
-{{- include "piped.fullname" . }}
-{{- else }}
+{{- if .Values.config.name }}
 {{- .Values.config.name }}
+{{- else }}
+{{- include "piped.fullname" . }}
 {{- end }}
 {{- end }}
 

--- a/manifests/piped/templates/rbac.yaml
+++ b/manifests/piped/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "piped.fullname" . }}
+  name: {{ include "piped.serviceAccountName" . }}
   labels:
     {{- include "piped.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -47,7 +47,7 @@ service:
 config:
   # Specifies whether a ConfigMap for piped configuration should be created.
   create: true
-  # The name of the ConfigMap to use when create is false.
+  # The name of the ConfigMap.
   name: ""
   # The name of the configuration file.
   fileName: piped-config.yaml
@@ -71,7 +71,7 @@ config:
 secret:
   # Specifies whether a Secret for storing sensitive data should be created.
   create: true
-  # The name of the Secret to use when create is false.
+  # The name of the Secret.
   name: ""
   # Where the secret files will be mounted to.
   mountPath: /etc/piped-secret
@@ -84,7 +84,7 @@ secret:
 temporaryVolume:
   # Specifies whether a PersistentVolumeClaim for storing temporary data should be created.
   create: false
-  # The name of the PersistentVolumeClaim to use when create is false.
+  # The name of the PersistentVolumeClaim.
   name: ""
   # The storage class name of the persistent volume claim.
   storageClassName: ""
@@ -117,7 +117,7 @@ resources: {}
 serviceAccount:
   # Specifies whether a ServiceAccount to be used by Piped should be created.
   create: true
-  # The name of existing ServiceAccount to use when create is false.
+  # The name of ServiceAccount.
   name: ""
   annotations: {}
 


### PR DESCRIPTION
**What this PR does**:

as title
I fixed the resource name for PVC、Service、ServiceAccount、Secret

**Why we need it**:

We consider the case when users prepare these resources in other ways.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
