### PR TITLE
[Plugins] Use new SDK import paths in the plugin implementations

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/determine.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 type containerImage struct {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
@@ -29,9 +29,9 @@ import (
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestPlugin_executeK8sPrimaryRolloutStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
@@ -29,9 +29,9 @@ import (
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestPlugin_executeK8sPrimaryRolloutStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestPlugin_executeK8sRollbackStage_NoPreviousDeployment(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestPlugin_executeK8sRollbackStage_NoPreviousDeployment(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestPlugin_executeK8sSyncStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/sync_test.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeConfigPkg "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestPlugin_executeK8sSyncStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -25,8 +25,8 @@ import (
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 type Plugin struct{}

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin_test.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func makeTestManifest(t *testing.T, yaml string) provider.Manifest {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/diff.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func Diff(old, new Manifest, logger *zap.Logger, opts ...diff.Option) (*diff.Result, error) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/diff_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/diff_test.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func TestDiff(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestTemplateLocalChart(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestKustomizeTemplate(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func mustParseManifests(t *testing.T, data string) []Manifest {

--- a/pkg/app/pipedv1/plugin/kubernetes/toolregistry/registry_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/toolregistry/registry_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestRegistry_Kubectl(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/determine.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 type containerImage struct {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback_test.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestPlugin_executeK8sMultiRollbackStage_compatibility_k8sPlugin_NoPreviousDeployment(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/rollback_test.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestPlugin_executeK8sMultiRollbackStage_compatibility_k8sPlugin_NoPreviousDeployment(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestPlugin_executeK8sMultiSyncStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync_test.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestPlugin_executeK8sMultiSyncStage(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -25,8 +25,8 @@ import (
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 type Plugin struct{}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -23,8 +23,8 @@ import (
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider"
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func makeTestManifest(t *testing.T, yaml string) provider.Manifest {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func Diff(old, new Manifest, logger *zap.Logger, opts ...diff.Option) (*diff.Result, error) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff_test.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/diff"
+	"github.com/pipe-cd/piped-plugin-sdk-go/diff"
 )
 
 func TestDiff(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/helm_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/helm_test.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestTemplateLocalChart(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kustomize_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kustomize_test.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestKustomizeTemplate(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/loader_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry"
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func mustParseManifests(t *testing.T, data string) []Manifest {

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry/registry_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/toolregistry/registry_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/toolregistry/toolregistrytest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 )
 
 func TestRegistry_Kubectl(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/wait/wait_test.go
+++ b/pkg/app/pipedv1/plugin/wait/wait_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pipe-cd/pipecd/pkg/plugin/logpersister/logpersistertest"
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
 )
 
 func TestWait_Complete(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

to make separate SDK module

**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
