### PR TITLE
Fix to be able to execute rollback stage for plugin-architectured piped

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -501,21 +501,23 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 
 	// Check whether to execute the script rollback stage or not.
 	// If the base stage is executed, the script rollback stage will be executed.
-	if ps.Rollback {
-		baseStageID := ps.Metadata["baseStageID"]
-		if baseStageID == "" {
-			return
-		}
 
-		baseStageStatus, ok := s.stageStatuses[baseStageID]
-		if !ok {
-			return
-		}
+	// TODO: move this logic into the script run plugin and remove this later.
+	// if ps.Rollback {
+	// 	baseStageID := ps.Metadata["baseStageID"]
+	// 	if baseStageID == "" {
+	// 		return
+	// 	}
 
-		if baseStageStatus == model.StageStatus_STAGE_NOT_STARTED_YET || baseStageStatus == model.StageStatus_STAGE_SKIPPED {
-			return
-		}
-	}
+	// 	baseStageStatus, ok := s.stageStatuses[baseStageID]
+	// 	if !ok {
+	// 		return
+	// 	}
+
+	// 	if baseStageStatus == model.StageStatus_STAGE_NOT_STARTED_YET || baseStageStatus == model.StageStatus_STAGE_SKIPPED {
+	// 		return
+	// 	}
+	// }
 
 	// Update stage status to RUNNING if needed.
 	if model.CanUpdateStageStatus(ps.Status, model.StageStatus_STAGE_RUNNING) {

--- a/pkg/app/pipedv1/controller/scheduler_test.go
+++ b/pkg/app/pipedv1/controller/scheduler_test.go
@@ -129,46 +129,6 @@ func TestExecuteStage(t *testing.T) {
 			expected: model.StageStatus_STAGE_SUCCESS,
 		},
 		{
-			name: "stage is rollback but base stage not started yet, should not trigger anything",
-			deployment: &model.Deployment{
-				Stages: []*model.PipelineStage{
-					{
-						Id:       "stage-rollback-id",
-						Name:     "stage-rollback-name",
-						Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
-						Rollback: true,
-						Metadata: map[string]string{
-							"baseStageId": "stage-id",
-						},
-					},
-				},
-			},
-			stageStatuses: map[string]model.StageStatus{
-				"stage-id": model.StageStatus_STAGE_NOT_STARTED_YET,
-			},
-			expected: model.StageStatus_STAGE_NOT_STARTED_YET,
-		},
-		{
-			name: "stage is rollback but base stage is skipped, should not trigger anything",
-			deployment: &model.Deployment{
-				Stages: []*model.PipelineStage{
-					{
-						Id:       "stage-rollback-id",
-						Name:     "stage-rollback-name",
-						Status:   model.StageStatus_STAGE_NOT_STARTED_YET,
-						Rollback: true,
-						Metadata: map[string]string{
-							"baseStageId": "stage-id",
-						},
-					},
-				},
-			},
-			stageStatuses: map[string]model.StageStatus{
-				"stage-id": model.StageStatus_STAGE_SKIPPED,
-			},
-			expected: model.StageStatus_STAGE_NOT_STARTED_YET,
-		},
-		{
 			name: "stage which can not be handled by the current scheduler, should be set as failed",
 			deployment: &model.Deployment{
 				Stages: []*model.PipelineStage{

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -157,6 +157,11 @@ func (d *Deployment) FindRollbackStage() (*PipelineStage, bool) {
 func (d *Deployment) FindRollbackStages() ([]*PipelineStage, bool) {
 	rollbackStages := make([]*PipelineStage, 0, len(d.Stages))
 	for i, stage := range d.Stages {
+		if d.Stages[i].GetRollback() {
+			rollbackStages = append(rollbackStages, stage)
+			continue
+		}
+
 		if d.Stages[i].Name == StageRollback.String() || d.Stages[i].Name == StageScriptRunRollback.String() {
 			rollbackStages = append(rollbackStages, stage)
 		}

--- a/pkg/model/deployment_test.go
+++ b/pkg/model/deployment_test.go
@@ -613,10 +613,12 @@ func TestFindRollbackStags(t *testing.T) {
 				{Name: StageK8sSync.String()},
 				{Name: StageRollback.String()},
 				{Name: StageScriptRunRollback.String()},
+				{Name: "CustomRollbackStage", Rollback: true},
 			},
 			wantStages: []*PipelineStage{
 				{Name: StageRollback.String()},
 				{Name: StageScriptRunRollback.String()},
+				{Name: "CustomRollbackStage", Rollback: true},
 			},
 			wantStageFound: true,
 		},


### PR DESCRIPTION
**What this PR does**:

as title.

Currently, the rollback stage doesn't work for two reasons.
1. Find rollback stages by checking only whether the stage name is `ROLLBACK` or `SCRIPT_RUN_ROLLBACK`.
2. baseStageID is used when the stage is for rollback, but it is not inserted into the metadata for plugin.

About 1, I added the new logic to check whether `stage.Rollback` is true.

About 2. Remove the logic because it is the `SCRIPT_RUN` specific spec.

**Why do we need it**:

I want to support executing rollback stage for plugin-architectured piped.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
