### PR TITLE
Use nodejs 20 as web image builder

### DIFF
--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # web builder
 # because this stage builds only web assets, we can use any platform
-FROM --platform=$BUILDPLATFORM node:18.20.5-alpine3.21 AS web
+FROM --platform=$BUILDPLATFORM node:20.19.0-alpine3.21 AS web
 
 WORKDIR /app
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

[We specify that the web requires Node JS 20 or later,](https://github.com/pipe-cd/pipecd/blob/a306b3f50b501e80850164e1454e073121742bf4/web/README.md#prerequisites) but we use Node JS 18 for building container images.
This comes from #5423, a pull request to improve CI stability.
We changed the build platform of the web asset builder in #5578, so we can now use NodeJS 20 for the web builder.
ref; https://github.com/pipe-cd/pipecd/pull/5578#discussion_r1957703555

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
