### PR TITLE
[K8s Plugin] Support templating method in loading manifests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -58,14 +58,24 @@ type KubernetesDeploymentInput struct {
 	// Version of kubectl will be used.
 	KubectlVersion string `json:"kubectlVersion,omitempty"`
 
+	// Version of kustomize will be used.
+	KustomizeVersion string `json:"kustomizeVersion,omitempty"`
+	// List of options that should be used by Kustomize commands.
+	KustomizeOptions map[string]string `json:"kustomizeOptions,omitempty"`
+
+	// Version of helm will be used.
+	HelmVersion string `json:"helmVersion,omitempty"`
+	// Where to fetch helm chart.
+	HelmChart *InputHelmChart `json:"helmChart,omitempty"`
+	// Configurable parameters for helm commands.
+	HelmOptions *InputHelmOptions `json:"helmOptions,omitempty"`
+
 	// The namespace where manifests will be applied.
 	Namespace string `json:"namespace,omitempty"`
 
 	// Automatically create a new namespace if it does not exist.
 	// Default is false.
 	AutoCreateNamespace bool `json:"autoCreateNamespace,omitempty"`
-
-	// TODO: Define fields for KubernetesDeploymentInput.
 }
 
 type KubernetesVariantLabel struct {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -105,9 +105,11 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 		ConfigFilename:   deploymentSource.ApplicationConfigFilename,
 		Manifests:        spec.Input.Manifests,
 		Namespace:        spec.Input.Namespace,
-		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
-
-		// TODO: Define other fields for LoaderInput
+		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeOptions: spec.Input.KustomizeOptions,
+		HelmVersion:      spec.Input.HelmVersion,
+		HelmChart:        spec.Input.HelmChart,
+		HelmOptions:      spec.Input.HelmOptions,
 	})
 
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -163,9 +163,11 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 		ConfigFilename:   input.Request.DeploymentSource.ApplicationConfigFilename,
 		Manifests:        spec.Input.Manifests,
 		Namespace:        spec.Input.Namespace,
-		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
-
-		// TODO: Define other fields for LoaderInput
+		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeOptions: spec.Input.KustomizeOptions,
+		HelmVersion:      spec.Input.HelmVersion,
+		HelmChart:        spec.Input.HelmChart,
+		HelmOptions:      spec.Input.HelmOptions,
 	})
 
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
@@ -442,22 +442,6 @@ metadata:
 			}(),
 			wantKinds: []string{"ConfigMap"},
 		},
-		{
-			name: "kustomize-with-helm",
-			input: LoaderInput{
-				AppName:          "testapp",
-				AppDir:           "testdata/testkustomize-with-helm",
-				KustomizeVersion: "5.4.3",
-				HelmVersion:      "3.16.1",
-				KustomizeOptions: map[string]string{
-					"load-restrictor": "LoadRestrictionsNone",
-					"enable-helm":     "",
-				},
-				Logger:    zap.NewNop(),
-				Namespace: "test-ns",
-			},
-			wantKinds: nil, // just check non-empty and namespace for now
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
@@ -382,3 +382,101 @@ func TestLoader_templateHelmChart(t *testing.T) {
 		})
 	}
 }
