### PR TITLE
[K8s Plugin] Implement duplicateManifests

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
@@ -106,3 +106,12 @@ func makeSuffixedName(name, suffix string) string {
 	}
 	return name
 }
+
+// duplicateManifests duplicates the given manifests and appends a name suffix to each manifest.
+func duplicateManifests(manifests []provider.Manifest, nameSuffix string) []provider.Manifest {
+	copied := make([]provider.Manifest, len(manifests))
+	for i, m := range manifests {
+		copied[i] = m.DeepCopyWithName(makeSuffixedName(m.Name(), nameSuffix))
+	}
+	return copied
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest.go
@@ -80,6 +80,13 @@ func (m Manifest) DeepCopy() Manifest {
 	return Manifest{body: m.body.DeepCopy()}
 }
 
+// DeepCopyWithName returns a deep copy of the manifest with the given name.
+func (m Manifest) DeepCopyWithName(name string) Manifest {
+	copied := m.DeepCopy()
+	copied.body.SetName(name)
+	return copied
+}
+
 func (m Manifest) Key() ResourceKey {
 	return makeResourceKey(m.body)
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/manifest_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/manifest_test.go
@@ -1026,6 +1026,99 @@ metadata:
 	}
 }
 
+func TestManifest_DeepCopyWithName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		yaml      string
+		newName   string
+		mutate    func(orig, copy *Manifest)
+		checkOrig func(orig Manifest)
+		checkCopy func(copy Manifest)
+	}{
+		{
+			name: "deep copy with new name does not affect original",
+			yaml: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: original-name
+  labels:
+    foo: bar
+`,
+			newName: "copied-name",
+			mutate:  nil,
+			checkOrig: func(orig Manifest) {
+				assert.Equal(t, "original-name", orig.Name())
+			},
+			checkCopy: func(copy Manifest) {
+				assert.Equal(t, "copied-name", copy.Name())
+			},
+		},
+		{
+			name: "mutate copy does not affect original",
+			yaml: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: original-name
+  labels:
+    foo: bar
+`,
+			newName: "copied-name",
+			mutate: func(orig, copy *Manifest) {
+				copy.AddLabels(map[string]string{"foo": "baz"})
+			},
+			checkOrig: func(orig Manifest) {
+				assert.Equal(t, "bar", orig.body.GetLabels()["foo"], "original label should remain unchanged")
+			},
+			checkCopy: func(copy Manifest) {
+				assert.Equal(t, "baz", copy.body.GetLabels()["foo"], "copy label should be updated")
+			},
+		},
+		{
+			name: "mutate original does not affect copy",
+			yaml: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: original-name
+  labels:
+    foo: bar
+`,
+			newName: "copied-name",
+			mutate: func(orig, copy *Manifest) {
+				orig.AddLabels(map[string]string{"foo": "baz"})
+			},
+			checkOrig: func(orig Manifest) {
+				assert.Equal(t, "baz", orig.body.GetLabels()["foo"], "original label should be updated")
+			},
+			checkCopy: func(copy Manifest) {
+				assert.Equal(t, "bar", copy.body.GetLabels()["foo"], "copy label should remain unchanged")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manifests := mustParseManifests(t, tt.yaml)
+			require.Len(t, manifests, 1)
+			orig := manifests[0]
+			copy := orig.DeepCopyWithName(tt.newName)
+
+			if tt.mutate != nil {
+				tt.mutate(&orig, &copy)
+			}
+
+			tt.checkOrig(orig)
+			tt.checkCopy(copy)
+		})
+	}
+}
+
 func TestFromStructuredObject(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does**:

- add DeepCopyWithName and duplicateManifests

**Why we need it**:

It is to be used in the canary/baseline rollout like the following codes:
https://github.com/pipe-cd/pipecd/blob/7375c07067f3d5f1db5f4b05998b57817f8ef02e/pkg/app/piped/executor/kubernetes/canary.go#L159-L167

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
