### PR TITLE
Add documentation on a single page on how to start a local dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ This will create the kubernetes namespace `pipecd` if it does not exist and star
 
 Run `make kind-down` to stop and delete the registery and the cluster.
 
-### Run Pipecd Control Plane
+### Run PipeCD Control Plane
 
 Run `make run/pipecd` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,72 @@ PipeCD consists of several components and docs:
 
 Note: While working with the PipeCD codebase, you may refer to [Makefile](./Makefile) for useful commands.
 
+### Starting a Local Development Environment
+
+#### Starting a local registry
+
+In order to start a local development environment, a registry needs to be running locally. 
+
+Run `make kind-up` to start a local registry. 
+
+This will create the kubernetes namespace `pipecd` if it does not exist and start a local registry in the namespace which can then be accessed by other components.
+
+When cleaning up, run `make kind-down` to stop and delete the registery and the cluster.
+
+#### Run PipeCD Control Plane
+
+Run `make run/pipecd` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
+
+Run `make stop/pipecd` to stop PipeCD Control Plane.
+
+#### Port Forward
+
+Run `kubectl port-forward -n pipecd svc/pipecd 8080` forward your local port to the `pipecd` pod port. 
+
+#### Access the PipeCD UI
+
+After port-forwarding, you can now access the PipeCD Control Plane console at `http://localhost:8080?project=quickstart`.
+
+To login, you can use the configured static admin account as below:
+
+- username: `hello-pipecd`
+- password: `hello-pipecd`
+
+#### Run Piped Agent
+
+1. Make sure that PipeCD Control Plane is running and you can access the UI and login.
+
+2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and base64 key for `piped-config.yaml`
+
+3. Create the piped configuration file `piped-config.yaml`. This is an example configuration. Use the PipeD ID and base64 key created in step 2.
+    ```yaml
+    apiVersion: pipecd.dev/v1beta1
+    kind: Piped
+    spec:
+      projectID: quickstart
+      # FIXME: Replace here with your piped ID.
+      pipedID: 7accd470-1786-49ee-ac09-3c4d4e31dc12
+      # Base64 encoded string of the piped private key.
+      # FIXME: Replace here with your piped base64 key.
+      pipedKeyData: OTl4c2RqdjUxNTF2OW1sOGw5ampndXUyZjB2aGJ4dGw0bHVkamF4Mmc3a3l1enFqY20K
+      # Write in a format like "host:443" because the communication is done via gRPC.
+      # FIXME: Replace here with your piped address if you connect Piped to a control plane that does not run locally.
+      apiAddress: localhost:8080
+      repositories:
+      - repoId: example
+        remote: git@github.com:pipe-cd/examples.git
+        branch: master
+      syncInterval: 1m
+      platformProviders:
+      - name: example-kubernetes
+        type: KUBERNETES
+        config:
+          # FIXME: Replace here with your kubeconfig absolute file path.
+          kubeConfigPath: /path/to/.kube/config
+    ```
+
+4. Run `make run/piped CONFIG_FILE=piped-config.yaml` to start Piped agent.
+
 ### Online one-click setup for contributing
 
 We are preparing Gitpod and Codespace to facilitate the setup process for contributing.
