### PR TITLE
remove temp sshKeyFile after use(#2215)

### DIFF
--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -72,8 +72,8 @@ func AddSSHConfig(cfg config.PipedGit) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(sshKeyFile.Name())
 
-	// TODO: Remove this key file when Piped terminating.
 	if _, err := sshKeyFile.Write(sshKey); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does**: remove the temporary ssh key file after using it for the config

**Why we need it**: clean up the ssh key folder

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
