### PR TITLE
docs: use Sync instead of AutoSync

### DIFF
--- a/docs/content/en/docs-dev/concepts/_index.md
+++ b/docs/content/en/docs-dev/concepts/_index.md
@@ -59,7 +59,7 @@ When the deployment is success, it means the running state is being synced with 
 There are 3 strategies that PipeCD supports while syncing your application state with its configuration stored in Git. Which are:
 - Quick Sync: a fast way to make the running application state as same as its Git stored configuration. The generated pipeline contains only one predefined `SYNC` stage.
 - Pipeline Sync: sync the running application state with its Git stored configuration through a pipeline defined in its application configuration.
-- Auto Sync: depends on your defined application configuration, `piped` will decide the best way to sync your application state with its Git stored configuration.
+- Sync: depends on your defined application configuration, `piped` will decide the best way to sync your application state with its Git stored configuration.
 
 ### Platform Provider
 

--- a/docs/content/en/docs-v0.51.x/concepts/_index.md
+++ b/docs/content/en/docs-v0.51.x/concepts/_index.md
@@ -59,7 +59,7 @@ When the deployment is success, it means the running state is being synced with 
 There are 3 strategies that PipeCD supports while syncing your application state with its configuration stored in Git. Which are:
 - Quick Sync: a fast way to make the running application state as same as its Git stored configuration. The generated pipeline contains only one predefined `SYNC` stage.
 - Pipeline Sync: sync the running application state with its Git stored configuration through a pipeline defined in its application configuration.
-- Auto Sync: depends on your defined application configuration, `piped` will decide the best way to sync your application state with its Git stored configuration.
+- Sync: depends on your defined application configuration, `piped` will decide the best way to sync your application state with its Git stored configuration.
 
 ### Platform Provider
 


### PR DESCRIPTION
**What this PR does**: Documentation and WebUI notations were different, so changes were made to align them.

![image](https://github.com/user-attachments/assets/5f3b6196-3d53-4897-b1bb-a1dbc2c89c3e)


**Why we need it**: Because of the confustion

**Which issue(s) this PR fixes**: None

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: No
- **Is this breaking change**: No 
