### PR TITLE
Fixed to add annotations after calling loader.LoadManifests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -114,6 +114,25 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 		return nil, err
 	}
 
+	// Add builtin labels and annotations for tracking application live state.
+	for i := range manifests {
+		manifests[i].AddLabels(map[string]string{
+			provider.LabelManagedBy:   provider.ManagedByPiped,
+			provider.LabelPiped:       deploy.PipedID,
+			provider.LabelApplication: deploy.ApplicationID,
+			provider.LabelCommitHash:  deploymentSource.CommitHash,
+		})
+
+		manifests[i].AddAnnotations(map[string]string{
+			provider.LabelManagedBy:          provider.ManagedByPiped,
+			provider.LabelPiped:              deploy.PipedID,
+			provider.LabelApplication:        deploy.ApplicationID,
+			provider.LabelOriginalAPIVersion: manifests[i].APIVersion(),
+			provider.LabelResourceKey:        manifests[i].Key().String(),
+			provider.LabelCommitHash:         deploymentSource.CommitHash,
+		})
+	}
+
 	return manifests, nil
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
@@ -91,23 +91,6 @@ func (l *Loader) LoadManifests(ctx context.Context, input LoaderInput) (manifest
 			if input.Namespace != "" {
 				manifests[i].body.SetNamespace(input.Namespace)
 			}
-
-			// Add builtin labels and annotations for tracking application live state.
-			manifests[i].AddLabels(map[string]string{
-				LabelManagedBy:   ManagedByPiped,
-				LabelPiped:       input.PipedID,
-				LabelApplication: input.AppID,
-				LabelCommitHash:  input.CommitHash,
-			})
-
-			manifests[i].AddAnnotations(map[string]string{
-				LabelManagedBy:          ManagedByPiped,
-				LabelPiped:              input.PipedID,
-				LabelApplication:        input.AppID,
-				LabelOriginalAPIVersion: manifests[i].body.GetAPIVersion(),
-				LabelResourceKey:        manifests[i].Key().String(),
-				LabelCommitHash:         input.CommitHash,
-			})
 		}
 
 		sortManifests(manifests)

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
@@ -65,6 +65,10 @@ func (m Manifest) Kind() string {
 	return m.body.GetKind()
 }
 
+func (m Manifest) APIVersion() string {
+	return m.body.GetAPIVersion()
+}
+
 func (m Manifest) Name() string {
 	return m.body.GetName()
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
@@ -98,6 +98,25 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 		return nil, err
 	}
 
+	// Add builtin labels and annotations for tracking application live state.
+	for i := range manifests {
+		manifests[i].AddLabels(map[string]string{
+			provider.LabelManagedBy:   provider.ManagedByPiped,
+			provider.LabelPiped:       deploy.PipedID,
+			provider.LabelApplication: deploy.ApplicationID,
+			provider.LabelCommitHash:  deploymentSource.CommitHash,
+		})
+
+		manifests[i].AddAnnotations(map[string]string{
+			provider.LabelManagedBy:          provider.ManagedByPiped,
+			provider.LabelPiped:              deploy.PipedID,
+			provider.LabelApplication:        deploy.ApplicationID,
+			provider.LabelOriginalAPIVersion: manifests[i].APIVersion(),
+			provider.LabelResourceKey:        manifests[i].Key().String(),
+			provider.LabelCommitHash:         deploymentSource.CommitHash,
+		})
+	}
+
 	return manifests, nil
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader.go
@@ -91,23 +91,6 @@ func (l *Loader) LoadManifests(ctx context.Context, input LoaderInput) (manifest
 			if input.Namespace != "" {
 				manifests[i].body.SetNamespace(input.Namespace)
 			}
-
-			// Add builtin labels and annotations for tracking application live state.
-			manifests[i].AddLabels(map[string]string{
-				LabelManagedBy:   ManagedByPiped,
-				LabelPiped:       input.PipedID,
-				LabelApplication: input.AppID,
-				LabelCommitHash:  input.CommitHash,
-			})
-
-			manifests[i].AddAnnotations(map[string]string{
-				LabelManagedBy:          ManagedByPiped,
-				LabelPiped:              input.PipedID,
-				LabelApplication:        input.AppID,
-				LabelOriginalAPIVersion: manifests[i].body.GetAPIVersion(),
-				LabelResourceKey:        manifests[i].Key().String(),
-				LabelCommitHash:         input.CommitHash,
-			})
 		}
 
 		sortManifests(manifests)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
@@ -65,6 +65,10 @@ func (m Manifest) Kind() string {
 	return m.body.GetKind()
 }
 
+func (m Manifest) APIVersion() string {
+	return m.body.GetAPIVersion()
+}
+
 func (m Manifest) Name() string {
 	return m.body.GetName()
 }


### PR DESCRIPTION
**What this PR does**:

Move the logic to add the annotation logic into the plugin side.

**Why we need it**:

When creating the commit, the fixes are not related to the target app, there is a diff for `pipecd.dev/commit-hash`.
The current logic detects diffs that are defined in the git repo but do not exist in the actual resource.

So, IMO, we shouldn't include them when loading manifests from the git repo because these annotations are set automatically before applying resources on the piped side.


![PipeCD](https://github.com/user-attachments/assets/bc030ae7-7c86-4d1b-a8af-7dec6052b4eb)

**Which issue(s) this PR fixes**:
Part of #5006 #5764 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
