### PR TITLE
Implement comparing bool with boolean string value

### DIFF
--- a/pkg/app/piped/driftdetector/cloudrun/detector.go
+++ b/pkg/app/piped/driftdetector/cloudrun/detector.go
@@ -211,6 +211,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		diff.WithEquateEmpty(),
 		diff.WithIgnoreAddingMapKeys(),
 		diff.WithCompareNumberAndNumericString(),
+		diff.WithCompareBooleanAndBooleanString(),
 	)
 	if err != nil {
 		return err

--- a/pkg/app/piped/planpreview/cloudrundiff.go
+++ b/pkg/app/piped/planpreview/cloudrundiff.go
@@ -66,6 +66,7 @@ func (b *builder) cloudrundiff(
 		newManifest,
 		diff.WithEquateEmpty(),
 		diff.WithCompareNumberAndNumericString(),
+		diff.WithCompareBooleanAndBooleanString(),
 	)
 	if err != nil {
 		fmt.Fprintf(buf, "failed to compare manifests (%v)\n", err)

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -42,6 +42,7 @@ func TestDiff(t *testing.T) {
 				WithEquateEmpty(),
 				WithIgnoreAddingMapKeys(),
 				WithCompareNumberAndNumericString(),
+				WithCompareBooleanAndBooleanString(),
 			},
 			diffNum: 0,
 		},

--- a/pkg/diff/renderer.go
+++ b/pkg/diff/renderer.go
@@ -206,6 +206,9 @@ func renderNodeValue(v reflect.Value, prefix string) (string, bool) {
 	case reflect.Float32, reflect.Float64:
 		return strconv.FormatFloat(v.Float(), 'f', -1, 64), false
 
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool()), false
+
 	default:
 		return v.String(), false
 	}

--- a/pkg/diff/renderer_test.go
+++ b/pkg/diff/renderer_test.go
@@ -43,6 +43,10 @@ func TestRenderNodeValue(t *testing.T) {
 			"one": []string{"one-1", "one-2"},
 			"two": []string{"two-1", "two-2"},
 		}
+		mapOfBool = map[string]interface{}{
+			"false": false,
+			"true":  true,
+		}
 	)
 
 	testcases := []struct {
@@ -64,6 +68,16 @@ func TestRenderNodeValue(t *testing.T) {
 			name:     "string value",
 			value:    reflect.ValueOf("hello"),
 			expected: "hello",
+		},
+		{
+			name:     "bool value (true)",
+			value:    reflect.ValueOf(true),
+			expected: "true",
+		},
+		{
+			name:     "bool value (false)",
+			value:    reflect.ValueOf(false),
+			expected: "false",
 		},
 		{
 			name: "slice of primitive elements",
@@ -141,6 +155,12 @@ two: two-value`,
   - a
   - b
 7-string: hi`,
+		},
+		{
+			name:  "map of bool",
+			value: reflect.ValueOf(mapOfBool),
+			expected: `false: false
+true: true`,
 		},
 	}
 

--- a/pkg/diff/testdata/no_diff.yaml
+++ b/pkg/diff/testdata/no_diff.yaml
@@ -9,6 +9,10 @@ metadata:
     zeroString1: ""
     zeroInt1: 0
     zeroFloat1: 0.0
+    booleanString1: "true"
+    booleanString2: true
+    booleanString3: "false"
+    booleanString4: false 
 spec:
   replicas: 2
   number: 1
@@ -53,6 +57,10 @@ metadata:
     zeroString2: ""
     zeroInt2: 0
     zeroFloat2: 0.0
+    booleanString1: true
+    booleanString2: "true"
+    booleanString3: false
+    booleanString4: "false"
 spec:
   replicas: 2
   number: 1.0

--- a/pkg/plugin/diff/diff.go
+++ b/pkg/plugin/diff/diff.go
@@ -24,11 +24,12 @@ import (
 )
 
 type differ struct {
-	ignoreAddingMapKeys           bool
-	equateEmpty                   bool
-	compareNumberAndNumericString bool
-	ignoredPaths                  map[string]struct{}
-	ignoreConfig                  map[string][]string
+	ignoreAddingMapKeys            bool
+	equateEmpty                    bool
+	compareNumberAndNumericString  bool
+	compareBooleanAndBooleanString bool
+	ignoredPaths                   map[string]struct{}
+	ignoreConfig                   map[string][]string
 
 	result *Result
 }
