### PR TITLE
delete all application resources when need

### DIFF
--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -124,6 +124,15 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 }
 
 func findRemoveResources(manifests []provider.Manifest, liveResources []provider.Manifest) []provider.ResourceKey {
+	// Special case of when no manifests exists
+	if len(manifests) == 0 {
+		// If there are no manifests in Git, all live resources should be removed
+		removeKeys := make([]provider.ResourceKey, 0, len(liveResources))
+		for _, m := range liveResources {
+			removeKeys = append(removeKeys, m.Key)
+		}
+		return removeKeys
+	}
 	var (
 		keys       = make(map[provider.ResourceKey]struct{}, len(manifests))
 		removeKeys = make([]provider.ResourceKey, 0)

--- a/pkg/app/piped/executor/kubernetes/sync_test.go
+++ b/pkg/app/piped/executor/kubernetes/sync_test.go
@@ -389,6 +389,56 @@ func TestFindRemoveResources(t *testing.T) {
 			},
 			want: []provider.ResourceKey{},
 		},
+		{
+			name:      "all resources removed when no manifests exist",
+			manifests: []provider.Manifest{},
+			liveResources: []provider.Manifest{
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Namespace:  "default",
+						Name:       "service1",
+					},
+				},
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Namespace:  "default",
+						Name:       "deployment1",
+					},
+				},
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Namespace:  "default",
+						Name:       "config1",
+					},
+				},
+			},
+			want: []provider.ResourceKey{
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Namespace:  "default",
+					Name:       "service1",
+				},
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Namespace:  "default",
+					Name:       "deployment1",
+				},
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Namespace:  "default",
+					Name:       "config1",
+				},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Vaidik Bhardwaj <vaidikbhardwaj00@gmail.com>

**What this PR does**:
1. Added special case for when there are no manifests, delete all resources when prune `enables` works.

2. Added a test case for no manifests 

**Why we need it**:
#5413 

The current logic was not explicitly handling, When there were no manifests

**Which issue(s) this PR fixes**:

Fixes #5413 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:No
- **Is this breaking change**:No
- **How to migrate (if breaking change)**:
