### PR TITLE
Disable register app for pipedv1 form

### DIFF
--- a/web/src/components/application-form/index.tsx
+++ b/web/src/components/application-form/index.tsx
@@ -2,7 +2,6 @@ import { Box, makeStyles, Tabs, Tab, IconButton } from "@material-ui/core";
 import { Help } from "@material-ui/icons";
 import { useState } from "react";
 import { Application } from "~/modules/applications";
-import ApplicationFormV1 from "./application-form-v1";
 import ApplicationFormV0 from "./application-form-v0";
 import ApplicationFormManualV0 from "./application-form-manual-v0";
 import TabPanel from "./tab-panel";
@@ -53,8 +52,7 @@ export type ApplicationFormProps = {
 
 enum TabKeys {
   V0 = 0,
-  V1 = 1,
-  MANUAL = 2,
+  MANUAL = 1,
 }
 
 export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
@@ -96,11 +94,6 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           />
           <Tab
             className={classes.tabLabel}
-            label="PIPED V1 ADD FROM SUGGESTIONS"
-            {...tabProps(TabKeys.V1)}
-          />
-          <Tab
-            className={classes.tabLabel}
             label="ADD MANUALLY"
             icon=" "
             {...tabProps(TabKeys.MANUAL)}
@@ -112,12 +105,6 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
         {...tabPanelProps(TabKeys.V0)}
       >
         <ApplicationFormV0 {...props} />
-      </TabPanel>
-      <TabPanel
-        selected={selectedTabIndex === TabKeys.V1}
-        {...tabPanelProps(TabKeys.V1)}
-      >
-        <ApplicationFormV1 {...props} />
       </TabPanel>
       <TabPanel
         selected={selectedTabIndex === TabKeys.MANUAL}


### PR DESCRIPTION
**What this PR does**:

Disable pipedv1 app register form

**Why we need it**:

In PipeCD v0.51.x, the current manually added application form is showing the pipedv1 app register form. This PR fixes that issue.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
