### PR TITLE
Fix some Staticcheck (qf) errors

### DIFF
--- a/pkg/app/pipectl/cmd/initialize/ecs.go
+++ b/pkg/app/pipectl/cmd/initialize/ecs.go
@@ -34,9 +34,9 @@ type genericECSApplicationSpec struct {
 func generateECSConfig(p prompt.Prompt) (*genericConfig, error) {
 	// inputs
 	var (
-		appName        string = "<YOUR_APPLICATION_NAME>"
-		serviceDefFile string = "<YOUR_SERVICE_DEFINITION_FILE>"
-		taskDefFile    string = "<YOUR_TASK_DEFINITION_FILE>"
+		appName        = "<YOUR_APPLICATION_NAME>"
+		serviceDefFile = "<YOUR_SERVICE_DEFINITION_FILE>"
+		taskDefFile    = "<YOUR_TASK_DEFINITION_FILE>"
 
 		deploymentStrategy string = "0" // QuickSync by default
 	)
@@ -144,7 +144,7 @@ func inputECSCanary(p *prompt.Prompt) (*config.ECSDeploymentInput, *genericDeplo
 
 	// pipeline configs
 	var (
-		canaryTrafficPercent int = 10
+		canaryTrafficPercent = 10
 	)
 	inputs := []prompt.Input{
 		{
@@ -275,7 +275,7 @@ func inputECSTargetGroup(p *prompt.Prompt, annotation string) (*config.ECSTarget
 	var (
 		targetGroupArn string = "<YOUR_TARGET_GROUP_ARN>"
 		containerName  string = "<YOUR_CONTAINER_NAME>"
-		containerPort  int    = 80
+		containerPort         = 80
 	)
 
 	inputs := []prompt.Input{

--- a/pkg/app/piped/executor/scriptrun/scriptrun.go
+++ b/pkg/app/piped/executor/scriptrun/scriptrun.go
@@ -40,7 +40,7 @@ type Executor struct {
 func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	e.LogPersister.Infof("Start executing the script run stage")
 
-	opts := e.Input.StageConfig.ScriptRunStageOptions
+	opts := e.StageConfig.ScriptRunStageOptions
 	if opts == nil {
 		e.LogPersister.Error("option for script run stage not found")
 		return model.StageStatus_STAGE_FAILURE

--- a/pkg/app/piped/platformprovider/kubernetes/diff.go
+++ b/pkg/app/piped/platformprovider/kubernetes/diff.go
@@ -273,10 +273,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 	})
 
 	var n, o int
-	for {
-		if n >= len(news) || o >= len(olds) {
-			break
-		}
+	for n < len(news) && o < len(olds) {
 		if news[n].Key.IsEqualWithIgnoringNamespace(olds[o].Key) {
 			newChanges = append(newChanges, news[n])
 			oldChanges = append(oldChanges, olds[o])

--- a/pkg/app/piped/platformprovider/terraform/terraform.go
+++ b/pkg/app/piped/platformprovider/terraform/terraform.go
@@ -256,7 +256,7 @@ func signMatchBracket(l *[]rune, r rune) rune {
 
 func headRuneWithoutWhiteSpace(r []rune) (rune, int) {
 	for i, ri := range r {
-		if !(ri == '\t' || ri == ' ') {
+		if ri != '\t' && ri != ' ' {
 			return ri, i
 		}
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
@@ -143,10 +143,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 	})
 
 	var n, o int
-	for {
-		if n >= len(news) || o >= len(olds) {
-			break
-		}
+	for n < len(news) && o < len(olds) {
 		if news[n].Key().normalize().String() == olds[o].Key().normalize().String() {
 			newChanges = append(newChanges, news[n])
 			oldChanges = append(oldChanges, olds[o])

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
@@ -143,10 +143,7 @@ func groupManifests(olds, news []Manifest) (adds, deletes, newChanges, oldChange
 	})
 
 	var n, o int
-	for {
-		if n >= len(news) || o >= len(olds) {
-			break
-		}
+	for n < len(news) && o < len(olds) {
 		if news[n].Key().normalize().String() == olds[o].Key().normalize().String() {
 			newChanges = append(newChanges, news[n])
 			oldChanges = append(oldChanges, olds[o])

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -476,7 +476,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := m.AnalysisMetrics.Validate(); err != nil {
+		if err := m.Validate(); err != nil {
 			return fmt.Errorf("one of metrics configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}
@@ -488,7 +488,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := l.AnalysisLog.Validate(); err != nil {
+		if err := l.Validate(); err != nil {
 			return fmt.Errorf("one of log configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}
@@ -499,7 +499,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := h.AnalysisHTTP.Validate(); err != nil {
+		if err := h.Validate(); err != nil {
 			return fmt.Errorf("one of http configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}

--- a/pkg/configv1/application.go
+++ b/pkg/configv1/application.go
@@ -287,7 +287,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := m.AnalysisMetrics.Validate(); err != nil {
+		if err := m.Validate(); err != nil {
 			return fmt.Errorf("one of metrics configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}
@@ -299,7 +299,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := l.AnalysisLog.Validate(); err != nil {
+		if err := l.Validate(); err != nil {
 			return fmt.Errorf("one of log configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}
@@ -310,7 +310,7 @@ func (a *AnalysisStageOptions) Validate() error {
 			}
 			continue
 		}
-		if err := h.AnalysisHTTP.Validate(); err != nil {
+		if err := h.Validate(); err != nil {
 			return fmt.Errorf("one of http configurations of ANALYSIS stage is invalid: %w", err)
 		}
 	}

--- a/pkg/insight/insightstore/deployment_store.go
+++ b/pkg/insight/insightstore/deployment_store.go
@@ -77,7 +77,7 @@ func (m *DeploymentBlockMetadata) FindChunks(from, to int64) []DeploymentChunkMe
 }
 
 func overlap(firstFrom, firstTo, secondFrom, secondTo int64) bool {
-	return !(firstTo < secondFrom || firstFrom > secondTo)
+	return firstTo >= secondFrom && firstFrom <= secondTo
 }
 
 func (s *store) ListCompletedDeployments(ctx context.Context, projectID string, from, to int64) ([]*insight.DeploymentData, error) {

--- a/pkg/oauth/oidc/oidc.go
+++ b/pkg/oauth/oidc/oidc.go
@@ -86,12 +86,12 @@ func NewOAuthClient(ctx context.Context,
 // GetUser returns a user model.
 func (c *OAuthClient) GetUser(ctx context.Context, clientID string) (*model.User, error) {
 
-	idTokenRAW, ok := c.Token.Extra("id_token").(string)
+	idTokenRAW, ok := c.Extra("id_token").(string)
 	if !ok {
 		return nil, fmt.Errorf("no id_token in oauth2 token")
 	}
 
-	verifier := c.Provider.Verifier(&oidc.Config{ClientID: clientID})
+	verifier := c.Verifier(&oidc.Config{ClientID: clientID})
 	idToken, err := verifier.Verify(ctx, idTokenRAW)
 	if err != nil {
 		return nil, err

--- a/pkg/oci/push_test.go
+++ b/pkg/oci/push_test.go
@@ -40,7 +40,7 @@ func pushTestFiles(t *testing.T, workDir, ociURL string) map[Platform]string {
 			t.Fatalf("could not create temporary file: %s", err)
 		}
 
-		if _, err := f.WriteString(fmt.Sprintf("test %s %s", platform.OS, platform.Arch)); err != nil {
+		if _, err := fmt.Fprintf(f, "test %s %s", platform.OS, platform.Arch); err != nil {
 			t.Fatalf("could not write to temporary file: %s", err)
 		}
 


### PR DESCRIPTION
**What this PR does**:

When trying out golangci-lint v2 to see if it would run, I noticed that Staticcheck was reporting a number of QF (quickfix) errors.

FYI: https://staticcheck.dev/docs/checks/#QF

Since these are literally "quickfix(es)" I have fixed them.

**Why we need it**:

To improve the quality of the codebase

**Note**:

<details><summary>the results of running the static check:</summary>

```
golangci-lint run  
pkg/app/pipectl/cmd/initialize/ecs.go:37:18: QF1011: could omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
                appName        string = "<YOUR_APPLICATION_NAME>"
                               ^
pkg/app/pipectl/cmd/initialize/ecs.go:38:18: QF1011: could omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
                serviceDefFile string = "<YOUR_SERVICE_DEFINITION_FILE>"
                               ^
pkg/app/pipectl/cmd/initialize/ecs.go:39:18: QF1011: could omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
                taskDefFile    string = "<YOUR_TASK_DEFINITION_FILE>"
                               ^
pkg/app/pipectl/cmd/initialize/ecs.go:147:24: QF1011: could omit type int from declaration; it will be inferred from the right-hand side (staticcheck)
                canaryTrafficPercent int = 10
                                     ^
pkg/app/pipectl/cmd/initialize/ecs.go:278:18: QF1011: could omit type int from declaration; it will be inferred from the right-hand side (staticcheck)
                containerPort  int    = 80
                               ^
pkg/app/piped/executor/scriptrun/scriptrun.go:43:12: QF1008: could remove embedded field "Input" from selector (staticcheck)
        opts := e.Input.StageConfig.ScriptRunStageOptions
                  ^
pkg/app/piped/platformprovider/kubernetes/diff.go:277:3: QF1006: could lift into loop condition (staticcheck)
                if n >= len(news) || o >= len(olds) {
                ^
pkg/app/piped/platformprovider/terraform/terraform.go:259:6: QF1001: could apply De Morgan's law (staticcheck)
                if !(ri == '\t' || ri == ' ') {
                   ^
pkg/app/pipedv1/plugin/kubernetes/provider/diff.go:147:3: QF1006: could lift into loop condition (staticcheck)
                if n >= len(news) || o >= len(olds) {
                ^
pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go:147:3: QF1006: could lift into loop condition (staticcheck)
                if n >= len(news) || o >= len(olds) {
                ^
pkg/config/application.go:479:15: QF1008: could remove embedded field "AnalysisMetrics" from selector (staticcheck)
                if err := m.AnalysisMetrics.Validate(); err != nil {
                            ^
pkg/config/application.go:491:15: QF1008: could remove embedded field "AnalysisLog" from selector (staticcheck)
                if err := l.AnalysisLog.Validate(); err != nil {
                            ^
pkg/config/application.go:502:15: QF1008: could remove embedded field "AnalysisHTTP" from selector (staticcheck)
                if err := h.AnalysisHTTP.Validate(); err != nil {
                            ^
pkg/configv1/application.go:290:15: QF1008: could remove embedded field "AnalysisMetrics" from selector (staticcheck)
                if err := m.AnalysisMetrics.Validate(); err != nil {
                            ^
pkg/configv1/application.go:302:15: QF1008: could remove embedded field "AnalysisLog" from selector (staticcheck)
                if err := l.AnalysisLog.Validate(); err != nil {
                            ^
pkg/configv1/application.go:313:15: QF1008: could remove embedded field "AnalysisHTTP" from selector (staticcheck)
                if err := h.AnalysisHTTP.Validate(); err != nil {
                            ^
pkg/insight/insightstore/deployment_store.go:80:9: QF1001: could apply De Morgan's law (staticcheck)
        return !(firstTo < secondFrom || firstFrom > secondTo)
               ^
pkg/oauth/oidc/oidc.go:89:22: QF1008: could remove embedded field "Token" from selector (staticcheck)
        idTokenRAW, ok := c.Token.Extra("id_token").(string)
                            ^
pkg/oauth/oidc/oidc.go:94:16: QF1008: could remove embedded field "Provider" from selector (staticcheck)
        verifier := c.Provider.Verifier(&oidc.Config{ClientID: clientID})
                      ^
pkg/oci/push_test.go:43:16: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
                if _, err := f.WriteString(fmt.Sprintf("test %s %s", platform.OS, platform.Arch)); err != nil {
                             ^
20 issues:
* staticcheck: 20

```
<details>

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
