### PR TITLE
Get only livestate-supported plugin clients when flushing the livestate

### DIFF
--- a/pkg/app/pipedv1/controller/planner_test.go
+++ b/pkg/app/pipedv1/controller/planner_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin"
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
@@ -114,6 +115,31 @@ func (p *fakePlugin) ExecuteStage(ctx context.Context, req *deployment.ExecuteSt
 }
 func pointerBool(b bool) *bool {
 	return &b
+}
+
+func (p *fakePlugin) ServerReflectionInfo(ctx context.Context, opts ...grpc.CallOption) (reflectionpb.ServerReflection_ServerReflectionInfoClient, error) {
+	return &fakeServerReflectionInfoClient{}, nil
+}
+
+type fakeServerReflectionInfoClient struct {
+	reflectionpb.ServerReflection_ServerReflectionInfoClient
+}
+
+func (c *fakeServerReflectionInfoClient) Send(req *reflectionpb.ServerReflectionRequest) error {
+	return nil
+}
+func (c *fakeServerReflectionInfoClient) Recv() (*reflectionpb.ServerReflectionResponse, error) {
+	return &reflectionpb.ServerReflectionResponse{
+		MessageResponse: &reflectionpb.ServerReflectionResponse_ListServicesResponse{
+			ListServicesResponse: &reflectionpb.ListServiceResponse{
+				Service: []*reflectionpb.ServiceResponse{
+					{
+						Name: "pipecd.plugin.api.v1alpha1.livestate.LivestateService",
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 func TestBuildQuickSyncStages(t *testing.T) {

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -212,9 +212,9 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 		return err
 	}
 
-	pluginClis, err := r.pluginRegistry.GetPluginClientsByAppConfig(cfg.Spec)
+	pluginClis, err := r.pluginRegistry.GetLivestateSupportedClientsByAppConfig(cfg.Spec)
 	if err != nil {
-		r.logger.Error("failed to get plugin clients", zap.Error(err))
+		r.logger.Error("unable to determine plugin", zap.Error(err))
 		return err
 	}
 

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter_test.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
@@ -120,6 +121,31 @@ func (p *fakePlugin) GetLivestate(ctx context.Context, in *livestate.GetLivestat
 	return &livestate.GetLivestateResponse{
 		ApplicationLiveState: &model.ApplicationLiveState{},
 		SyncState:            &model.ApplicationSyncState{},
+	}, nil
+}
+
+type fakeServerReflectionInfoClient struct {
+	reflectionpb.ServerReflection_ServerReflectionInfoClient
+}
+
+func (p *fakePlugin) ServerReflectionInfo(ctx context.Context, opts ...grpc.CallOption) (reflectionpb.ServerReflection_ServerReflectionInfoClient, error) {
+	return &fakeServerReflectionInfoClient{}, nil
+}
+
+func (c *fakeServerReflectionInfoClient) Send(req *reflectionpb.ServerReflectionRequest) error {
+	return nil
+}
+func (c *fakeServerReflectionInfoClient) Recv() (*reflectionpb.ServerReflectionResponse, error) {
+	return &reflectionpb.ServerReflectionResponse{
+		MessageResponse: &reflectionpb.ServerReflectionResponse_ListServicesResponse{
+			ListServicesResponse: &reflectionpb.ListServiceResponse{
+				Service: []*reflectionpb.ServiceResponse{
+					{
+						Name: "pipecd.plugin.api.v1alpha1.livestate.LivestateService",
+					},
+				},
+			},
+		},
 	}, nil
 }
 

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -51,9 +51,9 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{
-						"stage1": fakePluginClient{name: "stage1"},
-						"stage2": fakePluginClient{name: "stage2"},
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": Plugin{Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
 					},
 				}
 			},
@@ -71,9 +71,9 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					nameBasedPlugins: map[string]pluginapi.PluginClient{
-						"plugin1": fakePluginClient{name: "plugin1"},
-						"plugin2": fakePluginClient{name: "plugin2"},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": Plugin{Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": Plugin{Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
 					},
 				}
 			},
@@ -96,13 +96,13 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{
-						"stage1": fakePluginClient{name: "stage1"},
-						"stage2": fakePluginClient{name: "stage2"},
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": Plugin{Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
 					},
-					nameBasedPlugins: map[string]pluginapi.PluginClient{
-						"plugin1": fakePluginClient{name: "plugin1"},
-						"plugin2": fakePluginClient{name: "plugin2"},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": Plugin{Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": Plugin{Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
 					},
 				}
 			},
@@ -117,7 +117,7 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			cfg:  &config.GenericApplicationSpec{},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					nameBasedPlugins: map[string]pluginapi.PluginClient{},
+					nameBasedPlugins: map[string]Plugin{},
 				}
 			},
 			wantErr: true,
