### PR TITLE
remove temp sshKeyFile after use(#2215)

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -175,10 +175,12 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	// Configure SSH config if needed.
 	if cfg.Git.ShouldConfigureSSHConfig() {
-		if err := git.AddSSHConfig(cfg.Git); err != nil {
+		tempFile, err := git.AddSSHConfig(cfg.Git)
+		if err != nil {
 			input.Logger.Error("failed to configure ssh-config", zap.Error(err))
 			return err
 		}
+		defer os.Remove(tempFile)
 		input.Logger.Info("successfully configured ssh-config")
 	}
 


### PR DESCRIPTION
**What this PR does**: remove the temporary ssh key file after using it for the config

**Why we need it**: clean up the ssh key folder

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
