### PR TITLE
Fix to set head commit hash on pipedv1 LivestateReporter

### DIFF
--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -193,7 +193,13 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 		return err
 	}
 
-	dsp := deploysource.NewProvider(dir, deploysource.NewLocalSourceCloner(repo, "target", "HEAD"), app.GitPath, r.secretDecrypter)
+	headCommit, err := repo.GetLatestCommit(ctx)
+	if err != nil {
+		r.logger.Error("failed to get latest commit", zap.Error(err))
+		return err
+	}
+
+	dsp := deploysource.NewProvider(dir, deploysource.NewLocalSourceCloner(repo, "target", headCommit.Hash), app.GitPath, r.secretDecrypter)
 	ds, err := dsp.Get(ctx, io.Discard)
 	if err != nil {
 		r.logger.Error("failed to get deploy source", zap.String("application-id", app.Id), zap.Error(err))


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

I want to clarify the commit hash to track which commit is used.
Always used `HEAD` as the current revision in the current implementation.
![PipeCD](https://github.com/user-attachments/assets/3fc5d96f-f15e-40ef-af69-d7fdb4b649af)

**Which issue(s) this PR fixes**:

Part of #5363

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
