### PR TITLE
[K8s Plugin] Implement K8S_BASELINE_ROLLOUT

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
@@ -15,18 +15,142 @@
 package deployment
 
 import (
+	"cmp"
 	"context"
+	"encoding/json"
+	"fmt"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
 )
 
-func (p *Plugin) executeK8sBaselineRolloutStage(_ context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
-	input.Client.LogPersister().Error("Baseline rollout is not yet implemented")
-	return sdk.StageStatusFailure
+func (p *Plugin) executeK8sBaselineRolloutStage(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+	lp := input.Client.LogPersister()
+	lp.Info("Start baseline rollout")
+
+	// Get the deploy target config.
+	if len(dts) == 0 {
+		lp.Error("No deploy target was found")
+		return sdk.StageStatusFailure
+	}
+	deployTargetConfig := dts[0].Config
+
+	cfg, err := input.Request.RunningDeploymentSource.AppConfig()
+	if err != nil {
+		lp.Errorf("Failed while loading application config (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	var (
+		appCfg          = cfg.Spec
+		variantLabel    = appCfg.VariantLabel.Key
+		baselineVariant = appCfg.VariantLabel.BaselineValue
+	)
+
+	var stageCfg kubeconfig.K8sBaselineRolloutStageOptions
+	if err := json.Unmarshal(input.Request.StageConfig, &stageCfg); err != nil {
+		lp.Errorf("Failed while unmarshalling stage config (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
+	loader := provider.NewLoader(toolRegistry)
+
+	lp.Infof("Loading manifests at commit %s for handling", input.Request.RunningDeploymentSource.CommitHash)
+	manifests, err := p.loadManifests(ctx, &input.Request.Deployment, appCfg, &input.Request.RunningDeploymentSource, loader)
+	if err != nil {
+		lp.Errorf("Failed while loading manifests (%v)", err)
+		return sdk.StageStatusFailure
+	}
+	lp.Successf("Successfully loaded %d manifests", len(manifests))
+
+	if len(manifests) == 0 {
+		lp.Error("This application has no running Kubernetes manifests to handle")
+		return sdk.StageStatusFailure
+	}
+
+	baselineManifests, err := generateBaselineManifests(appCfg, manifests, stageCfg, variantLabel, baselineVariant)
+	if err != nil {
+		lp.Errorf("Unable to generate manifests for BASELINE variant (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	addVariantLabelsAndAnnotations(baselineManifests, variantLabel, baselineVariant)
+
+	// Get the kubectl tool path.
+	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(appCfg.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
+	if err != nil {
+		lp.Errorf("Failed while getting kubectl tool (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	// Create the kubectl wrapper for the target cluster.
+	kubectl := provider.NewKubectl(kubectlPath)
+
+	// Create the applier for the target cluster.
+	applier := provider.NewApplier(kubectl, appCfg.Input, deployTargetConfig, input.Logger)
+
+	lp.Infof("Start rolling out BASELINE variant...")
+	if err := applyManifests(ctx, applier, baselineManifests, appCfg.Input.Namespace, lp); err != nil {
+		return sdk.StageStatusFailure
+	}
+
+	lp.Success("Successfully rolled out BASELINE variant")
+	return sdk.StageStatusSuccess
 }
 
 func (p *Plugin) executeK8sBaselineCleanStage(_ context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
 	input.Client.LogPersister().Error("Baseline clean is not yet implemented")
 	return sdk.StageStatusFailure
+}
+
+func generateBaselineManifests(appCfg *kubeconfig.KubernetesApplicationSpec, manifests []provider.Manifest, stageCfg kubeconfig.K8sBaselineRolloutStageOptions, variantLabel, variant string) ([]provider.Manifest, error) {
+	suffix := variant
+	if stageCfg.Suffix != "" {
+		suffix = stageCfg.Suffix
+	}
+
+	workloads := findWorkloadManifests(manifests, appCfg.Workloads)
+	if len(workloads) == 0 {
+		return nil, fmt.Errorf("unable to find any workload manifests for BASELINE variant")
+	}
+
+	var baselineManifests []provider.Manifest
+
+	// Find service manifests and duplicate them for BASELINE variant.
+	if stageCfg.CreateService {
+		serviceName := appCfg.Service.Name
+		services := findManifests(provider.KindService, serviceName, manifests)
+		if len(services) == 0 {
+			return nil, fmt.Errorf("unable to find any service for name=%q", serviceName)
+		}
+		// Because the loaded manifests are read-only
+		// so we duplicate them to avoid updating the shared manifests data in cache.
+		services = provider.DeepCopyManifests(services)
+
+		generatedServices, err := generateVariantServiceManifests(services, variantLabel, variant, suffix)
+		if err != nil {
+			return nil, err
+		}
+		baselineManifests = append(baselineManifests, generatedServices...)
+	}
+
+	// Generate new workload manifests for VANARY variant.
+	// The generated ones will mount to the new ConfigMaps and Secrets.
+	replicasCalculator := func(cur *int32) int32 {
+		if cur == nil {
+			return 1
+		}
+		num := stageCfg.Replicas.Calculate(int(*cur), 1)
+		return int32(num)
+	}
+	generatedWorkloads, err := generateVariantWorkloadManifests(workloads, nil, nil, variantLabel, variant, suffix, replicasCalculator)
+	if err != nil {
+		return nil, err
+	}
+	baselineManifests = append(baselineManifests, generatedWorkloads...)
+
+	return baselineManifests, nil
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+
+	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
+	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
+	"github.com/pipe-cd/pipecd/pkg/plugin/sdk"
+	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+)
+
+func TestPlugin_executeK8sBaselineRolloutStage_withCreateService(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	configDir := filepath.Join("testdata", "baseline_rollout_with_create_service")
+
+	// read the application config from the example file
+	appCfg := sdk.LoadApplicationConfigForTest[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(configDir, "app.pipecd.yaml"), "kubernetes")
+
+	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+			StageName:   "K8S_BASELINE_ROLLOUT",
+			StageConfig: []byte(`{"createService": true}`),
+			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				ApplicationDirectory:      configDir,
+				CommitHash:                "0123456789",
+				ApplicationConfig:         appCfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	plugin := &Plugin{}
+
+	status := plugin.executeK8sBaselineRolloutStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	// Assert that Deployment and Service resources are created and have expected labels/annotations.
+	deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "simple-baseline", deployment.GetName())
+	assert.Equal(t, "simple", deployment.GetLabels()["app"])
+	assert.Equal(t, "baseline", deployment.GetLabels()["pipecd.dev/variant"])
+	assert.Equal(t, "baseline", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+	serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "simple-baseline", service.GetName())
+}
+
+func TestPlugin_executeK8sBaselineRolloutStage_withoutCreateService(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	configDir := filepath.Join("testdata", "baseline_rollout_without_create_service")
+
+	// read the application config from the example file
+	appCfg := sdk.LoadApplicationConfigForTest[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(configDir, "app.pipecd.yaml"), "kubernetes")
+
+	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+			StageName:   "K8S_BASELINE_ROLLOUT",
+			StageConfig: []byte(`{}`),
+			RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				ApplicationDirectory:      configDir,
+				CommitHash:                "0123456789",
+				ApplicationConfig:         appCfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	plugin := &Plugin{}
+
+	status := plugin.executeK8sBaselineRolloutStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	// Assert that Deployment and Service resources are created and have expected labels/annotations.
+	deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "simple-baseline", deployment.GetName())
+	assert.Equal(t, "simple", deployment.GetLabels()["app"])
+	assert.Equal(t, "baseline", deployment.GetLabels()["pipecd.dev/variant"])
+	assert.Equal(t, "baseline", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+	serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+	require.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
@@ -218,13 +218,16 @@ func makeSuffixedName(name, suffix string) string {
 }
 
 // addVariantLabelsAndAnnotations adds the variant label and annotation to the given manifests.
+// This also adds the resource key to the manifest.
+// This is because the resource key differs between variants.
 func addVariantLabelsAndAnnotations(m []provider.Manifest, variantLabel, variant string) {
 	for _, m := range m {
 		m.AddLabels(map[string]string{
 			variantLabel: variant,
 		})
 		m.AddAnnotations(map[string]string{
-			variantLabel: variant,
+			variantLabel:              variant,
+			provider.LabelResourceKey: m.Key().String(),
 		})
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc_test.go
@@ -361,7 +361,10 @@ metadata:
 			variantLabel: "pipecd.dev/variant",
 			variant:      "primary",
 			wantLabels:   map[string]string{"pipecd.dev/variant": "primary"},
-			wantAnnots:   map[string]string{"pipecd.dev/variant": "primary"},
+			wantAnnots: map[string]string{
+				"pipecd.dev/variant":      "primary",
+				"pipecd.dev/resource-key": ":ConfigMap::test-config",
+			},
 		},
 		{
 			name: "multiple manifests",
@@ -379,7 +382,7 @@ metadata:
 			variantLabel: "custom/label",
 			variant:      "canary",
 			wantLabels:   map[string]string{"custom/label": "canary"},
-			wantAnnots:   map[string]string{"custom/label": "canary"},
+			wantAnnots:   map[string]string{"custom/label": "canary"}, // we don't assert the resource key because it's different between two manifests
 		},
 	}
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/app.pipecd.yaml
@@ -1,0 +1,19 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: baseline-rollout
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for baseline rollout.
+  pipeline:
+    stages:
+      - name: K8S_BASELINE_ROLLOUT
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/deployment.yaml
@@ -9,12 +9,10 @@ spec:
   selector:
     matchLabels:
       app: simple
-      pipecd.dev/variant: baseline
   template:
     metadata:
       labels:
         app: simple
-        pipecd.dev/variant: baseline
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: baseline
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: baseline
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+    pipecd.dev/variant: baseline
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_with_create_service/service.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     app: simple
-    pipecd.dev/variant: baseline
   ports:
     - protocol: TCP
       port: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/app.pipecd.yaml
@@ -1,0 +1,21 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: baseline-rollout
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for baseline rollout.
+  pipeline:
+    stages:
+      - name: K8S_BASELINE_ROLLOUT
+        with:
+          createService: true
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/deployment.yaml
@@ -9,12 +9,10 @@ spec:
   selector:
     matchLabels:
       app: simple
-      pipecd.dev/variant: baseline
   template:
     metadata:
       labels:
         app: simple
-        pipecd.dev/variant: baseline
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: baseline
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: baseline
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+    pipecd.dev/variant: baseline
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_rollout_without_create_service/service.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     app: simple
-    pipecd.dev/variant: baseline
   ports:
     - protocol: TCP
       port: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc.go
@@ -39,7 +39,8 @@ func addVariantLabelsAndAnnotations(m []provider.Manifest, variantLabel, variant
 			variantLabel: variant,
 		})
 		m.AddAnnotations(map[string]string{
-			variantLabel: variant,
+			variantLabel:              variant,
+			provider.LabelResourceKey: m.Key().String(),
 		})
 	}
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc_test.go
@@ -183,7 +183,10 @@ metadata:
 			variantLabel: "pipecd.dev/variant",
 			variant:      "primary",
 			wantLabels:   map[string]string{"pipecd.dev/variant": "primary"},
-			wantAnnots:   map[string]string{"pipecd.dev/variant": "primary"},
+			wantAnnots: map[string]string{
+				"pipecd.dev/variant":      "primary",
+				"pipecd.dev/resource-key": ":ConfigMap::test-config",
+			},
 		},
 		{
 			name: "multiple manifests",
@@ -201,7 +204,7 @@ metadata:
 			variantLabel: "custom/label",
 			variant:      "canary",
 			wantLabels:   map[string]string{"custom/label": "canary"},
-			wantAnnots:   map[string]string{"custom/label": "canary"},
+			wantAnnots:   map[string]string{"custom/label": "canary"}, // we don't assert the resource key because it's different between two manifests
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**:

- fix resource key annotation bug in the baseline/canary resources
- implement K8S_BASELINE_ROLLOUT and its test

**Why we need it**:

To support k8s pipeline sync in the plugin

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
