### PR TITLE
Change the order of commit in Traces UI by time DESC

### DIFF
--- a/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
+++ b/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
@@ -43,9 +43,9 @@ const useGroupedDeploymentTrace = (): GroupedDeploymentTrace => {
   const dates = useMemo(
     () =>
       Object.keys(deploymentTracesMap).sort((a, b) =>
-        sortDateFunc(a, b, "DESC"),
+        sortDateFunc(a, b, "DESC")
       ),
-    [deploymentTracesMap],
+    [deploymentTracesMap]
   );
 
   return { dates, deploymentTracesMap };

--- a/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
+++ b/web/src/components/deployment-trace-page/useGroupedDeploymentTrace.tsx
@@ -41,8 +41,11 @@ const useGroupedDeploymentTrace = (): GroupedDeploymentTrace => {
   }, [traceList]);
 
   const dates = useMemo(
-    () => Object.keys(deploymentTracesMap).sort(sortDateFunc),
-    [deploymentTracesMap]
+    () =>
+      Object.keys(deploymentTracesMap).sort((a, b) =>
+        sortDateFunc(a, b, "DESC"),
+      ),
+    [deploymentTracesMap],
   );
 
   return { dates, deploymentTracesMap };


### PR DESCRIPTION
**What this PR does**:

- Change the order of the commits on the `Traces` tab on PipeCD console to DESC

**Why we need it**:

- The newest commit should go first for easily tracing

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:


- **How are users affected by this change**: The order of tracing commit will be reverted.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
