### PR TITLE
[K8s Plugin] Refactor to use LoadConfigSpec to load application config

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -21,7 +21,6 @@ import (
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
@@ -35,7 +34,7 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 
 	lp.Info("Start rolling back the deployment")
 
-	cfg, err := config.DecodeYAML[*kubeconfig.KubernetesApplicationSpec](input.Request.RunningDeploymentSource.ApplicationConfig)
+	spec, err := sdk.LoadConfigSpec[*kubeconfig.KubernetesApplicationSpec](input.Request.RunningDeploymentSource)
 	if err != nil {
 		lp.Errorf("Failed while decoding application config (%v)", err)
 		return sdk.StageStatusFailure
@@ -43,7 +42,7 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 
 	lp.Infof("Loading manifests at commit %s for handling", input.Request.RunningDeploymentSource.CommitHash)
 	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
-	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.RunningDeploymentSource, provider.NewLoader(toolRegistry))
+	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, input.Request.RunningDeploymentSource, provider.NewLoader(toolRegistry))
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return sdk.StageStatusFailure
@@ -57,13 +56,13 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
 	var (
-		variantLabel   = cfg.Spec.VariantLabel.Key
-		primaryVariant = cfg.Spec.VariantLabel.PrimaryValue
+		variantLabel   = spec.VariantLabel.Key
+		primaryVariant = spec.VariantLabel.PrimaryValue
 	)
 	// TODO: Consider other fields to configure whether to add a variant label to the selector
 	// because the rollback stage is executed in both quick sync and pipeline sync strategies.
