### PR TITLE
Revert "Do treeless clone for git clone to improve performance"

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -166,7 +166,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 				return nil, err
 			}
 			out, err := retryCommand(3, time.Second, logger, func() ([]byte, error) {
-				args := []string{"clone", "--mirror", "--filter=tree:0", remote, repoCachePath}
+				args := []string{"clone", "--mirror", remote, repoCachePath}
 				args = append(authArgs, args...)
 				return runGitCommand(ctx, c.gitPath, "", c.envsForRepo(remote), args...)
 			})

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -164,12 +164,11 @@ func (r *repo) Copy(dest string) (Worktree, error) {
 }
 
 // CopyToModify does cloning the repository to the given destination.
-// This method clones the repository from remote origin to the given destination, not from local repository.
 // The repository is cloned to the given destination with the .
 // NOTE: the given “dest” must be a path that doesn’t exist yet.
 // If you don't, you will get an error.
 func (r *repo) CopyToModify(dest string) (Repo, error) {
-	cmd := exec.Command(r.gitPath, "clone", "--filter=tree:0", "--branch", r.clonedBranch, r.remote, dest)
+	cmd := exec.Command(r.gitPath, "clone", r.dir, dest)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, formatCommandError(err, out)
 	}
@@ -186,6 +185,16 @@ func (r *repo) CopyToModify(dest string) (Repo, error) {
 		if err := cloned.setUser(context.Background(), r.username, r.email); err != nil {
 			return nil, fmt.Errorf("failed to set user: %v", err)
 		}
+	}
+
+	// because we did a local cloning so set the remote url of origin
+	if err := cloned.setRemote(context.Background(), r.remote); err != nil {
+		return nil, err
+	}
+
+	// fetch the latest changes which doesn't exist in the local repository
+	if out, err := cloned.runGitCommand(context.Background(), "fetch"); err != nil {
+		return nil, formatCommandError(err, out)
 	}
 
 	return cloned, nil

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -288,12 +288,9 @@ func TestCopyToModify(t *testing.T) {
 	err = faker.makeRepo(org, repoName)
 	require.NoError(t, err)
 	r := &repo{
-		dir:          faker.repoDir(org, repoName),
-		gitPath:      faker.gitPath,
-		remote:       faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
-		username:     "test-user",
-		email:        "test-email",
-		clonedBranch: "master",
+		dir:     faker.repoDir(org, repoName),
+		gitPath: faker.gitPath,
+		remote:  faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
 	}
 
 	commits, err := r.ListCommits(ctx, "")


### PR DESCRIPTION
Reverts pipe-cd/pipecd#5722

The eventwatcher calls `repo.CopyToModify` every time, regardless of whether the event is registered.
This causes git clone from remote, e.g., GitHub, every time and costs network I/O.

The solution might be to call it `CopyToModify` only when the modification occurs.
For now, I revert the treeless clone because I don't have enough time to do so.

https://github.com/pipe-cd/pipecd/blob/24a573d32640e2dc78835af3ec161023cd07017d/pkg/app/piped/eventwatcher/eventwatcher.go#L322-L336