### PR TITLE
Support go modules in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,15 +17,33 @@ env:
   HELM_VERSION: 3.17.3
 
 jobs:
+  list-go-modules:
+    runs-on: ubuntu-24.04
+    outputs:
+      modules: ${{ steps.list-go-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: List go modules
+        id: list-go-modules
+        run: |
+          echo "modules=$(find . -name go.mod -exec dirname {} \; | sort | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+
   go:
     runs-on: ubuntu-24.04
+    needs: list-go-modules
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJSON(needs.list-go-modules.outputs.modules) }}
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@f3dc5fadcaff5d8da3574b129a58db433171b1a8 #v2.1.3
         with:
+          working_directory: ${{ matrix.module }}
           go_version: ${{ env.GO_VERSION }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
+          golangci_lint_flags: --config ${{ github.workspace }}/.golangci.yml
           fail_on_error: true # this option is deprecated on v2.7.0, but we use v2.1.3, so it's still available
 
   web:


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We decided to split go modules, so we have to run golangci-lint for each module.

**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
