### PR TITLE
Fix the build quick sync stages method to return an empty response

### DIFF
--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -263,7 +263,7 @@ func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigS
 	return buildPipelineSyncStages(ctx, s.name, s.base, &s.config, client, request, s.logger)
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
-	// Return an empty response in case the plugin does not support the QuickSync strategy. 
+	// Return an empty response in case the plugin does not support the QuickSync strategy.
 	return &deployment.BuildQuickSyncStagesResponse{}, nil
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -263,7 +263,8 @@ func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigS
 	return buildPipelineSyncStages(ctx, s.name, s.base, &s.config, client, request, s.logger)
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method BuildQuickSyncStages not implemented")
+	// There is no stage, so just return an empty response.
+	return &deployment.BuildQuickSyncStagesResponse{}, nil
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {
 	lp := s.logPersister.StageLogPersister(request.GetInput().GetDeployment().GetId(), request.GetInput().GetStage().GetId())

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -263,7 +263,7 @@ func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigS
 	return buildPipelineSyncStages(ctx, s.name, s.base, &s.config, client, request, s.logger)
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) BuildQuickSyncStages(context.Context, *deployment.BuildQuickSyncStagesRequest) (*deployment.BuildQuickSyncStagesResponse, error) {
-	// There is no stage, so just return an empty response.
+	// Return an empty response in case the plugin does not support the QuickSync strategy. 
 	return &deployment.BuildQuickSyncStagesResponse{}, nil
 }
 func (s *StagePluginServiceServer[Config, DeployTargetConfig, ApplicationConfigSpec]) ExecuteStage(ctx context.Context, request *deployment.ExecuteStageRequest) (response *deployment.ExecuteStageResponse, _ error) {

--- a/pkg/plugin/sdk/deployment_test.go
+++ b/pkg/plugin/sdk/deployment_test.go
@@ -308,13 +308,9 @@ func TestStagePluginServiceServer_BuildQuickSyncStages(t *testing.T) {
 
 	request := &deployment.BuildQuickSyncStagesRequest{}
 	response, err := server.BuildQuickSyncStages(context.Background(), request)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-
-	if response != nil {
-		t.Errorf("expected nil response, got %v", response)
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Empty(t, response.GetStages())
 }
 
 func TestStageStatus_toModelEnum(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

The stage plugins don't support quick sync stages, so it's enough to just return an empty response.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
