### PR TITLE
Normalize resource key before grouping manifests to convert default namespace to empty

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
@@ -136,10 +136,10 @@ func DiffList(liveManifests, desiredManifests []Manifest, logger *zap.Logger, op
 func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChanges []Manifest) {
 	// Sort the manifests before comparing.
 	sort.Slice(news, func(i, j int) bool {
-		return news[i].Key().String() < news[j].Key().String()
+		return news[i].Key().normalize().String() < news[j].Key().normalize().String()
 	})
 	sort.Slice(olds, func(i, j int) bool {
-		return olds[i].Key().String() < olds[j].Key().String()
+		return olds[i].Key().normalize().String() < olds[j].Key().normalize().String()
 	})
 
 	var n, o int
@@ -147,7 +147,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 		if n >= len(news) || o >= len(olds) {
 			break
 		}
-		if news[n].Key().String() == olds[o].Key().String() {
+		if news[n].Key().normalize().String() == olds[o].Key().normalize().String() {
 			newChanges = append(newChanges, news[n])
 			oldChanges = append(oldChanges, olds[o])
 			n++
@@ -155,7 +155,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 			continue
 		}
 		// Has in news but not in olds so this should be a added one.
-		if news[n].Key().String() < olds[o].Key().String() {
+		if news[n].Key().normalize().String() < olds[o].Key().normalize().String() {
 			adds = append(adds, news[n])
 			n++
 			continue

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
@@ -136,10 +136,10 @@ func DiffList(liveManifests, desiredManifests []Manifest, logger *zap.Logger, op
 func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChanges []Manifest) {
 	// Sort the manifests before comparing.
 	sort.Slice(news, func(i, j int) bool {
-		return news[i].Key().String() < news[j].Key().String()
+		return news[i].Key().normalize().String() < news[j].Key().normalize().String()
 	})
 	sort.Slice(olds, func(i, j int) bool {
-		return olds[i].Key().String() < olds[j].Key().String()
+		return olds[i].Key().normalize().String() < olds[j].Key().normalize().String()
 	})
 
 	var n, o int
@@ -147,7 +147,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 		if n >= len(news) || o >= len(olds) {
 			break
 		}
-		if news[n].Key().String() == olds[o].Key().String() {
+		if news[n].Key().normalize().String() == olds[o].Key().normalize().String() {
 			newChanges = append(newChanges, news[n])
 			oldChanges = append(oldChanges, olds[o])
 			n++
@@ -155,7 +155,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 			continue
 		}
 		// Has in news but not in olds so this should be a added one.
-		if news[n].Key().String() < olds[o].Key().String() {
+		if news[n].Key().normalize().String() < olds[o].Key().normalize().String() {
 			adds = append(adds, news[n])
 			n++
 			continue


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

When no namespace is set for resources in the `app.pipecd.yaml` or actual resource manifests, there is the diffs like below.

![PipeCD](https://github.com/user-attachments/assets/caf97ceb-5b18-4be0-afcf-269c5cad45ac)


When loading manifests from git, set an empty string as the namespace if no namespace is set.
But when loading manifests from actual clusters, the value `default` is set as the namespace.

So we need to normalize the namespace before comparing the manifests from git and the ones from the actual cluster.
Especially set empty value considering the case when no namespace is set in the manifests from git repo.

**Which issue(s) this PR fixes**:

Part of #5006 #5764 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
