### PR TITLE
Fix deployment tracing loading nonStop when loadmore

### DIFF
--- a/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
+++ b/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
@@ -41,7 +41,10 @@ const useGroupedDeploymentTrace = (): GroupedDeploymentTrace => {
   }, [traceList]);
 
   const dates = useMemo(
-    () => Object.keys(deploymentTracesMap).sort(sortDateFunc),
+    () =>
+      Object.keys(deploymentTracesMap).sort((a, b) =>
+        sortDateFunc(a, b, "DESC")
+      ),
     [deploymentTracesMap]
   );
 

--- a/web/src/modules/deploymentTrace/index.ts
+++ b/web/src/modules/deploymentTrace/index.ts
@@ -82,13 +82,13 @@ export const fetchMoreDeploymentTraces = createAsyncThunk<
   DeploymentTraceFilterOptions,
   { state: AppState }
 >("deploymentTrace/fetchMoreList", async (options, thunkAPI) => {
-  const { deployments } = thunkAPI.getState();
+  const { deploymentTrace } = thunkAPI.getState();
 
   const response = await deploymentTracesApi.getDeploymentTraces({
     options: convertFilterOptions(options),
     pageSize: FETCH_MORE_ITEMS_PER_PAGE,
-    cursor: deployments.cursor,
-    pageMinUpdatedAt: deployments.minUpdatedAt,
+    cursor: deploymentTrace.cursor,
+    pageMinUpdatedAt: deploymentTrace.minUpdatedAt,
   });
 
   return response;


### PR DESCRIPTION
**What this PR does**:

- Fix wrong place for saving minUpdatedAt of deploymentTraces in redux store.
- Reverse sort traces date to show Date in Desc order. 
   <img src="https://github.com/user-attachments/assets/70cee4b5-bcb1-42cb-ae88-d6693de09448" width="800px" height="600px" alt="CleanShot 2025-04-26 at 01 47 27"/>


**Why we need it**:

- In page Traces, when we scroll down to load more. Api fetch more traces is run non-stop due to wrong saving minUpdatedAt in redux store.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
