### PR TITLE
Ignore when DetermineStrategy() is unsupported or returns nil

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -379,6 +379,10 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *common.Dep
 			p.logger.Warn("Unable to determine strategy using current plugin", zap.Error(err))
 			continue
 		}
+		if res == nil {
+			p.logger.Warn("plugin returned nil for DetermineStrategy()")
+			continue
+		}
 		// If the plugin does not support DetermineStrategy(), then ignore.
 		if res.Unsupported {
 			continue

--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -379,6 +379,10 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *common.Dep
 			p.logger.Warn("Unable to determine strategy using current plugin", zap.Error(err))
 			continue
 		}
+		// If the plugin does not support DetermineStrategy(), then ignore.
+		if res.Unsupported {
+			continue
+		}
 		strategy = res.SyncStrategy
 		summary = res.Summary
 		// If one of plugins returns PIPELINE_SYNC, use that as strategy intermediately

--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -379,10 +379,6 @@ func (p *planner) buildPlan(ctx context.Context, runningDS, targetDS *common.Dep
 			p.logger.Warn("Unable to determine strategy using current plugin", zap.Error(err))
 			continue
 		}
-		if res == nil {
-			p.logger.Warn("plugin returned nil for DetermineStrategy()")
-			continue
-		}
 		// If the plugin does not support DetermineStrategy(), then ignore.
 		if res.Unsupported {
 			continue

--- a/pkg/app/pipedv1/controller/planner_test.go
+++ b/pkg/app/pipedv1/controller/planner_test.go
@@ -1050,6 +1050,89 @@ func TestPlanner_BuildPlan(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "ignore plugin that does not support DetermineStrategy",
+			isFirstDeploy: false,
+			pluginRegistry: func() plugin.PluginRegistry {
+				pr, err := plugin.NewPluginRegistry(context.TODO(), []plugin.Plugin{
+					{
+						Name: "plugin-1",
+						Cli: &fakePlugin{
+							syncStrategy: &deployment.DetermineStrategyResponse{
+								Unsupported: true,
+							},
+							pipelineStages: []*model.PipelineStage{
+								{
+									Id:      "plugin-1-stage-1",
+									Name:    "plugin-1-stage-1",
+									Visible: true,
+								},
+							},
+						},
+					},
+					{
+						Name: "plugin-2",
+						Cli: &fakePlugin{
+							syncStrategy: &deployment.DetermineStrategyResponse{
+								SyncStrategy: model.SyncStrategy_QUICK_SYNC,
+								Summary:      "determined by plugin-2",
+							},
+							pipelineStages: []*model.PipelineStage{
+								{
+									Id:      "plugin-2-stage-1",
+									Name:    "plugin-2-stage-1",
+									Visible: true,
+								},
+							},
+							quickStages: []*model.PipelineStage{
+								{
+									Id:      "plugin-2-quick-stage-1",
+									Visible: true,
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				return pr
+			}(),
+			cfg: &config.GenericApplicationSpec{
+				Plugins: map[string]struct{}{"plugin-1": {}, "plugin-2": {}},
+				Pipeline: &config.DeploymentPipeline{
+					Stages: []config.PipelineStage{
+						{
+							ID:   "plugin-1-stage-1",
+							Name: "plugin-1-stage-1",
+						},
+						{
+							ID:   "plugin-2-stage-1",
+							Name: "plugin-2-stage-1",
+						},
+					},
+				},
+			},
+			deployment: &model.Deployment{
+				Trigger: &model.DeploymentTrigger{},
+			},
+			wantErr: false,
+			expectedOutput: &plannerOutput{
+				SyncStrategy: model.SyncStrategy_QUICK_SYNC,
+				Summary:      "determined by plugin-2",
+				Stages: []*model.PipelineStage{
+					{
+						Id:      "plugin-2-quick-stage-1",
+						Visible: true,
+					},
+				},
+				Versions: []*model.ArtifactVersion{
+					{
+						Kind:    model.ArtifactVersion_UNKNOWN,
+						Version: versionUnknown,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

- To handle `Unsupported` flag for plugins like StagePlugin
- To prevent nil panic when the plugin returns nil (unintentionally?)



**Which issue(s) this PR fixes**:

Part of #4980

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
