### PR TITLE
Add implementation of OCI push and pull with authentication

### DIFF
--- a/pkg/oci/main_test.go
+++ b/pkg/oci/main_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,9 +39,22 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to connect to docker: %s", err)
 	}
 
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to get working directory: %s", err)
+	}
+
 	opts := &dockertest.RunOptions{
 		Repository: repository,
 		Tag:        tag,
+		Env: []string{
+			"REGISTRY_AUTH=htpasswd",
+			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
+			"REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
+		},
+		Mounts: []string{
+			filepath.Join(wd, "testdata", "auth") + ":/auth",
+		},
 	}
 	hcOpts := func(config *docker.HostConfig) {
 		config.AutoRemove = true

--- a/pkg/oci/options.go
+++ b/pkg/oci/options.go
@@ -24,6 +24,8 @@ const (
 // PushOptions holds options for pushing to an OCI registry.
 type PushOptions struct {
 	insecure bool
+	username string
+	password string
 }
 
 // PushOption is an interface for applying push options.
@@ -34,6 +36,8 @@ type PushOption interface {
 // PullOptions holds options for pulling from an OCI registry.
 type PullOptions struct {
 	insecure     bool
+	username     string
+	password     string
 	targetOS     string
 	targetArch   string
 	mediaType    string
@@ -49,6 +53,39 @@ type PullOption interface {
 type Option interface {
 	PushOption
 	PullOption
+}
+
+// usernameOption is an option to specify the username for pushing.
+type usernameOption string
+
+// applyPushOption applies the username option to PushOptions.
+func (o usernameOption) applyPushOption(opts *PushOptions) {
+	opts.username = string(o)
+}
+
+func (o usernameOption) applyPullOption(opts *PullOptions) {
+	opts.username = string(o)
+}
+
+// WithUsername returns a Option that sets the username.
+func WithUsername(username string) Option {
+	return usernameOption(username)
+}
+
+type passwordOption string
+
+// applyPushOption applies the password option to PushOptions.
+func (o passwordOption) applyPushOption(opts *PushOptions) {
+	opts.password = string(o)
+}
+
+func (o passwordOption) applyPullOption(opts *PullOptions) {
+	opts.password = string(o)
+}
+
+// WithPassword returns a Option that sets the password.
+func WithPassword(password string) Option {
+	return passwordOption(password)
 }
 
 // insecureOption is an option to enable insecure connections.

--- a/pkg/oci/pull_test.go
+++ b/pkg/oci/pull_test.go
@@ -45,6 +45,8 @@ func TestPullFileFromRegistry(t *testing.T) {
 				dst,
 				ociURL,
 				WithInsecure(),
+				WithUsername("testuser"),
+				WithPassword("testpassword"),
 				WithTargetOS(platform.OS),
 				WithTargetArch(platform.Arch),
 				WithMediaType("text/plain"),

--- a/pkg/oci/push_test.go
+++ b/pkg/oci/push_test.go
@@ -56,7 +56,7 @@ func pushTestFiles(t *testing.T, workDir, ociURL string) map[Platform]string {
 		FilePaths:    artifactFiles,
 	}
 
-	if err := PushFilesToRegistry(t.Context(), workDir, artifact, ociURL, WithInsecure()); err != nil {
+	if err := PushFilesToRegistry(t.Context(), workDir, artifact, ociURL, WithInsecure(), WithUsername("testuser"), WithPassword("testpassword")); err != nil {
 		t.Fatalf("could not push files to OCI: %s", err)
 	}
 

--- a/pkg/oci/testdata/auth/htpasswd
+++ b/pkg/oci/testdata/auth/htpasswd
@@ -1,0 +1,1 @@
+testuser:$2y$05$kGzzxsFBJdwLiPGDq4XVtO/1fPJB.8YW64ITiB6PxUiSdK4GJ/tK2


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We want to support push/pull plugins to/from OCI Registry with authentication.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