@@ -135,6 +135,7 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 		})
 	}
 }
+
 func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 	t.Parallel()
 
@@ -142,7 +143,7 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 		name     string
 		pipeline *config.DeploymentPipeline
 		setup    func() *pluginRegistry
-		expected []pluginapi.PluginClient
+		expected []Plugin
 		wantErr  bool
 	}{
 		{
@@ -155,15 +156,15 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{
-						"stage1": fakePluginClient{name: "stage1"},
-						"stage2": fakePluginClient{name: "stage2"},
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": Plugin{Name: "stage1"},
+						"stage2": Plugin{Name: "stage2"},
 					},
 				}
 			},
-			expected: []pluginapi.PluginClient{
-				fakePluginClient{name: "stage1"},
-				fakePluginClient{name: "stage2"},
+			expected: []Plugin{
+				Plugin{Name: "stage1"},
+				Plugin{Name: "stage2"},
 			},
 			wantErr: false,
 		},
@@ -174,7 +175,7 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{},
+					stageBasedPlugins: map[string]Plugin{},
 				}
 			},
 			expected: nil,
@@ -190,7 +191,7 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 			},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{},
+					stageBasedPlugins: map[string]Plugin{},
 				}
 			},
 			expected: nil,
@@ -209,6 +210,7 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 		})
 	}
 }
+
 func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 	t.Parallel()
 
@@ -216,7 +218,7 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 		name        string
 		pluginNames map[string]struct{}
 		setup       func() *pluginRegistry
-		expected    []pluginapi.PluginClient
+		expected    []Plugin
 		wantErr     bool
 	}{
 		{
@@ -224,15 +226,15 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					nameBasedPlugins: map[string]pluginapi.PluginClient{
-						"plugin1": fakePluginClient{name: "plugin1"},
-						"plugin2": fakePluginClient{name: "plugin2"},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": Plugin{Name: "plugin1"},
+						"plugin2": Plugin{Name: "plugin2"},
 					},
 				}
 			},
-			expected: []pluginapi.PluginClient{
-				fakePluginClient{name: "plugin1"},
-				fakePluginClient{name: "plugin2"},
+			expected: []Plugin{
+				Plugin{Name: "plugin1"},
+				Plugin{Name: "plugin2"},
 			},
 			wantErr: false,
 		},
@@ -241,9 +243,9 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			pluginNames: map[string]struct{}{},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					nameBasedPlugins: map[string]pluginapi.PluginClient{
-						"plugin1": fakePluginClient{name: "plugin1"},
-						"plugin2": fakePluginClient{name: "plugin2"},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": Plugin{Name: "plugin1"},
+						"plugin2": Plugin{Name: "plugin2"},
 					},
 				}
 			},
@@ -254,9 +256,9 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			pluginNames: map[string]struct{}{"plugin1": {}, "plugin2": {}},
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					nameBasedPlugins: map[string]pluginapi.PluginClient{
-						"plugin3": fakePluginClient{name: "plugin3"},
-						"plugin4": fakePluginClient{name: "plugin4"},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin3": Plugin{Name: "plugin3"},
+						"plugin4": Plugin{Name: "plugin4"},
 					},
 				}
 			},
@@ -275,6 +277,7 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 		})
 	}
 }
+
 func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 	t.Parallel()
 
@@ -290,8 +293,8 @@ func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 			stage: "stage1",
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{
-						"stage1": fakePluginClient{name: "stage1"},
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
 					},
 				}
 			},
@@ -303,8 +306,8 @@ func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 			stage: "stage2",
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
-					stageBasedPlugins: map[string]pluginapi.PluginClient{
-						"stage1": fakePluginClient{name: "stage1"},
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
 					},
 				}
 			},
