### PR TITLE
add more fields from deployment proto to deployment model for scriptrun plugin

### DIFF
--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -596,6 +596,12 @@ type Deployment struct {
 	TriggeredBy string
 	// CreatedAt is the time when the deployment was created.
 	CreatedAt int64
+	// RepositoryURL is the repo remote path
+	RepositoryURL string
+	// Summary is the simple description about what this deployment does
+	Summary string
+	// Labels are custom attributes to identify applications
+	Labels map[string]string
 }
 
 // newDeployment converts the model.Deployment to the internal representation.
@@ -608,6 +614,9 @@ func newDeployment(deployment *model.Deployment) Deployment {
 		ProjectID:       deployment.GetProjectId(),
 		TriggeredBy:     deployment.TriggeredBy(),
 		CreatedAt:       deployment.GetCreatedAt(),
+		RepositoryURL:   deployment.GetGitPath().GetRepo().GetRemote(),
+		Summary:         deployment.GetSummary(),
+		Labels:          deployment.GetLabels(),
 	}
 }
 


### PR DESCRIPTION
**What this PR does**: add repositoryURL, summary, and labels available from deployment proto to deployment model

**Why we need it**: scriptrun env tagging utilize this. need to be a separate commit because we need to have a new concrete piped-plugin-sdk-go version to point to from the plugin

**Which issue(s) this PR fixes**: Part of #5901



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
