### PR TITLE
[K8s Plugin] Enhance Manifest struct with deep copy functionality and conversion methods

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback.go
@@ -51,7 +51,7 @@ func (p *Plugin) executeK8sRollbackStage(ctx context.Context, input *sdk.Execute
 
 	// Because the loaded manifests are read-only
 	// we duplicate them to avoid updating the shared manifests data in cache.
-	// TODO: implement duplicateManifests function
+	manifests = provider.DeepCopyManifests(manifests)
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync.go
@@ -51,7 +51,7 @@ func (p *Plugin) executeK8sSyncStage(ctx context.Context, input *sdk.ExecuteStag
 
 	// Because the loaded manifests are read-only
 	// we duplicate them to avoid updating the shared manifests data in cache.
-	// TODO: implement duplicateManifests function
+	manifests = provider.DeepCopyManifests(manifests)
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/hasher_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/hasher_test.go
@@ -88,7 +88,7 @@ type: my-type
 data:
   "one": ""
 `,
-			expected: "74bd68bm66",
+			expected: "2k5dh9h9h9",
 		},
 		{
 			name: "secret: there keys for checking order",
@@ -101,7 +101,7 @@ data:
   one: ""
   three: Mw==
 `,
-			expected: "dgcb6h9tmk",
+			expected: "5852t69tb5",
 		},
 		{
 			name: "multiple configs",
@@ -120,7 +120,7 @@ data:
   one: ""
   three: Mw==
 `,
-			expected: "57hhd7795k",
+			expected: "fhgh2849tk",
 		},
 		{
 			name: "not config manifest",
@@ -158,6 +158,8 @@ spec:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			manifests, err := ParseManifests(tc.manifests)
 			require.NoError(t, err)
 

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
@@ -15,10 +15,10 @@
 package provider
 
 import (
-	"encoding/json"
 	"maps"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
@@ -55,6 +55,29 @@ func isBuiltinAPIGroup(apiGroup string) bool {
 // Manifest represents a Kubernetes resource manifest.
 type Manifest struct {
 	body *unstructured.Unstructured
+}
+
+// FromStructuredObject creates a new Manifest from a structured Kubernetes object.
+func FromStructuredObject(o any) (Manifest, error) {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+	if err != nil {
+		return Manifest{}, err
+	}
+	return Manifest{body: &unstructured.Unstructured{Object: obj}}, nil
+}
+
+// DeepCopyManifests returns a deep copy of the given manifests.
+func DeepCopyManifests(manifests []Manifest) []Manifest {
+	copied := make([]Manifest, len(manifests))
+	for i, m := range manifests {
+		copied[i] = m.DeepCopy()
+	}
+	return copied
+}
+
+// DeepCopy returns a deep copy of the manifest.
+func (m Manifest) DeepCopy() Manifest {
+	return Manifest{body: m.body.DeepCopy()}
 }
 
 func (m Manifest) Key() ResourceKey {
@@ -108,13 +131,9 @@ func (m *Manifest) MarshalJSON() ([]byte, error) {
 
 // ConvertToStructuredObject converts the manifest into a structured Kubernetes object.
 // The provided interface should be a pointer to a concrete Kubernetes type (e.g. *v1.Pod).
-// It first marshals the manifest to JSON and then unmarshals it into the provided object.
-func (m Manifest) ConvertToStructuredObject(o interface{}) error {
-	data, err := m.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, o)
+// It uses the runtime.DefaultUnstructuredConverter to convert the manifest into the provided object.
+func (m Manifest) ConvertToStructuredObject(o any) error {
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(m.body.Object, o)
 }
 
 func (m *Manifest) YamlBytes() ([]byte, error) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback.go
@@ -52,7 +52,7 @@ func (p *Plugin) executeK8sMultiRollbackStage(ctx context.Context, input *sdk.Ex
 
 	// Because the loaded manifests are read-only
 	// we duplicate them to avoid updating the shared manifests data in cache.
-	// TODO: implement duplicateManifests function
+	manifests = provider.DeepCopyManifests(manifests)
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -126,7 +126,7 @@ func (p *Plugin) sync(
 
 	// Because the loaded manifests are read-only
 	// we duplicate them to avoid updating the shared manifests data in cache.
-	// TODO: implement duplicateManifests function
+	manifests = provider.DeepCopyManifests(manifests)
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/hasher_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/hasher_test.go
@@ -88,7 +88,7 @@ type: my-type
 data:
   "one": ""
 `,
-			expected: "74bd68bm66",
+			expected: "2k5dh9h9h9",
 		},
 		{
 			name: "secret: there keys for checking order",
@@ -101,7 +101,7 @@ data:
   one: ""
   three: Mw==
 `,
-			expected: "dgcb6h9tmk",
+			expected: "5852t69tb5",
 		},
 		{
 			name: "multiple configs",
@@ -120,7 +120,7 @@ data:
   one: ""
   three: Mw==
 `,
-			expected: "57hhd7795k",
+			expected: "fhgh2849tk",
 		},
 		{
 			name: "not config manifest",
@@ -158,6 +158,8 @@ spec:
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			manifests, err := ParseManifests(tc.manifests)
 			require.NoError(t, err)
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
@@ -15,10 +15,10 @@
 package provider
 
 import (
-	"encoding/json"
 	"maps"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
@@ -55,6 +55,29 @@ func isBuiltinAPIGroup(apiGroup string) bool {
 // Manifest represents a Kubernetes resource manifest.
 type Manifest struct {
 	body *unstructured.Unstructured
+}
+
+// FromStructuredObject creates a new Manifest from a structured Kubernetes object.
+func FromStructuredObject(o any) (Manifest, error) {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+	if err != nil {
+		return Manifest{}, err
+	}
+	return Manifest{body: &unstructured.Unstructured{Object: obj}}, nil
+}
+
+// DeepCopyManifests returns a deep copy of the given manifests.
+func DeepCopyManifests(manifests []Manifest) []Manifest {
+	copied := make([]Manifest, len(manifests))
+	for i, m := range manifests {
+		copied[i] = m.DeepCopy()
+	}
+	return copied
+}
+
+// DeepCopy returns a deep copy of the manifest.
+func (m Manifest) DeepCopy() Manifest {
+	return Manifest{body: m.body.DeepCopy()}
 }
 
 func (m Manifest) Key() ResourceKey {
@@ -108,13 +131,9 @@ func (m *Manifest) MarshalJSON() ([]byte, error) {
 
 // ConvertToStructuredObject converts the manifest into a structured Kubernetes object.
 // The provided interface should be a pointer to a concrete Kubernetes type (e.g. *v1.Pod).
-// It first marshals the manifest to JSON and then unmarshals it into the provided object.
-func (m Manifest) ConvertToStructuredObject(o interface{}) error {
-	data, err := m.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, o)
+// It uses the runtime.DefaultUnstructuredConverter to convert the manifest into the provided object.
+func (m Manifest) ConvertToStructuredObject(o any) error {
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(m.body.Object, o)
 }
 
 func (m *Manifest) YamlBytes() ([]byte, error) {


### PR DESCRIPTION
**What this PR does**:

- refactor (Manifest).ConvertToStructuredObject to use `runtime.DefaultUnstructuredConverter.FromUnstructured`.
- add deep-copy functionality of manifests
    - and use it to resolve TODOs
- add FromStructuredObject to create Manifest from k8s structured object

**Why we need it**:

- refactoring of ConvertToStructuredObject
    - it's better to use the provided way
- deep-copy
    - to avoid unexpected side-effective modifications
- FromStructuredObject
    - to use in the following scenario
        1. convert Manifest to structured object with ConvertToStructuredObject
        2. modify it
        3. re-convert modified object with FromStructuredObject

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
