### PR TITLE
Set install path for setup-envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,9 +270,9 @@ kind-down:
 	kind delete cluster --name pipecd
 
 .PHONY: setup-envtest
-setup-envtest: export GOBIN ?= ${PWD}/.dev/bin # Where to install the setup-envtest binary
-setup-envtest: ## Download setup-envtest locally if necessary.
-	test -s $(GOBIN)/setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+setup-envtest: export GOBIN ?= ${PWD}/.dev/bin
+setup-envtest: ## Download setup-envtest locally if necessary. The setup-envtest binary is installed under the ${PWD}/.dev/bin directory.
+	test -x $(GOBIN)/setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 # Check commands
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,10 @@ test/go: COVERAGE ?= false
 test/go: COVERAGE_OPTS ?= -covermode=atomic
 test/go: COVERAGE_OUTPUT ?= coverage.out
 test/go: setup-envtest
-test/go: GOBIN ?= ${PWD}/.dev/bin # Where to find the setup-envtest binary
-test/go: ENVTEST_BIN ?= ${PWD}/.dev/bin # We need an absolute path for setup-envtest
+# Where to find the setup-envtest binary
+test/go: GOBIN ?= ${PWD}/.dev/bin
+# We need an absolute path for setup-envtest
+test/go: ENVTEST_BIN ?= ${PWD}/.dev/bin
 test/go: KUBEBUILDER_ASSETS ?= "$(shell $(GOBIN)/setup-envtest use --bin-dir $(ENVTEST_BIN) -p path)"
 test/go:
 ifeq ($(COVERAGE), true)
@@ -270,8 +272,9 @@ kind-down:
 	kind delete cluster --name pipecd
 
 .PHONY: setup-envtest
+# Where to install the setup-envtest binary
 setup-envtest: export GOBIN ?= ${PWD}/.dev/bin
-setup-envtest: ## Download setup-envtest locally if necessary. The setup-envtest binary is installed under the ${PWD}/.dev/bin directory.
+setup-envtest: ## Download setup-envtest locally if necessary.
 	test -x $(GOBIN)/setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 # Check commands

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,9 @@ test/go: COVERAGE ?= false
 test/go: COVERAGE_OPTS ?= -covermode=atomic
 test/go: COVERAGE_OUTPUT ?= coverage.out
 test/go: setup-envtest
+test/go: GOBIN ?= ${PWD}/.dev/bin # Where to find the setup-envtest binary
 test/go: ENVTEST_BIN ?= ${PWD}/.dev/bin # We need an absolute path for setup-envtest
-test/go: KUBEBUILDER_ASSETS ?= "$(shell setup-envtest use --bin-dir $(ENVTEST_BIN) -p path)"
+test/go: KUBEBUILDER_ASSETS ?= "$(shell $(GOBIN)/setup-envtest use --bin-dir $(ENVTEST_BIN) -p path)"
 test/go:
 ifeq ($(COVERAGE), true)
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test -failfast -race $(COVERAGE_OPTS) -coverprofile=$(COVERAGE_OUTPUT).tmp ./pkg/... ./cmd/...
@@ -269,6 +270,7 @@ kind-down:
 	kind delete cluster --name pipecd
 
 .PHONY: setup-envtest
+setup-envtest: export GOBIN ?= ${PWD}/.dev/bin # Where to install the setup-envtest binary
 setup-envtest: ## Download setup-envtest locally if necessary.
 	test -s $(GOBIN)/setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Without this PR, setup-envtest is installed under the `$HOME/go/bin` or user-defined GOBIN directory.
The tests fail when the user does not include it in the PATH variable.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
