### PR TITLE
Add area/plugin-sdk labeler rule

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -31,5 +31,5 @@ area/pipedv1:
 - pkg/configv1/*
 - pkg/configv1/**/*
 
-area/sdk-plugins:
+area/plugin-sdk:
 - pkg/plugin/sdk/**/*


### PR DESCRIPTION
**What this PR does**:

Automatically put the label to `pkg/plugin/sdk/**/*` files (recursive).

**Why we need it**:

To clarify which PRs are related to SDK updates.


**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