@@ -56,6 +57,15 @@ func WithEquateEmpty() Option {
 func WithCompareNumberAndNumericString() Option {
 	return func(d *differ) {
 		d.compareNumberAndNumericString = true
+	}
+}
+
+// WithCompareBooleanAndBooleanString configures differ to compare a boolean with a string.
+// Differ parses the string to boolean before comparing their values.
+// e.g. true == "true"
+func WithCompareBooleanAndBooleanString() Option {
+	return func(d *differ) {
+		d.compareBooleanAndBooleanString = true
 	}
 }
 
@@ -131,6 +141,24 @@ func (d *differ) diff(path []PathStep, vx, vy reflect.Value) error {
 		if isNumberValue(vy) {
 			if x, ok := convertToNumber(vx); ok {
 				return d.diffNumber(path, x, vy)
+			}
+		}
+	}
+
+	if isBooleanValue(vx) && isBooleanValue(vy) {
+		return d.diffBool(path, vx, vy)
+	}
+
+	if d.compareBooleanAndBooleanString {
+		if isBooleanValue(vx) {
+			if y, ok := convertToBoolean(vy); ok {
+				return d.diffBool(path, vx, y)
+			}
+		}
+
+		if isBooleanValue(vy) {
+			if x, ok := convertToBoolean(vx); ok {
+				return d.diffBool(path, x, vy)
 			}
 		}
 	}
@@ -323,6 +351,18 @@ func convertToNumber(v reflect.Value) (reflect.Value, bool) {
 	default:
 		return v, false
 	}
+}
+
+func isBooleanValue(v reflect.Value) bool {
+	return v.Kind() == reflect.Bool
+}
+
+func convertToBoolean(v reflect.Value) (reflect.Value, bool) {
+	if v.Kind() == reflect.String {
+		b, err := strconv.ParseBool(v.String())
+		return reflect.ValueOf(b), err == nil
+	}
+	return v, false
 }
 
 func newSlicePath(path []PathStep, index int) []PathStep {

--- a/pkg/plugin/diff/diff_test.go
+++ b/pkg/plugin/diff/diff_test.go
@@ -42,6 +42,7 @@ func TestDiff(t *testing.T) {
 				WithEquateEmpty(),
 				WithIgnoreAddingMapKeys(),
 				WithCompareNumberAndNumericString(),
+				WithCompareBooleanAndBooleanString(),
 			},
 			diffNum: 0,
 		},

--- a/pkg/plugin/diff/renderer.go
+++ b/pkg/plugin/diff/renderer.go
@@ -201,6 +201,9 @@ func renderNodeValue(v reflect.Value, prefix string) (string, bool) {
 	case reflect.Float32, reflect.Float64:
 		return strconv.FormatFloat(v.Float(), 'f', -1, 64), false
 
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool()), false
+
 	default:
 		return v.String(), false
 	}

--- a/pkg/plugin/diff/renderer_test.go
+++ b/pkg/plugin/diff/renderer_test.go
@@ -43,6 +43,10 @@ func TestRenderNodeValue(t *testing.T) {
 			"one": []string{"one-1", "one-2"},
 			"two": []string{"two-1", "two-2"},
 		}
+		mapOfBool = map[string]interface{}{
+			"false": false,
+			"true":  true,
+		}
 	)
 
 	testcases := []struct {
@@ -64,6 +68,16 @@ func TestRenderNodeValue(t *testing.T) {
 			name:     "string value",
 			value:    reflect.ValueOf("hello"),
 			expected: "hello",
+		},
+		{
+			name:     "bool value (true)",
+			value:    reflect.ValueOf(true),
+			expected: "true",
+		},
+		{
+			name:     "bool value (false)",
+			value:    reflect.ValueOf(false),
+			expected: "false",
 		},
 		{
 			name: "slice of primitive elements",
@@ -141,6 +155,12 @@ two: two-value`,
   - a
   - b
 7-string: hi`,
+		},
+		{
+			name:  "map of bool",
+			value: reflect.ValueOf(mapOfBool),
+			expected: `false: false
+true: true`,
 		},
 	}
 

--- a/pkg/plugin/diff/testdata/no_diff.yaml
+++ b/pkg/plugin/diff/testdata/no_diff.yaml
@@ -9,6 +9,10 @@ metadata:
     zeroString1: ""
     zeroInt1: 0
     zeroFloat1: 0.0
+    booleanString1: "true"
+    booleanString2: true
+    booleanString3: "false"
+    booleanString4: false
 spec:
   replicas: 2
   number: 1
@@ -53,6 +57,10 @@ metadata:
     zeroString2: ""
     zeroInt2: 0
     zeroFloat2: 0.0
+    booleanString1: true
+    booleanString2: "true"
+    booleanString3: false
+    booleanString4: "false"
 spec:
   replicas: 2
   number: 1.0


### PR DESCRIPTION
**What this PR does**:

- Add support for comparing boolean values with boolean strings

**Why we need it**:

Sometimes, we write a boolean value in the fields whose type is a string. In this case, such fields are converted to strings in the retrieved livestate. This makes non-sense diffs in the drift detection.

**Which issue(s) this PR fixes**:

Fixes #4790 

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**:
Some diffs affected by this bug will disappear.

- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
