### PR TITLE
feat(plugin/opentofu): add OpenTofu deployment plugin with tests

### DIFF
--- a/pkg/app/pipedv1/plugin/opentofu/main.go
+++ b/pkg/app/pipedv1/plugin/opentofu/main.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+func main() {
+	plugin, err := sdk.NewPlugin("opentofu", "0.0.1", sdk.WithStagePlugin(&plugin{}))
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if err := plugin.Run(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/pkg/app/pipedv1/plugin/opentofu/plugin.go
+++ b/pkg/app/pipedv1/plugin/opentofu/plugin.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+// allow exec.CommandContext to be overridden in tests
+var execCommand = exec.CommandContext
+
+type plugin struct{}
+
+type config struct{}
+
+type applicationConfigSpec struct{}
+
+const (
+	stagePlan    = "OPENTOFU_PLAN"
+	stageApply   = "OPENTOFU_APPLY"
+	stageDestroy = "OPENTOFU_DESTROY"
+)
+
+// BuildPipelineSyncStages implements sdk.StagePlugin.
+func (p *plugin) BuildPipelineSyncStages(context.Context, *config, *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	return &sdk.BuildPipelineSyncStagesResponse{}, nil
+}
+
+// ExecuteStage implements sdk.StagePlugin.
+func (p *plugin) ExecuteStage(ctx context.Context, _ *config, _ sdk.DeployTargetsNone, input *sdk.ExecuteStageInput[applicationConfigSpec]) (*sdk.ExecuteStageResponse, error) {
+	stage := input.Request.StageName
+	var out bytes.Buffer
+	var err error
+
+	switch stage {
+	case stagePlan:
+		cmd := execCommand(ctx, "tofu", "plan")
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err = cmd.Run()
+	case stageApply:
+		cmd := execCommand(ctx, "tofu", "apply", "-auto-approve")
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err = cmd.Run()
+	case stageDestroy:
+		cmd := execCommand(ctx, "tofu", "destroy", "-auto-approve")
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err = cmd.Run()
+	default:
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+
+	if err != nil {
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+	return &sdk.ExecuteStageResponse{Status: sdk.StageStatusSuccess}, nil
+}
+
+// FetchDefinedStages implements sdk.StagePlugin.
+func (p *plugin) FetchDefinedStages() []string {
+	return []string{stagePlan, stageApply, stageDestroy}
+}

--- a/pkg/app/pipedv1/plugin/opentofu/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/opentofu/plugin_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+)
+
+// mockExecCommand is used to mock exec.CommandContext
+var mockExecCommand func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+func TestMain(m *testing.M) {
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if mockExecCommand != nil {
+			return mockExecCommand(ctx, name, args...)
+		}
+		return exec.CommandContext(ctx, name, args...)
+	}
+	m.Run()
+}
+
+// override exec.CommandContext for testing
+// var execCommand = exec.CommandContext
+
+func (p *plugin) testableExecuteStage(ctx context.Context, stage string) (*sdk.ExecuteStageResponse, error) {
+	input := &sdk.ExecuteStageInput[applicationConfigSpec]{
+		Request: sdk.ExecuteStageRequest[applicationConfigSpec]{
+			StageName: stage,
+		},
+	}
+	return p.ExecuteStage(ctx, nil, nil, input)
+}
+
+func TestExecuteStage_Success(t *testing.T) {
+	p := &plugin{}
+	mockExecCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "echo", "success")
+	}
+	defer func() { mockExecCommand = nil }()
+
+	stages := []string{stagePlan, stageApply, stageDestroy}
+	for _, stage := range stages {
+		resp, err := p.testableExecuteStage(context.Background(), stage)
+		if err != nil {
+			t.Errorf("unexpected error for stage %s: %v", stage, err)
+		}
+		if resp.Status != sdk.StageStatusSuccess {
+			t.Errorf("expected success for stage %s, got %v", stage, resp.Status)
+		}
+	}
+}
+
+func TestExecuteStage_UnknownStage(t *testing.T) {
+	p := &plugin{}
+	resp, err := p.testableExecuteStage(context.Background(), "UNKNOWN_STAGE")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.Status != sdk.StageStatusFailure {
+		t.Errorf("expected failure for unknown stage, got %v", resp.Status)
+	}
+}


### PR DESCRIPTION
**What this PR does**
- Adds a new OpenTofu deployment plugin for PipeCD using the new plugin architecture.
- Supports the following stages: `OPENTOFU_PLAN`, `OPENTOFU_APPLY`, and `OPENTOFU_DESTROY`.
- Implements command execution for OpenTofu (`tofu` CLI) in a testable way.
- Includes unit tests with command mocking for all supported stages.

**Why we need it**
- OpenTofu is a community-driven, open-source alternative to Terraform.
- This plugin enables PipeCD users to deploy infrastructure using OpenTofu, aligning with the latest trends in the cloud-native ecosystem.
- Follows the new plugin architecture, making it easy to maintain and extend.

**Which issue(s) this PR fixes**
- Fixes #5807

**Does this PR introduce a user-facing change?**
- **How are users affected by this change:**  
  Users can now define and deploy OpenTofu applications via PipeCD using the new plugin.
- **Is this a breaking change:**  
  No, this is a new feature and does not break existing functionality.
- **How to migrate (if breaking change):**  
  N/A