### PR TITLE
Fix the type of the Plugins field in the GenericApplicationSpec struct

### DIFF
--- a/pkg/app/pipedv1/controller/planner_test.go
+++ b/pkg/app/pipedv1/controller/planner_test.go
@@ -157,7 +157,7 @@ func TestBuildQuickSyncStages(t *testing.T) {
 				Planner: config.DeploymentPlanner{
 					AutoRollback: pointerBool(true),
 				},
-				Plugins: []string{"plugin-1"},
+				Plugins: map[string]struct{}{"plugin-1": {}},
 			},
 			wantErr: false,
 			expectedStages: []*model.PipelineStage{
@@ -221,7 +221,7 @@ func TestBuildQuickSyncStages(t *testing.T) {
 				Planner: config.DeploymentPlanner{
 					AutoRollback: pointerBool(true),
 				},
-				Plugins: []string{"plugin-1", "plugin-2"},
+				Plugins: map[string]struct{}{"plugin-1": {}, "plugin-2": {}},
 			},
 			wantErr: false,
 			expectedStages: []*model.PipelineStage{
@@ -294,7 +294,7 @@ func TestBuildQuickSyncStages(t *testing.T) {
 				Planner: config.DeploymentPlanner{
 					AutoRollback: pointerBool(false),
 				},
-				Plugins: []string{"plugin-1", "plugin-2"},
+				Plugins: map[string]struct{}{"plugin-1": {}, "plugin-2": {}},
 			},
 			wantErr: false,
 			expectedStages: []*model.PipelineStage{
@@ -704,7 +704,7 @@ func TestPlanner_BuildPlan(t *testing.T) {
 				Planner: config.DeploymentPlanner{
 					AutoRollback: pointerBool(true),
 				},
-				Plugins: []string{"plugin-1"},
+				Plugins: map[string]struct{}{"plugin-1": {}},
 			},
 			deployment: &model.Deployment{
 				Trigger: &model.DeploymentTrigger{
@@ -819,7 +819,7 @@ func TestPlanner_BuildPlan(t *testing.T) {
 				Planner: config.DeploymentPlanner{
 					AutoRollback: pointerBool(true),
 				},
-				Plugins: []string{"plugin-1"},
+				Plugins: map[string]struct{}{"plugin-1": {}},
 			},
 			deployment: &model.Deployment{
 				Trigger: &model.DeploymentTrigger{},

--- a/pkg/app/pipedv1/plugin/registry.go
+++ b/pkg/app/pipedv1/plugin/registry.go
@@ -112,13 +112,13 @@ func (pr *pluginRegistry) getPluginClientsByPipeline(pipeline *config.Deployment
 	return plugins, nil
 }
 
-func (pr *pluginRegistry) getPluginClientsByNames(names []string) ([]pluginapi.PluginClient, error) {
+func (pr *pluginRegistry) getPluginClientsByNames(names map[string]struct{}) ([]pluginapi.PluginClient, error) {
 	if len(names) == 0 {
 		return nil, fmt.Errorf("no plugin names are set")
 	}
 
 	plugins := make([]pluginapi.PluginClient, 0, len(names))
-	for _, name := range names {
+	for name := range names {
 		plugin, ok := pr.nameBasedPlugins[name]
 		if !ok {
 			return nil, fmt.Errorf("no plugin found for the given plugin name %v", name)

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -67,7 +67,7 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			name: "get plugins by plugin names",
 			cfg: &config.GenericApplicationSpec{
 				Pipeline: nil,
-				Plugins:  []string{"plugin1", "plugin2"},
+				Plugins:  map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
@@ -92,7 +92,7 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 						{Name: "stage2"},
 					},
 				},
-				Plugins: []string{"plugin1", "plugin2"},
+				Plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
@@ -214,14 +214,14 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		pluginNames []string
+		pluginNames map[string]struct{}
 		setup       func() *pluginRegistry
 		expected    []pluginapi.PluginClient
 		wantErr     bool
 	}{
 		{
 			name:        "get plugins by valid plugin names",
-			pluginNames: []string{"plugin1", "plugin2"},
+			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{
@@ -238,7 +238,7 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 		},
 		{
 			name:        "no plugins found for empty plugin names",
-			pluginNames: []string{},
+			pluginNames: map[string]struct{}{},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{
@@ -251,7 +251,7 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 		},
 		{
 			name:        "no plugins found for non-existent plugin names",
-			pluginNames: []string{"plugin1", "plugin2"},
+			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{

--- a/pkg/configv1/application.go
+++ b/pkg/configv1/application.go
@@ -59,7 +59,7 @@ type GenericApplicationSpec struct {
 	// Configuration for drift detection
 	DriftDetection *DriftDetection `json:"driftDetection"`
 	// List of the plugin name
-	Plugins []string `json:"plugins"`
+	Plugins map[string]struct{} `json:"plugins"`
 }
 
 type DeploymentPlanner struct {


### PR DESCRIPTION
**What this PR does**:

Change the type of the Plugins field from []string to map[string]struct in the GenericApplicationSpec struct.

**Why we need it**:

We want to put the plugins' config under the `.spec.plugins.${plugin-name}`, so this field becomes map type.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No, because the plugin-arch piped has not been released yet.

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