@@ -151,72 +217,6 @@ If your change introcudes a user-facing change, please update the following sect
 ```
 
 Note that if it's a new breaking change, make sure to complete the two latter questions.
-
-## Starting a Local Development Environment
-
-### Starting a local registry
-
-In order to start a local development environment, a registry needs to be running locally. 
-
-Run `make kind-up` to start a local registry. 
-
-This will create the kubernetes namespace `pipecd` if it does not exist and start a local registry in the namespace which can then be accessed by other components.
-
-When cleaning up, run `make kind-down` to stop and delete the registery and the cluster.
-
-### Run PipeCD Control Plane
-
-Run `make run/pipecd` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
-
-Run `make stop/pipecd` to stop PipeCD Control Plane.
-
-### Port Forward
-
-Run `kubectl port-forward -n pipecd svc/pipecd 8080` forward your local port to the `pipecd` pod port. 
-
-### Access the PipeCD UI
-
-After port-forwarding, you can now access the PipeCD Control Plane console at `http://localhost:8080?project=quickstart`.
-
-To login, you can use the configured static admin account as below:
-
-- username: `hello-pipecd`
-- password: `hello-pipecd`
-
-### Run Piped Agent
-
-1. Make sure that PipeCD Control Plane is running and you can access the UI and login.
-
-2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and base64 key for `piped-config.yaml`
-
-3. Create the piped configuration file `piped-config.yaml`. This is an example configuration. Use the PipeD ID and base64 key created in step 2.
-    ```yaml
-    apiVersion: pipecd.dev/v1beta1
-    kind: Piped
-    spec:
-      projectID: quickstart
-      # FIXME: Replace here with your piped ID.
-      pipedID: 7accd470-1786-49ee-ac09-3c4d4e31dc12
-      # Base64 encoded string of the piped private key.
-      # FIXME: Replace here with your piped base64 key.
-      pipedKeyData: OTl4c2RqdjUxNTF2OW1sOGw5ampndXUyZjB2aGJ4dGw0bHVkamF4Mmc3a3l1enFqY20K
-      # Write in a format like "host:443" because the communication is done via gRPC.
-      # FIXME: Replace here with your piped address if you connect Piped to a control plane that does not run locally.
-      apiAddress: localhost:8080
-      repositories:
-      - repoId: example
-        remote: git@github.com:pipe-cd/examples.git
-        branch: master
-      syncInterval: 1m
-      platformProviders:
-      - name: example-kubernetes
-        type: KUBERNETES
-        config:
-          # FIXME: Replace here with your kubeconfig absolute file path.
-          kubeConfigPath: /path/to/.kube/config
-    ```
-
-4. Run `make run/piped CONFIG_FILE=piped-config.yaml` to start Piped agent.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,11 @@ To login, you can use the configured static admin account as below:
 
 1. Make sure that PipeCD Control Plane is running and you can access the UI and login.
 
