### PR TITLE
Allow deploy source to be nil considering the first deploy

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/common"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 )
 
@@ -543,13 +544,20 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	// ensure pass nil as running deployment source in case of the first deployment
+	// because the running deployment source is not available at this time.
+	var pRds *common.DeploymentSource
+	if rds != nil {
+		pRds = rds.ToPluginDeploySource()
+	}
+
 	// Start running executor.
 	res, err := plugin.ExecuteStage(ctx, &deployment.ExecuteStageRequest{
 		Input: &deployment.ExecutePluginInput{
 			Deployment:              s.deployment,
 			Stage:                   ps,
 			StageConfig:             stageConfig,
-			RunningDeploymentSource: rds.ToPluginDeploySource(),
+			RunningDeploymentSource: pRds,
 			TargetDeploymentSource:  tds.ToPluginDeploySource(),
 		},
 	})

--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -485,7 +485,7 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	rds := &deploysource.DeploySource{}
+	var rds *deploysource.DeploySource
 	if s.runningDSP != nil {
 		rds, err = s.runningDSP.Get(ctx, io.Discard)
 		if err != nil {

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -38,10 +38,6 @@ type DeploySource struct {
 }
 
 func (d *DeploySource) ToPluginDeploySource() *common.DeploymentSource {
-	if d == nil {
-		return nil
-	}
-
 	return &common.DeploymentSource{
 		ApplicationDirectory:      d.AppDir,
 		CommitHash:                d.Revision,

--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -38,6 +38,10 @@ type DeploySource struct {
 }
 
 func (d *DeploySource) ToPluginDeploySource() *common.DeploymentSource {
+	if d == nil {
+		return nil
+	}
+
 	return &common.DeploymentSource{
 		ApplicationDirectory:      d.AppDir,
 		CommitHash:                d.Revision,

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -307,14 +307,18 @@ func executeStage[Config, DeployTargetConfig, ApplicationConfigSpec any](
 	request *deployment.ExecuteStageRequest,
 	logger *zap.Logger,
 ) (*deployment.ExecuteStageResponse, error) {
-	runningDeploymentSource, err := newDeploymentSource[ApplicationConfigSpec](request.GetInput().GetRunningDeploymentSource())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create running deployment source: %v", err)
-	}
-
 	targetDeploymentSource, err := newDeploymentSource[ApplicationConfigSpec](request.GetInput().GetTargetDeploymentSource())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create target deployment source: %v", err)
+	}
+
+	// running deploy source is empty on the first deployment
+	runningDeploymentSource := DeploymentSource[ApplicationConfigSpec]{}
+	if request.GetInput().GetRunningDeploymentSource() != nil {
+		runningDeploymentSource, err = newDeploymentSource[ApplicationConfigSpec](request.GetInput().GetRunningDeploymentSource())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to create running deployment source: %v", err)
+		}
 	}
 
 	in := &ExecuteStageInput[ApplicationConfigSpec]{


### PR DESCRIPTION
**What this PR does**:

Fix to allow deploy target to be nil considering the first deploy.

**Why we need it**:

When I register an app with plugin-architected pipd, the first deployment fails because the SDK does not consider the running deploy source to be nil.

FYI, this is the error msg I encountered.
```
failed to handle an unary gRPC request: /grpc.plugin.deploymentapi.v1alpha1.DeploymentService/ExecuteStage{"error": "rpc error: code = Internal desc = failed to create running deployment source: failed to decode application config: unsupported version: ", "duration": 3.26620525}
github.com/pipe-cd/pipecd/pkg/rpc.WithLogUnaryInterceptor.func1.LogUnaryServerInterceptor.1
        /Users/s14218/oss/pipe-cd/pipecd/pkg/rpc/log_interceptor.go:37
github.com/pipe-cd/pipecd/pkg/rpc.(*Server).init.ChainUnaryServerInterceptors.func2.1.1
        /Users/s14218/oss/pipe-cd/pipecd/pkg/rpc/chain_interceptor.go:30
github.com/pipe-cd/pipecd/pkg/rpc.(*Server).init.ChainUnaryServerInterceptors.func2
        /Users/s14218/oss/pipe-cd/pipecd/pkg/rpc/chain_interceptor.go:37
github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment._DeploymentService_ExecuteStage_Handler
        /Users/s14218/oss/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go:260
google.golang.org/grpc.(*Server).processUnaryRPC
        /Users/s14218/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1379
google.golang.org/grpc.(*Server).handleStream
        /Users/s14218/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
        /Users/s14218/go/pkg/mod/google.golang.org/grpc@v1.64.1/server.go:1029
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
