### PR TITLE
fix: regex based tag replacement scheme

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -209,7 +209,7 @@ One of `yamlField` or `regex` is required.
 |-|-|-|-|
 | file | string | The relative path from the repository root to the file to be updated. | Yes |
 | yamlField | string | The yaml path to the field to be updated. It requires to start with `$` which represents the root element. e.g. `$.foo.bar[0].baz`. | No |
-| regex | string | The regex string that specify what should be replaced. The only first capturing group enclosed by `()` will be replaced with the new value. e.g. `host.xz/foo/bar:(v[0-9].[0-9].[0-9])` | No |
+| regex | string | The regex string that specify what should be replaced. The only first capturing group enclosed by `()` will be replaced with the new value. e.g. `host.xz/foo/bar:(v[0-9].[0-9].[0-9])`, `host.xz/foo/bar:([0-9a-z]+)` | No |
 
 ## CommitMatcher
 

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -18,6 +18,7 @@
 package eventwatcher
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -789,9 +790,17 @@ func convertStr(value interface{}) (out string, err error) {
 	return
 }
 
-// modifyText returns a new text replacing all matches of the given regex with the newValue.
-// The only first capturing group enclosed by `()` will be replaced.
-// True as a second returned value means it's already up-to-date.
+// modifyText returns a modified text of the file contents by replacing the first capturing group
+// of all matches of the provided regular expression with the specified newValue.
+// The replacement is applied only to the part of each match that corresponds to the first capturing
+// group (the portion enclosed in the first pair of parentheses `()`).
+//
+// It returns the updated content, a boolean indicating whether the file was already up-to-date,
+// and an error if any issue occurs during reading, regular expression parsing, or matching.
+//
+// If no matches are found, an error is returned.
+// If all first capturing groups already equal newValue, the original content is returned,
+// the boolean is true, and no changes are applied.
 func modifyText(path, regexText, newValue string) ([]byte, bool, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -819,17 +828,32 @@ func modifyText(path, regexText, newValue string) ([]byte, bool, error) {
 	if firstGroup == "" {
 		return nil, false, fmt.Errorf("capturing group not found in the given regex")
 	}
-	subRegex, err := pool.Get(firstGroup)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to compile the first capturing group: %w", err)
-	}
 
 	var touched, outDated bool
 	newText := regex.ReplaceAllFunc(content, func(match []byte) []byte {
 		touched = true
-		outDated = string(subRegex.Find(match)) != newValue
-		// Return text replacing the only first capturing group with the newValue.
-		return subRegex.ReplaceAll(match, []byte(newValue))
+		submatches := regex.FindSubmatchIndex(match)
+
+		if len(submatches) < 4 {
+			return match
+		}
+
+		groupStart, groupEnd := submatches[2], submatches[3]
+
+		// no update on the value
+		if string(match[groupStart:groupEnd]) == newValue {
+			return match
+		}
+
+		outDated = true
+
+		var buf bytes.Buffer
+
+		buf.Write(match[:groupStart])
+		buf.WriteString(newValue)
+		buf.Write(match[groupEnd:])
+
+		return buf.Bytes()
 	})
 	if !touched {
 		return nil, false, fmt.Errorf("the content of %s doesn't match %s", path, regexText)

--- a/pkg/app/piped/eventwatcher/eventwatcher_test.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher_test.go
@@ -221,7 +221,7 @@ spec:
 			wantErr:      false,
 		},
 		{
-			name:     "replace text",
+			name:     "replace text for semantic version",
 			path:     "testdata/kustomization.yaml",
 			regex:    "newTag: (v[0-9].[0-9].[0-9])",
 			newValue: "v0.2.0",
@@ -231,6 +231,26 @@ spec:
 `),
 			wantUpToDate: false,
 			wantErr:      false,
+		},
+		{
+			name:     "replace text for non-semantic version (commit hash)",
+			path:     "testdata/kustomization2.yaml",
+			regex:    "newTag: ([0-9a-z]+)",
+			newValue: "cba4321",
+			want: []byte(`images:
+- name: gcr.io/pipecd/foo
+  newTag: cba4321
+`),
+		},
+		{
+			name:     "replace text for non-semantic version (sha256)",
+			path:     "testdata/kustomization3.yaml",
+			regex:    "newTag: sha256:([0-9a-z]+)",
+			newValue: "cba4321",
+			want: []byte(`images:
+- name: gcr.io/pipecd/foo
+  newTag: sha256:cba4321
+`),
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/app/piped/eventwatcher/testdata/kustomization2.yaml
+++ b/pkg/app/piped/eventwatcher/testdata/kustomization2.yaml
@@ -1,0 +1,3 @@
+images:
+- name: gcr.io/pipecd/foo
+  newTag: abc1234

--- a/pkg/app/piped/eventwatcher/testdata/kustomization3.yaml
+++ b/pkg/app/piped/eventwatcher/testdata/kustomization3.yaml
@@ -1,0 +1,3 @@
+images:
+- name: gcr.io/pipecd/foo
+  newTag: sha256:abc1234

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -719,7 +719,7 @@ func convertStr(value interface{}) (out string, err error) {
 	return
 }
 
-// modifyText returns a modified version of the file contents by replacing the first capturing group
+// modifyText returns a modified text of the file contents by replacing the first capturing group
 // of all matches of the provided regular expression with the specified newValue.
 // The replacement is applied only to the part of each match that corresponds to the first capturing
 // group (the portion enclosed in the first pair of parentheses `()`).
@@ -768,11 +768,13 @@ func modifyText(path, regexText, newValue string) ([]byte, bool, error) {
 		}
 
 		groupStart, groupEnd := submatches[2], submatches[3]
-		if string(match[groupStart:groupEnd]) != newValue {
-			outDated = true
-		} else {
+
+		// no update on the value
+		if string(match[groupStart:groupEnd]) == newValue {
 			return match
 		}
+
+		outDated = true
 
 		var buf bytes.Buffer
 

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher_test.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher_test.go
@@ -221,7 +221,7 @@ spec:
 			wantErr:      false,
 		},
 		{
-			name:     "replace text",
+			name:     "replace text for semantic version",
 			path:     "testdata/kustomization.yaml",
 			regex:    "newTag: (v[0-9].[0-9].[0-9])",
 			newValue: "v0.2.0",
@@ -231,6 +231,26 @@ spec:
 `),
 			wantUpToDate: false,
 			wantErr:      false,
+		},
+		{
+			name:     "replace text for non-semantic version (commit hash)",
+			path:     "testdata/kustomization2.yaml",
+			regex:    "newTag: ([0-9a-z]+)",
+			newValue: "cba4321",
+			want: []byte(`images:
+- name: gcr.io/pipecd/foo
+  newTag: cba4321
+`),
+		},
+		{
+			name:     "replace text for non-semantic version (sha256)",
+			path:     "testdata/kustomization3.yaml",
+			regex:    "newTag: sha256:([0-9a-z]+)",
+			newValue: "cba4321",
+			want: []byte(`images:
+- name: gcr.io/pipecd/foo
+  newTag: sha256:cba4321
+`),
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/app/pipedv1/eventwatcher/testdata/kustomization2.yaml
+++ b/pkg/app/pipedv1/eventwatcher/testdata/kustomization2.yaml
@@ -1,0 +1,3 @@
+images:
+- name: gcr.io/pipecd/foo
+  newTag: abc1234

--- a/pkg/app/pipedv1/eventwatcher/testdata/kustomization3.yaml
+++ b/pkg/app/pipedv1/eventwatcher/testdata/kustomization3.yaml
@@ -1,0 +1,3 @@
+images:
+- name: gcr.io/pipecd/foo
+  newTag: sha256:abc1234


### PR DESCRIPTION
**What this PR does**:

Tag replacement using the `regex` directive currently does not support patterns other than semantic versions.

This PR supports for replacing commit hash or SHA-based tags.

**Why we need it**:

Please refer to the related issue for more details:

- https://github.com/pipe-cd/pipecd/issues/5712
- https://github.com/pipe-cd/pipecd/issues/5688

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipecd/issues/5712

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
