### PR TITLE
Add depguard rule to restrict pipedv1 to use configv1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,12 @@ linters-settings:
             desc: "Use go.uber.org/atomic instead of sync/atomic."
           - pkg: "io/ioutil"
             desc: "Use corresponding 'os' or 'io' functions instead."
+      pipedv1:
+        files:
+          - "**/pkg/app/pipedv1/**/*.go"
+        deny:
+          - pkg: "github.com/pipe-cd/pipecd/pkg/config$"
+            desc: "Use github.com/pipe-cd/pipecd/pkg/configv1 instead."
   gocritic:
     disabled-checks:
       - appendAssign

--- a/pkg/app/pipedv1/livestatestore/livestatestore.go
+++ b/pkg/app/pipedv1/livestatestore/livestatestore.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
@@ -56,9 +56,6 @@ func NewStore(ctx context.Context, cfg *config.PipedSpec, appLister applicationL
 	s := &store{
 		gracePeriod: gracePeriod,
 		logger:      logger,
-	}
-	for _, cp := range cfg.PlatformProviders {
-		_ = cp // TODO: general state from plugin from store fields
 	}
 
 	return s

--- a/pkg/app/pipedv1/notifier/matcher.go
+++ b/pkg/app/pipedv1/notifier/matcher.go
@@ -15,7 +15,7 @@
 package notifier
 
 import (
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 

--- a/pkg/app/pipedv1/notifier/matcher_test.go
+++ b/pkg/app/pipedv1/notifier/matcher_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 

--- a/pkg/app/pipedv1/notifier/slack.go
+++ b/pkg/app/pipedv1/notifier/slack.go
@@ -29,7 +29,7 @@ import (
 	slackgo "github.com/slack-go/slack"
 	"go.uber.org/zap"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/git"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )

--- a/pkg/app/pipedv1/notifier/webhook.go
+++ b/pkg/app/pipedv1/notifier/webhook.go
@@ -24,7 +24,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We must use configv1 package under the pipedv1 package

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
