### PR TITLE
Add config loading utility for the plugin SDK

### DIFF
--- a/pkg/plugin/sdk/config.go
+++ b/pkg/plugin/sdk/config.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import config "github.com/pipe-cd/pipecd/pkg/configv1"
+
+// Spec[T] represents both of follows
+// - the type is pointer type of T
+// - the type has Validate method
+type Spec[T any] interface {
+	*T
+	Validate() error
+}
+
+// LoadConfigSpec loads the config spec from the application config.
+// The type T must be a pointer to a struct that has Validate method.
+func LoadConfigSpec[T Spec[RT], RT any](ds DeploymentSource) (T, error) {
+	cfg, err := config.DecodeYAML[T](ds.ApplicationConfig)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Spec, nil
+}

--- a/pkg/plugin/sdk/config.go
+++ b/pkg/plugin/sdk/config.go
@@ -19,10 +19,7 @@ import config "github.com/pipe-cd/pipecd/pkg/configv1"
 // Spec[T] represents both of follows
 // - the type is pointer type of T
 // - the type has Validate method
-type Spec[T any] interface {
-	*T
-	Validate() error
-}
+type Spec[T any] = config.Spec[T]
 
 // LoadConfigSpec loads the config spec from the application config.
 // The type T must be a pointer to a struct that has Validate method.

--- a/pkg/plugin/sdk/config_test.go
+++ b/pkg/plugin/sdk/config_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Define a test struct and its pointer type satisfying the Spec interface.
+type testSpecRuntime struct {
+	Field1 string `yaml:"field1"`
+	Field2 int    `yaml:"field2"`
+	// Used to trigger validation error in tests
+	ShouldFailValidation bool `yaml:"shouldFailValidation"`
+}
+
+func (s *testSpecRuntime) Validate() error {
+	if s.ShouldFailValidation {
+		return errors.New("validation failed")
+	}
+	return nil
+}
+
+func TestLoadConfigSpec(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		inputYAML  string
+		wantErr    bool
+		wantErrMsg string
+		wantSpec   *testSpecRuntime
+	}{
+		{
+			name: "success",
+			inputYAML: `
+apiVersion: pipecd.dev/v1beta1
+kind: TestPlugin
+spec:
+  field1: "value1"
+  field2: 123
+`,
+			wantErr: false,
+			wantSpec: &testSpecRuntime{
+				Field1: "value1",
+				Field2: 123,
+			},
+		},
+		{
+			name: "invalid yaml",
+			inputYAML: `
+apiVersion: pipecd.dev/v1beta1
+kind: TestPlugin
+spec:
+  field1: "value1"
+  field2: 123
+invalid-yaml-token
+`,
+			wantErr:    true,
+			wantErrMsg: "yaml:",
+		},
+		{
+			name: "validation fail",
+			inputYAML: `
+apiVersion: pipecd.dev/v1beta1
+kind: TestPlugin
+spec:
+  field1: "value1"
+  field2: 456
+  shouldFailValidation: true
+`,
+			wantErr:    true,
+			wantErrMsg: "validation failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ds := DeploymentSource{
+				ApplicationConfig: []byte(tc.inputYAML),
+			}
+
+			spec, err := LoadConfigSpec[*testSpecRuntime](ds)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, spec)
+				if tc.wantErrMsg != "" {
+					assert.ErrorContains(t, err, tc.wantErrMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantSpec, spec)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

I don't want plugin developers to import `pkg/configv1` directly because it's not a part of SDK.

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
