### PR TITLE
Add comment for the plugins field in generic application config

### DIFF
--- a/pkg/configv1/application.go
+++ b/pkg/configv1/application.go
@@ -58,7 +58,7 @@ type GenericApplicationSpec struct {
 	EventWatcher []EventWatcherConfig `json:"eventWatcher"`
 	// Configuration for drift detection
 	DriftDetection *DriftDetection `json:"driftDetection"`
-	// List of the plugin name
+	// List of the configuration for plugin
 	// This field is plugin-specific, so intentionally restrict the access for the actual value here and decode it on the SDK side.
 	Plugins map[string]struct{} `json:"plugins"`
 }

--- a/pkg/configv1/application.go
+++ b/pkg/configv1/application.go
@@ -59,6 +59,7 @@ type GenericApplicationSpec struct {
 	// Configuration for drift detection
 	DriftDetection *DriftDetection `json:"driftDetection"`
 	// List of the plugin name
+	// This field is plugin-specific, so intentionally restrict the access for the actual value here and decode it on the SDK side.
 	Plugins map[string]struct{} `json:"plugins"`
 }
 


### PR DESCRIPTION
**What this PR does**:

as titlw

**Why we need it**:

We want to clarify why defined `spec.plugins` are empty struct.

**Which issue(s) this PR fixes**:

Follow https://github.com/pipe-cd/pipecd/pull/5789

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: 