-2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and base64 key for `piped-config.yaml`
+2. Access to Control Plane console, go to Piped list page - click the three vertical dots on the top right corner and then click on settings. After clicking on settings you will land on the Piped settings page. Next, add a new piped. 
+
+Alternatively, you can go to `http://localhost:8080/settings/piped?project=quickstart`, please adjust the port and the project in the url if they are different from default. 
+
+Then, copy generated Piped ID and base64 key for `piped-config.yaml`
 
 3. Create the piped configuration file `piped-config.yaml`. This is an example configuration. Use the PipeD ID and base64 key created in step 2.
     ```yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,10 @@ Note: While working with the PipeCD codebase, you may refer to [Makefile](./Make
 
 ### Starting a Local Development Environment
 
+#### Update dependencies
+
+Run `make update/go-deps` and `update/web-deps` to update the dependencies. Starting a local development environment might fail if the dependencies are not up to date.
+
 #### Starting a local registry
 
 In order to start a local development environment, a registry needs to be running locally. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Run `make kind-up` to start a local registry.
 
 This will create the kubernetes namespace `pipecd` if it does not exist and start a local registry in the namespace which can then be accessed by other components.
 
-Run `make kind-down` to stop and delete the registery and the cluster.
+When cleaning up, run `make kind-down` to stop and delete the registery and the cluster.
 
 ### Run PipeCD Control Plane
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,73 @@ If your change introcudes a user-facing change, please update the following sect
 
 Note that if it's a new breaking change, make sure to complete the two latter questions.
 
+## Starting a Local Development Environment
+
+### Starting a local registry
+
+In order to start a local development environment, a registry needs to be running locally. 
+
+Run `make kind-up` to start a local registry. 
+
+This will create the kubernetes namespace `pipecd` if it does not exist and start a local registry in the namespace which can then be accessed by other components.
+
+Run `make kind-down` to stop and delete the registery and the cluster.
+
+### Run Pipecd Control Plane
+
+Run `make run/pipecd` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
+
+Run `make stop/pipecd` to stop PipeCD Control Plane.
+
+### Port Forward
+
+Run `kubectl port-forward -n pipecd svc/pipecd 8080` forward your local port to the `pipecd` pod port. 
+
+### Access the PipeCD UI
+
+After port-forwarding, you can now access the PipeCD Control Plane console at `http://localhost:8080?project=quickstart`.
+
+To login, you can use the configured static admin account as below:
+
+- username: `hello-pipecd`
+- password: `hello-pipecd`
+
+### Run Piped Agent
+
+1. Make sure that PipeCD Control Plane is running and you can access the UI and login.
+
+2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and base64 key for `piped-config.yaml`
+
+3. Create the piped configuration file `piped-config.yaml`. This is an example configuration. Use the PipeD ID and base64 key created in step 2.
+    ```yaml
+    apiVersion: pipecd.dev/v1beta1
+    kind: Piped
+    spec:
+      projectID: quickstart
+      # FIXME: Replace here with your piped ID.
+      pipedID: 7accd470-1786-49ee-ac09-3c4d4e31dc12
+      # Base64 encoded string of the piped private key. You can generate it by the following command.
+      # echo -n "your-piped-key" | base64
+      # FIXME: Replace here with your piped base64 key.
+      pipedKeyData: OTl4c2RqdjUxNTF2OW1sOGw5ampndXUyZjB2aGJ4dGw0bHVkamF4Mmc3a3l1enFqY20K
+      # Write in a format like "host:443" because the communication is done via gRPC.
+      # FIXME: Replace here with your piped address if you connect Piped to a control plane that does not run locally.
+      apiAddress: localhost:8080
+      repositories:
+      - repoId: example
+        remote: git@github.com:pipe-cd/examples.git
+        branch: master
+      syncInterval: 1m
+      platformProviders:
+      - name: example-kubernetes
+        type: KUBERNETES
+        config:
+          # FIXME: Replace here with your kubeconfig absolute file path.
+          kubeConfigPath: /path/to/.kube/config
+    ```
+
+4. Run `make run/piped CONFIG_FILE=piped-config.yaml` to start Piped agent.
+
 ## Contributor License Agreement
 
 For any code contribution, please carefully read the following documents:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Note: While working with the PipeCD codebase, you may refer to [Makefile](./Make
 
 #### Update dependencies
 
-Run `make update/go-deps` and `update/web-deps` to update the dependencies. Starting a local development environment might fail if the dependencies are not up to date.
+Run `make update/go-deps` and `make update/web-deps` to update the dependencies. Starting a local development environment might fail with errors if the dependencies are not up to date.
 
 #### Starting a local registry
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,7 @@ To login, you can use the configured static admin account as below:
       projectID: quickstart
       # FIXME: Replace here with your piped ID.
       pipedID: 7accd470-1786-49ee-ac09-3c4d4e31dc12
-      # Base64 encoded string of the piped private key. You can generate it by the following command.
-      # echo -n "your-piped-key" | base64
+      # Base64 encoded string of the piped private key.
       # FIXME: Replace here with your piped base64 key.
       pipedKeyData: OTl4c2RqdjUxNTF2OW1sOGw5ampndXUyZjB2aGJ4dGw0bHVkamF4Mmc3a3l1enFqY20K
       # Write in a format like "host:443" because the communication is done via gRPC.


### PR DESCRIPTION
**What this PR does**: It adds a single documentation on a single page on how to start a local dev env.

**Why we need it**: What I needed to speed up contribution was a single documentation. This PR should be helpful for new contributors to start a local dev env faster.

**Which issue(s) this PR fixes**: Closes https://github.com/pipe-cd/pipecd/issues/5776 

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: NA
