### PR TITLE
[SDK] Allow users to set nothing config for the plugin in the app.pipecd.yaml

### DIFF
--- a/pkg/plugin/sdk/deployment_source.go
+++ b/pkg/plugin/sdk/deployment_source.go
@@ -128,7 +128,7 @@ func (c *ApplicationConfig[Spec]) parsePluginConfig(pluginName string) error {
 	}
 
 	// Validate the spec if it implements the Validate method.
-	if v, ok := any(&spec).(interface{ Validate() error }); ok {
+	if v, ok := any(spec).(interface{ Validate() error }); ok {
 		if err := v.Validate(); err != nil {
 			return fmt.Errorf("failed to validate plugin spec: %w", err)
 		}

--- a/pkg/plugin/sdk/deployment_source.go
+++ b/pkg/plugin/sdk/deployment_source.go
@@ -111,7 +111,7 @@ func (c *ApplicationConfig[Spec]) parsePluginConfig(pluginName string) error {
 		c.pluginConfigs = nil
 	}()
 
-	// It is necessary to prepare config with default value when users doesn't set any config.
+	// It is necessary to prepare config with default value when users doesn't set any config, or when developers implements custom unmarshalling logic.
 	data := []byte("{}")
 
 	if c.pluginConfigs != nil && c.pluginConfigs[pluginName] != nil {

--- a/pkg/plugin/sdk/deployment_source.go
+++ b/pkg/plugin/sdk/deployment_source.go
@@ -111,7 +111,7 @@ func (c *ApplicationConfig[Spec]) parsePluginConfig(pluginName string) error {
 		c.pluginConfigs = nil
 	}()
 
-	// It is necessary to prepare config with default value when users doesn't set any config, or when developers implements custom unmarshalling logic.
+	// It is necessary to prepare config with default value when users don't set any config, or when plugin developers implement custom unmarshalling logic.
 	data := []byte("{}")
 
 	if c.pluginConfigs != nil && c.pluginConfigs[pluginName] != nil {

--- a/pkg/plugin/sdk/deployment_source_test.go
+++ b/pkg/plugin/sdk/deployment_source_test.go
@@ -106,14 +106,13 @@ func TestApplicationConfig_HasStage(t *testing.T) {
 }
 
 type testPluginSpec struct {
-	Name    string `json:"name"`
-	Value   int    `json:"value" default:"42"`
-	Require string `json:"require"`
+	Name  string `json:"name"`
+	Value int    `json:"value" default:"42"`
 }
 
 func (s *testPluginSpec) Validate() error {
-	if s.Require == "" {
-		return fmt.Errorf("require must not be empty")
+	if s.Value < 0 {
+		return fmt.Errorf("value must not be a negative value")
 	}
 	return nil
 }
@@ -134,8 +133,11 @@ func TestApplicationConfig_ParsePluginConfig(t *testing.T) {
 			config: &ApplicationConfig[testPluginSpec]{
 				pluginConfigs: nil,
 			},
-			wantSpec: &testPluginSpec{},
-			wantErr:  false,
+			wantSpec: &testPluginSpec{
+				Name:  "",
+				Value: 42,
+			},
+			wantErr: false,
 		},
 		{
 			name:       "empty plugin configs map",
@@ -143,21 +145,23 @@ func TestApplicationConfig_ParsePluginConfig(t *testing.T) {
 			config: &ApplicationConfig[testPluginSpec]{
 				pluginConfigs: make(map[string]json.RawMessage),
 			},
-			wantSpec: &testPluginSpec{},
-			wantErr:  false,
+			wantSpec: &testPluginSpec{
+				Name:  "",
+				Value: 42,
+			},
+			wantErr: false,
 		},
 		{
 			name:       "valid plugin config with defaults",
 			pluginName: "test-plugin",
 			config: &ApplicationConfig[testPluginSpec]{
 				pluginConfigs: map[string]json.RawMessage{
-					"test-plugin": json.RawMessage(`{"name": "test", "require": "yes"}`),
+					"test-plugin": json.RawMessage(`{"name": "test"}`),
 				},
 			},
 			wantSpec: &testPluginSpec{
-				Name:    "test",
-				Value:   42,
-				Require: "yes",
+				Name:  "test",
+				Value: 42,
 			},
 			wantErr: false,
 		},
@@ -177,7 +181,7 @@ func TestApplicationConfig_ParsePluginConfig(t *testing.T) {
 			pluginName: "test-plugin",
 			config: &ApplicationConfig[testPluginSpec]{
 				pluginConfigs: map[string]json.RawMessage{
-					"test-plugin": json.RawMessage(`{"name": "test", "value": 10}`),
+					"test-plugin": json.RawMessage(`{"name": "test", "value": -1}`),
 				},
 			},
 			wantSpec: nil,
@@ -188,13 +192,12 @@ func TestApplicationConfig_ParsePluginConfig(t *testing.T) {
 			pluginName: "test-plugin",
 			config: &ApplicationConfig[testPluginSpec]{
 				pluginConfigs: map[string]json.RawMessage{
-					"test-plugin": json.RawMessage(`{"name": "test", "value": 100, "require": "yes"}`),
+					"test-plugin": json.RawMessage(`{"name": "test", "value": 100}`),
 				},
 			},
 			wantSpec: &testPluginSpec{
-				Name:    "test",
-				Value:   100,
-				Require: "yes",
+				Name:  "test",
+				Value: 100,
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
**What this PR does**:

as ttile

**Why we need it**:

There is a case when users deploy without any plugin config in app.pipecd.yaml.

**Which issue(s) this PR fixes**:

Follow #5922

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
