### PR TITLE
Add support for OCI registry to push/pull plugins

### DIFF
--- a/cmd/pipectl/main.go
+++ b/cmd/pipectl/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/migrate"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/piped"
 	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/planpreview"
+	"github.com/pipe-cd/pipecd/pkg/app/pipectl/cmd/plugin"
 	"github.com/pipe-cd/pipecd/pkg/cli"
 )
 
@@ -43,6 +44,7 @@ func main() {
 		encrypt.NewCommand(),
 		initialize.NewCommand(),
 		migrate.NewCommand(),
+		plugin.NewCommand(),
 	)
 
 	if err := app.Run(); err != nil {

--- a/pkg/app/pipectl/cmd/plugin/plugin.go
+++ b/pkg/app/pipectl/cmd/plugin/plugin.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type command struct{}
+
+func NewCommand() *cobra.Command {
+	c := &command{}
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Do plugin tasks.",
+	}
+
+	cmd.AddCommand(
+		newPushCommand(c),
+	)
+
+	return cmd
+}

--- a/pkg/app/pipectl/cmd/plugin/push.go
+++ b/pkg/app/pipectl/cmd/plugin/push.go
@@ -71,6 +71,8 @@ func (p *push) run(ctx context.Context, input cli.Input) error {
 
 	targetURL := fmt.Sprintf("oci://%s/%s:%s", p.registry, p.repository, p.tag)
 
+	input.Logger.Info("pushing plugin to the server", zap.String("target", targetURL), zap.Strings("files", p.files))
+
 	opts := make([]oci.PushOption, 0, 1)
 	if p.insecure {
 		opts = append(opts, oci.WithInsecure())
@@ -81,8 +83,6 @@ func (p *push) run(ctx context.Context, input cli.Input) error {
 		input.Logger.Error("failed to parse file paths", zap.Error(err))
 		return err
 	}
-
-	input.Logger.Info("pushing plugin to the server", zap.String("target", targetURL), zap.Any("files", files))
 
 	artifact := &oci.Artifact{
 		MediaType:    oci.MediaTypePipedPlugin,

--- a/pkg/app/pipectl/cmd/plugin/push.go
+++ b/pkg/app/pipectl/cmd/plugin/push.go
@@ -1,0 +1,135 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/cli"
+	"github.com/pipe-cd/pipecd/pkg/oci"
+)
+
+type push struct {
+	root *command
+
+	files      []string
+	tag        string
+	insecure   bool
+	registry   string
+	repository string
+}
+
+func newPushCommand(root *command) *cobra.Command {
+	p := &push{
+		root: root,
+	}
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "Push a plugin to the server.",
+		RunE:  cli.WithContext(p.run),
+	}
+
+	cmd.Flags().StringSliceVar(&p.files, "files", p.files, "The list of files to push. For example, 'linux/amd64=file1,linux/arm64=file2'")
+	cmd.Flags().StringVar(&p.tag, "tag", p.tag, "The tag of the plugin.")
+	cmd.Flags().BoolVar(&p.insecure, "insecure", p.insecure, "If true, the plugin will be pushed to the server without TLS verification.")
+	cmd.Flags().StringVar(&p.registry, "registry", p.registry, "The registry of the plugin.")
+	cmd.Flags().StringVar(&p.repository, "repository", p.repository, "The repository of the plugin.")
+
+	cmd.MarkFlagRequired("files")
+	cmd.MarkFlagRequired("tag")
+	cmd.MarkFlagRequired("registry")
+	cmd.MarkFlagRequired("repository")
+
+	return cmd
+}
+
+func (p *push) run(ctx context.Context, input cli.Input) error {
+	workdir, err := os.MkdirTemp("", "pipectl-plugin-push")
+	if err != nil {
+		input.Logger.Error("failed to create temp directory", zap.Error(err))
+		return err
+	}
+	defer os.RemoveAll(workdir)
+
+	targetURL := fmt.Sprintf("%s/%s:%s", p.registry, p.repository, p.tag)
+
+	opts := make([]oci.PushOption, 0, 1)
+	if p.insecure {
+		opts = append(opts, oci.WithInsecure())
+	}
+
+	files, err := p.parseFilePaths(p.files)
+	if err != nil {
+		input.Logger.Error("failed to parse file paths", zap.Error(err))
+		return err
+	}
+
+	input.Logger.Info("pushing plugin to the server", zap.String("target", targetURL), zap.Any("files", files))
+
+	artifact := &oci.Artifact{
+		MediaType:    oci.MediaTypePipedPlugin,
+		ArtifactType: oci.ArtifactTypePipedPlugin,
+		FilePaths:    files,
+	}
+
+	if err := oci.PushFilesToRegistry(ctx, workdir, artifact, targetURL, opts...); err != nil {
+		input.Logger.Error("failed to push plugin to the server", zap.Error(err))
+		return err
+	}
+
+	input.Logger.Info("successfully pushed plugin to the server", zap.String("target", targetURL))
+
+	return nil
+}
+
+func (p *push) parseFilePaths(fps []string) (map[oci.Platform]string, error) {
+	files := make(map[oci.Platform]string, len(fps))
+	for _, fp := range fps {
+		platform, path, ok := strings.Cut(fp, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid file format: %s", fp)
+		}
+
+		p, err := p.parsePlatform(platform)
+		if err != nil {
+			return nil, fmt.Errorf("invalid platform format: %s", platform)
+		}
+
+		files[p] = path
+	}
+
+	return files, nil
+}
+
+func (p *push) parsePlatform(platform string) (oci.Platform, error) {
+	parts := strings.Split(platform, "/")
+	if len(parts) < 2 {
+		return oci.Platform{}, fmt.Errorf("invalid platform format: %s", platform)
+	}
+	if len(parts) > 2 {
+		return oci.Platform{}, fmt.Errorf("current implementation only supports OS/Arch format and does not support variant: %s", platform)
+	}
+
+	return oci.Platform{
+		OS:   parts[0],
+		Arch: parts[1],
+	}, nil
+}

--- a/pkg/app/pipectl/cmd/plugin/push.go
+++ b/pkg/app/pipectl/cmd/plugin/push.go
@@ -69,7 +69,7 @@ func (p *push) run(ctx context.Context, input cli.Input) error {
 	}
 	defer os.RemoveAll(workdir)
 
-	targetURL := fmt.Sprintf("%s/%s:%s", p.registry, p.repository, p.tag)
+	targetURL := fmt.Sprintf("oci://%s/%s:%s", p.registry, p.repository, p.tag)
 
 	opts := make([]oci.PushOption, 0, 1)
 	if p.insecure {

--- a/pkg/app/pipectl/cmd/plugin/push_test.go
+++ b/pkg/app/pipectl/cmd/plugin/push_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipecd/pkg/oci"
+)
+
+func TestPush_parseFilePaths(t *testing.T) {
+	t.Parallel()
+
+	p := &push{}
+	tests := []struct {
+		name    string
+		input   []string
+		want    map[oci.Platform]string
+		wantErr bool
+	}{
+		{
+			name:  "single valid entry",
+			input: []string{"linux/amd64=/path/to/file1"},
+			want: map[oci.Platform]string{
+				{OS: "linux", Arch: "amd64"}: "/path/to/file1",
+			},
+			wantErr: false,
+		},
+		{
+			name:  "multiple valid entries",
+			input: []string{"linux/amd64=/path/to/file1", "linux/arm64=/path/to/file2"},
+			want: map[oci.Platform]string{
+				{OS: "linux", Arch: "amd64"}: "/path/to/file1",
+				{OS: "linux", Arch: "arm64"}: "/path/to/file2",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid format (missing =)",
+			input:   []string{"linux/amd64:/path/to/file1"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid platform (missing arch)",
+			input:   []string{"linux=/path/to/file1"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid platform (extra part)",
+			input:   []string{"linux/amd64/extra=/path/to/file1"},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := p.parseFilePaths(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/app/pipectl/cmd/plugin/push_test.go
+++ b/pkg/app/pipectl/cmd/plugin/push_test.go
@@ -83,3 +83,54 @@ func TestPush_parseFilePaths(t *testing.T) {
 		})
 	}
 }
+
+func TestPush_parsePlatform(t *testing.T) {
+	t.Parallel()
+
+	p := &push{}
+	tests := []struct {
+		name    string
+		input   string
+		want    oci.Platform
+		wantErr bool
+	}{
+		{
+			name:    "valid linux/amd64",
+			input:   "linux/amd64",
+			want:    oci.Platform{OS: "linux", Arch: "amd64"},
+			wantErr: false,
+		},
+		{
+			name:    "valid darwin/arm64",
+			input:   "darwin/arm64",
+			want:    oci.Platform{OS: "darwin", Arch: "arm64"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid (missing arch)",
+			input:   "linux",
+			want:    oci.Platform{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid (extra part)",
+			input:   "linux/amd64/extra",
+			want:    oci.Platform{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := p.parsePlatform(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -1155,8 +1155,8 @@ func (p *PipedPlugin) Validate() error {
 	if err != nil {
 		return fmt.Errorf("invalid plugin url: %w", err)
 	}
-	if u.Scheme != "file" && u.Scheme != "https" {
-		return errors.New("only file and https schemes are supported")
+	if u.Scheme != "file" && u.Scheme != "https" && u.Scheme != "oci" {
+		return errors.New("only file, https and oci schemes are supported")
 	}
 	return nil
 }

--- a/pkg/oci/options.go
+++ b/pkg/oci/options.go
@@ -17,6 +17,8 @@ package oci
 const (
 	// MediaTypePipedPlugin is the media type for PipeCD Agent plugins.
 	MediaTypePipedPlugin = "application/vnd.pipecd.piped.plugin"
+	// ArtifactTypePipedPlugin is the artifact type for PipeCD Agent plugins.
+	ArtifactTypePipedPlugin = "application/vnd.pipecd.piped.plugin+type"
 )
 
 // PushOptions holds options for pushing to an OCI registry.

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -121,6 +121,11 @@ func pushFile(ctx context.Context, workDir string, repo *remote.Repository, path
 		return ocispec.Descriptor{}, fmt.Errorf("could not create file system: %w", err)
 	}
 
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("could not get absolute path: %w", err)
+	}
+
 	desc, err := fs.Add(ctx, filepath.Base(path), mediaType, path)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("could not add file to file system: %w", err)


### PR DESCRIPTION
**What this PR does**:

- add `pipectl plugin push` command to push plugin binary to OCI Registry
    - The auth feature has not been implemented yet
- add `oci` as an allowed scheme to download a plugin

We can use the `pipectl plugin push` as the command below
```sh
$ docker run -d --rm -p 5001:5000 --name registry registry
$ pipectl plugin push --tag=latest --registry=localhost:5001 --repository=piped-kubernetes --files=darwin/arm64=./.artifacts/plugins/kubernetes --insecure
$ pipectl plugin push --tag=latest --registry=localhost:5001 --repository=piped-wait --files=darwin/arm64=./.artifacts/plugins/wait --insecure
```

And we can pull the plugins from OCI Registry with the config below.
```yaml
apiVersion: pipecd.dev/v1beta1
kind: Piped
spec:
  projectID: ***
  pipedID: ***
  pipedKeyData: ***
  apiAddress: ***
  git: ***
  repositories: ***
  plugins:
    - name: kubernetes
      port: 7001
      url: oci://localhost:5001/piped-kubernetes:latest
      deployTargets:
        - name: local-k8s
          config:
            kubeConfigPath: ***
    - name: wait
      port: 7002
      url: oci://localhost:5001/piped-wait:latest
```

Before trying the config above, we have to patch the below lines to include the option `oci.WithInsecure()` because the local registry hosts the HTTP protocol, not the HTTPS protocol.
https://github.com/pipe-cd/pipecd/blob/9cc23559616e0b5995272739f895c4e9b2b4aafe/pkg/lifecycle/binary.go#L152-L159

**Why we need it**:

We want to support OCI Registry in hosting a piped plugin.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