+
+func TestLoader_LoadManifests(t *testing.T) {
+	t.Parallel()
+
+	c := toolregistrytest.NewTestToolRegistry(t)
+	loader := &Loader{
+		toolRegistry: toolregistry.NewRegistry(c),
+	}
+
+	tests := []struct {
+		name      string
+		input     LoaderInput
+		wantKinds []string
+	}{
+		{
+			name: "kustomize",
+			input: LoaderInput{
+				AppName:          "testapp",
+				AppDir:           "testdata/testkustomize",
+				KustomizeVersion: "5.4.3",
+				Logger:           zap.NewNop(),
+				Namespace:        "test-ns",
+			},
+			wantKinds: []string{"Deployment"},
+		},
+		{
+			name: "helm",
+			input: LoaderInput{
+				AppName:     "test-app",
+				AppDir:      "testdata/testhelm/appconfdir",
+				Namespace:   "test-ns",
+				HelmVersion: "3.16.1",
+				HelmChart:   &config.InputHelmChart{Path: "../../testchart"},
+				HelmOptions: &config.InputHelmOptions{},
+				Logger:      zap.NewNop(),
+			},
+			wantKinds: []string{"Deployment", "Service", "ServiceAccount"},
+		},
+		{
+			name: "plain yaml",
+			input: func() LoaderInput {
+				dir := t.TempDir()
+				manifestFile := filepath.Join(dir, "cm.yaml")
+				content := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+`
+				require.NoError(t, os.WriteFile(manifestFile, []byte(content), 0644))
+				return LoaderInput{
+					AppDir:         dir,
+					Manifests:      []string{"cm.yaml"},
+					ConfigFilename: "app.pipecd.yaml",
+					Namespace:      "test-ns",
+					Logger:         zap.NewNop(),
+				}
+			}(),
+			wantKinds: []string{"ConfigMap"},
+		},
+		{
+			name: "kustomize-with-helm",
+			input: LoaderInput{
+				AppName:          "testapp",
+				AppDir:           "testdata/testkustomize-with-helm",
+				KustomizeVersion: "5.4.3",
+				HelmVersion:      "3.16.1",
+				KustomizeOptions: map[string]string{
+					"load-restrictor": "LoadRestrictionsNone",
+					"enable-helm":     "",
+				},
+				Logger:    zap.NewNop(),
+				Namespace: "test-ns",
+			},
+			wantKinds: nil, // just check non-empty and namespace for now
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manifests, err := loader.LoadManifests(context.Background(), tt.input)
+			require.NoError(t, err)
+			require.NotEmpty(t, manifests)
+			for _, m := range manifests {
+				assert.Equal(t, "test-ns", m.body.GetNamespace())
+			}
+			if tt.wantKinds != nil {
+				var gotKinds []string
+				for _, m := range manifests {
+					gotKinds = append(gotKinds, m.Kind())
+				}
+				assert.ElementsMatch(t, gotKinds, tt.wantKinds)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
@@ -67,6 +67,18 @@ type KubernetesDeploymentInput struct {
 	// Version of kubectl will be used.
 	KubectlVersion string `json:"kubectlVersion,omitempty"`
 
+	// Version of kustomize will be used.
+	KustomizeVersion string `json:"kustomizeVersion,omitempty"`
+	// List of options that should be used by Kustomize commands.
+	KustomizeOptions map[string]string `json:"kustomizeOptions,omitempty"`
+
+	// Version of helm will be used.
+	HelmVersion string `json:"helmVersion,omitempty"`
+	// Where to fetch helm chart.
+	HelmChart *InputHelmChart `json:"helmChart,omitempty"`
+	// Configurable parameters for helm commands.
+	HelmOptions *InputHelmOptions `json:"helmOptions,omitempty"`
+
 	// The namespace where manifests will be applied.
 	Namespace string `json:"namespace,omitempty"`
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
@@ -89,9 +89,11 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 		ConfigFilename:   deploymentSource.ApplicationConfigFilename,
 		Manifests:        manifestPathes,
 		Namespace:        spec.Input.Namespace,
-		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
-
-		// TODO: Define other fields for LoaderInput
+		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeOptions: spec.Input.KustomizeOptions,
+		HelmVersion:      spec.Input.HelmVersion,
+		HelmChart:        spec.Input.HelmChart,
+		HelmOptions:      spec.Input.HelmOptions,
 	})
 
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -267,9 +267,11 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 		ConfigFilename:   input.Request.DeploymentSource.ApplicationConfigFilename,
 		Manifests:        manifestPathes,
 		Namespace:        spec.Input.Namespace,
-		TemplatingMethod: provider.TemplatingMethodNone, // TODO: Implement detection of templating method or add it to the config spec.
-
-		// TODO: Define other fields for LoaderInput
+		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeOptions: spec.Input.KustomizeOptions,
+		HelmVersion:      spec.Input.HelmVersion,
+		HelmChart:        spec.Input.HelmChart,
+		HelmOptions:      spec.Input.HelmOptions,
 	})
 
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
@@ -442,22 +442,6 @@ metadata:
 			}(),
 			wantKinds: []string{"ConfigMap"},
 		},
-		{
-			name: "kustomize-with-helm",
-			input: LoaderInput{
-				AppName:          "testapp",
-				AppDir:           "testdata/testkustomize-with-helm",
-				KustomizeVersion: "5.4.3",
-				HelmVersion:      "3.16.1",
-				KustomizeOptions: map[string]string{
-					"load-restrictor": "LoadRestrictionsNone",
-					"enable-helm":     "",
-				},
-				Logger:    zap.NewNop(),
-				Namespace: "test-ns",
-			},
-			wantKinds: nil, // just check non-empty and namespace for now
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
@@ -382,3 +382,101 @@ func TestLoader_templateHelmChart(t *testing.T) {
 		})
 	}
 }
+
+func TestLoader_LoadManifests(t *testing.T) {
+	t.Parallel()
+
+	c := toolregistrytest.NewTestToolRegistry(t)
+	loader := &Loader{
+		toolRegistry: toolregistry.NewRegistry(c),
+	}
+
+	tests := []struct {
+		name      string
+		input     LoaderInput
+		wantKinds []string
+	}{
+		{
+			name: "kustomize",
+			input: LoaderInput{
+				AppName:          "testapp",
+				AppDir:           "testdata/testkustomize",
+				KustomizeVersion: "5.4.3",
+				Logger:           zap.NewNop(),
+				Namespace:        "test-ns",
+			},
+			wantKinds: []string{"Deployment"},
+		},
+		{
+			name: "helm",
+			input: LoaderInput{
+				AppName:     "test-app",
+				AppDir:      "testdata/testhelm/appconfdir",
+				Namespace:   "test-ns",
+				HelmVersion: "3.16.1",
+				HelmChart:   &config.InputHelmChart{Path: "../../testchart"},
+				HelmOptions: &config.InputHelmOptions{},
+				Logger:      zap.NewNop(),
+			},
+			wantKinds: []string{"Deployment", "Service", "ServiceAccount"},
+		},
+		{
+			name: "plain yaml",
+			input: func() LoaderInput {
+				dir := t.TempDir()
+				manifestFile := filepath.Join(dir, "cm.yaml")
+				content := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+`
+				require.NoError(t, os.WriteFile(manifestFile, []byte(content), 0644))
+				return LoaderInput{
+					AppDir:         dir,
+					Manifests:      []string{"cm.yaml"},
+					ConfigFilename: "app.pipecd.yaml",
+					Namespace:      "test-ns",
+					Logger:         zap.NewNop(),
+				}
+			}(),
+			wantKinds: []string{"ConfigMap"},
+		},
+		{
+			name: "kustomize-with-helm",
+			input: LoaderInput{
+				AppName:          "testapp",
+				AppDir:           "testdata/testkustomize-with-helm",
+				KustomizeVersion: "5.4.3",
+				HelmVersion:      "3.16.1",
+				KustomizeOptions: map[string]string{
+					"load-restrictor": "LoadRestrictionsNone",
+					"enable-helm":     "",
+				},
+				Logger:    zap.NewNop(),
+				Namespace: "test-ns",
+			},
+			wantKinds: nil, // just check non-empty and namespace for now
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manifests, err := loader.LoadManifests(context.Background(), tt.input)
+			require.NoError(t, err)
+			require.NotEmpty(t, manifests)
+			for _, m := range manifests {
+				assert.Equal(t, "test-ns", m.body.GetNamespace())
+			}
+			if tt.wantKinds != nil {
+				var gotKinds []string
+				for _, m := range manifests {
+					gotKinds = append(gotKinds, m.Kind())
+				}
+				assert.ElementsMatch(t, gotKinds, tt.wantKinds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Implement determination of templating method when loading them.

**Why we need it**:

To support Kustomize and Helm manifests

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
