### PR TITLE
[K8s plugin] Fix to get all resources without using 'kubectl get all'

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl.go
@@ -342,6 +342,7 @@ func (c *Kubectl) GetAll(ctx context.Context, kubeconfig, namespace string, sele
 
 	cmd := exec.CommandContext(ctx, c.execPath, args...)
 
+	// use only stdout for output to prevent manifest parsing failures caused by messages on stderr, like warning messages.
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl.go
@@ -350,10 +350,7 @@ func (c *Kubectl) GetAll(ctx context.Context, kubeconfig, namespace string, sele
 		return nil, fmt.Errorf("failed to get namespace-scoped resources: stdout: %s, stderr: %s, %v", string(out), stderr.String(), err)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to get: %s, %w", string(out), err)
-	}
-	if strings.Contains(string(out), "(NotFound)") {
+	if strings.Contains(stderr.String(), "(NotFound)") {
 		// No resources found. Return nil. This is not an error.
 		return nil, nil
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl_test.go
@@ -278,7 +278,7 @@ metadata:
   labels:
     env: test
 data:
-  key: value			
+  key: value
 `),
 			want: []ResourceKey{
 				{
@@ -298,6 +298,34 @@ data:
 					name:      "nginx-service",
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name:      "no error when there are no selected resources",
+			namespace: "test",
+			selectors: []string{"env=wrong_value"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3			
+`),
+			want:    []ResourceKey{},
 			wantErr: false,
 		},
 	}
@@ -339,5 +367,4 @@ data:
 			assert.ElementsMatch(t, tt.want, keys)
 		})
 	}
