### PR TITLE
[K8s Pluigin] Implement generatePrimaryManifests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
@@ -199,7 +199,7 @@ func (p *Plugin) executeK8sPrimaryRolloutStage(ctx context.Context, input *sdk.E
 }
 
 // generatePrimaryManifests generates manifests for the PRIMARY variant.
-// It shallowly duplicates the input manifests, adds the variant label to workloads if needed,
+// It duplicates the input manifests, adds the variant label to workloads if needed,
 // and generates Service manifests with a name suffix and variant selector if requested.
 func generatePrimaryManifests(manifests []provider.Manifest, stageCfg kubeconfig.K8sPrimaryRolloutStageOptions, variantLabel, variant string) ([]provider.Manifest, error) {
 	suffix := variant

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary.go
@@ -136,7 +136,7 @@ func (p *Plugin) executeK8sPrimaryRolloutStage(ctx context.Context, input *sdk.E
 	applier := provider.NewApplier(kubectl, cfg.Spec.Input, deployTargetConfig, input.Logger)
 
 	// Start applying all manifests to add or update running resources.
-	if err := applyManifests(ctx, applier, manifests, cfg.Spec.Input.Namespace, lp); err != nil {
+	if err := applyManifests(ctx, applier, primaryManifests, cfg.Spec.Input.Namespace, lp); err != nil {
 		lp.Errorf("Failed while applying manifests (%v)", err)
 		return sdk.StageStatusSuccess
 	}
@@ -172,7 +172,7 @@ func (p *Plugin) executeK8sPrimaryRolloutStage(ctx context.Context, input *sdk.E
 
 	lp.Successf("Successfully loaded %d live resources", len(namespacedLiveResources)+len(clusterScopedLiveResources))
 
-	removeKeys := provider.FindRemoveResources(manifests, namespacedLiveResources, clusterScopedLiveResources)
+	removeKeys := provider.FindRemoveResources(primaryManifests, namespacedLiveResources, clusterScopedLiveResources)
 	if len(removeKeys) == 0 {
 		lp.Info("There are no live resources should be removed")
 		return sdk.StageStatusSuccess

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
@@ -21,11 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
@@ -194,4 +197,161 @@ func TestPlugin_executeK8sPrimaryRolloutStage_withPrune(t *testing.T) {
 		assert.Error(t, err)
 		require.Truef(t, apierrors.IsNotFound(err), "expected error to be NotFound, but got %v", err)
 	})
+}
+
+func TestGeneratePrimaryManifests(t *testing.T) {
+	t.Parallel()
+
+	const variantLabel = "pipecd.dev/variant"
+	const variant = "primary"
+
+	testcases := []struct {
+		name       string
+		inputYAML  string
+		stageCfg   kubeConfigPkg.K8sPrimaryRolloutStageOptions
+		expectYAML string
+		expectErr  bool
+	}{
+		{
+			name: "add variant label to selector",
+			inputYAML: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			stageCfg: kubeConfigPkg.K8sPrimaryRolloutStageOptions{
+				AddVariantLabelToSelector: true,
+			},
+			expectYAML: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+`,
+		},
+		{
+			name: "create service with suffix",
+			inputYAML: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: my-app
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+`,
+			stageCfg: kubeConfigPkg.K8sPrimaryRolloutStageOptions{
+				CreateService: true,
+				Suffix:        "custom",
+			},
+			expectYAML: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: my-app
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-custom
+spec:
+  selector:
+    app: my-app
+    pipecd.dev/variant: primary
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+`,
+		},
+		{
+			name: "error when no service found for CreateService",
+			inputYAML: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+`,
+			stageCfg: kubeConfigPkg.K8sPrimaryRolloutStageOptions{
+				CreateService: true,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifests, err := provider.ParseManifests(tc.inputYAML)
+			require.NoError(t, err)
+
+			result, err := generatePrimaryManifests(manifests, tc.stageCfg, variantLabel, variant)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			expects, err := provider.ParseManifests(tc.expectYAML)
+			require.NoError(t, err)
+			require.Equal(t, len(expects), len(result))
+
+			for i := range expects {
+				// Compare manifests by converting to structured objects.
+				switch expects[i].Kind() {
+				case "Deployment":
+					var want, got appsv1.Deployment
+					err := expects[i].ConvertToStructuredObject(&want)
+					require.NoError(t, err)
+					err = result[i].ConvertToStructuredObject(&got)
+					require.NoError(t, err)
+					assert.Equal(t, want, got)
+				case "Service":
+					var want, got corev1.Service
+					err := expects[i].ConvertToStructuredObject(&want)
+					require.NoError(t, err)
+					err = result[i].ConvertToStructuredObject(&got)
+					require.NoError(t, err)
+					assert.Equal(t, want, got)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:

- implement generatePrimaryManifests
- implement generateVariantServiceManifests

**Why we need it**:

To use it in the K8S_PRIMARY_ROLLOUT stage

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
