### PR TITLE
Make release note generate logic run on Release PR reopen

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -2,7 +2,7 @@ name: prerelease
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     branches:
       - master
     paths:


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Need this to trigger release note generate on Release PR which opened by another workflow

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
