### PR TITLE
ECS: Fix bug of rolling back when canaryTargetGroup was newly introduced

### DIFF
--- a/pkg/app/piped/executor/ecs/deploy.go
+++ b/pkg/app/piped/executor/ecs/deploy.go
@@ -206,6 +206,9 @@ func (e *deployExecutor) ensureTrafficRouting(ctx context.Context) model.StageSt
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	// Persist to identify targetGroup in rollback.
+	e.Input.MetadataStore.Shared().Put(ctx, canaryTargetGroupArnKey, *canary.TargetGroupArn)
+
 	if !routing(ctx, &e.Input, e.platformProviderName, e.platformProviderCfg, *primary, *canary) {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -40,6 +40,7 @@ const (
 	trafficRouteCanaryMetadataKey  = "canary-percentage"
 	canaryScaleMetadataKey         = "canary-scale"
 	currentListenersKey            = "current-listeners"
+	canaryTargetGroupArnKey        = "canary-target-group-arn"
 )
 
 type registerer interface {

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -171,6 +171,7 @@ func rollbackELB(ctx context.Context, in *executor.Input, client provider.Client
 			in.LogPersister.Infof("Skip rolling back ELB listeners because it seems the deployment failed before updating them")
 			return true
 		}
+		in.LogPersister.Infof("Successfully got canary target group ARN from metadata store, although it was not included in the last successful commit: %s", canaryTargetGroupArn)
 	} else {
 		// When canaryTargetGroup exists in the previous commit, simply use it.
 		canaryTargetGroupArn = *canaryTargetGroup.TargetGroupArn
@@ -198,5 +199,6 @@ func rollbackELB(ctx context.Context, in *executor.Input, client provider.Client
 		return false
 	}
 
+	in.LogPersister.Infof("Successfully rolled back ELB listeners of target groups %s (PRIMARY) and %s (CANARY)", *primaryTargetGroup.TargetGroupArn, canaryTargetGroupArn)
 	return true
 }

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -140,26 +140,8 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 	}
 
 	// Reset routing in case of rolling back progressive pipeline.
-	if primaryTargetGroup != nil && canaryTargetGroup != nil {
-		routingTrafficCfg := provider.RoutingTrafficConfig{
-			{
-				TargetGroupArn: *primaryTargetGroup.TargetGroupArn,
-				Weight:         100,
-			},
-			{
-				TargetGroupArn: *canaryTargetGroup.TargetGroupArn,
-				Weight:         0,
-			},
-		}
-
-		currListenerArns, err := client.GetListenerArns(ctx, *primaryTargetGroup)
-		if err != nil {
-			in.LogPersister.Errorf("Failed to get current active listeners: %v", err)
-			return false
-		}
-
-		if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
-			in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
+	if primaryTargetGroup != nil {
+		if !rollbackELB(ctx, in, client, primaryTargetGroup, canaryTargetGroup) {
 			return false
 		}
 	}
@@ -175,5 +157,46 @@ func rollback(ctx context.Context, in *executor.Input, platformProviderName stri
 	}
 
 	in.LogPersister.Infof("Rolled back the ECS service %s and task definition %s configuration to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
+	return true
+}
+
+func rollbackELB(ctx context.Context, in *executor.Input, client provider.Client, primaryTargetGroup *types.LoadBalancer, canaryTargetGroup *types.LoadBalancer) bool {
+	var canaryTargetGroupArn string
+	if canaryTargetGroup == nil {
+		// Get the touched canary target group from a TRAFFIC_ROUTING stage.
+		// canaryTargetGroup does not exist in the previous commit when the attempted deployment newly introduced it.
+		var ok bool
+		canaryTargetGroupArn, ok = in.MetadataStore.Shared().Get(canaryTargetGroupArnKey)
+		if !ok {
+			in.LogPersister.Infof("Skip rolling back ELB listeners because it seems the deployment failed before updating them")
+			return true
+		}
+	} else {
+		// When canaryTargetGroup exists in the previous commit, simply use it.
+		canaryTargetGroupArn = *canaryTargetGroup.TargetGroupArn
+	}
+
+	routingTrafficCfg := provider.RoutingTrafficConfig{
+		{
+			TargetGroupArn: *primaryTargetGroup.TargetGroupArn,
+			Weight:         100,
+		},
+		{
+			TargetGroupArn: canaryTargetGroupArn,
+			Weight:         0,
+		},
+	}
+
+	currListenerArns, err := client.GetListenerArns(ctx, *primaryTargetGroup)
+	if err != nil {
+		in.LogPersister.Errorf("Failed to get current active listeners: %v", err)
+		return false
+	}
+
+	if err := client.ModifyListeners(ctx, currListenerArns, routingTrafficCfg); err != nil {
+		in.LogPersister.Errorf("Failed to routing traffic to PRIMARY/CANARY variants: %v", err)
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
**What this PR does**:

- as title


Note: canaryTargetGroup is necessary for rollback due to the following spec:

> When you use an ELB for deployments, all listener rules that have the same target groups as configured in app.pipecd.yaml will be controlled.

https://pipecd.dev/docs-v0.51.x/user-guide/managing-application/defining-app-configuration/ecs/#note


**Why we need it**:

Without this PR, traffic weights won't be rolled back if the deployment newly introduced canaryTargetGroup.




**Which issue(s) this PR fixes**:

Fixes #5280 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
