### PR TITLE
Revert "Use oracle runners as larger runner"

### DIFF
--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   artifacts:
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tool:
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: ubuntu-latest-8-cores
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-latest-8-cores # we cannot use self-hosted oracle runners for go tests because it has no gcc installed but we need it for the go tests with race detector
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Reverts pipe-cd/pipecd#5738

The publish_tool workflow failed after merging #5738, and the publish_image_chart workflow became 2x slower.

https://github.com/pipe-cd/pipecd/actions/runs/14896540574

<img width="1299" alt="スクリーンショット 2025-05-08 10 33 30" src="https://github.com/user-attachments/assets/052d1b93-59b1-4904-a9b6-269795b5da92" />
