### PR TITLE
Enable pipedv0 to parse app config with plugins

### DIFF
--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -60,7 +60,6 @@ type GenericApplicationSpec struct {
 	DriftDetection *DriftDetection `json:"driftDetection"`
 	// NOTE: Do not use the field, only added here to avoid unmarshalling error.
 	// List of the configuration for plugin
-	// This field is plugin-specific, so intentionally restrict the access for the actual value here and decode it on the SDK side.
 	Plugins map[string]struct{} `json:"plugins"`
 }
 

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -58,7 +58,7 @@ type GenericApplicationSpec struct {
 	EventWatcher []EventWatcherConfig `json:"eventWatcher"`
 	// Configuration for drift detection
 	DriftDetection *DriftDetection `json:"driftDetection"`
-	// NOTE: Do not use the field, only added here to avoid unmarshalling error.
+	// NOTE: Do not use the field in pipedv0, only added here to avoid unmarshalling error for compatibility with pipedv1.
 	// List of the configuration for plugin
 	Plugins map[string]struct{} `json:"plugins"`
 }

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -58,6 +58,10 @@ type GenericApplicationSpec struct {
 	EventWatcher []EventWatcherConfig `json:"eventWatcher"`
 	// Configuration for drift detection
 	DriftDetection *DriftDetection `json:"driftDetection"`
+	// NOTE: Do not use the field, only added here to avoid unmarshalling error.
+	// List of the configuration for plugin
+	// This field is plugin-specific, so intentionally restrict the access for the actual value here and decode it on the SDK side.
+	Plugins map[string]struct{} `json:"plugins"`
 }
 
 type DeploymentPlanner struct {


### PR DESCRIPTION
**What this PR does**:

**Why we need it**:

we want to make pipedv0 works with applications which registered by pipedv1 - thus contains plugins config in its config

I tried referring to the `configv1/appplication` structure directly from pipedv0, but it's overcomplicated, compared to this way, we just need to keep the configuration surface the same, but the logic for pipedv0 remained using `config/application` structure.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
