### PR TITLE
Rename completed job to avoid confusing behavior

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,7 +48,7 @@ jobs:
 
   # This job is used to check if the go linting is completed successfully
   # It is used to set as required check for the branch protection rules
-  go-completed:
+  go-lint-completed:
     runs-on: ubuntu-24.04
     needs: go
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
 
   # This job is used to check if the go testing is completed successfully
   # It is used to set as required check for the branch protection rules
-  go-completed:
+  go-test-completed:
     runs-on: ubuntu-24.04
     needs: go
     steps:


### PR DESCRIPTION
**What this PR does**:

Rename GitHub Action Job

**Why we need it**:

We set `go-completed` as the required check, but this condition passes at one of the lint/test passes and the other is not running yet.
This behavior is not expected; we want to set both of the lint/test as required.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: 

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
