### PR TITLE
Implement K8S_CANARY_CLEAN stage

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/app.pipecd.yaml
@@ -1,0 +1,22 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary-clean
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for canary clean.
+  pipeline:
+    stages:
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          createService: true
+      - name: K8S_CANARY_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_create_service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/app.pipecd.yaml
@@ -1,0 +1,34 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary-clean-patch
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for canary clean with patch.
+  pipeline:
+    stages:
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          patches:
+          - target:
+              kind: ConfigMap
+              name: canary-patch-weight-config
+              documentRoot: $.data.'weight.yaml'
+            ops:
+            - op: yaml-replace
+              path: $.primary.weight
+              value: "90"
+            - op: yaml-replace
+              path: $.canary.weight
+              value: "10"
+      - name: K8S_CANARY_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+          - configmap.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/configmap.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: canary-patch-weight-config
+data:
+  weight.yaml: |-
+    primary:
+      weight: 100
+    canary:
+      weight: 0

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_with_patch/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/app.pipecd.yaml
@@ -1,0 +1,20 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary-clean
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for canary clean.
+  pipeline:
+    stages:
+      - name: K8S_CANARY_ROLLOUT
+      - name: K8S_CANARY_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/canary_clean_without_create_service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085 


### PR DESCRIPTION
**What this PR does**:

Implemented K8S_CANARY_CLEAN and its test

**Why we need it**:

We want to support k8s plugin pipeline sync.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5764

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
