### PR TITLE
Add a make command to setup OIDC IdP instantly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ gomock_reflect_*/
 
 # Cache
 .cache
+
+# hack
+hack/oidc/realm.local.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,10 @@ Then, copy generated Piped ID and base64 key for `piped-config.yaml`
 
 4. Run `make run/piped CONFIG_FILE=piped-config.yaml` to start Piped agent.
 
+#### Set Up Local OIDC Provider(Keycloak)
+
+Run `make setup-local-oidc` to set up local OIDC provider(keycloak). This will create a new Keycloak realm and an OIDC client for PipeCD. See [Local Keycloak](./hack/oidc/README.md) for more details.
+
 ### Online one-click setup for contributing
 
 We are preparing Gitpod and Codespace to facilitate the setup process for contributing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,10 +237,6 @@ Then, copy generated Piped ID and base64 key for `piped-config.yaml`
 
 4. Run `make run/piped CONFIG_FILE=piped-config.yaml` to start Piped agent.
 
-#### Set Up Local OIDC Provider(Keycloak)
-
-Run `make setup-local-oidc` to set up local OIDC provider(keycloak). This will create a new Keycloak realm and an OIDC client for PipeCD. See [Local Keycloak](./hack/oidc/README.md) for more details.
-
 ### Online one-click setup for contributing
 
 We are preparing Gitpod and Codespace to facilitate the setup process for contributing.

--- a/Makefile
+++ b/Makefile
@@ -285,3 +285,7 @@ check/gen: gen/code
 .PHONY: check/dco
 check/dco:
 	./hack/ensure-dco.sh
+
+.PHONY: setup-local-oidc
+setup-local-oidc:
+	./hack/oidc/run-local-keycloak.sh

--- a/Makefile
+++ b/Makefile
@@ -289,3 +289,7 @@ check/dco:
 .PHONY: setup-local-oidc
 setup-local-oidc:
 	./hack/oidc/run-local-keycloak.sh
+
+.PHONY: delete-local-oidc
+delete-local-oidc:
+	docker compose -f ./hack/oidc/docker-compose.yml down

