### PR TITLE
Implement K8S_MULTI_SYNC with non template for multicluster 

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
@@ -75,6 +75,8 @@ type KubernetesDeploymentInput struct {
 	AutoCreateNamespace bool `json:"autoCreateNamespace,omitempty"`
 
 	// TODO: Define fields for KubernetesDeploymentInput.
+
+	MultiTargets []KubernetesMultiTarget `json:"multiTargets,omitempty"`
 }
 
 type KubernetesVariantLabel struct {
@@ -133,4 +135,16 @@ func FindDeployTarget(cfg *config.PipedPlugin, name string) (KubernetesDeployTar
 	}
 
 	return targetCfg, nil
+}
+
+type KubernetesMultiTarget struct {
+	Target         KubernetesMultiTargetDeployTarget `json:"target"`
+	Manifests      []string                          `json:"manifests,omitempty"`
+	KubectlVersion string                            `json:"kubectlVersion,omitempty"`
+	KustomizeDir   string                            `json:"kustomizeDir,omitempty"`
+}
+
+type KubernetesMultiTargetDeployTarget struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin_test.go
@@ -111,3 +111,25 @@ func setupTestDeployTargetConfigAndDynamicClient(t *testing.T) (*kubeConfigPkg.K
 
 	return deployTargetCfg, dynamicClient
 }
+
+type cluster struct {
+	name string
+	cli  dynamic.Interface
+	dtc  *kubeConfigPkg.KubernetesDeployTargetConfig
+}
+
+func setupCluster(t *testing.T, name string) *cluster {
+	t.Helper()
+
+	clusterCfg := setupEnvTest(t)
+	dtc := setupTestDeployTargetConfig(t, clusterCfg)
+
+	cli, err := dynamic.NewForConfig(clusterCfg)
+	require.NoError(t, err)
+
+	return &cluster{
+		name: name,
+		cli:  cli,
+		dtc:  dtc,
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback.go
@@ -42,7 +42,8 @@ func (p *Plugin) executeK8sMultiRollbackStage(ctx context.Context, input *sdk.Ex
 
 	lp.Infof("Loading manifests at commit %s for handling", input.Request.RunningDeploymentSource.CommitHash)
 	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
-	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.RunningDeploymentSource, provider.NewLoader(toolRegistry))
+	// TODO: consider multiTarget later
+	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.RunningDeploymentSource, provider.NewLoader(toolRegistry), &kubeconfig.KubernetesMultiTarget{})
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return sdk.StageStatusFailure

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -27,6 +27,10 @@ import (
 )
 
 func (p *Plugin) executeK8sMultiSyncStage(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+	return p.sync(ctx, input, dts)
+}
+
+func (p *Plugin) sync(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -18,7 +18,10 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider"
@@ -27,10 +30,78 @@ import (
 )
 
 func (p *Plugin) executeK8sMultiSyncStage(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
-	return p.sync(ctx, input, dts)
+	lp := input.Client.LogPersister()
+
+	cfg, err := input.Request.TargetDeploymentSource.AppConfig()
+	if err != nil {
+		lp.Errorf("Failed while decoding application config (%v)", err.Error())
+		return sdk.StageStatusFailure
+	}
+
+	type targetConfig struct {
+		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
+		multiTarget  *kubeconfig.KubernetesMultiTarget
+	}
+
+	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], 0)
+	targetConfigs := make([]targetConfig, 0, len(dts))
+
+	// prevent the deployment when its deployTarget is not found in the piped config
+	for _, target := range dts {
+		deployTargetMap[target.Name] = target
+	}
+
+	// If no multi-targets are specified, sync to all deploy targets.
+	if len(cfg.Spec.Input.MultiTargets) == 0 {
+		for _, dt := range dts {
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  nil,
+			})
+		}
+	} else {
+		// Sync to the specified multi-targets.
+		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
+			dt, ok := deployTargetMap[multiTarget.Target.Name]
+			if !ok {
+				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
+				continue
+			}
+
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  &multiTarget,
+			})
+		}
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, tc := range targetConfigs {
+		// Start syncing the deployment to the target.
+		eg.Go(func() error {
+			lp.Infof("Start syncing the deployment to the target %s", tc.deployTarget.Name)
+			status := p.sync(ctx, input, tc.deployTarget, tc.multiTarget)
+			if status == sdk.StageStatusFailure {
+				return fmt.Errorf("failed to sync the deployment to the target %s", tc.deployTarget.Name)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		lp.Errorf("Failed while syncing the deployment (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	return sdk.StageStatusSuccess
 }
 
-func (p *Plugin) sync(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+func (p *Plugin) sync(
+	ctx context.Context,
+	input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec],
+	dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig],
+	multiTarget *kubeconfig.KubernetesMultiTarget,
+) sdk.StageStatus {
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
 
@@ -89,12 +160,7 @@ func (p *Plugin) sync(ctx context.Context, input *sdk.ExecuteStageInput[kubeconf
 		return sdk.StageStatusFailure
 	}
 
-	// Get the deploy target config.
-	if len(dts) == 0 {
-		lp.Error("No deploy target was found")
-		return sdk.StageStatusFailure
-	}
-	deployTargetConfig := dts[0].Config
+	deployTargetConfig := dt.Config
 
 	// Get the kubectl tool path.
 	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -117,7 +117,7 @@ func (p *Plugin) sync(
 	loader := provider.NewLoader(toolRegistry)
 
 	lp.Infof("Loading manifests at commit %s for handling", input.Request.TargetDeploymentSource.CommitHash)
-	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.TargetDeploymentSource, loader)
+	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.TargetDeploymentSource, loader, multiTarget)
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return sdk.StageStatusFailure

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
@@ -16,6 +16,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -632,6 +633,78 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster(t *testing.T) {
 		assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
 		assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
 		assert.Equal(t, "apps:Deployment::simple", deployment.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
+		assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+	}
+}
+
+func TestPlugin_executeK8sMultiSyncStage_multiCluster_templateNone(t *testing.T) {
+	t.Parallel()
+
+	target := filepath.Join("./", "testdata", "multicluster_template_none", "target")
+	// read the application config from the example file
+	cfg, err := os.ReadFile(filepath.Join(target, "app.pipecd.yaml"))
+	require.NoError(t, err)
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// prepare the input
+	input := &sdk.ExecuteStageInput{
+		Request: sdk.ExecuteStageRequest{
+			StageName: "K8S_MULTI_SYNC",
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+			StageConfig:             []byte(``),
+			RunningDeploymentSource: sdk.DeploymentSource{},
+			TargetDeploymentSource: sdk.DeploymentSource{
+				ApplicationDirectory:      target,
+				CommitHash:                "0123456789",
+				ApplicationConfig:         cfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "app-id", "stage-id", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	// prepare the first cluster
+	cluster1 := setupCluster(t, "cluster1")
+	cluster2 := setupCluster(t, "cluster2")
+
+	dts := []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+			Name:   "cluster1",
+			Config: *cluster1.dtc,
+		},
+		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+			Name:   "cluster2",
+			Config: *cluster2.dtc,
+		},
+	}
+
+	plugin := &Plugin{}
+	status := plugin.executeK8sMultiSyncStage(t.Context(), input, dts)
+
+	require.Equal(t, sdk.StageStatusSuccess, status)
+
+	for _, cluster := range []*cluster{cluster1, cluster2} {
+		deployment, err := cluster.cli.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(context.Background(), fmt.Sprintf("simple-%s", cluster.name), metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("simple-%s", cluster.name), deployment.GetName())
+		assert.Equal(t, fmt.Sprintf("simple-%s", cluster.name), deployment.GetLabels()["app"])
+
+		assert.Equal(t, "piped", deployment.GetLabels()["pipecd.dev/managed-by"])
+		assert.Equal(t, "piped-id", deployment.GetLabels()["pipecd.dev/piped"])
+		assert.Equal(t, "app-id", deployment.GetLabels()["pipecd.dev/application"])
+		assert.Equal(t, "0123456789", deployment.GetLabels()["pipecd.dev/commit-hash"])
+
+		assert.Equal(t, "piped", deployment.GetAnnotations()["pipecd.dev/managed-by"])
+		assert.Equal(t, "piped-id", deployment.GetAnnotations()["pipecd.dev/piped"])
+		assert.Equal(t, "app-id", deployment.GetAnnotations()["pipecd.dev/application"])
+		assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
+		assert.Equal(t, "apps:Deployment::"+fmt.Sprintf("simple-%s", cluster.name), deployment.GetAnnotations()["pipecd.dev/resource-key"]) // This assertion differs from the non-plugin-arched piped's Kubernetes platform provider, but we decided to change this behavior.
 		assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
@@ -41,18 +40,18 @@ func TestPlugin_executeK8sMultiSyncStage(t *testing.T) {
 	ctx := context.Background()
 
 	// read the application config from the example file
-	appCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	appCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
 
 	// initialize tool registry
 	testRegistry := toolregistrytest.NewTestToolRegistry(t)
 
 	// prepare the input
-	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+	input := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 			StageName:               "K8S_MULTI_SYNC",
 			StageConfig:             []byte(``),
-			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+			RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+			TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
 				CommitHash:                "0123456789",
 				ApplicationConfig:         appCfg,
@@ -106,7 +105,7 @@ func TestPlugin_executeK8sMultiSyncStage_withInputNamespace(t *testing.T) {
 	ctx := context.Background()
 
 	// read the application config from the example file
-	appCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	appCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
 
 	// override the autoCreateNamespace and namespace
 	appCfg.Spec.Input.AutoCreateNamespace = true
@@ -116,12 +115,12 @@ func TestPlugin_executeK8sMultiSyncStage_withInputNamespace(t *testing.T) {
 	testRegistry := toolregistrytest.NewTestToolRegistry(t)
 
 	// prepare the input
-	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+	input := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 			StageName:               "K8S_MULTI_SYNC",
 			StageConfig:             []byte(``),
-			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+			RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+			TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
 				CommitHash:                "0123456789",
 				ApplicationConfig:         appCfg,
@@ -182,16 +181,16 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune(t *testing.T) {
 	running := filepath.Join("./", "testdata", "prune", "running")
 
 	// read the running application config from the testdata file
-	runningCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
+	runningCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
 
 	ok := t.Run("prepare", func(t *testing.T) {
 		// prepare the input to ensure the running deployment exists
-		runningInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		runningInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:               "K8S_MULTI_SYNC",
 				StageConfig:             []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
@@ -237,20 +236,20 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune(t *testing.T) {
 		target := filepath.Join("./", "testdata", "prune", "target")
 
 		// read the running application config from the testdata file
-		targetCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
+		targetCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
 
 		// prepare the input to ensure the running deployment exists
-		targetInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		targetInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:   "K8S_MULTI_SYNC",
 				StageConfig: []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
 					ApplicationConfigFilename: "app.pipecd.yaml",
 				},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      target,
 					CommitHash:                "0012345678",
 					ApplicationConfig:         targetCfg,
@@ -294,16 +293,16 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_changesNamespace(t *testing.T
 	running := filepath.Join("./", "testdata", "prune_with_change_namespace", "running")
 
 	// read the running application config from the example file
-	runningCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
+	runningCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
 
 	ok := t.Run("prepare", func(t *testing.T) {
 		// prepare the input to ensure the running deployment exists
-		runningInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		runningInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:               "K8S_MULTI_SYNC",
 				StageConfig:             []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
@@ -349,20 +348,20 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_changesNamespace(t *testing.T
 		target := filepath.Join("./", "testdata", "prune_with_change_namespace", "target")
 
 		// read the running application config from the example file
-		targetCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
+		targetCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
 
 		// prepare the input to ensure the running deployment exists
-		targetInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		targetInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:   "K8S_MULTI_SYNC",
 				StageConfig: []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
 					ApplicationConfigFilename: "app.pipecd.yaml",
 				},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      target,
 					CommitHash:                "0012345678",
 					ApplicationConfig:         targetCfg,
@@ -424,16 +423,16 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_clusterScoped(t *testing.T) {
 	// prepare the custom resource definition
 	prepare := filepath.Join("./", "testdata", "prune_cluster_scoped_resource", "prepare")
 
-	prepareCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(prepare, "app.pipecd.yaml"))
+	prepareCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(prepare, "app.pipecd.yaml"))
 
 	ok := t.Run("prepare crd", func(t *testing.T) {
 		// prepare the input to ensure the running deployment exists
-		prepareInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		prepareInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:               "K8S_MULTI_SYNC",
 				StageConfig:             []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      prepare,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         prepareCfg,
@@ -463,16 +462,16 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_clusterScoped(t *testing.T) {
 	running := filepath.Join("./", "testdata", "prune_cluster_scoped_resource", "running")
 
 	// read the running application config from the example file
-	runningCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
+	runningCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(running, "app.pipecd.yaml"))
 
 	ok = t.Run("prepare running", func(t *testing.T) {
 		// prepare the input to ensure the running deployment exists
-		runningInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		runningInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:               "K8S_MULTI_SYNC",
 				StageConfig:             []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
@@ -507,20 +506,20 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_clusterScoped(t *testing.T) {
 		target := filepath.Join("./", "testdata", "prune_cluster_scoped_resource", "target")
 
 		// read the running application config from the example file
-		targetCfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
+		targetCfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
 
 		// prepare the input to ensure the running deployment exists
-		targetInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+		targetInput := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 				StageName:   "K8S_MULTI_SYNC",
 				StageConfig: []byte(``),
-				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      running,
 					CommitHash:                "0123456789",
 					ApplicationConfig:         runningCfg,
 					ApplicationConfigFilename: "app.pipecd.yaml",
 				},
-				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 					ApplicationDirectory:      target,
 					CommitHash:                "0012345678",
 					ApplicationConfig:         targetCfg,
@@ -532,7 +531,7 @@ func TestPlugin_executeK8sMultiSyncStage_withPrune_clusterScoped(t *testing.T) {
 		}
 
 		plugin := &Plugin{}
-		status := plugin.executeK8sMultiSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		status := plugin.executeK8sMultiSyncStage(ctx, targetInput, []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
 			{
 				Name:   "default",
 				Config: *dtConfig,
@@ -558,22 +557,22 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster(t *testing.T) {
 	t.Parallel()
 
 	// read the application config from the example file
-	cfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
+	cfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(examplesDir(), "kubernetes", "simple", "app.pipecd.yaml"))
 
 	// initialize tool registry
 	testRegistry := toolregistrytest.NewTestToolRegistry(t)
 
 	// prepare the input
-	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+	input := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 			StageName: "K8S_MULTI_SYNC",
 			Deployment: sdk.Deployment{
 				PipedID:       "piped-id",
 				ApplicationID: "app-id",
 			},
 			StageConfig:             []byte(``),
-			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+			RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+			TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 				ApplicationDirectory:      filepath.Join(examplesDir(), "kubernetes", "simple"),
 				CommitHash:                "0123456789",
 				ApplicationConfig:         cfg,
@@ -589,11 +588,11 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster(t *testing.T) {
 	cluster2 := setupCluster(t, "cluster2")
 
 	dts := []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster1",
 			Config: *cluster1.dtc,
 		},
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster2",
 			Config: *cluster2.dtc,
 		},
@@ -629,22 +628,22 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster_templateNone(t *testing.T)
 
 	target := filepath.Join("./", "testdata", "multicluster_template_none", "target")
 	// read the application config from the example file
-	cfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
+	cfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
 
 	// initialize tool registry
 	testRegistry := toolregistrytest.NewTestToolRegistry(t)
 
 	// prepare the input
-	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+	input := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 			StageName: "K8S_MULTI_SYNC",
 			Deployment: sdk.Deployment{
 				PipedID:       "piped-id",
 				ApplicationID: "app-id",
 			},
 			StageConfig:             []byte(``),
-			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+			RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+			TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 				ApplicationDirectory:      target,
 				CommitHash:                "0123456789",
 				ApplicationConfig:         cfg,
@@ -660,11 +659,11 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster_templateNone(t *testing.T)
 	cluster2 := setupCluster(t, "cluster2")
 
 	dts := []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster1",
 			Config: *cluster1.dtc,
 		},
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster2",
 			Config: *cluster2.dtc,
 		},
@@ -700,22 +699,22 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster_failed_one_of_the_sync(t *
 
 	target := filepath.Join("./", "testdata", "multicluster_failed_one_of_the_sync", "target")
 
-	cfg := sdktest.LoadApplicationConfig[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
+	cfg := sdktest.LoadApplicationConfig[kubeconfig.KubernetesApplicationSpec](t, filepath.Join(target, "app.pipecd.yaml"))
 
 	// initialize tool registry
 	testRegistry := toolregistrytest.NewTestToolRegistry(t)
 
 	// prepare the input
-	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
-		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+	input := &sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeconfig.KubernetesApplicationSpec]{
 			StageName: "K8S_MULTI_SYNC",
 			Deployment: sdk.Deployment{
 				PipedID:       "piped-id",
 				ApplicationID: "app-id",
 			},
 			StageConfig:             []byte(``),
-			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{},
-			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+			RunningDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{},
+			TargetDeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
 				ApplicationDirectory:      target,
 				CommitHash:                "0123456789",
 				ApplicationConfig:         cfg,
@@ -731,11 +730,11 @@ func TestPlugin_executeK8sMultiSyncStage_multiCluster_failed_one_of_the_sync(t *
 	cluster2 := setupCluster(t, "cluster2")
 
 	dts := []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster1",
 			Config: *cluster1.dtc,
 		},
-		&sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+		{
 			Name:   "cluster2",
 			Config: *cluster2.dtc,
 		},

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/app.pipecd.yaml
@@ -1,0 +1,26 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: simple
+  labels:
+    env: example
+    team: product
+  quickSync:
+    prune: true
+  input:
+    kubectlVersion: 1.31.0
+    multiTargets:
+      - target:
+          name: cluster1
+        manifests:
+          - ./cluster1/deployment.yaml
+        kubectlVersion: 1.31.0
+      - target:
+          name: cluster2
+        manifests:
+          - ./cluster_hoge/deployment.yaml # wrong path
+        kubectlVersion: 1.31.0
+  description: |
+    This app demonstrates how to deploy a Kubernetes application with [Quick Sync](https://pipecd.dev/docs/concepts/#sync-strategy) strategy.\
+    No pipeline is specified then in each deployment PipeCD will roll out the new version and switch all traffic to it immediately.\
+    References: [adding a new app](https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs/user-guide/configuration-reference/)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster1/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster1/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster1
+  labels:
+    app: simple-cluster1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster1
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster1
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster2/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_failed_one_of_the_sync/target/cluster2/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster2
+  labels:
+    app: simple-cluster2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster2
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster2
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/app.pipecd.yaml
@@ -1,0 +1,26 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: simple
+  labels:
+    env: example
+    team: product
+  quickSync:
+    prune: true
+  input:
+    kubectlVersion: 1.31.0
+    multiTargets:
+      - target:
+          name: cluster1
+        manifests:
+          - ./cluster1/deployment.yaml
+        kubectlVersion: 1.31.0
+      - target:
+          name: cluster2
+        manifests:
+          - ./cluster2/deployment.yaml
+        kubectlVersion: 1.31.0
+  description: |
+    This app demonstrates how to deploy a Kubernetes application with [Quick Sync](https://pipecd.dev/docs/concepts/#sync-strategy) strategy.\
+    No pipeline is specified then in each deployment PipeCD will roll out the new version and switch all traffic to it immediately.\
+    References: [adding a new app](https://pipecd.dev/docs/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs/user-guide/configuration-reference/)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/cluster1/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/cluster1/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster1
+  labels:
+    app: simple-cluster1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster1
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster1
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/cluster2/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/testdata/multicluster_template_none/target/cluster2/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-cluster2
+  labels:
+    app: simple-cluster2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple-cluster2
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple-cluster2
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085


### PR DESCRIPTION
**What this PR does**:

I implemented the K8S_MULTI_SYNC to deploy an app to the multiple clusters.
It also aims to keep the capability for the K8S_SYNC in k8s plugin.

Currently, it can Apply to the multiple clusters.
If you have any questions, feel free to add comments.

**Details**
I introduced `spec.input.multiTargets` field.
We can control the settings (manifests, kubectlVersion and so on) for each deploy target.

Here is the example of the app.pipecd.yaml with it.
```yaml
apiVersion: pipecd.dev/v1beta1
kind: Application
spec:
  name: multiCluster-template-none
  labels:
    env: example
    team: product
  quickSync:
    prune: true
  input:
    kubectlVersion: 1.31.0
    multiTargets:
      - target:
          name: cluster1
        manifests:
          - ./cluster1/deployment.yaml
        kubectlVersion: 1.31.0
      - target:
          name: kubernetes-dev
        manifests:
          - ./cluster2/deployment.yaml
        kubectlVersion: 1.31.0
  description: |
    multi cluster with template none
  plugins:
    - kubernetes_multicluster
```

![PipeCD](https://github.com/user-attachments/assets/766fcbdc-2a80-4bbe-b3cf-a1243076396a)


If multiTargets are set, the configuration for each target is applied and deployed accordingly. If multiTargets is not set, the deployment is executed for all deploy targets.

Also, each multi-target process is executed in parallel. 
K8S_MULTI_SYNC is successful when all of the processes are executed successfully.

**Why we need it**:

We aim to support multi-cluster features.

**Which issue(s) this PR fixes**:

Part of #5006
Follow https://github.com/pipe-cd/pipecd/pull/5535

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:

