### PR TITLE
Fix release docs gen script

### DIFF
--- a/hack/gen-release-docs.sh
+++ b/hack/gen-release-docs.sh
@@ -31,7 +31,8 @@ CONTENT_DIR=docs/content/en
 # Create new $CONTENT_DIR/docs-$VERSION
 rm -rf $CONTENT_DIR/docs-$VERSION
 cp -rf $CONTENT_DIR/docs-dev $CONTENT_DIR/docs-$VERSION
-cp -rf docs/themes/docsy/layouts/docs/ docs/layouts/docs-$VERSION
+rm -rf docs/layouts/docs-$VERSION
+cp -rf docs/themes/docsy/layouts/docs docs/layouts/docs-$VERSION
 cat <<EOT > $CONTENT_DIR/docs-$VERSION/_index.md
 ---
 title: "Welcome to PipeCD"


### PR DESCRIPTION
**What this PR does**:

Update release docs gen script to avoid this miss generating bug (ref: [PR](https://github.com/pipe-cd/pipecd/pull/5749/files#diff-91bd2fc94a14c62115a393c00606f19bbf1e37de4c01917113044ddccb2f3b22))

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
