### PR TITLE
[K8s plugin] Delete baseline/canary variant resources on K8S_ROLLBACK stage

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/rollback_test.go
@@ -255,6 +255,10 @@ func TestPlugin_executeK8sRollbackStage_PrunesCanaryAndBaselineVariants(t *testi
 		Status: sdk.StageStatusSuccess,
 	}
 
+	deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	configMapRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
 	baselineOk := t.Run("baseline rollout", func(t *testing.T) {
 		baselineInput := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
 			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
@@ -270,6 +274,26 @@ func TestPlugin_executeK8sRollbackStage_PrunesCanaryAndBaselineVariants(t *testi
 		status, err := plugin.ExecuteStage(ctx, nil, deployTargets, baselineInput)
 		require.NoError(t, err)
 		assert.Equal(t, successResponse, status)
+
+		// baseline deployment/service should exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline deployment should exist after baseline rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline service should exist after baseline rollout")
+
+		// canary/primary should not exist yet
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-canary", metav1.GetOptions{})
+		assert.Error(t, err, "canary deployment should not exist after baseline rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-canary", metav1.GetOptions{})
+		assert.Error(t, err, "canary service should not exist after baseline rollout")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config-canary", metav1.GetOptions{})
+		assert.Error(t, err, "canary configmap should not exist after baseline rollout")
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		assert.Error(t, err, "primary deployment should not exist after baseline rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		assert.Error(t, err, "primary service should not exist after baseline rollout")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config", metav1.GetOptions{})
+		assert.Error(t, err, "primary configmap should not exist after baseline rollout")
 	})
 	require.True(t, baselineOk, "baseline rollout subtest failed, aborting")
 
@@ -299,6 +323,26 @@ func TestPlugin_executeK8sRollbackStage_PrunesCanaryAndBaselineVariants(t *testi
 		status, err := plugin.ExecuteStage(ctx, nil, deployTargets, canaryInput)
 		require.NoError(t, err)
 		assert.Equal(t, successResponse, status)
+
+		// baseline deployment/service should exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline deployment should exist after baseline rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline service should exist after baseline rollout")
+
+		// canary deployment/configmap should exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-canary", metav1.GetOptions{})
+		require.NoError(t, err, "canary deployment should exist after canary rollout")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config-canary", metav1.GetOptions{})
+		require.NoError(t, err, "canary configmap should exist after canary rollout")
+
+		// primary should not exist yet
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		assert.Error(t, err, "primary deployment should not exist after canary rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		assert.Error(t, err, "primary service should not exist after canary rollout")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config", metav1.GetOptions{})
+		assert.Error(t, err, "primary configmap should not exist after canary rollout")
 	})
 	require.True(t, canaryOk, "canary rollout subtest failed, aborting")
 
@@ -317,6 +361,30 @@ func TestPlugin_executeK8sRollbackStage_PrunesCanaryAndBaselineVariants(t *testi
 		status, err := plugin.ExecuteStage(ctx, nil, deployTargets, primaryInput)
 		require.NoError(t, err)
 		assert.Equal(t, successResponse, status)
+
+		// baseline deployment/service should exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline deployment should exist after baseline rollout")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		require.NoError(t, err, "baseline service should exist after baseline rollout")
+
+		// canary deployment/configmap should exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-canary", metav1.GetOptions{})
+		require.NoError(t, err, "canary deployment should exist after canary rollout")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config-canary", metav1.GetOptions{})
+		require.NoError(t, err, "canary configmap should exist after canary rollout")
+
+		// Assert that the primary resources having the commit-hash of the target deployment
+		primaryDep, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err, "primary deployment should exist")
+		assert.Equal(t, "target-hash", primaryDep.GetAnnotations()["pipecd.dev/commit-hash"])
+		primarySvc, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err, "primary service should exist")
+		assert.Equal(t, "target-hash", primarySvc.GetAnnotations()["pipecd.dev/commit-hash"])
+		primaryCfg, err := dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config", metav1.GetOptions{})
+		require.NoError(t, err, "primary configmap should exist")
+		assert.Equal(t, "target-hash", primaryCfg.GetAnnotations()["pipecd.dev/commit-hash"])
+
 	})
 	require.True(t, primaryOk, "primary rollout subtest failed, aborting")
 
@@ -335,9 +403,40 @@ func TestPlugin_executeK8sRollbackStage_PrunesCanaryAndBaselineVariants(t *testi
 		status, err := plugin.ExecuteStage(ctx, nil, deployTargets, rollbackInput)
 		require.NoError(t, err)
 		assert.Equal(t, successResponse, status)
-	})
-	require.True(t, rollbackOk, "rollback subtest failed, aborting")
 