-
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kubectl_test.go
@@ -1,0 +1,343 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func setupEnvTest(t *testing.T) *rest.Config {
+	t.Helper()
+
+	tEnv := new(envtest.Environment)
+	kubeCfg, err := tEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { tEnv.Stop() })
+
+	return kubeCfg
+}
+
+func kubeconfigFromRestConfig(restConfig *rest.Config) (string, error) {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters["default-cluster"] = &clientcmdapi.Cluster{
+		Server:                   restConfig.Host,
+		CertificateAuthorityData: restConfig.CAData,
+	}
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:  "default-cluster",
+		AuthInfo: "default-user",
+	}
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos["default-user"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: restConfig.CertData,
+		ClientKeyData:         restConfig.KeyData,
+	}
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+	b, err := clientcmd.Write(clientConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func TestKubectl_GetAll(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name      string
+		namespace string
+		selectors []string
+		manifests []Manifest
+		want      []ResourceKey
+		wantErr   bool
+	}{
+		{
+			name:      "get all namespace-scoped resources in defau namespace",
+			namespace: "default",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "default",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "default",
+					name:      "nginx-service",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "ConfigMap",
+					},
+					namespace: "default",
+					name:      "test-config",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "get all namespace-scoped resources for all namespaces when namespace is empty",
+			namespace: "",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "test",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "test",
+					name:      "nginx-service",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "ConfigMap",
+					},
+					namespace: "default",
+					name:      "test-config",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "get all namespace-scoped resources in a specific namespace",
+			namespace: "test",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value			
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "test",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "test",
+					name:      "nginx-service",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// prepare k8s cluster
+			restConfig := setupEnvTest(t)
+			kubeconfig, err := kubeconfigFromRestConfig(restConfig)
+			require.NoError(t, err)
+
+			kubeconfigPath := path.Join(t.TempDir(), "kubeconfig")
+			err = os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0755)
+			require.NoError(t, err)
+
+			kubectl := NewKubectl(path.Join(os.Getenv("KUBEBUILDER_ASSETS"), "kubectl"))
+
+			// create namespace for testing
+			err = kubectl.CreateNamespace(t.Context(), kubeconfigPath, "test")
+			require.NoError(t, err)
+
+			// apply resources before testing
+			for _, m := range tt.manifests {
+				// set empty namespace to use defined one in the manifest
+				err := kubectl.Apply(t.Context(), kubeconfigPath, "", m)
+				require.NoError(t, err)
+			}
+
+			got, err := kubectl.GetAll(t.Context(), kubeconfigPath, tt.namespace, tt.selectors...)
+			assert.Equal(t, tt.wantErr, err != nil)
+
+			keys := make([]ResourceKey, 0, len(tt.want))
+			for _, m := range got {
+				keys = append(keys, m.Key())
+			}
+
+			assert.ElementsMatch(t, tt.want, keys)
+		})
+	}
+
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl.go
@@ -350,10 +350,7 @@ func (c *Kubectl) GetAll(ctx context.Context, kubeconfig, namespace string, sele
 		return nil, fmt.Errorf("failed to get namespace-scoped resources: stdout: %s, stderr: %s, %v", string(out), stderr.String(), err)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to get: %s, %w", string(out), err)
-	}
-	if strings.Contains(string(out), "(NotFound)") {
+	if strings.Contains(stderr.String(), "(NotFound)") {
 		// No resources found. Return nil. This is not an error.
 		return nil, nil
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl.go
@@ -295,12 +295,42 @@ func (c *Kubectl) GetAllClusterScoped(ctx context.Context, kubeconfig string, se
 	return ms, nil
 }
 
+// getNamespaceScopedAPIResources retrieves the list of available API resources from the Kubernetes cluster.
+// It runs the `kubectl api-resources` command with the specified kubeconfig and returns the
+// names of the resources that support the "list", "get", and "delete" verbs, and are namespace-scoped.
+func (c *Kubectl) getNamespaceScopedAPIResources(ctx context.Context, kubeconfig string) ([]string, error) {
+	args := []string{"api-resources", "--namespaced=true", "--verbs=list,get,delete", "--output=name"}
+	if kubeconfig != "" {
+		args = append(args, "--kubeconfig", kubeconfig)
+	}
+	cmd := exec.CommandContext(ctx, c.execPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API resources: %s, %v", string(out), err)
+	}
+	lines := strings.Split(string(out), "\n")
+	resources := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			resources = append(resources, line)
+		}
+	}
+
+	return resources, nil
+}
+
 // GetAll retrieves all Kubernetes resources in the specified namespace and matching the given selector.
 // It returns a list of manifests or an error if the retrieval or unmarshalling fails.
 // If no resources are found, it returns nil without an error.
 func (c *Kubectl) GetAll(ctx context.Context, kubeconfig, namespace string, selector ...string) (ms []Manifest, err error) {
-	args := make([]string, 0, 7)
-	args = append(args, "get", "all", "-o", "yaml", "--selector", strings.Join(selector, ","))
+	resources, err := c.getNamespaceScopedAPIResources(ctx, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]string, 0, 8)
+	args = append(args, "get", strings.Join(resources, ","), "-o", "yaml", "--selector", strings.Join(selector, ","))
+
 	if kubeconfig != "" {
 		args = append(args, "--kubeconfig", kubeconfig)
 	}
@@ -309,8 +339,16 @@ func (c *Kubectl) GetAll(ctx context.Context, kubeconfig, namespace string, sele
 	} else {
 		args = append(args, "--namespace", namespace)
 	}
+
 	cmd := exec.CommandContext(ctx, c.execPath, args...)
-	out, err := cmd.CombinedOutput()
+
+	// use only stdout for output to prevent manifest parsing failures caused by messages on stderr, like warning messages.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace-scoped resources: stdout: %s, stderr: %s, %v", string(out), stderr.String(), err)
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get: %s, %w", string(out), err)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl_test.go
@@ -278,7 +278,7 @@ metadata:
   labels:
     env: test
 data:
-  key: value			
+  key: value
 `),
 			want: []ResourceKey{
 				{
@@ -298,6 +298,34 @@ data:
 					name:      "nginx-service",
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name:      "no error when there are no selected resources",
+			namespace: "test",
+			selectors: []string{"env=wrong_value"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3			
+`),
+			want:    []ResourceKey{},
 			wantErr: false,
 		},
 	}