@@ -320,6 +323,140 @@ func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 			pr := tt.setup()
 			plugin, err := pr.GetPluginClientByStageName(tt.stage)
 			assert.Equal(t, tt.expected, plugin)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestPluginRegistry_GetLivestateSupportedClientsByAppConfig(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		cfg *config.GenericApplicationSpec
+	}
+	tests := []struct {
+		name     string
+		cfg      *config.GenericApplicationSpec
+		setup    func() *pluginRegistry
+		expected []pluginapi.PluginClient
+		wantErr  bool
+	}{
+		{
+			name: "returns only livestate supported plugin clients by pipeline",
+			cfg: &config.GenericApplicationSpec{
+				Pipeline: &config.DeploymentPipeline{
+					Stages: []config.PipelineStage{
+						{Name: "stage1"},
+						{Name: "stage2"},
+					},
+				},
+			},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": {Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
+					},
+					livestateSupportedPlugins: map[string]Plugin{
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+					},
+				}
+			},
+			expected: []pluginapi.PluginClient{
+				fakePluginClient{name: "stage1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns only livestate supported plugin clients by plugin names",
+			cfg: &config.GenericApplicationSpec{
+				Plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
+			},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": {Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+					},
+					livestateSupportedPlugins: map[string]Plugin{
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+					},
+				}
+			},
+			expected: []pluginapi.PluginClient{
+				fakePluginClient{name: "plugin2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns empty slice if no plugin is livestate supported",
+			cfg: &config.GenericApplicationSpec{
+				Plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
+			},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": {Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+					},
+					livestateSupportedPlugins: map[string]Plugin{},
+				}
+			},
+			expected: []pluginapi.PluginClient{},
+			wantErr:  false,
+		},
+		{
+			name: "returns error if no plugin specified",
+			cfg:  &config.GenericApplicationSpec{},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					nameBasedPlugins:          map[string]Plugin{},
+					stageBasedPlugins:         map[string]Plugin{},
+					livestateSupportedPlugins: map[string]Plugin{},
+				}
+			},
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name: "returns only livestate supported plugin clients when both pipeline and plugins are specified (pipeline takes precedence)",
+			cfg: &config.GenericApplicationSpec{
+				Pipeline: &config.DeploymentPipeline{
+					Stages: []config.PipelineStage{
+						{Name: "stage1"},
+						{Name: "stage2"},
+					},
+				},
+				Plugins: map[string]struct{}{"plugin1": {}, "plugin2": {}},
+			},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					stageBasedPlugins: map[string]Plugin{
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": {Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
+					},
+					nameBasedPlugins: map[string]Plugin{
+						"plugin1": {Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+					},
+					livestateSupportedPlugins: map[string]Plugin{
+						"stage2": {Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
+					},
+				}
+			},
+			expected: []pluginapi.PluginClient{
+				fakePluginClient{name: "stage2"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pr := tt.setup()
+			got, err := pr.GetLivestateSupportedClientsByAppConfig(tt.cfg)
+			assert.ElementsMatch(t, tt.expected, got)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -52,8 +52,8 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					stageBasedPlugins: map[string]Plugin{
-						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
-						"stage2": Plugin{Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": {Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
 					},
 				}
 			},
@@ -72,8 +72,8 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]Plugin{
-						"plugin1": Plugin{Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
-						"plugin2": Plugin{Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+						"plugin1": {Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
 					},
 				}
 			},
@@ -97,12 +97,12 @@ func TestPluginRegistry_GetPluginClientsByAppConfig(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					stageBasedPlugins: map[string]Plugin{
-						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
-						"stage2": Plugin{Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage2": {Name: "stage2", Cli: fakePluginClient{name: "stage2"}},
 					},
 					nameBasedPlugins: map[string]Plugin{
-						"plugin1": Plugin{Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
-						"plugin2": Plugin{Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
+						"plugin1": {Name: "plugin1", Cli: fakePluginClient{name: "plugin1"}},
+						"plugin2": {Name: "plugin2", Cli: fakePluginClient{name: "plugin2"}},
 					},
 				}
 			},
@@ -157,14 +157,14 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					stageBasedPlugins: map[string]Plugin{
-						"stage1": Plugin{Name: "stage1"},
-						"stage2": Plugin{Name: "stage2"},
+						"stage1": {Name: "stage1"},
+						"stage2": {Name: "stage2"},
 					},
 				}
 			},
 			expected: []Plugin{
-				Plugin{Name: "stage1"},
-				Plugin{Name: "stage2"},
+				{Name: "stage1"},
+				{Name: "stage2"},
 			},
 			wantErr: false,
 		},
