### PR TITLE
Pass plugin name from Piped to plugin

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -663,6 +663,7 @@ func (p *piped) runPlugins(ctx context.Context, pluginsCfg []config.PipedPlugin,
 			return nil, fmt.Errorf("failed to prepare plugin %s config: %w", pCfg.Name, err)
 		}
 		args = append(args, "--config", string(b))
+		args = append(args, "--name", pCfg.Name)
 
 		// Run the plugin binary.
 		cmd, err := lifecycle.RunBinary(ctx, pPath, args)

--- a/pkg/plugin/sdk/plugin.go
+++ b/pkg/plugin/sdk/plugin.go
@@ -102,9 +102,11 @@ func WithLivestatePlugin[Config, DeployTargetConfig, ApplicationConfigSpec any](
 // Plugin is a wrapper for the plugin.
 // It provides a way to run the plugin with the given config and deploy target config.
 type Plugin[Config, DeployTargetConfig, ApplicationConfigSpec any] struct {
+
 	// plugin info
-	name    string
 	version string
+	// name is the name of the plugin defined in the piped plugin config.
+	name string
 
 	// plugin implementations
 	stagePlugin      StagePlugin[Config, DeployTargetConfig, ApplicationConfigSpec]
@@ -122,9 +124,8 @@ type Plugin[Config, DeployTargetConfig, ApplicationConfigSpec any] struct {
 }
 
 // NewPlugin creates a new plugin.
-func NewPlugin[Config, DeployTargetConfig, ApplicationConfigSpec any](name, version string, options ...PluginOption[Config, DeployTargetConfig, ApplicationConfigSpec]) (*Plugin[Config, DeployTargetConfig, ApplicationConfigSpec], error) {
+func NewPlugin[Config, DeployTargetConfig, ApplicationConfigSpec any](version string, options ...PluginOption[Config, DeployTargetConfig, ApplicationConfigSpec]) (*Plugin[Config, DeployTargetConfig, ApplicationConfigSpec], error) {
 	plugin := &Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]{
-		name:    name,
 		version: version,
 
 		// Default values of command line options
@@ -153,7 +154,7 @@ func NewPlugin[Config, DeployTargetConfig, ApplicationConfigSpec any](name, vers
 // Run runs the plugin.
 func (p *Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]) Run() error {
 	app := cli.NewApp(
-		fmt.Sprintf("pipecd-plugin-%s", p.name),
+		"pipecd-plugin",
 		"Plugin component for Piped.",
 	)
 
@@ -172,9 +173,11 @@ func (p *Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]) Run() error 
 func (p *Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: fmt.Sprintf("Start running a %s plugin.", p.name),
+		Short: "Start running a plugin.",
 		RunE:  cli.WithContext(p.run),
 	}
+
+	cmd.Flags().StringVar(&p.name, "name", p.name, "The name of the plugin defined in the piped plugin config.")
 
 	cmd.Flags().StringVar(&p.pipedPluginService, "piped-plugin-service", p.pipedPluginService, "The address used to connect to the piped plugin service.")
 	cmd.Flags().StringVar(&p.config, "config", p.config, "The configuration for the plugin.")
@@ -187,6 +190,7 @@ func (p *Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]) command() *c
 	// For debugging early in development
 	cmd.Flags().BoolVar(&p.enableGRPCReflection, "enable-grpc-reflection", p.enableGRPCReflection, "Whether to enable the reflection service or not.")
 
+	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("piped-plugin-service")
 	cmd.MarkFlagRequired("config")
 

--- a/pkg/plugin/sdk/plugin_test.go
+++ b/pkg/plugin/sdk/plugin_test.go
@@ -121,7 +121,7 @@ func (e ExampleLivestatePlugin) Version() string {
 }
 
 func ExampleNewPlugin() {
-	plugin, err := NewPlugin("test", "1.0.0",
+	plugin, err := NewPlugin("1.0.0",
 		WithDeploymentPlugin(ExampleDeploymentPlugin{}),
 		WithLivestatePlugin(ExampleLivestatePlugin{}),
 	)
@@ -141,7 +141,7 @@ func ExampleNewPlugin() {
 }
 
 func ExampleWithStagePlugin() {
-	plugin, err := NewPlugin("test", "1.0.0",
+	plugin, err := NewPlugin("1.0.0",
 		WithStagePlugin(ExampleStagePlugin{}),
 	)
 	if err != nil {
@@ -153,7 +153,7 @@ func ExampleWithStagePlugin() {
 }
 
 func ExampleWithDeploymentPlugin() {
-	plugin, err := NewPlugin("test", "1.0.0",
+	plugin, err := NewPlugin("1.0.0",
 		WithDeploymentPlugin(ExampleDeploymentPlugin{}),
 	)
 	if err != nil {
@@ -165,7 +165,7 @@ func ExampleWithDeploymentPlugin() {
 }
 
 func ExampleWithLivestatePlugin() {
-	plugin, err := NewPlugin("test", "1.0.0",
+	plugin, err := NewPlugin("1.0.0",
 		WithLivestatePlugin(ExampleLivestatePlugin{}),
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

- Deleted the `name` arg from `sdk.NewPlugin()`
- Instead, pass the name from the piped plugin config

After merging this PR, we need to update the plugins.

**Why we need it**:

- The uniqueness scope of `name` is confusing for plugin developers 
- Currently, users need to get plugin names from each plugin code since they must be matched
    - Now, deploymentSource is looked up by the name defined in the plugin.
      https://github.com/pipe-cd/pipecd/blob/8dbe938c3e948dba12031a56c2473562df5e2254/pkg/plugin/sdk/deployment_source.go#L42-L51


**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**:

This is a breaking change of the SDK. Not a user-facing change.

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
