### PR TITLE
Add go-completed job to lint and test workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,6 +46,15 @@ jobs:
           golangci_lint_flags: --config ${{ github.workspace }}/.golangci.yml
           fail_on_error: true # this option is deprecated on v2.7.0, but we use v2.1.3, so it's still available
 
+  # This job is used to check if the go linting is completed successfully
+  # It is used to set as required check for the branch protection rules
+  go-completed:
+    runs-on: ubuntu-24.04
+    needs: go
+    steps:
+      - run: |
+          echo completed
+
   web:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,15 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # This job is used to check if the go testing is completed successfully
+  # It is used to set as required check for the branch protection rules
+  go-completed:
+    runs-on: ubuntu-24.04
+    needs: go
+    steps:
+      - run: |
+          echo completed
+
   web:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
**What this PR does**:

Add job `go-completed`, which runs after the lint and test.

**Why we need it**:

To set this as required checks at branch protection rules.
We cannot set lint/test as required when merging PRs without this.

**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
