### PR TITLE
[K8s plugin] implement K8S_BASELINE_CLEAN stage

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
@@ -140,7 +140,7 @@ func (p *Plugin) executeK8sBaselineCleanStage(ctx context.Context, input *sdk.Ex
 	// Create the applier for the target cluster.
 	applier := provider.NewApplier(kubectl, appCfg.Input, deployTargetConfig, input.Logger)
 
-	if err := deleteVariantResources(ctx, lp, kubectl, applier, input.Request.Deployment.ApplicationID, variantLabel, baselineVariant); err != nil {
+	if err := deleteVariantResources(ctx, lp, kubectl, deployTargetConfig.KubeConfigPath, applier, input.Request.Deployment.ApplicationID, variantLabel, baselineVariant); err != nil {
 		lp.Errorf("Failed while deleting variant resources (%v)", err)
 		return sdk.StageStatusFailure
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline.go
@@ -102,9 +102,51 @@ func (p *Plugin) executeK8sBaselineRolloutStage(ctx context.Context, input *sdk.
 	return sdk.StageStatusSuccess
 }
 
-func (p *Plugin) executeK8sBaselineCleanStage(_ context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], _ []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
-	input.Client.LogPersister().Error("Baseline clean is not yet implemented")
-	return sdk.StageStatusFailure
+func (p *Plugin) executeK8sBaselineCleanStage(ctx context.Context, input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec], dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]) sdk.StageStatus {
+	lp := input.Client.LogPersister()
+	lp.Info("Start baseline clean")
+
+	// Get the deploy target config.
+	if len(dts) == 0 {
+		lp.Error("No deploy target was found")
+		return sdk.StageStatusFailure
+	}
+	deployTargetConfig := dts[0].Config
+
+	cfg, err := input.Request.RunningDeploymentSource.AppConfig()
+	if err != nil {
+		lp.Errorf("Failed while loading application config (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	var (
+		appCfg          = cfg.Spec
+		variantLabel    = appCfg.VariantLabel.Key
+		baselineVariant = appCfg.VariantLabel.BaselineValue
+	)
+
+	toolRegistry := toolregistry.NewRegistry(input.Client.ToolRegistry())
+
+	// Get the kubectl tool path.
+	kubectlPath, err := toolRegistry.Kubectl(ctx, cmp.Or(appCfg.Input.KubectlVersion, deployTargetConfig.KubectlVersion))
+	if err != nil {
+		lp.Errorf("Failed while getting kubectl tool (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	// Create the kubectl wrapper for the target cluster.
+	kubectl := provider.NewKubectl(kubectlPath)
+
+	// Create the applier for the target cluster.
+	applier := provider.NewApplier(kubectl, appCfg.Input, deployTargetConfig, input.Logger)
+
+	if err := deleteVariantResources(ctx, lp, kubectl, applier, input.Request.Deployment.ApplicationID, variantLabel, baselineVariant); err != nil {
+		lp.Errorf("Failed while deleting variant resources (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	lp.Success("Successfully cleaned BASELINE variant")
+	return sdk.StageStatusSuccess
 }
 
 func generateBaselineManifests(appCfg *kubeconfig.KubernetesApplicationSpec, manifests []provider.Manifest, stageCfg kubeconfig.K8sBaselineRolloutStageOptions, variantLabel, variant string) ([]provider.Manifest, error) {

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
@@ -362,3 +362,174 @@ func TestPlugin_executeK8sBaselineCleanStage_withCreateService(t *testing.T) {
 		assert.True(t, errors.IsNotFound(err))
 	})
 }
+
+func TestPlugin_executeK8sBaselineCleanStage_withoutCreateService(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	plugin := &Plugin{}
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	configDir := filepath.Join("testdata", "baseline_clean_without_create_service")
+
+	// read the application config from the example file
+	appCfg := sdk.LoadApplicationConfigForTest[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(configDir, "app.pipecd.yaml"), "kubernetes")
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+	dts := []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	}
+
+	ok := t.Run("prepare primary resources", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_SYNC",
+				StageConfig: []byte(`{}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sSyncStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that Deployment and Service resources are created and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "primary", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "primary", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", service.GetName())
+	})
+	require.True(t, ok, "prepare primary resources subtest failed, aborting")
+
+	ok = t.Run("prepare baseline resources", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_BASELINE_ROLLOUT",
+				StageConfig: []byte(`{}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sBaselineRolloutStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that Deployment and Service resources are created and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple-baseline", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "baseline", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "baseline", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+	})
+	require.True(t, ok, "prepare baseline resources subtest failed, aborting")
+
+	t.Run("execute K8S_BASELINE_CLEAN stage", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_BASELINE_CLEAN",
+				StageConfig: []byte(`{}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sBaselineCleanStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that primary variant of Deployment and Service resources are not removed and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "primary", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "primary", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", service.GetName())
+
+		// Assert that baseline variant of Deployment and Service resources are removed.
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+	})
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/baseline_test.go
@@ -191,3 +191,174 @@ func TestPlugin_executeK8sBaselineRolloutStage_withoutCreateService(t *testing.T
 	require.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
 }
+
+func TestPlugin_executeK8sBaselineCleanStage_withCreateService(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	plugin := &Plugin{}
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	configDir := filepath.Join("testdata", "baseline_clean_with_create_service")
+
+	// read the application config from the example file
+	appCfg := sdk.LoadApplicationConfigForTest[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join(configDir, "app.pipecd.yaml"), "kubernetes")
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+	dts := []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	}
+
+	ok := t.Run("prepare primary resources", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_SYNC",
+				StageConfig: []byte(`{}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sSyncStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that Deployment and Service resources are created and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "primary", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "primary", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", service.GetName())
+	})
+	require.True(t, ok, "prepare primary resources subtest failed, aborting")
+
+	ok = t.Run("prepare baseline resources", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_BASELINE_ROLLOUT",
+				StageConfig: []byte(`{"createService": true}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sBaselineRolloutStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that Deployment and Service resources are created and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple-baseline", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "baseline", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "baseline", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple-baseline", service.GetName())
+	})
+	require.True(t, ok, "prepare baseline resources subtest failed, aborting")
+
+	t.Run("execute K8S_BASELINE_CLEAN stage", func(t *testing.T) {
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_BASELINE_CLEAN",
+				StageConfig: []byte(`{}`),
+				RunningDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir,
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      configDir, // it's weired that the same directory is used for both running and target, but it's ok for the test
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		status := plugin.executeK8sBaselineCleanStage(ctx, input, dts)
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// Assert that primary variant of Deployment and Service resources are not removed and have expected labels/annotations.
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		deployment, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", deployment.GetName())
+		assert.Equal(t, "simple", deployment.GetLabels()["app"])
+		assert.Equal(t, "primary", deployment.GetLabels()["pipecd.dev/variant"])
+		assert.Equal(t, "primary", deployment.GetAnnotations()["pipecd.dev/variant"])
+
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		service, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "simple", service.GetName())
+
+		// Assert that baseline variant of Deployment and Service resources are removed.
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.Error(t, err)
+		assert.True(t, errors.IsNotFound(err))
+	})
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
-	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -275,7 +274,7 @@ func deleteResources(ctx context.Context, lp sdk.StageLogPersister, applier *pro
 // deleteVariantResources deletes the resources of the specified variant.
 // It finds the resources of the specified variant and deletes them.
 // It deletes the resources in the order of Service -> Workload -> Others -> Cluster-scoped resources.
-func deleteVariantResources(ctx context.Context, lp logpersister.StageLogPersister, kubectl *provider.Kubectl, applier *provider.Applier, applicationID, variantLabel, variant string) error {
+func deleteVariantResources(ctx context.Context, lp sdk.StageLogPersister, kubectl *provider.Kubectl, applier *provider.Applier, applicationID, variantLabel, variant string) error {
 	namespacedLiveResources, clusterScopedLiveResources, err := provider.GetLiveResources(ctx, kubectl, applicationID, fmt.Sprintf("%s=%s", variantLabel, variant))
 	if err != nil {
 		return err

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/misc.go
@@ -274,8 +274,8 @@ func deleteResources(ctx context.Context, lp sdk.StageLogPersister, applier *pro
 // deleteVariantResources deletes the resources of the specified variant.
 // It finds the resources of the specified variant and deletes them.
 // It deletes the resources in the order of Service -> Workload -> Others -> Cluster-scoped resources.
-func deleteVariantResources(ctx context.Context, lp sdk.StageLogPersister, kubectl *provider.Kubectl, applier *provider.Applier, applicationID, variantLabel, variant string) error {
-	namespacedLiveResources, clusterScopedLiveResources, err := provider.GetLiveResources(ctx, kubectl, applicationID, fmt.Sprintf("%s=%s", variantLabel, variant))
+func deleteVariantResources(ctx context.Context, lp sdk.StageLogPersister, kubectl *provider.Kubectl, kubeConfig string, applier *provider.Applier, applicationID, variantLabel, variant string) error {
+	namespacedLiveResources, clusterScopedLiveResources, err := provider.GetLiveResources(ctx, kubectl, kubeConfig, applicationID, fmt.Sprintf("%s=%s", variantLabel, variant))
 	if err != nil {
 		return err
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/app.pipecd.yaml
@@ -1,0 +1,21 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: baseline-rollout
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for baseline rollout.
+  pipeline:
+    stages:
+      - name: K8S_SYNC
+      - name: K8S_BASELINE_ROLLOUT
+      - name: K8S_BASELINE_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_with_create_service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/app.pipecd.yaml
@@ -1,0 +1,23 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: baseline-rollout
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for baseline rollout.
+  pipeline:
+    stages:
+      - name: K8S_SYNC
+      - name: K8S_BASELINE_ROLLOUT
+        with:
+          createService: true
+      - name: K8S_BASELINE_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/baseline_clean_without_create_service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 


### PR DESCRIPTION
**What this PR does**:

- fixed deleteVariantResources's argument
- implement K8S_BASELINE_CLEAN and its test

**Why we need it**:

to support pipeline sync with k8s plugin

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
