### PR TITLE
Fixed from getPluginClientsByNames to getPluginClientsByPlugins to determine the plugin with app config

### DIFF
--- a/pkg/app/pipedv1/plugin/registry.go
+++ b/pkg/app/pipedv1/plugin/registry.go
@@ -89,7 +89,7 @@ func (pr *pluginRegistry) GetPluginClientsByAppConfig(cfg *config.GenericApplica
 	}
 
 	if cfg.Plugins != nil {
-		return pr.getPluginClientsByNames(cfg.Plugins)
+		return pr.getPluginClientsByPlugins(cfg.Plugins)
 	}
 
 	return nil, fmt.Errorf("no plugin specified")
@@ -112,19 +112,19 @@ func (pr *pluginRegistry) getPluginClientsByPipeline(pipeline *config.Deployment
 	return plugins, nil
 }
 
-func (pr *pluginRegistry) getPluginClientsByNames(names map[string]struct{}) ([]pluginapi.PluginClient, error) {
-	if len(names) == 0 {
-		return nil, fmt.Errorf("no plugin names are set")
+func (pr *pluginRegistry) getPluginClientsByPlugins(plugins map[string]struct{}) ([]pluginapi.PluginClient, error) {
+	if len(plugins) == 0 {
+		return nil, fmt.Errorf("no plugin config are set")
 	}
 
-	plugins := make([]pluginapi.PluginClient, 0, len(names))
-	for name := range names {
+	clients := make([]pluginapi.PluginClient, 0, len(plugins))
+	for name := range plugins {
 		plugin, ok := pr.nameBasedPlugins[name]
 		if !ok {
 			return nil, fmt.Errorf("no plugin found for the given plugin name %v", name)
 		}
-		plugins = append(plugins, plugin)
+		clients = append(clients, plugin)
 	}
 
-	return plugins, nil
+	return clients, nil
 }

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -209,19 +209,19 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 		})
 	}
 }
-func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
+func TestPluginRegistry_getPluginClientsByPlugins(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		pluginNames map[string]struct{}
-		setup       func() *pluginRegistry
-		expected    []pluginapi.PluginClient
-		wantErr     bool
+		name     string
+		plugins  map[string]struct{}
+		setup    func() *pluginRegistry
+		expected []pluginapi.PluginClient
+		wantErr  bool
 	}{
 		{
-			name:        "get plugins by valid plugin names",
-			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
+			name:    "get plugins by valid plugin names",
+			plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{
@@ -237,8 +237,8 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "no plugins found for empty plugin names",
-			pluginNames: map[string]struct{}{},
+			name:    "no plugins found for empty plugin names",
+			plugins: map[string]struct{}{},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{
@@ -250,8 +250,8 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "no plugins found for non-existent plugin names",
-			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
+			name:    "no plugins found for non-existent plugin names",
+			plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]pluginapi.PluginClient{
@@ -269,7 +269,7 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			t.Parallel()
 
 			pr := tt.setup()
-			plugins, err := pr.getPluginClientsByNames(tt.pluginNames)
+			plugins, err := pr.getPluginClientsByPlugins(tt.plugins)
 			assert.ElementsMatch(t, tt.expected, plugins)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We want to clarify the role for the method.

**Which issue(s) this PR fixes**:

Part of #4980
Follow #5789

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**:
