### PR TITLE
[Plugin] Remove plugin name from the arg when calling `sdk.NewPlugin`

### DIFF
--- a/pkg/app/pipedv1/plugin/example/go.mod
+++ b/pkg/app/pipedv1/plugin/example/go.mod
@@ -2,7 +2,7 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/example
 
 go 1.24.1
 
-require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
+require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/pkg/app/pipedv1/plugin/example/go.mod
+++ b/pkg/app/pipedv1/plugin/example/go.mod
@@ -2,7 +2,7 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/example
 
 go 1.24.1
 
-require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
+require github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
 
 require (
 	cloud.google.com/go v0.112.1 // indirect

--- a/pkg/app/pipedv1/plugin/example/go.sum
+++ b/pkg/app/pipedv1/plugin/example/go.sum
@@ -209,8 +209,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/example/go.sum
+++ b/pkg/app/pipedv1/plugin/example/go.sum
@@ -209,8 +209,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf h1:+/Pt5kCbSlkcVRQD0xf2mOHh448N3BpJtl4we3RD33M=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/example/main.go
+++ b/pkg/app/pipedv1/plugin/example/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	plugin, err := sdk.NewPlugin("example", "0.0.1", sdk.WithStagePlugin(&plugin{}))
+	plugin, err := sdk.NewPlugin("0.0.1", sdk.WithStagePlugin(&plugin{}))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/goccy/go-yaml v1.9.8
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -3,9 +3,10 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes
 go 1.24.1
 
 require (
+	github.com/goccy/go-yaml v1.9.8
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0
@@ -37,7 +38,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
-	github.com/goccy/go-yaml v1.9.8 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/pkg/app/pipedv1/plugin/kubernetes/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.sum
@@ -429,8 +429,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.sum
@@ -429,8 +429,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf h1:+/Pt5kCbSlkcVRQD0xf2mOHh448N3BpJtl4we3RD33M=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	plugin, err := sdk.NewPlugin(
-		"kubernetes", "0.0.1",
+		"0.0.1",
 		sdk.WithDeploymentPlugin(&deployment.Plugin{}),
 		sdk.WithLivestatePlugin(&livestate.Plugin{}),
 	)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/creasty/defaults v1.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/creasty/defaults v1.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
@@ -412,8 +412,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf h1:+/Pt5kCbSlkcVRQD0xf2mOHh448N3BpJtl4we3RD33M=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/go.sum
@@ -412,8 +412,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	plugin, err := sdk.NewPlugin(
-		"kubernetes_multicluster", "0.0.1",
+		"0.0.1",
 		sdk.WithDeploymentPlugin(&deployment.Plugin{}),
 		sdk.WithLivestatePlugin(&livestate.Plugin{}),
 	)

--- a/pkg/app/pipedv1/plugin/wait/go.mod
+++ b/pkg/app/pipedv1/plugin/wait/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 )

--- a/pkg/app/pipedv1/plugin/wait/go.mod
+++ b/pkg/app/pipedv1/plugin/wait/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 )

--- a/pkg/app/pipedv1/plugin/wait/go.sum
+++ b/pkg/app/pipedv1/plugin/wait/go.sum
@@ -211,8 +211,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf h1:+/Pt5kCbSlkcVRQD0xf2mOHh448N3BpJtl4we3RD33M=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250611015256-e41eb352a1cf/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/wait/go.sum
+++ b/pkg/app/pipedv1/plugin/wait/go.sum
@@ -211,8 +211,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370 h1:wgoxvc+vFMU2P2RISAE6I/6dj7+rp8/camJyVJpRmfM=
-github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250529023641-8bd42026e370/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded h1:QzYzmpq4b1f37I+jE/EVUdF/NGI4Lc0bFFXqGBrACWU=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250610110220-8b7d2c785ded/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/wait/main.go
+++ b/pkg/app/pipedv1/plugin/wait/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	plugin, err := sdk.NewPlugin("wait", "0.0.1", sdk.WithStagePlugin(&plugin{}))
+	plugin, err := sdk.NewPlugin("0.0.1", sdk.WithStagePlugin(&plugin{}))
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We need to support `--name` option for each plugin to pipedv1 start them from #5931.

**Which issue(s) this PR fixes**:

Follow #5931

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