--- a/cmd/pipecd/README.md
+++ b/cmd/pipecd/README.md
@@ -55,3 +55,7 @@ For the full list of available commands, please see the Makefile at the root of 
 
 ## How to run Piped locally and add an application to your cluster
 See [How to run Piped agent locally](https://github.com/pipe-cd/pipecd/tree/master/cmd/piped#how-to-run-piped-agent-locally).
+
+## How to set up OIDC provider(Keycloak) locally
+
+Run `make setup-local-oidc` to set up local OIDC provider(keycloak). This will create a new Keycloak realm and an OIDC client for PipeCD. See [Local Keycloak](../../hack/oidc/README.md) for more details.

--- a/hack/oidc/README.md
+++ b/hack/oidc/README.md
@@ -35,6 +35,9 @@ make setup-local-oidc
 | Default PipeCD OIDC Client | `pipecd-keycloak`                                       |
 | Issuer URL                 | `http://<private-ip>:8081/realms/pipecd-test-realm`     |
 | Redirect URI(PipeCD)       | `http://localhost:8080/auth/callback`                   |
+| Imported Groups            | `Admin`, `Editor`, `Viewer`                             |
+| Imported Realm Roles       | `Admin`, `Editor`, `Viewer`                             |
+| Imported Client Roles      | `Admin`, `Editor`, `Viewer`                             |
 
 ### ⚠️ Note
 

--- a/hack/oidc/README.md
+++ b/hack/oidc/README.md
@@ -4,13 +4,23 @@ This setup provides a ready-to-use local Keycloak instance for testing OIDC auth
 
 ---
 
+## 📦 Dependencies
+
+- Docker
+- docker-compose (v2+ recommended)
+- `envsubst` (usually part of GNU `gettext`)
+
 ## ✅ How to Run
+
+1. Run a local KeyCloak
 
 ```bash
 make setup-local-oidc
 ```
 
-You may override the following environment variables:
+Then, you will receive an example config of `sharedSSOConfigs`.
+
+(Optional) You may override the following environment variables:
 
 ```bash
 PIPECD_CONTROL_PLANE_ADDRESS=http://localhost:8080 \
@@ -18,11 +28,11 @@ LOCAL_KEYCLOAK_ADDRESS=http://192.168.1.100:8081 \
 make setup-local-oidc
 ```
 
-📦 Dependencies
+2. Run a Control Plane with the `sharedSSOConfigs` you received.
 
-- Docker
-- docker-compose (v2+ recommended)
-- `envsubst` (usually part of GNU `gettext`)
+3. Add a project via the Owner Page, and login with the static admin, and add a User Group, and then logout. See [Adding a Project](https://pipecd.dev/docs/user-guide/managing-controlplane/adding-a-project/).
+
+4. Login with OIDC
 
 ## ⚙️ Default Configuration
 

--- a/hack/oidc/README.md
+++ b/hack/oidc/README.md
@@ -1,0 +1,117 @@
+# 🔐 Testing OIDC with Keycloak
+
+This setup provides a ready-to-use local Keycloak instance for testing OIDC authentication flows. It includes realm import automation, default test users, client roles, realm roles, group-based mappings, and preconfigured mappers.
+
+---
+
+## ✅ How to Run
+
+```bash
+make setup-local-oidc
+```
+
+You may override the following environment variables:
+
+```bash
+PIPECD_CONTROL_PLANE_ADDRESS=http://localhost:8080 \
+LOCAL_KEYCLOAK_ADDRESS=http://192.168.1.100:8081 \
+make setup-local-oidc
+```
+
+📦 Dependencies
+
+- Docker
+- docker-compose (v2+ recommended)
+- `envsubst` (usually part of GNU `gettext`)
+
+## ⚙️ Default Configuration
+
+| Item                       | Value                                                   |
+| -------------------------- | ------------------------------------------------------- |
+| Realm Name                 | `pipecd-test-realm`                                     |
+| Admin Console              | `http://localhost:8081/` or `http://<private-ip>:8081/` |
+| Default Admin User         | `admin` / `password`                                    |
+| Imported Users             | `Admin`, `Editor`, `Viewer` (all password: `password`)  |
+| Default PipeCD OIDC Client | `pipecd-keycloak`                                       |
+| Issuer URL                 | `http://<private-ip>:8081/realms/pipecd-test-realm`     |
+| Redirect URI(PipeCD)       | `http://localhost:8080/auth/callback`                   |
+
+### ⚠️ Note
+
+- This configuration is for **local testing only**.
+- The default `issuer` uses the host's **private IP** and port 8081 (injected via shell).
+- If you plan to use **HTTPS**, be sure to configure HTTPS endpoints for both Keycloak and PipeCD.
+  - You can read more about [PipeCD Keycloak Connecting Issues](https://github.com/pipe-cd/pipecd/issues/5770#issuecomment-2888943178)
+
+---
+
+## 👥 Roles and Groups
+
+This test realm demonstrates **three types of role-based access control**:
+
+| Type        | Description                         | Example Claim  |
+| ----------- | ----------------------------------- | -------------- |
+| Realm Role  | Assigned at realm level             | `realm_roles`  |
+| Client Role | Specific to OIDC client             | `client_roles` |
+| Group Role  | Inferred from user group membership | `groups`       |
+
+### 🛠️ Switching `rolesClaimKey` in PipeCD config
+
+You can control which claim is used by PipeCD via:
+
+```yaml
+rolesClaimKey: realm_roles | client_roles | groups
+```
+
+For example:
+
+```yaml
+rolesClaimKey: client_roles
+```
+
+### 🔧 `realm.json` Customization
+
+There are two main ways to customize the `realm.json` used in this setup: via the Keycloak admin console or by directly editing the JSON file.
+
+---
+
+#### 🖥️ Using the Keycloak Console
+
+- You can modify users, roles, groups, clients, and token mappers via the Keycloak admin UI (`http://localhost:8081/`).
+- After making changes in the console, **don't forget to export your updated realm** if you want to persist or version-control it.
+
+---
+
+#### 📝 Editing `realm.json` Directly
+
+You can also edit the `realm.json` file manually if you prefer Git-based configuration.
+
+Here are the key sections:
+
+| Purpose      | Path                              | Description                                              |
+| ------------ | --------------------------------- | -------------------------------------------------------- |
+| Users        | `users[*]`                        | Define test users with username, password, roles, groups |
+| Realm Roles  | `roles.realm[*]`                  | Define realm-level roles (e.g. `Admin`, `Viewer`)        |
+| Client Roles | `roles.client.pipecd-keycloak[*]` | Define roles specific to the OIDC client                 |
+| Groups       | `groups[*]`                       | Define user groups with assigned roles                   |
+
+#### 🔄 Role Mappings
+
+| Type                | Path                            | Description                                        |
+| ------------------- | ------------------------------- | -------------------------------------------------- |
+| Realm Role Mapping  | `scopeMappings[*]`              | Maps realm roles to the client                     |
+| Token Claim Mapping | `clients[*].protocolMappers[*]` | Controls how user info appears in ID/access tokens |
+
+Example claim mappers included:
+
+- `client_roles`
+- `realm_roles`
+- `groups`
+
+Each claim is already mapped to the corresponding token via `protocolMappers`.
+
+To change role usage in your app (e.g. PipeCD), update:
+
+```yaml
+rolesClaimKey: realm_roles | client_roles | groups
+```

--- a/hack/oidc/docker-compose.yml
+++ b/hack/oidc/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.5
+    container_name: keycloak
+    command: start-dev --import-realm
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: password
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./realm.local.json:/opt/keycloak/data/import/realm.json

--- a/hack/oidc/realm.json
+++ b/hack/oidc/realm.json
@@ -1,0 +1,390 @@
+{
+  "id": "2f3b0c4e-1a2d-4b5c-8f3b-9a2f3b0c4e1d",
+  "realm": "pipecd-test-realm",
+  "displayName": "PipeCD Test Realm",
+  "displayNameHtml": "<h1 style=\"font-size: 40pt; font-weight: 400;\">PipeCD Test Realm</h1>",
+  "notBefore": 0,
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 60,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": true,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "users": [
+    {
+      "username": "Admin",
+      "enabled": true,
+      "email": "admin@example.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Admin"
+        ]
+      },
+      "realmRoles": [
+        "Admin"
+      ],
+      "groups": [
+        "/Admin"
+      ]
+    },
+    {
+      "username": "Editor",
+      "enabled": true,
+      "email": "editor@example.com",
+      "firstName": "Editor",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Editor"
+        ]
+      },
+      "realmRoles": [
+        "Editor"
+      ],
+      "groups": [
+        "/Editor"
+      ]
+    },
+    {
+      "username": "Viewer",
+      "enabled": true,
+      "email": "viewer@example.com",
+      "firstName": "Viewer",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Viewer"
+        ]
+      },
+      "realmRoles": [
+        "Viewer"
+      ],
+      "groups": [
+        "/Viewer"
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "id": "9e17c6ec-1df7-4eea-b896-c1fb564cffbe",
+        "name": "Viewer",
+        "description": "Viewer role.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1427c8c3-5062-4015-816c-a241182ccb64"
+      },
+      {
+        "id": "648755f7-14a9-40b7-b41c-84b1800541a3",
+        "name": "Editor",
+        "description": "Editor role.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1427c8c3-5062-4015-816c-a241182ccb64"
+      },
+      {
+        "id": "ff805070-808f-4ba4-8673-bcd4247249b2",
+        "name": "Admin",
+        "description": "Admin role.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "1427c8c3-5062-4015-816c-a241182ccb64"
+      }
+    ],
+    "client": {
+      "pipecd-keycloak": [
+        {
+          "name": "Admin",
+          "description": "Admin role for pipecd",
+          "composite": false,
+          "clientRole": true
+        },
+        {
+          "name": "Editor",
+          "description": "Editor role for pipecd",
+          "composite": false,
+          "clientRole": true
+        },
+        {
+          "name": "Viewer",
+          "description": "Viewer role for pipecd",
+          "composite": false,
+          "clientRole": true
+        }
+      ]
+    }
+  },
+  "groups": [
+    {
+      "id": "568e4ddd-0b18-401f-a873-f84fb11e8c9e",
+      "name": "Admin",
+      "path": "/Admin",
+      "subGroups": [],
+      "attributes": {},
+      "realmRoles": [
+        "Admin"
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Admin"
+        ]
+      }
+    },
+    {
+      "id": "1aa433d4-9daa-4455-820e-ecf93f3663e7",
+      "name": "Editor",
+      "path": "/Editor",
+      "subGroups": [],
+      "attributes": {},
+      "realmRoles": [
+        "Editor"
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Editor"
+        ]
+      }
+    },
+    {
+      "id": "e9939fc3-641d-454c-8e0f-5cefeed66e2f",
+      "name": "Viewer",
+      "path": "/Viewer",
+      "subGroups": [],
+      "attributes": {},
+      "realmRoles": [
+        "Viewer"
+      ],
+      "clientRoles": {
+        "pipecd-keycloak": [
+          "Viewer"
+        ]
+      }
+    }
+  ],
+  "defaultRoles": [
+    "Viewer"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "scopeMappings": [
+    {
+      "client": "pipecd-keycloak",
+      "roles": [
+        "Viewer",
+        "Editor",
+        "Admin"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "pipecd-keycloak",
+      "secret": "L702XzhZfnYDzcA0dbtoaMRt3ZUTw9m9",
+      "name": "PipeCD Keycloak OIDC",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "clientAuthenticatorType": "client-secret",
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "nodeReRegistrationTimeout": -1,
+      "redirectUris": [
+        "${PIPECD_CONTROL_PLANE_ADDRESS}/auth/callback"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "fullScopeAllowed": false,
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ],
+      "protocolMappers": [
+        {
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "clientId": "pipecd-keycloak",
+            "introspection.token.claim": "true",
+            "user.client.role.mapping.clientId": "pipecd-keycloak",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "client_roles",
+            "jsonType.label": "String",
+            "usermodel.clientRoleMapping.clientId": "pipecd-keycloak"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "",
+            "claim.name": "realm_roles",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "groups",
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "identityProviders": [
+    {
+      "alias": "github",
+      "internalId": "f21e0722-deec-4170-85c8-24d4c9697aba",
+      "providerId": "github",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": false,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "hideOnLoginPage": "",
+        "clientSecret": "9ba88d155e24145b6ab638629ac82d973b3afd11",
+        "clientId": "cb1df4ef524c5229c108",
+        "disableUserInfo": "",
+        "useJwksUrl": "true"
+      }
+    },
+    {
+      "alias": "saml",
+      "displayName": "Simple SAML",
+      "internalId": "f670a102-f411-4730-b18a-e4dd17442b8c",
+      "providerId": "saml",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": false,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "hideOnLoginPage": "",
+        "validateSignature": "",
+        "samlXmlKeyNameTranformer": "KEY_ID",
+        "postBindingLogout": "",
+        "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+        "postBindingResponse": "",
+        "singleLogoutServiceUrl": "http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php",
+        "backchannelSupported": "",
+        "signatureAlgorithm": "RSA_SHA256",
+        "wantAssertionsEncrypted": "",
+        "useJwksUrl": "true",
+        "wantAssertionsSigned": "",
+        "postBindingAuthnRequest": "",
+        "forceAuthn": "",
+        "singleSignOnServiceUrl": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
+        "wantAuthnRequestsSigned": ""
+      }
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "keycloakVersion": "4.5.0.Final",
+  "userManagedAccessAllowed": false
+}

--- a/hack/oidc/run-local-keycloak.sh
+++ b/hack/oidc/run-local-keycloak.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -eu
+
+# function to get the private IP address
+get_private_ip() {
+  # macOS
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    ip=$(ipconfig getifaddr en0 2>/dev/null)
+    if [[ -z "$ip" ]]; then
+      ip=$(ipconfig getifaddr en1 2>/dev/null)
+    fi
+    echo "$ip"
+    return
+  fi
+
+  # Linux
+  if command -v ip >/dev/null 2>&1; then
+    # 優先的に wlan0 → eth0 → enp0s3 を探す
+    for iface in wlan0 eth0 enp0s3; do
+      ip=$(ip -4 addr show "$iface" 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1)
+      if [[ -n "$ip" && "$ip" != "127.0.0.1" ]]; then
+        echo "$ip"
+        return
+      fi
+    done
+
+    # fallback: デフォルトルートの出口から推測
+    ip=$(ip route get 1.1.1.1 2>/dev/null | awk '/src/ {print $NF; exit}')
+    if [[ -n "$ip" && "$ip" != "127.0.0.1" ]]; then
+      echo "$ip"
+      return
+    fi
+  fi
+
+  # ifconfig fallback (BusyBoxなど)
+  if command -v ifconfig >/dev/null 2>&1; then
+    ip=$(ifconfig | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}' | sed 's/addr://')
+    echo "$ip"
+    return
+  fi
+
+  echo "Could not determine private IP address" >&2
+  return 1
+}
+
+# ====== Defaults ======
+PIPECD_CONTROL_PLANE_ADDRESS=${PIPECD_CONTROL_PLANE_ADDRESS:-http://localhost:8080}
+LOCAL_KEYCLOAK_ADDRESS=${LOCAL_KEYCLOAK_ADDRESS:-"http://$(get_private_ip):8081"}
+
+# ====== File Setup ======
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_FILE="$SCRIPT_DIR/realm.json"
+WORKING_FILE="$SCRIPT_DIR/realm.local.json"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "❌ $SOURCE_FILE not found. Aborting."
+  exit 1
+fi
+
+echo "📁 Copying $SOURCE_FILE to $WORKING_FILE"
+cp "$SOURCE_FILE" "$WORKING_FILE"
+
+echo "🔧 Replacing environment variables in $WORKING_FILE"
+export PIPECD_CONTROL_PLANE_ADDRESS LOCAL_KEYCLOAK_ADDRESS
+envsubst <"$WORKING_FILE" >"${WORKING_FILE}.tmp" && mv "${WORKING_FILE}.tmp" "$WORKING_FILE"
+
+# ====== Docker Compose Up ======
+echo ""
+echo "🚀 Starting Keycloak via docker compose"
+cd "$SCRIPT_DIR"
+docker compose up -d --force-recreate --wait
+
+# ====== Output Preview ======
+echo ""
+echo "✅ Generated $WORKING_FILE successfully"
+echo ""
+echo "🔍 Configuration (for your reference):"
+echo ""
+cat <<EOF
+apiVersion: "pipecd.dev/v1beta1"
+kind: ControlPlane
+spec:
+  stateKey: test
+  sharedSSOConfigs:
+  - name: oidc
+    provider: OIDC
+    oidc:
+      clientId: pipecd-keycloak
+      clientSecret: L702XzhZfnYDzcA0dbtoaMRt3ZUTw9m9
+      issuer: ${LOCAL_KEYCLOAK_ADDRESS}/realms/pipecd-test-realm
+      redirectUri: ${PIPECD_CONTROL_PLANE_ADDRESS}/auth/callback
+      usernameClaimKey: name
+      rolesClaimKey: realm_roles
+      scopes:
+      - openid
+      - profile
+EOF

--- a/hack/oidc/run-local-keycloak.sh
+++ b/hack/oidc/run-local-keycloak.sh
@@ -15,7 +15,6 @@ get_private_ip() {
 
   # Linux
   if command -v ip >/dev/null 2>&1; then
-    # 優先的に wlan0 → eth0 → enp0s3 を探す
     for iface in wlan0 eth0 enp0s3; do
       ip=$(ip -4 addr show "$iface" 2>/dev/null | awk '/inet / {print $2}' | cut -d/ -f1)
       if [[ -n "$ip" && "$ip" != "127.0.0.1" ]]; then
@@ -24,7 +23,6 @@ get_private_ip() {
       fi
     done
 
-    # fallback: デフォルトルートの出口から推測
     ip=$(ip route get 1.1.1.1 2>/dev/null | awk '/src/ {print $NF; exit}')
     if [[ -n "$ip" && "$ip" != "127.0.0.1" ]]; then
       echo "$ip"
@@ -32,7 +30,7 @@ get_private_ip() {
     fi
   fi
 
-  # ifconfig fallback (BusyBoxなど)
+  # ifconfig fallback (BusyBox etc.)
   if command -v ifconfig >/dev/null 2>&1; then
     ip=$(ifconfig | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}' | sed 's/addr://')
     echo "$ip"


### PR DESCRIPTION
**What this PR does**:

Sets up a local OIDC provider using Keycloak for testing and development purposes.
This includes a preconfigured realm, users, roles, groups, and a PipeCD-compatible OIDC client with claim mappers.
A setup script and Docker Compose file are also included for easy bootstrapping.

**Why we need it**:

To allow developers to test OIDC authentication flows locally without depending on external identity providers.
This improves development speed and testing reliability when integrating with control plane development

**Which issue(s) this PR fixes**:

Fixes #5770 

**Does this PR introduce a user-facing change?**: 
- **How are users affected by this change**: Developers can now run `make setup-local-oidc` to provision a local Keycloak instance for testing PipeCD integration with OIDC.
- **Is this breaking change**: No 
- **How to migrate (if breaking change)**: N/A
