### PR TITLE
[k8s multicluster plugin] Calculate status for multiple livestate

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -133,8 +133,8 @@ func (p Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, deployTarge
 	for _, ss := range syncStates {
 		appSyncState.Reason = fmt.Sprintf("%s\n%s", appSyncState.Reason, ss.Reason)
 		appSyncState.ShortReason = fmt.Sprintf("%s\n%s", appSyncState.ShortReason, ss.ShortReason)
-		appSyncState.Status = sdk.ApplicationSyncStateOutOfSync // TODO: Implement health status calculation
 	}
+	appSyncState.Status = calculateSyncStatus(syncStates)
 
 	return &sdk.GetLivestateResponse{
 		LiveState: appLiveState,
@@ -209,6 +209,38 @@ func calculateSyncState(diffResult *provider.DiffListResult, commit string, dt *
 		ShortReason: shortReason,
 		Reason:      b.String(),
 	}
+}
+
+func calculateSyncStatus(states []sdk.ApplicationSyncState) sdk.ApplicationSyncStatus {
+	var (
+		hasInvalidConfig bool
+		hasUnknown       bool
+		hasOutOfSync     bool
+	)
+	for _, state := range states {
+		switch state.Status {
+		case sdk.ApplicationSyncStateInvalidConfig:
+			hasInvalidConfig = true
+		case sdk.ApplicationSyncStateUnknown:
+			hasUnknown = true
+		case sdk.ApplicationSyncStateOutOfSync:
+			hasOutOfSync = true
+		}
+	}
+
+	if hasInvalidConfig {
+		return sdk.ApplicationSyncStateInvalidConfig
+	}
+
+	if hasUnknown {
+		return sdk.ApplicationSyncStateUnknown
+	}
+
+	if hasOutOfSync {
+		return sdk.ApplicationSyncStateOutOfSync
+	}
+
+	return sdk.ApplicationSyncStateSynced
 }
 
 type loader interface {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -660,3 +660,59 @@ func Test_calculateSyncStatus(t *testing.T) {
 		})
 	}
 }
+func Test_calculateHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		states []sdk.ApplicationLiveState
+		want   sdk.ApplicationHealthStatus
+	}{
+		{
+			name: "all states are Healthy",
+			states: []sdk.ApplicationLiveState{
+				{HealthStatus: sdk.ApplicationHealthStateHealthy},
+				{HealthStatus: sdk.ApplicationHealthStateHealthy},
+			},
+			want: sdk.ApplicationHealthStateHealthy,
+		},
+		{
+			name: "one state is Other",
+			states: []sdk.ApplicationLiveState{
+				{HealthStatus: sdk.ApplicationHealthStateHealthy},
+				{HealthStatus: sdk.ApplicationHealthStateOther},
+			},
+			want: sdk.ApplicationHealthStateOther,
+		},
+		{
+			name: "one state is Unknown",
+			states: []sdk.ApplicationLiveState{
+				{HealthStatus: sdk.ApplicationHealthStateHealthy},
+				{HealthStatus: sdk.ApplicationHealthStateUnknown},
+			},
+			want: sdk.ApplicationHealthStateUnknown,
+		},
+		{
+			name: "priority: Unknown > Other > Healthy",
+			states: []sdk.ApplicationLiveState{
+				{HealthStatus: sdk.ApplicationHealthStateOther},
+				{HealthStatus: sdk.ApplicationHealthStateUnknown},
+			},
+			want: sdk.ApplicationHealthStateUnknown,
+		},
+		{
+			name:   "empty states returns Healthy",
+			states: []sdk.ApplicationLiveState{},
+			want:   sdk.ApplicationHealthStateHealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := calculateHealthStatus(tt.states)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -652,7 +652,6 @@ func Test_calculateSyncStatus(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := calculateSyncStatus(tt.args.states)
@@ -708,7 +707,6 @@ func Test_calculateHealthStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := calculateHealthStatus(tt.states)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -559,3 +559,104 @@ data:
 		})
 	}
 }
+func Test_calculateSyncStatus(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		states []sdk.ApplicationSyncState
+	}
+	tests := []struct {
+		name string
+		args args
+		want sdk.ApplicationSyncStatus
+	}{
+		{
+			name: "all states are Synced",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateSynced},
+				},
+			},
+			want: sdk.ApplicationSyncStateSynced,
+		},
+		{
+			name: "one state is OutOfSync",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateOutOfSync},
+				},
+			},
+			want: sdk.ApplicationSyncStateOutOfSync,
+		},
+		{
+			name: "one state is Unknown",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateUnknown},
+				},
+			},
+			want: sdk.ApplicationSyncStateUnknown,
+		},
+		{
+			name: "one state is InvalidConfig",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateInvalidConfig},
+				},
+			},
+			want: sdk.ApplicationSyncStateInvalidConfig,
+		},
+		{
+			name: "priority: InvalidConfig > Unknown > OutOfSync > Synced",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateOutOfSync},
+					{Status: sdk.ApplicationSyncStateUnknown},
+					{Status: sdk.ApplicationSyncStateInvalidConfig},
+				},
+			},
+			want: sdk.ApplicationSyncStateInvalidConfig,
+		},
+		{
+			name: "priority: Unknown > OutOfSync > Synced",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateOutOfSync},
+					{Status: sdk.ApplicationSyncStateUnknown},
+				},
+			},
+			want: sdk.ApplicationSyncStateUnknown,
+		},
+		{
+			name: "priority: OutOfSync > Synced",
+			args: args{
+				states: []sdk.ApplicationSyncState{
+					{Status: sdk.ApplicationSyncStateSynced},
+					{Status: sdk.ApplicationSyncStateOutOfSync},
+				},
+			},
+			want: sdk.ApplicationSyncStateOutOfSync,
+		},
+		{
+			name: "empty states returns Synced",
+			args: args{
+				states: []sdk.ApplicationSyncState{},
+			},
+			want: sdk.ApplicationSyncStateSynced,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := calculateSyncStatus(tt.args.states)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Since there are multiple livestates, I want to determine a single final status based on them.

**Which issue(s) this PR fixes**:

Follow #5778

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
