### PR TITLE
docs: Add note of not supporting CloudRun job yet

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -59,6 +59,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/cloudrun.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/defining-app-configuration/cloudrun.md
@@ -6,6 +6,8 @@ description: >
   Specific guide to configuring deployment for Cloud Run application.
 ---
 
+*Note: Cloud Run job has not been supported yet.*
+
 Deploying a Cloud Run application requires a `service.yaml` file placing inside the application directory. That file contains the service specification used by Cloud Run as following: 
 
 ``` yaml

--- a/docs/content/en/docs-v0.39.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.39.x/feature-status/_index.md
@@ -57,6 +57,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Application live state](../user-guide/managing-application/application-live-state/) | Alpha |
 | [Plan preview](../user-guide/plan-preview) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.40.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.40.x/feature-status/_index.md
@@ -57,6 +57,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Application live state](../user-guide/managing-application/application-live-state/) | Alpha |
 | [Plan preview](../user-guide/plan-preview) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.41.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.41.x/feature-status/_index.md
@@ -57,6 +57,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Application live state](../user-guide/managing-application/application-live-state/) | Alpha |
 | [Plan preview](../user-guide/plan-preview) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.42.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.42.x/feature-status/_index.md
@@ -57,6 +57,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Application live state](../user-guide/managing-application/application-live-state/) | Beta |
 | [Plan preview](../user-guide/plan-preview) | Beta |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.43.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.43.x/feature-status/_index.md
@@ -57,6 +57,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Application live state](../user-guide/managing-application/application-live-state/) | Beta |
 | [Plan preview](../user-guide/plan-preview) | Beta |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.44.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.44.x/feature-status/_index.md
@@ -60,6 +60,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.45.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.45.x/feature-status/_index.md
@@ -60,6 +60,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.46.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.46.x/feature-status/_index.md
@@ -60,6 +60,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.47.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.47.x/feature-status/_index.md
@@ -60,6 +60,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.48.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.48.x/feature-status/_index.md
@@ -60,6 +60,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.49.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.49.x/feature-status/_index.md
@@ -59,6 +59,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.50.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.50.x/feature-status/_index.md
@@ -59,6 +59,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.51.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.51.x/feature-status/_index.md
@@ -59,6 +59,8 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Plan preview](../user-guide/plan-preview) | Beta |
 | [Manifest attachment](../user-guide/managing-application/manifest-attachment) | Alpha |
 
+Note: These are statuses for Cloud Run service. Cloud Run job has not been supported yet.
+
 ### Lambda
 
 | Feature | Phase |

--- a/docs/content/en/docs-v0.51.x/user-guide/managing-application/defining-app-configuration/cloudrun.md
+++ b/docs/content/en/docs-v0.51.x/user-guide/managing-application/defining-app-configuration/cloudrun.md
@@ -6,6 +6,8 @@ description: >
   Specific guide to configuring deployment for Cloud Run application.
 ---
 
+*Note: Cloud Run job has not been supported yet.*
+
 Deploying a Cloud Run application requires a `service.yaml` file placing inside the application directory. That file contains the service specification used by Cloud Run as following: 
 
 ``` yaml


### PR DESCRIPTION
**What this PR does**:

as titile.
in feature-status and defining-app-configuration.

**Why we need it**:

Users who try to deploy a CloudRun job app will face the problem.

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
