### PR TITLE
[Plugins] Remove replace directive from go.mod

### DIFF
--- a/pkg/app/pipedv1/plugin/example/go.mod
+++ b/pkg/app/pipedv1/plugin/example/go.mod
@@ -2,11 +2,7 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/example
 
 go 1.24.1
 
-replace github.com/pipe-cd/pipecd => ../../../../../
-
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
-require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-00010101000000-000000000000
+require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/pkg/app/pipedv1/plugin/example/go.sum
+++ b/pkg/app/pipedv1/plugin/example/go.sum
@@ -207,6 +207,10 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
+github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -2,14 +2,10 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes
 
 go 1.24.1
 
-replace github.com/pipe-cd/pipecd => ../../../../../
-
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/kubernetes/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.sum
@@ -410,6 +410,10 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
+github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
@@ -2,15 +2,11 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster
 
 go 1.24.1
 
-replace github.com/pipe-cd/pipecd => ../../../../../
-
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
 require (
 	github.com/creasty/defaults v1.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
@@ -410,6 +410,10 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
+github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/wait/go.mod
+++ b/pkg/app/pipedv1/plugin/wait/go.mod
@@ -2,13 +2,9 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/wait
 
 go 1.24.1
 
-replace github.com/pipe-cd/pipecd => ../../../../../
-
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
 require (
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 )

--- a/pkg/app/pipedv1/plugin/wait/go.sum
+++ b/pkg/app/pipedv1/plugin/wait/go.sum
@@ -209,6 +209,10 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
+github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
**What this PR does**:

Remove the replace directive from the go.mod of each plugin.

**Why we need it**:

To use published SDK

**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