-	if cfg.Spec.QuickSync.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, cfg.Spec.Workloads)
+	if spec.QuickSync.AddVariantLabelToSelector {
+		workloads := findWorkloadManifests(manifests, spec.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
 				lp.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key().ReadableString(), err)
@@ -95,17 +94,17 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 	deployTargetConfig := dts[0].Config
 
 	// Get the kubectl tool path.
-	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
+	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
 	if err != nil {
 		lp.Errorf("Failed while getting kubectl tool (%v)", err)
 		return sdk.StageStatusFailure
 	}
 
 	// Create the applier for the target cluster.
-	applier := provider.NewApplier(provider.NewKubectl(kubectlPath), cfg.Spec.Input, deployTargetConfig, input.Logger)
+	applier := provider.NewApplier(provider.NewKubectl(kubectlPath), spec.Input, deployTargetConfig, input.Logger)
 
 	// Start applying all manifests to add or update running resources.
-	if err := applyManifests(ctx, applier, manifests, cfg.Spec.Input.Namespace, lp); err != nil {
+	if err := applyManifests(ctx, applier, manifests, spec.Input.Namespace, lp); err != nil {
 		lp.Errorf("Failed while applying manifests (%v)", err)
 		return sdk.StageStatusFailure
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
@@ -23,7 +23,6 @@ import (
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
@@ -31,7 +30,7 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 	lp := input.Client.LogPersister()
 	lp.Info("Start syncing the deployment")
 
-	cfg, err := config.DecodeYAML[*kubeconfig.KubernetesApplicationSpec](input.Request.TargetDeploymentSource.ApplicationConfig)
+	spec, err := sdk.LoadConfigSpec[*kubeconfig.KubernetesApplicationSpec](input.Request.TargetDeploymentSource)
 	if err != nil {
 		lp.Errorf("Failed while decoding application config (%v)", err)
 		return sdk.StageStatusFailure
@@ -43,7 +42,7 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 	loader := provider.NewLoader(toolRegistry)
 
 	lp.Infof("Loading manifests at commit %s for handling", input.Request.TargetDeploymentSource.CommitHash)
-	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, cfg.Spec, &input.Request.TargetDeploymentSource, loader)
+	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, input.Request.TargetDeploymentSource, loader)
 	if err != nil {
 		lp.Errorf("Failed while loading manifests (%v)", err)
 		return sdk.StageStatusFailure
@@ -57,12 +56,12 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
 	var (
-		variantLabel   = cfg.Spec.VariantLabel.Key
-		primaryVariant = cfg.Spec.VariantLabel.PrimaryValue
+		variantLabel   = spec.VariantLabel.Key
+		primaryVariant = spec.VariantLabel.PrimaryValue
 	)
 	// TODO: treat the stage options specified under "with"
-	if cfg.Spec.QuickSync.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, cfg.Spec.Workloads)
+	if spec.QuickSync.AddVariantLabelToSelector {
+		workloads := findWorkloadManifests(manifests, spec.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, variantLabel, primaryVariant); err != nil {
 				lp.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key().ReadableString(), err)
@@ -94,7 +93,7 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 	deployTargetConfig := dts[0].Config
 
 	// Get the kubectl tool path.
-	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
+	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
 	if err != nil {
 		lp.Errorf("Failed while getting kubectl tool (%v)", err)
 		return sdk.StageStatusFailure
@@ -104,17 +103,17 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 	kubectl := provider.NewKubectl(kubectlPath)
 
 	// Create the applier for the target cluster.
-	applier := provider.NewApplier(kubectl, cfg.Spec.Input, deployTargetConfig, input.Logger)
+	applier := provider.NewApplier(kubectl, spec.Input, deployTargetConfig, input.Logger)
 
 	// Start applying all manifests to add or update running resources.
 	// TODO: use applyManifests instead of applyManifestsSDK
-	if err := applyManifests(ctx, applier, manifests, cfg.Spec.Input.Namespace, lp); err != nil {
+	if err := applyManifests(ctx, applier, manifests, spec.Input.Namespace, lp); err != nil {
 		lp.Errorf("Failed while applying manifests (%v)", err)
 		return sdk.StageStatusSuccess
 	}
 
 	// TODO: treat the stage options specified under "with"
-	if !cfg.Spec.QuickSync.Prune {
+	if !spec.QuickSync.Prune {
 		lp.Info("Resource GC was skipped because sync.prune was not configured")
 		return sdk.StageStatusSuccess
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
@@ -110,13 +111,11 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode and override the autoCreateNamespace and namespace
-	spec, err := sdk.LoadConfigSpec[*kubeConfigPkg.KubernetesApplicationSpec](sdk.DeploymentSource{
-		ApplicationConfig:         cfg,
-		ApplicationConfigFilename: "app.pipecd.yaml",
-	})
+	// TODO: Do not use configv1 package in this plugin
+	spec, err := config.DecodeYAML[*kubeConfigPkg.KubernetesApplicationSpec](cfg)
 	require.NoError(t, err)
-	spec.Input.AutoCreateNamespace = true
-	spec.Input.Namespace = "test-namespace"
+	spec.Spec.Input.AutoCreateNamespace = true
+	spec.Spec.Input.Namespace = "test-namespace"
 	cfg, err = yaml.Marshal(spec)
 	require.NoError(t, err)
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -111,7 +111,8 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode and override the autoCreateNamespace and namespace
-	// TODO: Do not use configv1 package in this plugin
+	// TODO: Do not use configv1 package in this plugin.
+	// We cannot use LoadConfigSpec because this use case involves constructing the application config with modifications from base one; it means we need the full application config.
 	spec, err := config.DecodeYAML[*kubeConfigPkg.KubernetesApplicationSpec](cfg)
 	require.NoError(t, err)
 	spec.Spec.Input.AutoCreateNamespace = true

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
@@ -111,10 +110,13 @@ func TestPlugin_executeK8sSyncStage_withInputNamespace(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode and override the autoCreateNamespace and namespace
-	spec, err := config.DecodeYAML[*kubeConfigPkg.KubernetesApplicationSpec](cfg)
+	spec, err := sdk.LoadConfigSpec[*kubeConfigPkg.KubernetesApplicationSpec](sdk.DeploymentSource{
+		ApplicationConfig:         cfg,
+		ApplicationConfigFilename: "app.pipecd.yaml",
+	})
 	require.NoError(t, err)
-	spec.Spec.Input.AutoCreateNamespace = true
-	spec.Spec.Input.Namespace = "test-namespace"
+	spec.Input.AutoCreateNamespace = true
+	spec.Input.Namespace = "test-namespace"
 	cfg, err = yaml.Marshal(spec)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does**:

This PR does a refactoring to use sdk.LoadConfigSpec instead of configv1.DecodeYAML

**Why we need it**:

We don't want to import the configv1 package under plugin implementation because it is not a package for plugin implementation.

**Which issue(s) this PR fixes**:

Part of #5530
Follows #5731 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
