### PR TITLE
Fix codecov CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          root_dir: ${{ matrix.module }}
           flags: ${{ steps.make-flag.outputs.flags }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "github.com/pipe-cd/piped-plugin-sdk-go/::pkg/plugin/sdk/" # SDK's go module path is different from the root directory


### PR DESCRIPTION
**What this PR does**:

- Remove root_dir option from codecov-action
- Add codecov.yml to fix SDK paths
    - ref; https://docs.codecov.com/docs/fixing-paths

**Why we need it**:

The coverage.out is located at the root of the working directory, and codecov-action failed to find it.
ref; https://github.com/pipe-cd/pipecd/actions/runs/15271899587/job/42949250362#step:6:31

The SDK's go module path is different from this repository's path, so we have to use the `Fixing Paths` feature of CodeCov.

**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
