### PR TITLE
[K8s plugin] Add health status calculation for Deployment resources

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/health_status.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/health_status.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func (m Manifest) calculateHealthStatus() (sdk.ResourceHealthStatus, string) {
+	switch {
+	case m.IsDeployment():
+		obj := &appsv1.Deployment{}
+		if err := m.ConvertToStructuredObject(obj); err != nil {
+			return sdk.ResourceHealthStateUnknown, ""
+		}
+		return deploymentHealthStatus(obj)
+	default:
+		// TODO: Implement health status calculation for other resource types.
+		return sdk.ResourceHealthStateUnknown, fmt.Sprintf("Unimplemented or unknown resource: %s", m.body.GroupVersionKind())
+	}
+}
+
+func deploymentHealthStatus(obj *appsv1.Deployment) (sdk.ResourceHealthStatus, string) {
+	if obj.Spec.Paused {
+		return sdk.ResourceHealthStateUnknown, "Deployment is paused"
+	}
+	if obj.Generation > obj.Status.ObservedGeneration {
+		return sdk.ResourceHealthStateUnknown, "Waiting for rollout to finish because observed deployment generation less than desired generation"
+	}
+	const (
+		reasonTimeout = "ProgressDeadlineExceeded"
+	)
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing && cond.Reason == reasonTimeout {
+			return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Deployment %q exceeded its progress deadline", obj.GetName())
+		}
+	}
+
+	if obj.Spec.Replicas == nil {
+		return sdk.ResourceHealthStateUnknown, "The number of desired replicas is unspecified"
+	}
+	if obj.Status.Replicas < *obj.Spec.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be updated", obj.Status.Replicas-obj.Status.AvailableReplicas, obj.Status.Replicas)
+	}
+	if obj.Status.UpdatedReplicas < obj.Status.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("%d old replicas are pending termination", obj.Status.Replicas-obj.Status.UpdatedReplicas)
+	}
+	if obj.Status.AvailableReplicas < obj.Status.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be available", obj.Status.Replicas-obj.Status.AvailableReplicas, obj.Status.Replicas)
+	}
+	return sdk.ResourceHealthStateHealthy, ""
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/health_status.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/health_status.go
@@ -55,8 +55,8 @@ func deploymentHealthStatus(obj *appsv1.Deployment) (sdk.ResourceHealthStatus, s
 	if obj.Spec.Replicas == nil {
 		return sdk.ResourceHealthStateUnknown, "The number of desired replicas is unspecified"
 	}
-	if obj.Status.Replicas < *obj.Spec.Replicas {
-		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be updated", obj.Status.Replicas-obj.Status.AvailableReplicas, obj.Status.Replicas)
+	if obj.Status.UpdatedReplicas < *obj.Spec.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be updated", obj.Status.UpdatedReplicas, *obj.Spec.Replicas)
 	}
 	if obj.Status.UpdatedReplicas < obj.Status.Replicas {
 		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("%d old replicas are pending termination", obj.Status.Replicas-obj.Status.UpdatedReplicas)

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/health_status_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/health_status_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func TestDeploymentHealthStatus(t *testing.T) {
+	int32Ptr := func(i int32) *int32 { return &i }
+
+	tests := []struct {
+		name   string
+		obj    *appsv1.Deployment
+		health sdk.ResourceHealthStatus
+		msg    string
+	}{
+		{
+			name: "paused",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Paused: true, Replicas: int32Ptr(3)},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "Deployment is paused",
+		},
+		{
+			name: "generation mismatch",
+			obj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "Waiting for rollout to finish because observed deployment generation less than desired generation",
+		},
+		{
+			name: "progress deadline exceeded",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{{
+						Type:   appsv1.DeploymentProgressing,
+						Reason: "ProgressDeadlineExceeded",
+					}},
+				},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "exceeded its progress deadline",
+		},
+		{
+			name: "unspecified replicas",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "The number of desired replicas is unspecified",
+		},
+		{
+			name: "not enough replicas",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(5)},
+				Status: appsv1.DeploymentStatus{Replicas: 3, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "Waiting for remaining",
+		},
+		{
+			name: "old replicas pending termination",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 2, AvailableReplicas: 3},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "old replicas are pending termination",
+		},
+		{
+			name: "not enough available replicas",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(4)},
+				Status: appsv1.DeploymentStatus{Replicas: 4, UpdatedReplicas: 4, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "Waiting for remaining",
+		},
+		{
+			name: "healthy",
+			obj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "healthy-deploy"},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+				Status:     appsv1.DeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateHealthy,
+			msg:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h, msg := deploymentHealthStatus(tt.obj)
+			assert.Equal(t, tt.health, h)
+			if tt.msg != "" {
+				require.NotEmpty(t, msg)
+				assert.Contains(t, msg, tt.msg)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/health_status_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/health_status_test.go
@@ -90,7 +90,7 @@ func TestDeploymentHealthStatus(t *testing.T) {
 				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 2, AvailableReplicas: 3},
 			},
 			health: sdk.ResourceHealthStateUnhealthy,
-			msg:    "old replicas are pending termination",
+			msg:    "Waiting for remaining",
 		},
 		{
 			name: "not enough available replicas",

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
@@ -210,12 +210,14 @@ func (m Manifest) ToResourceState(deployTarget string) sdk.ResourceState {
 		}
 	}
 