@@ -227,14 +227,14 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]Plugin{
-						"plugin1": Plugin{Name: "plugin1"},
-						"plugin2": Plugin{Name: "plugin2"},
+						"plugin1": {Name: "plugin1"},
+						"plugin2": {Name: "plugin2"},
 					},
 				}
 			},
 			expected: []Plugin{
-				Plugin{Name: "plugin1"},
-				Plugin{Name: "plugin2"},
+				{Name: "plugin1"},
+				{Name: "plugin2"},
 			},
 			wantErr: false,
 		},
@@ -244,8 +244,8 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]Plugin{
-						"plugin1": Plugin{Name: "plugin1"},
-						"plugin2": Plugin{Name: "plugin2"},
+						"plugin1": {Name: "plugin1"},
+						"plugin2": {Name: "plugin2"},
 					},
 				}
 			},
@@ -257,8 +257,8 @@ func TestPluginRegistry_getPluginClientsByNames(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					nameBasedPlugins: map[string]Plugin{
-						"plugin3": Plugin{Name: "plugin3"},
-						"plugin4": Plugin{Name: "plugin4"},
+						"plugin3": {Name: "plugin3"},
+						"plugin4": {Name: "plugin4"},
 					},
 				}
 			},
@@ -294,7 +294,7 @@ func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					stageBasedPlugins: map[string]Plugin{
-						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
 					},
 				}
 			},
@@ -307,7 +307,7 @@ func TestPluginRegistry_GetPluginClientByStageName(t *testing.T) {
 			setup: func() *pluginRegistry {
 				return &pluginRegistry{
 					stageBasedPlugins: map[string]Plugin{
-						"stage1": Plugin{Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
+						"stage1": {Name: "stage1", Cli: fakePluginClient{name: "stage1"}},
 					},
 				}
 			},

--- a/pkg/plugin/api/v1alpha1/client.go
+++ b/pkg/plugin/api/v1alpha1/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/deployment"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/livestate"
@@ -27,12 +28,14 @@ import (
 type PluginClient interface {
 	deployment.DeploymentServiceClient
 	livestate.LivestateServiceClient
+	reflectionpb.ServerReflectionClient
 	Close() error
 }
 
 type client struct {
 	deployment.DeploymentServiceClient
 	livestate.LivestateServiceClient
+	reflectionpb.ServerReflectionClient
 	conn *grpc.ClientConn
 }
 
@@ -45,6 +48,7 @@ func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption
 	return &client{
 		DeploymentServiceClient: deployment.NewDeploymentServiceClient(conn),
 		LivestateServiceClient:  livestate.NewLivestateServiceClient(conn),
+		ServerReflectionClient:  reflectionpb.NewServerReflectionClient(conn),
 		conn:                    conn,
 	}, nil
 }

--- a/pkg/plugin/sdk/plugin.go
+++ b/pkg/plugin/sdk/plugin.go
@@ -21,11 +21,12 @@ import (
 	"net/http/pprof"
 	"time"
 
-	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister"
-	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry"
 
 	"github.com/pipe-cd/pipecd/pkg/admin"
 	"github.com/pipe-cd/pipecd/pkg/cli"
@@ -320,6 +321,7 @@ func (p *Plugin[Config, DeployTargetConfig, ApplicationConfigSpec]) run(ctx cont
 				rpc.WithLogUnaryInterceptor(input.Logger),
 				rpc.WithRequestValidationUnaryInterceptor(),
 				rpc.WithSignalHandlingUnaryInterceptor(),
+				rpc.WithGRPCReflection(),
 			}
 		)
 		if p.tls {


### PR DESCRIPTION
**What this PR does**:

This is the fix for pluginRegistry's logic.

- Fixed to check whether the plugin server supports `LivestateService` in advance, by using gRPC reflection.
- Get only livestate-supported plugin clients when flushing the livestate.

**Why we need it**:

Currently, the livestate reporter fails to report when there are some plugins that don't support the livestate feature. (e.g. wait stage).

Livestate reporter calls `GetLivestate` for each plugin when flushing an app.
But currently, it fails when one of them has an error, including an unimplemented status.


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
