### PR TITLE
Untag removed tags from ECS

### DIFF
--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -189,8 +189,8 @@ func applyServiceDefinition(ctx context.Context, cli provider.Client, serviceDef
 func findRemovedTags(currentTags, desiredTags []types.Tag) []string {
 	var tagsToRemove []string
 
-	// Avoid removing PipeCD-managed tags, even though they're usually set in loadServiceDefinition()
 	for _, t := range currentTags {
+		// Avoid removing PipeCD-managed tags, even though they're usually set in loadServiceDefinition()
 		if *t.Key == provider.LabelManagedBy || *t.Key == provider.LabelPiped || *t.Key == provider.LabelApplication || *t.Key == provider.LabelCommitHash {
 			continue
 		}

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -189,6 +189,7 @@ func applyServiceDefinition(ctx context.Context, cli provider.Client, serviceDef
 func findRemovedTags(currentTags, desiredTags []types.Tag) []string {
 	var tagsToRemove []string
 
+	// Avoid removing PipeCD-managed tags, even though they're usually set in loadServiceDefinition()
 	for _, t := range currentTags {
 		if *t.Key == provider.LabelManagedBy || *t.Key == provider.LabelPiped || *t.Key == provider.LabelApplication || *t.Key == provider.LabelCommitHash {
 			continue

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -191,7 +191,7 @@ func findRemovedTags(currentTags, desiredTags []types.Tag) []string {
 
 	for _, t := range currentTags {
 		// Avoid removing PipeCD-managed tags, even though they're usually set in loadServiceDefinition()
-		if *t.Key == provider.LabelManagedBy || *t.Key == provider.LabelPiped || *t.Key == provider.LabelApplication || *t.Key == provider.LabelCommitHash {
+		if provider.IsPipeCDManagedTag(*t.Key) {
 			continue
 		}
 

--- a/pkg/app/piped/executor/ecs/ecs_test.go
+++ b/pkg/app/piped/executor/ecs/ecs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ import (
 func TestFindRemovedTags(t *testing.T) {
 	currentTags := []types.Tag{
 		{Key: strPtr(provider.LabelManagedBy), Value: strPtr("piped")},
+		{Key: strPtr(provider.LabelPiped), Value: strPtr("piped-id")},
+		{Key: strPtr(provider.LabelApplication), Value: strPtr("app-id")},
+		{Key: strPtr(provider.LabelCommitHash), Value: strPtr("commit-sha")},
 		{Key: strPtr("region"), Value: strPtr("us-west-1")},
 		{Key: strPtr("project"), Value: strPtr("abc")},
 	}

--- a/pkg/app/piped/executor/ecs/ecs_test.go
+++ b/pkg/app/piped/executor/ecs/ecs_test.go
@@ -1,0 +1,29 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/stretchr/testify/assert"
+
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/ecs"
+)
+
+func TestFindRemovedTags(t *testing.T) {
+	currentTags := []types.Tag{
+		{Key: strPtr(provider.LabelManagedBy), Value: strPtr("piped")},
+		{Key: strPtr("region"), Value: strPtr("us-west-1")},
+		{Key: strPtr("project"), Value: strPtr("abc")},
+	}
+
+	desiredTags := []types.Tag{
+		{Key: strPtr("project"), Value: strPtr("abc")},
+	}
+
+	got := findRemovedTags(currentTags, desiredTags)
+	assert.ElementsMatch(t, []string{"region"}, got)
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/app/piped/executor/ecs/ecs_test.go
+++ b/pkg/app/piped/executor/ecs/ecs_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ecs
 
 import (

--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -648,3 +648,33 @@ func (c *client) GetTaskSetTasks(ctx context.Context, taskSet types.TaskSet) ([]
 
 	return tasks, nil
 }
+
+func (c *client) ListTags(ctx context.Context, resourceArn string) ([]types.Tag, error) {
+	input := &ecs.ListTagsForResourceInput{
+		ResourceArn: aws.String(resourceArn),
+	}
+
+	output, err := c.ecsClient.ListTagsForResource(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make([]types.Tag, 0, len(output.Tags))
+	for _, t := range output.Tags {
+		tags = append(tags, types.Tag{
+			Key:   t.Key,
+			Value: t.Value,
+		})
+	}
+	return tags, nil
+}
+
+func (c *client) UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error {
+	input := &ecs.UntagResourceInput{
+		ResourceArn: aws.String(resourceArn),
+		TagKeys:     tagKeys,
+	}
+
+	_, err := c.ecsClient.UntagResource(ctx, input)
+	return err
+}

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -58,6 +58,8 @@ type ECS interface {
 	DeleteTaskSet(ctx context.Context, taskSet types.TaskSet) error
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 	TagResource(ctx context.Context, resourceArn string, tags []types.Tag) error
+	ListTags(ctx context.Context, resourceArn string) ([]types.Tag, error)
+	UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error
 }
 
 type ELB interface {

--- a/pkg/app/piped/platformprovider/ecs/ecs.go
+++ b/pkg/app/piped/platformprovider/ecs/ecs.go
@@ -137,3 +137,8 @@ func MakeTags(tags map[string]string) []types.Tag {
 	}
 	return resourceTags
 }
+
+// IsPipeCDManagedTag checks if the given tag key is managed by PipeCD.
+func IsPipeCDManagedTag(key string) bool {
+	return key == LabelManagedBy || key == LabelPiped || key == LabelApplication || key == LabelCommitHash
+}


### PR DESCRIPTION
**What this PR does**:
Removes outdated ECS service tags while preserving Pipecd-managed tags
**Why we need it**:
To keep service tags in sync with desired state 

1. ListTags() retrieves all the current tags
2. The findRemovedTags() helper function identifies tags that are no longer desired
3.The tagsToRemove list is passed to UntagResource() to remove outdated tags
4.[pipecd managed tags](https://github.com/pipe-cd/pipecd/blob/eadee8b7f6d1cb85512dfe47636d3ca36748223f/pkg/app/piped/platformprovider/ecs/ecs.go#L31-L34) are skipped and never removed

**Which issue(s) this PR fixes**:

Fixes #4696 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