+	status, desc := m.calculateHealthStatus()
+
 	return sdk.ResourceState{
 		ID:                string(m.body.GetUID()),
 		Name:              m.body.GetName(),
 		ParentIDs:         parents,
-		HealthStatus:      sdk.ResourceHealthStateUnknown, // TODO: Implement health status calculation
-		HealthDescription: "",                             // TODO: Implement health status calculation
+		HealthStatus:      status,
+		HealthDescription: desc,
 		ResourceType:      m.body.GetKind(),
 		ResourceMetadata: map[string]string{
 			"Namespace":   m.body.GetNamespace(),

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest_test.go
@@ -822,7 +822,7 @@ func TestManifest_ToResourceState(t *testing.T) {
 				Name:              "nginx-deployment",
 				ParentIDs:         nil,
 				HealthStatus:      sdk.ResourceHealthStateUnknown,
-				HealthDescription: "",
+				HealthDescription: "The number of desired replicas is unspecified",
 				ResourceType:      "Deployment",
 				ResourceMetadata: map[string]string{
 					"Namespace":   "default",
@@ -863,7 +863,7 @@ func TestManifest_ToResourceState(t *testing.T) {
 				Name:              "nginx-deployment",
 				ParentIDs:         []string{"67890"},
 				HealthStatus:      sdk.ResourceHealthStateUnknown,
-				HealthDescription: "",
+				HealthDescription: "The number of desired replicas is unspecified",
 				ResourceType:      "Deployment",
 				ResourceMetadata: map[string]string{
 					"Namespace":   "default",

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func (m Manifest) calculateHealthStatus() (sdk.ResourceHealthStatus, string) {
+	switch {
+	case m.IsDeployment():
+		obj := &appsv1.Deployment{}
+		if err := m.ConvertToStructuredObject(obj); err != nil {
+			return sdk.ResourceHealthStateUnknown, ""
+		}
+		return deploymentHealthStatus(obj)
+	default:
+		// TODO: Implement health status calculation for other resource types.
+		return sdk.ResourceHealthStateUnknown, fmt.Sprintf("Unimplemented or unknown resource: %s", m.body.GroupVersionKind())
+	}
+}
+
+func deploymentHealthStatus(obj *appsv1.Deployment) (sdk.ResourceHealthStatus, string) {
+	if obj.Spec.Paused {
+		return sdk.ResourceHealthStateUnknown, "Deployment is paused"
+	}
+	if obj.Generation > obj.Status.ObservedGeneration {
+		return sdk.ResourceHealthStateUnknown, "Waiting for rollout to finish because observed deployment generation less than desired generation"
+	}
+	const (
+		reasonTimeout = "ProgressDeadlineExceeded"
+	)
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing && cond.Reason == reasonTimeout {
+			return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Deployment %q exceeded its progress deadline", obj.GetName())
+		}
+	}
+
+	if obj.Spec.Replicas == nil {
+		return sdk.ResourceHealthStateUnknown, "The number of desired replicas is unspecified"
+	}
+	if obj.Status.UpdatedReplicas < *obj.Spec.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be updated", obj.Status.UpdatedReplicas, *obj.Spec.Replicas)
+	}
+	if obj.Status.UpdatedReplicas < obj.Status.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("%d old replicas are pending termination", obj.Status.Replicas-obj.Status.UpdatedReplicas)
+	}
+	if obj.Status.AvailableReplicas < obj.Status.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be available", obj.Status.Replicas-obj.Status.AvailableReplicas, obj.Status.Replicas)
+	}
+	return sdk.ResourceHealthStateHealthy, ""
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func TestDeploymentHealthStatus(t *testing.T) {
+	int32Ptr := func(i int32) *int32 { return &i }
+
+	tests := []struct {
+		name   string
+		obj    *appsv1.Deployment
+		health sdk.ResourceHealthStatus
+		msg    string
+	}{
+		{
+			name: "paused",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Paused: true, Replicas: int32Ptr(3)},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "Deployment is paused",
+		},
+		{
+			name: "generation mismatch",
+			obj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status:     appsv1.DeploymentStatus{ObservedGeneration: 1},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "Waiting for rollout to finish because observed deployment generation less than desired generation",
+		},
+		{
+			name: "progress deadline exceeded",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{{
+						Type:   appsv1.DeploymentProgressing,
+						Reason: "ProgressDeadlineExceeded",
+					}},
+				},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "exceeded its progress deadline",
+		},
+		{
+			name: "unspecified replicas",
+			obj: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{},
+			},
+			health: sdk.ResourceHealthStateUnknown,
+			msg:    "The number of desired replicas is unspecified",
+		},
+		{
+			name: "not enough replicas",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(5)},
+				Status: appsv1.DeploymentStatus{Replicas: 3, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "Waiting for remaining",
+		},
+		{
+			name: "old replicas pending termination",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+				Status: appsv1.DeploymentStatus{Replicas: 3, UpdatedReplicas: 2, AvailableReplicas: 3},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "Waiting for remaining",
+		},
+		{
+			name: "not enough available replicas",
+			obj: &appsv1.Deployment{
+				Spec:   appsv1.DeploymentSpec{Replicas: int32Ptr(4)},
+				Status: appsv1.DeploymentStatus{Replicas: 4, UpdatedReplicas: 4, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateUnhealthy,
+			msg:    "Waiting for remaining",
+		},
+		{
+			name: "healthy",
+			obj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "healthy-deploy"},
+				Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+				Status:     appsv1.DeploymentStatus{Replicas: 2, UpdatedReplicas: 2, AvailableReplicas: 2},
+			},
+			health: sdk.ResourceHealthStateHealthy,
+			msg:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h, msg := deploymentHealthStatus(tt.obj)
+			assert.Equal(t, tt.health, h)
+			if tt.msg != "" {
+				require.NotEmpty(t, msg)
+				assert.Contains(t, msg, tt.msg)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
@@ -210,12 +210,14 @@ func (m Manifest) ToResourceState(deployTarget string) sdk.ResourceState {
 		}
 	}
 
+	status, desc := m.calculateHealthStatus()
+
 	return sdk.ResourceState{
 		ID:                string(m.body.GetUID()),
 		Name:              m.body.GetName(),
 		ParentIDs:         parents,
-		HealthStatus:      sdk.ResourceHealthStateUnknown, // TODO: Implement health status calculation
-		HealthDescription: "",                             // TODO: Implement health status calculation
+		HealthStatus:      status,
+		HealthDescription: desc,
 		ResourceType:      m.body.GetKind(),
 		ResourceMetadata: map[string]string{
 			"Namespace":   m.body.GetNamespace(),

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest_test.go
@@ -822,7 +822,7 @@ func TestManifest_ToResourceState(t *testing.T) {
 				Name:              "nginx-deployment",
 				ParentIDs:         nil,
 				HealthStatus:      sdk.ResourceHealthStateUnknown,
-				HealthDescription: "",
+				HealthDescription: "The number of desired replicas is unspecified",
 				ResourceType:      "Deployment",
 				ResourceMetadata: map[string]string{
 					"Namespace":   "default",
@@ -863,7 +863,7 @@ func TestManifest_ToResourceState(t *testing.T) {
 				Name:              "nginx-deployment",
 				ParentIDs:         []string{"67890"},
 				HealthStatus:      sdk.ResourceHealthStateUnknown,
-				HealthDescription: "",
+				HealthDescription: "The number of desired replicas is unspecified",
 				ResourceType:      "Deployment",
 				ResourceMetadata: map[string]string{
 					"Namespace":   "default",


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We want to display health statuses in the web UI

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
