### PR TITLE
Add note of 'Visible':  each stage is not visible until it starts.

### DIFF
--- a/cmd/pipedv1/README-usage-alpha.md
+++ b/cmd/pipedv1/README-usage-alpha.md
@@ -111,3 +111,8 @@ spec:
 - wait stage plugin: TBA
 - example-stage plugin: TBA
 
+## Note
+
+- Currently, on the Deployment detail UI, each stage is not visible until it starts.
+  - The cause is that the `Visible` field of each stage is set to `false` by default in pipedv1. Instead, the new field `Rollback` is used to determine if the stage is a rollback stage.
+  - This will be modified before releasing pipedv1 beta.


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

To prevent earlier users from getting confused when deploying for now.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
