### PR TITLE
Implement livestate for k8s multicluster plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -31,82 +31,145 @@ import (
 
 type Plugin struct{}
 
-// GetLivestate implements sdk.LivestatePlugin.
 func (p Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.GetLivestateResponse, error) {
-	if len(deployTargets) != 1 {
-		return nil, fmt.Errorf("only 1 deploy target is allowed but got %d", len(deployTargets))
-	}
-
-	deployTarget := deployTargets[0]
-	deployTargetConfig := deployTarget.Config
-
 	cfg, err := input.Request.DeploymentSource.AppConfig()
 	if err != nil {
 		input.Logger.Error("Failed to load application config", zap.Error(err))
 		return nil, err
 	}
 
+	logger := input.Logger
+
+	type targetConfig struct {
+		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
+		multiTarget  *kubeconfig.KubernetesMultiTarget
+	}
+
+	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], 0)
+	targetConfigs := make([]targetConfig, 0, len(deployTargets))
+
+	// prevent the deployment when its deployTarget is not found in the piped config
+	for _, target := range deployTargets {
+		deployTargetMap[target.Name] = target
+	}
+
+	// If no multi-targets are specified, sync to all deploy targets.
+	if len(cfg.Spec.Input.MultiTargets) == 0 {
+		for _, dt := range deployTargets {
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  nil,
+			})
+		}
+	} else {
+		// Sync to the specified multi-targets.
+		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
+			dt, ok := deployTargetMap[multiTarget.Target.Name]
+			if !ok {
+				logger.Info("Ignore multi target '%s': not matched any deployTarget", zap.String("multiTargetName", multiTarget.Target.Name))
+				continue
+			}
+
+			targetConfigs = append(targetConfigs, targetConfig{
+				deployTarget: dt,
+				multiTarget:  &multiTarget,
+			})
+		}
+	}
+
 	// TODO: find the way to hold the tool registry and loader in the plugin.
 	// Currently, we create them every time the stage is executed beucause we can't pass input.Client.toolRegistry to the plugin when starting the plugin.
 	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
 