@@ -339,5 +367,4 @@ data:
 			assert.ElementsMatch(t, tt.want, keys)
 		})
 	}
-
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/kubectl_test.go
@@ -1,0 +1,343 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func setupEnvTest(t *testing.T) *rest.Config {
+	t.Helper()
+
+	tEnv := new(envtest.Environment)
+	kubeCfg, err := tEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { tEnv.Stop() })
+
+	return kubeCfg
+}
+
+func kubeconfigFromRestConfig(restConfig *rest.Config) (string, error) {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters["default-cluster"] = &clientcmdapi.Cluster{
+		Server:                   restConfig.Host,
+		CertificateAuthorityData: restConfig.CAData,
+	}
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:  "default-cluster",
+		AuthInfo: "default-user",
+	}
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos["default-user"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: restConfig.CertData,
+		ClientKeyData:         restConfig.KeyData,
+	}
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+	b, err := clientcmd.Write(clientConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func TestKubectl_GetAll(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name      string
+		namespace string
+		selectors []string
+		manifests []Manifest
+		want      []ResourceKey
+		wantErr   bool
+	}{
+		{
+			name:      "get all namespace-scoped resources in defau namespace",
+			namespace: "default",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "default",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "default",
+					name:      "nginx-service",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "ConfigMap",
+					},
+					namespace: "default",
+					name:      "test-config",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "get all namespace-scoped resources for all namespaces when namespace is empty",
+			namespace: "",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "test",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "test",
+					name:      "nginx-service",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "ConfigMap",
+					},
+					namespace: "default",
+					name:      "test-config",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "get all namespace-scoped resources in a specific namespace",
+			namespace: "test",
+			selectors: []string{"env=test"},
+			manifests: mustParseManifests(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    matchLabels:
+      env: test
+  template:
+    metadata:
+      labels:
+        env: test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: test
+  labels:
+    env: test
+spec:
+  selector:
+    env: test
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  labels:
+    env: test
+data:
+  key: value			
+`),
+			want: []ResourceKey{
+				{
+					groupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					namespace: "test",
+					name:      "nginx-deployment",
+				},
+				{
+					groupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "Service",
+					},
+					namespace: "test",
+					name:      "nginx-service",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// prepare k8s cluster
+			restConfig := setupEnvTest(t)
+			kubeconfig, err := kubeconfigFromRestConfig(restConfig)
+			require.NoError(t, err)
+
+			kubeconfigPath := path.Join(t.TempDir(), "kubeconfig")
+			err = os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0755)
+			require.NoError(t, err)
+
+			kubectl := NewKubectl(path.Join(os.Getenv("KUBEBUILDER_ASSETS"), "kubectl"))
+
+			// create namespace for testing
+			err = kubectl.CreateNamespace(t.Context(), kubeconfigPath, "test")
+			require.NoError(t, err)
+
+			// apply resources before testing
+			for _, m := range tt.manifests {
+				// set empty namespace to use defined one in the manifest
+				err := kubectl.Apply(t.Context(), kubeconfigPath, "", m)
+				require.NoError(t, err)
+			}
+
+			got, err := kubectl.GetAll(t.Context(), kubeconfigPath, tt.namespace, tt.selectors...)
+			assert.Equal(t, tt.wantErr, err != nil)
+
+			keys := make([]ResourceKey, 0, len(tt.want))
+			for _, m := range got {
+				keys = append(keys, m.Key())
+			}
+
+			assert.ElementsMatch(t, tt.want, keys)
+		})
+	}
+
+}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Currently, some of the resources (such as configmap) can't be obtained from the cluster because of using `kubectl get all`. 
Not all resources can't be got by `kubectl get all` and this command is not recommended.
https://github.com/kubernetes/kubernetes/issues/124538

We can't prune resources because of it.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5764

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
