### PR TITLE
Ignore unsupported plugin when reporting livestate

### DIFF
--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -27,6 +27,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/deploysource"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin"
@@ -230,6 +232,13 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 			DeployTargets:   app.GetDeployTargets(),
 		})
 		if err != nil {
+			st, ok := status.FromError(err)
+			if ok && st.Code() == codes.Unimplemented {
+				// TODO: show plugin name
+				r.logger.Info("plugin does not support livestate feature")
+				continue
+			}
+
 			r.logger.Info(fmt.Sprintf("no app state of application %s to report", app.Id))
 			return err
 		}

--- a/pkg/app/pipedv1/plugin/registry.go
+++ b/pkg/app/pipedv1/plugin/registry.go
@@ -101,12 +101,18 @@ func (pr *pluginRegistry) getPluginClientsByPipeline(pipeline *config.Deployment
 	}
 
 	plugins := make([]pluginapi.PluginClient, 0, len(pipeline.Stages))
+	alreadyFound := make(map[pluginapi.PluginClient]struct{})
 	for _, stage := range pipeline.Stages {
 		plugin, ok := pr.stageBasedPlugins[stage.Name.String()]
 		if !ok {
 			return nil, fmt.Errorf("no plugin found for the stage %s", stage.Name.String())
 		}
-		plugins = append(plugins, plugin)
+
+		// avoid to add duplicate plugin client
+		if _, ok := alreadyFound[plugin]; !ok {
+			plugins = append(plugins, plugin)
+			alreadyFound[plugin] = struct{}{}
+		}
 	}
 
 	return plugins, nil

--- a/pkg/app/pipedv1/plugin/registry_test.go
+++ b/pkg/app/pipedv1/plugin/registry_test.go
@@ -168,6 +168,30 @@ func TestPluginRegistry_getPluginClientsByPipeline(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "get unique plugins by valid pipeline stages",
+			pipeline: &config.DeploymentPipeline{
+				Stages: []config.PipelineStage{
+					{Name: "stage1"},
+					{Name: "stage2-0"},
+					{Name: "stage2-1"},
+				},
+			},
+			setup: func() *pluginRegistry {
+				return &pluginRegistry{
+					stageBasedPlugins: map[string]pluginapi.PluginClient{
+						"stage1":   fakePluginClient{name: "plugin1"},
+						"stage2-0": fakePluginClient{name: "plugin2"},
+						"stage2-1": fakePluginClient{name: "plugin2"},
+					},
+				}
+			},
+			expected: []pluginapi.PluginClient{
+				fakePluginClient{name: "plugin1"},
+				fakePluginClient{name: "plugin2"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "no plugins found for empty pipeline stages",
 			pipeline: &config.DeploymentPipeline{
 				Stages: []config.PipelineStage{},


### PR DESCRIPTION
**What this PR does**:

Get only livestate-supported plugin clients when flushing the livestate.

Currently, the livestate reporter fails to report when there are some plugins that don't support the livestate feature. (e.g. wait stage).

Livestate reporter calls GetLivestate for each plugin when flushing an app.
But currently, it fails when one of them has an error, including an unimplemented status.

**Why we need it**:

**Which issue(s) this PR fixes**:

Follow https://github.com/pipe-cd/pipecd/pull/5940
Part of #5363

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