-	// Get the kubectl tool path.
-	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(cfg.Spec.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
-	if err != nil {
-		input.Logger.Error("Failed to get kubectl tool", zap.Error(err))
-		return nil, err
+	liveStates := make([]sdk.ApplicationLiveState, 0, len(targetConfigs))
+	syncStates := make([]sdk.ApplicationSyncState, 0, len(targetConfigs))
+	for _, tc := range targetConfigs {
+		// Get the kubectl tool path.
+		kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(cfg.Spec.Input.KubectlVersion, tc.deployTarget.Config.KubectlVersion))
+		if err != nil {
+			input.Logger.Error("Failed to get kubectl tool", zap.Error(err))
+			return nil, err
+		}
+
+		// Create the kubectl wrapper for the target cluster.
+		kubectl := provider.NewKubectl(kubectlPath)
+
+		// TODO: We need to implement including/excluding resources.
+		// ref; https://pipecd.dev/docs-v0.50.x/user-guide/managing-piped/configuration-reference/#kubernetesappstateinformer
+		namespacedLiveResources, clusterScopedLiveResources, err := provider.GetLiveResources(ctx, kubectl, tc.deployTarget.Config.KubeConfigPath, input.Request.ApplicationID)
+		if err != nil {
+			input.Logger.Error("Failed to get live resources", zap.Error(err))
+			return nil, err
+		}
+
+		liveState := p.makeAppLivestate(namespacedLiveResources, clusterScopedLiveResources, tc.deployTarget)
+		liveStates = append(liveStates, liveState)
+
+		liveManifests := make([]provider.Manifest, 0, len(namespacedLiveResources)+len(clusterScopedLiveResources))
+		liveManifests = append(liveManifests, namespacedLiveResources...)
+		liveManifests = append(liveManifests, clusterScopedLiveResources...)
+
+		manifests, err := p.loadManifests(ctx, input, cfg.Spec, provider.NewLoader(toolRegistry), tc.multiTarget)
+		if err != nil {
+			input.Logger.Error("Failed to load manifests", zap.Error(err))
+			return nil, err
+		}
+
+		syncState, err := p.makeAppSyncState(liveManifests, manifests, tc.deployTarget, input.Request.DeploymentSource.CommitHash, logger)
+		if err != nil {
+			input.Logger.Error("Failed to make app sync state", zap.Error(err), zap.String("deployTarget", tc.deployTarget.Name))
+			return nil, err
+		}
+		syncStates = append(syncStates, syncState)
 	}
 
-	// Create the kubectl wrapper for the target cluster.
-	kubectl := provider.NewKubectl(kubectlPath)
-
-	// TODO: We need to implement including/excluding resources.
-	// ref; https://pipecd.dev/docs-v0.50.x/user-guide/managing-piped/configuration-reference/#kubernetesappstateinformer
-	namespacedLiveResources, clusterScopedLiveResources, err := provider.GetLiveResources(ctx, kubectl, deployTargetConfig.KubeConfigPath, input.Request.ApplicationID)
-	if err != nil {
-		input.Logger.Error("Failed to get live resources", zap.Error(err))
-		return nil, err
+	appLiveState := sdk.ApplicationLiveState{}
+	for _, ls := range liveStates {
+		appLiveState.Resources = append(appLiveState.Resources, ls.Resources...)
+		appLiveState.HealthStatus = sdk.ApplicationHealthStateUnknown // TODO: Implement health status calculation
 	}
 
+	appSyncState := sdk.ApplicationSyncState{}
+	for _, ss := range syncStates {
+		appSyncState.Reason = fmt.Sprintf("%s\n", ss.Reason)
+		appSyncState.ShortReason = fmt.Sprintf("%s\n", ss.ShortReason)
+		appSyncState.Status = sdk.ApplicationSyncStateUnknown // TODO: Implement health status calculation
+	}
+
+	return &sdk.GetLivestateResponse{
+		LiveState: appLiveState,
+		SyncState: appSyncState,
+	}, nil
+}
+
+func (p Plugin) makeAppLivestate(namespacedLiveResources, clusterScopedLiveResources []provider.Manifest, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.ApplicationLiveState {
 	resourceStates := make([]sdk.ResourceState, 0, len(namespacedLiveResources)+len(clusterScopedLiveResources))
 	for _, m := range namespacedLiveResources {
-		resourceStates = append(resourceStates, m.ToResourceState(deployTarget.Name))
+		resourceStates = append(resourceStates, m.ToResourceState(dt.Name))
 	}
 	for _, m := range clusterScopedLiveResources {
-		resourceStates = append(resourceStates, m.ToResourceState(deployTarget.Name))
+		resourceStates = append(resourceStates, m.ToResourceState(dt.Name))
 	}
 
-	manifests, err := p.loadManifests(ctx, input, cfg.Spec, provider.NewLoader(toolRegistry))
-	if err != nil {
-		input.Logger.Error("Failed to load manifests", zap.Error(err))
-		return nil, err
+	return sdk.ApplicationLiveState{
+		Resources:    resourceStates,
+		HealthStatus: sdk.ApplicationHealthStateUnknown, // TODO: Implement health status calculation
 	}
+}
 
-	liveManifests := make([]provider.Manifest, 0, len(namespacedLiveResources)+len(clusterScopedLiveResources))
-	liveManifests = append(liveManifests, namespacedLiveResources...)
-	liveManifests = append(liveManifests, clusterScopedLiveResources...)
-
+func (p Plugin) makeAppSyncState(liveManifests, gitManifests []provider.Manifest, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], commit string, logger *zap.Logger) (sdk.ApplicationSyncState, error) {
 	// Calculate SyncState by comparing live manifests with desired manifests
 	// TODO: Implement drift detection ignore configs
-	diffResult, err := provider.DiffList(liveManifests, manifests, input.Logger,
+	diffResult, err := provider.DiffList(liveManifests, gitManifests, logger,
 		diff.WithEquateEmpty(),
 		diff.WithIgnoreAddingMapKeys(),
 		diff.WithCompareNumberAndNumericString(),
 	)
 	if err != nil {
-		input.Logger.Error("Failed to calculate diff", zap.Error(err))
-		return nil, err
+		return sdk.ApplicationSyncState{}, err
 	}
 
-	syncState := calculateSyncState(diffResult, input.Request.DeploymentSource.CommitHash)
-
-	return &sdk.GetLivestateResponse{
-		LiveState: sdk.ApplicationLiveState{
-			Resources:    resourceStates,
-			HealthStatus: sdk.ApplicationHealthStateUnknown, // TODO: Implement health status calculation
-		},
-		SyncState: syncState,
-	}, nil
+	return calculateSyncState(diffResult, commit), nil
 }
 
 func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.ApplicationSyncState {
@@ -131,7 +194,7 @@ func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual state in cluster:\n\n", commit))
+	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual state in cluster: %s\n\n", commit, dt.Name))
 	b.WriteString("--- Actual   (LiveState)\n+++ Expected (Git)\n\n")
 
 	details := diffResult.Render(provider.DiffRenderOptions{
@@ -154,7 +217,15 @@ type loader interface {
 }
 
 // TODO: share this implementation with the deployment plugin
-func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec], spec *kubeconfig.KubernetesApplicationSpec, loader loader) ([]provider.Manifest, error) {
+func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec], spec *kubeconfig.KubernetesApplicationSpec, loader loader, multiTarget *kubeconfig.KubernetesMultiTarget) ([]provider.Manifest, error) {
+	// override values if multiTarget has value.
+	manifestPathes := spec.Input.Manifests
+	if multiTarget != nil {
+		if len(multiTarget.Manifests) > 0 {
+			manifestPathes = multiTarget.Manifests
+		}
+	}
+
 	manifests, err := loader.LoadManifests(ctx, provider.LoaderInput{
 		PipedID:          input.Request.PipedID,
 		AppID:            input.Request.ApplicationID,
@@ -162,7 +233,7 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 		AppName:          input.Request.ApplicationName,
 		AppDir:           input.Request.DeploymentSource.ApplicationDirectory,
 		ConfigFilename:   input.Request.DeploymentSource.ApplicationConfigFilename,
-		Manifests:        spec.Input.Manifests,
+		Manifests:        manifestPathes,
 		Namespace:        spec.Input.Namespace,
 		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -131,9 +131,9 @@ func (p Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, deployTarge
 
 	appSyncState := sdk.ApplicationSyncState{}
 	for _, ss := range syncStates {
-		appSyncState.Reason = fmt.Sprintf("%s\n", ss.Reason)
-		appSyncState.ShortReason = fmt.Sprintf("%s\n", ss.ShortReason)
-		appSyncState.Status = sdk.ApplicationSyncStateUnknown // TODO: Implement health status calculation
+		appSyncState.Reason = fmt.Sprintf("%s\n%s", appSyncState.Reason, ss.Reason)
+		appSyncState.ShortReason = fmt.Sprintf("%s\n%s", appSyncState.ShortReason, ss.ShortReason)
+		appSyncState.Status = sdk.ApplicationSyncStateOutOfSync // TODO: Implement health status calculation
 	}
 
 	return &sdk.GetLivestateResponse{
@@ -169,10 +169,10 @@ func (p Plugin) makeAppSyncState(liveManifests, gitManifests []provider.Manifest
 		return sdk.ApplicationSyncState{}, err
 	}
 
-	return calculateSyncState(diffResult, commit), nil
+	return calculateSyncState(diffResult, commit, dt), nil
 }
 
-func calculateSyncState(diffResult *provider.DiffListResult, commit string) sdk.ApplicationSyncState {
+func calculateSyncState(diffResult *provider.DiffListResult, commit string, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.ApplicationSyncState {
 	if diffResult.NoChanges() {
 		return sdk.ApplicationSyncState{
 			Status:      sdk.ApplicationSyncStateSynced,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider"
 	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
@@ -69,10 +70,11 @@ func TestCalculateSyncState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		diffResult *provider.DiffListResult
-		commitHash string
-		want       sdk.ApplicationSyncState
+		name         string
+		diffResult   *provider.DiffListResult
+		commitHash   string
+		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
+		want         sdk.ApplicationSyncState
 	}{
 		{
 			name: "all resources are in sync",
@@ -82,6 +84,9 @@ func TestCalculateSyncState(t *testing.T) {
 				Changes: []provider.DiffListChange{},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateSynced,
 				ShortReason: "",
@@ -134,10 +139,13 @@ spec:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 1 manifests not synced (0 adds, 0 deletes, 1 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -230,10 +238,13 @@ spec:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 2 manifests not synced (0 adds, 0 deletes, 2 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -307,10 +318,13 @@ spec:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 2 manifests not synced (1 adds, 1 deletes, 0 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -346,10 +360,13 @@ data:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 1 manifests not synced (0 adds, 0 deletes, 1 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -391,10 +408,13 @@ data:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 1 manifests not synced (0 adds, 0 deletes, 1 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -489,10 +509,13 @@ data:
 				},
 			},
 			commitHash: "1234567",
+			deployTarget: &sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]{
+				Name: "cluster1",
+			},
 			want: sdk.ApplicationSyncState{
 				Status:      sdk.ApplicationSyncStateOutOfSync,
 				ShortReason: "There are 4 manifests not synced (0 adds, 0 deletes, 4 changes)",
-				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster:
+				Reason: `Diff between the defined state in Git at commit 1234567 and actual state in cluster: cluster1
 
 --- Actual   (LiveState)
 +++ Expected (Git)
@@ -531,7 +554,7 @@ data:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := calculateSyncState(tt.diffResult, tt.commitHash)
+			got := calculateSyncState(tt.diffResult, tt.commitHash, tt.deployTarget)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	plugin, err := sdk.NewPlugin(
-		"kubernetes", "0.0.1",
+		"kubernetes_multicluster", "0.0.1",
 		sdk.WithDeploymentPlugin(&deployment.Plugin{}),
 		sdk.WithLivestatePlugin(&livestate.Plugin{}),
 	)


### PR DESCRIPTION
**What this PR does**:

as title. This is a PoC.

<img width="1720" alt="PipeCD" src="https://github.com/user-attachments/assets/a210a584-bda5-488c-87e4-a1c36dbf1ec4" />

**Spec summary**

- Show each diff in one UI
- Show each resource state with a tab

**TODOs**
- decide synstate from multiple sync state
- decide resource state from multiple resource state

**Why we need it**:

We want to support livestate feature for multi cluster plugin.

**Which issue(s) this PR fixes**:

Part of #5006

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