-	_ = dynamicClient
-	// TODO: assert that the canary and baseline resources are deleted
+		// Assert that canary and baseline resources are deleted
+		deploymentRes := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+		serviceRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+		configMapRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+		// baseline deployment/service should not exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		assert.Error(t, err, "baseline deployment should be deleted")
+		_, err = dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple-baseline", metav1.GetOptions{})
+		assert.Error(t, err, "baseline service should be deleted")
+
+		// canary deployment/configmap should not exist
+		_, err = dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple-canary", metav1.GetOptions{})
+		assert.Error(t, err, "canary deployment should be deleted")
+		_, err = dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config-canary", metav1.GetOptions{})
+		assert.Error(t, err, "canary configmap should be deleted")
+
+		// Assert that primary resources still exist
+		primaryDep, err := dynamicClient.Resource(deploymentRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err, "primary deployment should exist")
+		assert.Equal(t, "primary", primaryDep.GetLabels()["pipecd.dev/variant"])
+		primarySvc, err := dynamicClient.Resource(serviceRes).Namespace("default").Get(ctx, "simple", metav1.GetOptions{})
+		require.NoError(t, err, "primary service should exist")
+		assert.Equal(t, "simple", primarySvc.GetName())
+		primaryCfg, err := dynamicClient.Resource(configMapRes).Namespace("default").Get(ctx, "canary-patch-weight-config", metav1.GetOptions{})
+		require.NoError(t, err, "primary configmap should exist")
+		assert.Equal(t, "canary-patch-weight-config", primaryCfg.GetName())
+
+		// Assert that the primary resources having the commit-hash of the running deployment
+		assert.Equal(t, "running-hash", primaryDep.GetAnnotations()["pipecd.dev/commit-hash"])
+		assert.Equal(t, "running-hash", primarySvc.GetAnnotations()["pipecd.dev/commit-hash"])
+		assert.Equal(t, "running-hash", primaryCfg.GetAnnotations()["pipecd.dev/commit-hash"])
+	})
+
+	require.True(t, rollbackOk, "rollback subtest failed, aborting")
 }

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/app.pipecd.yaml
@@ -1,0 +1,39 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary-clean-patch
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for canary clean with patch.
+  pipeline:
+    stages:
+      - name: K8S_BASELINE_ROLLOUT
+        with:
+          createService: true
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          patches:
+          - target:
+              kind: ConfigMap
+              name: canary-patch-weight-config
+              documentRoot: $.data.'weight.yaml'
+            ops:
+            - op: yaml-replace
+              path: $.primary.weight
+              value: "90"
+            - op: yaml-replace
+              path: $.canary.weight
+              value: "10"
+      - name: K8S_PRIMARY_ROLLOUT
+      - name: K8S_BASELINE_CLEAN
+      - name: K8S_CANARY_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+          - configmap.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/app.pipecd.yaml
@@ -1,12 +1,12 @@
 apiVersion: pipecd.dev/v1beta1
 kind: Application
 spec:
-  name: canary-clean-patch
+  name: rollback-prune
   labels:
     env: example
     team: product
   description: |
-    This app is test data for canary clean with patch.
+    This app is test data for rollback with prune.
   pipeline:
     stages:
       - name: K8S_BASELINE_ROLLOUT

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/configmap.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: canary-patch-weight-config
+data:
+  weight.yaml: |-
+    primary:
+      weight: 100
+    canary:
+      weight: 0

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/running/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/app.pipecd.yaml
@@ -1,0 +1,39 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary-clean-patch
+  labels:
+    env: example
+    team: product
+  description: |
+    This app is test data for canary clean with patch.
+  pipeline:
+    stages:
+      - name: K8S_BASELINE_ROLLOUT
+        with:
+          createService: true
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          patches:
+          - target:
+              kind: ConfigMap
+              name: canary-patch-weight-config
+              documentRoot: $.data.'weight.yaml'
+            ops:
+            - op: yaml-replace
+              path: $.primary.weight
+              value: "90"
+            - op: yaml-replace
+              path: $.canary.weight
+              value: "10"
+      - name: K8S_PRIMARY_ROLLOUT
+      - name: K8S_BASELINE_CLEAN
+      - name: K8S_CANARY_CLEAN
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+          - configmap.yaml
+        kubectlVersion: 1.32.2

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/app.pipecd.yaml
@@ -1,12 +1,12 @@
 apiVersion: pipecd.dev/v1beta1
 kind: Application
 spec:
-  name: canary-clean-patch
+  name: rollback-prune
   labels:
     env: example
     team: product
   description: |
-    This app is test data for canary clean with patch.
+    This app is test data for rollback with prune.
   pipeline:
     stages:
       - name: K8S_BASELINE_ROLLOUT

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/configmap.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: canary-patch-weight-config
+data:
+  weight.yaml: |-
+    primary:
+      weight: 100
+    canary:
+      weight: 0

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: simple
+        pipecd.dev/variant: primary
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/prune_rollback/target/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple
+spec:
+  selector:
+    app: simple
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

It's supported in pipedv0, so we want to support it in the plugin, also.

**Which issue(s) this PR fixes**:

Part of #5764 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
