### PR TITLE
[docs] Add note of checking the SSH key

### DIFF
--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -61,4 +61,4 @@ For the full list of available commands, please see the Makefile at the root of 
     make run/piped CONFIG_FILE=piped-config.yaml
     ```
 
-Note: If you have a problem with accessing the example repository, please follow [this guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to register the SSH key or try specifying `remote: https://github.com/pipe-cd/examples.git` instead.
+Note: If you have a problem with accessing the example repository, please follow [this guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to register the SSH key or try specifying `remote: https://github.com/pipe-cd/examples.git` instead in the above `piped-config.yaml`.

--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -60,3 +60,5 @@ For the full list of available commands, please see the Makefile at the root of 
     ``` console
     make run/piped CONFIG_FILE=piped-config.yaml
     ```
+
+Note: If you have a problem with accessing the example repository, please follow [this guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to register the SSH key or try specifying `remote: https://github.com/pipe-cd/examples.git` instead.


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

To help troubleshooting.
The app suggestion on UI won't work if a user hasn't set up an SSH key for cloning `git@github.com:pipe-cd/examples.git`.


**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
