### PR TITLE
Add index validation of buildPipelineSyncStages in planner

### DIFF
--- a/pkg/app/pipedv1/controller/planner_test.go
+++ b/pkg/app/pipedv1/controller/planner_test.go
@@ -1204,6 +1204,7 @@ func TestValidateStageIndexes(t *testing.T) {
 				{Index: 0},
 				{Index: 1},
 				{Index: 2},
+				{Index: 0, Rollback: true},
 			},
 			wantErr: nil,
 		},
@@ -1216,6 +1217,7 @@ func TestValidateStageIndexes(t *testing.T) {
 			},
 			res: []*model.PipelineStage{
 				{Index: 1},
+				{Index: 1, Rollback: true},
 			},
 			wantErr: nil,
 		},
@@ -1230,6 +1232,19 @@ func TestValidateStageIndexes(t *testing.T) {
 				{Index: 0}, // duplicated
 			},
 			wantErr: fmt.Errorf("stage index 0 from plugin is duplicated"),
+		},
+		{
+			name: "duplicated rollback",
+			req: []*deployment.BuildPipelineSyncStagesRequest_StageConfig{
+				{Index: 0},
+				{Index: 1},
+			},
+			res: []*model.PipelineStage{
+				{Index: 0},
+				{Index: 1, Rollback: true},
+				{Index: 1, Rollback: true}, // duplicated
+			},
+			wantErr: fmt.Errorf("rollback stage index 1 from plugin is duplicated"),
 		},
 		{
 			name: "index not in request",

--- a/pkg/plugin/api/v1alpha1/deployment/api.proto
+++ b/pkg/plugin/api/v1alpha1/deployment/api.proto
@@ -31,7 +31,10 @@ service DeploymentService {
     // DetermineStrategy determines which strategy should be used for the given deployment.
     rpc DetermineStrategy(DetermineStrategyRequest) returns (DetermineStrategyResponse) {}
     // BuildPipelineSyncStages builds the deployment pipeline stages.
-    // Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
+    // Note about the respones indexes:
+    //   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
+    //     A non-rollback stage and a rollback stage can have the same index.
+    //   - All indexes of the response stages must exist in the indexes of the request stages.
     rpc BuildPipelineSyncStages(BuildPipelineSyncStagesRequest) returns (BuildPipelineSyncStagesResponse) {}
     // BuildQuickSyncStages builds the deployment quick sync stages.
     rpc BuildQuickSyncStages(BuildQuickSyncStagesRequest) returns (BuildQuickSyncStagesResponse) {}

--- a/pkg/plugin/api/v1alpha1/deployment/api.proto
+++ b/pkg/plugin/api/v1alpha1/deployment/api.proto
@@ -31,6 +31,7 @@ service DeploymentService {
     // DetermineStrategy determines which strategy should be used for the given deployment.
     rpc DetermineStrategy(DetermineStrategyRequest) returns (DetermineStrategyResponse) {}
     // BuildPipelineSyncStages builds the deployment pipeline stages.
+    // Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
     rpc BuildPipelineSyncStages(BuildPipelineSyncStagesRequest) returns (BuildPipelineSyncStagesResponse) {}
     // BuildQuickSyncStages builds the deployment quick sync stages.
     rpc BuildQuickSyncStages(BuildQuickSyncStagesRequest) returns (BuildQuickSyncStagesResponse) {}

--- a/pkg/plugin/api/v1alpha1/deployment/api.proto
+++ b/pkg/plugin/api/v1alpha1/deployment/api.proto
@@ -31,7 +31,7 @@ service DeploymentService {
     // DetermineStrategy determines which strategy should be used for the given deployment.
     rpc DetermineStrategy(DetermineStrategyRequest) returns (DetermineStrategyResponse) {}
     // BuildPipelineSyncStages builds the deployment pipeline stages.
-    // Note about the respones indexes:
+    // Note about the response indexes:
     //   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
     //     A non-rollback stage and a rollback stage can have the same index.
     //   - All indexes of the response stages must exist in the indexes of the request stages.

--- a/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
+++ b/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
@@ -29,7 +29,10 @@ type DeploymentServiceClient interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(ctx context.Context, in *DetermineStrategyRequest, opts ...grpc.CallOption) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
-	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
+	// Note about the respones indexes:
+	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
+	//     A non-rollback stage and a rollback stage can have the same index.
+	//   - All indexes of the response stages must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(ctx context.Context, in *BuildPipelineSyncStagesRequest, opts ...grpc.CallOption) (*BuildPipelineSyncStagesResponse, error)
 	// BuildQuickSyncStages builds the deployment quick sync stages.
 	BuildQuickSyncStages(ctx context.Context, in *BuildQuickSyncStagesRequest, opts ...grpc.CallOption) (*BuildQuickSyncStagesResponse, error)
@@ -110,7 +113,10 @@ type DeploymentServiceServer interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(context.Context, *DetermineStrategyRequest) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
-	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
+	// Note about the respones indexes:
+	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
+	//     A non-rollback stage and a rollback stage can have the same index.
+	//   - All indexes of the response stages must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(context.Context, *BuildPipelineSyncStagesRequest) (*BuildPipelineSyncStagesResponse, error)
 	// BuildQuickSyncStages builds the deployment quick sync stages.
 	BuildQuickSyncStages(context.Context, *BuildQuickSyncStagesRequest) (*BuildQuickSyncStagesResponse, error)

--- a/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
+++ b/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
@@ -29,6 +29,7 @@ type DeploymentServiceClient interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(ctx context.Context, in *DetermineStrategyRequest, opts ...grpc.CallOption) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
+	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(ctx context.Context, in *BuildPipelineSyncStagesRequest, opts ...grpc.CallOption) (*BuildPipelineSyncStagesResponse, error)
 	// BuildQuickSyncStages builds the deployment quick sync stages.
 	BuildQuickSyncStages(ctx context.Context, in *BuildQuickSyncStagesRequest, opts ...grpc.CallOption) (*BuildQuickSyncStagesResponse, error)
@@ -109,6 +110,7 @@ type DeploymentServiceServer interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(context.Context, *DetermineStrategyRequest) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
+	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(context.Context, *BuildPipelineSyncStagesRequest) (*BuildPipelineSyncStagesResponse, error)
 	// BuildQuickSyncStages builds the deployment quick sync stages.
 	BuildQuickSyncStages(context.Context, *BuildQuickSyncStagesRequest) (*BuildQuickSyncStagesResponse, error)

--- a/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
+++ b/pkg/plugin/api/v1alpha1/deployment/api_grpc.pb.go
@@ -29,7 +29,7 @@ type DeploymentServiceClient interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(ctx context.Context, in *DetermineStrategyRequest, opts ...grpc.CallOption) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
-	// Note about the respones indexes:
+	// Note about the response indexes:
 	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
 	//     A non-rollback stage and a rollback stage can have the same index.
 	//   - All indexes of the response stages must exist in the indexes of the request stages.
@@ -113,7 +113,7 @@ type DeploymentServiceServer interface {
 	// DetermineStrategy determines which strategy should be used for the given deployment.
 	DetermineStrategy(context.Context, *DetermineStrategyRequest) (*DetermineStrategyResponse, error)
 	// BuildPipelineSyncStages builds the deployment pipeline stages.
-	// Note about the respones indexes:
+	// Note about the response indexes:
 	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
 	//     A non-rollback stage and a rollback stage can have the same index.
 	//   - All indexes of the response stages must exist in the indexes of the request stages.

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -53,6 +53,7 @@ type StagePlugin[Config, DeployTargetConfig, ApplicationConfigSpec any] interfac
 	// FetchDefinedStages returns the list of stages that the plugin can execute.
 	FetchDefinedStages() []string
 	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
+	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(context.Context, *Config, *BuildPipelineSyncStagesInput) (*BuildPipelineSyncStagesResponse, error)
 	// ExecuteStage executes the given stage.
 	ExecuteStage(context.Context, *Config, []*DeployTarget[DeployTargetConfig], *ExecuteStageInput[ApplicationConfigSpec]) (*ExecuteStageResponse, error)

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -53,7 +53,7 @@ type StagePlugin[Config, DeployTargetConfig, ApplicationConfigSpec any] interfac
 	// FetchDefinedStages returns the list of stages that the plugin can execute.
 	FetchDefinedStages() []string
 	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
-	// Note about the respones indexes:
+	// Note about the response indexes:
 	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
 	//     A non-rollback stage and a rollback stage can have the same index.
 	//   - All indexes of the response stages must exist in the indexes of the request stages.

--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -53,7 +53,10 @@ type StagePlugin[Config, DeployTargetConfig, ApplicationConfigSpec any] interfac
 	// FetchDefinedStages returns the list of stages that the plugin can execute.
 	FetchDefinedStages() []string
 	// BuildPipelineSyncStages builds the stages that will be executed by the plugin.
-	// Indexes of the response stages must not be duplicated and must exist in the indexes of the request stages.
+	// Note about the respones indexes:
+	//   - Indexes of the response stages must not be duplicated within non-rollback stages and rollback stages.
+	//     A non-rollback stage and a rollback stage can have the same index.
+	//   - All indexes of the response stages must exist in the indexes of the request stages.
 	BuildPipelineSyncStages(context.Context, *Config, *BuildPipelineSyncStagesInput) (*BuildPipelineSyncStagesResponse, error)
 	// ExecuteStage executes the given stage.
 	ExecuteStage(context.Context, *Config, []*DeployTarget[DeployTargetConfig], *ExecuteStageInput[ApplicationConfigSpec]) (*ExecuteStageResponse, error)


### PR DESCRIPTION
**What this PR does**:

- Add index validations for duplication and range.
- Add the API spec comments in api.proto and the SDK

**Why we need it**:

- To prevent errors in the [scheduler](https://github.com/pipe-cd/pipecd/blob/d522ec41f5893c4dd1108c7024e06e84933443e8/pkg/app/pipedv1/controller/scheduler.go#L539-L547).
- To make the rollback order determinate
- To keep the rollback spec simple

**Which issue(s) this PR fixes**:

Part of #5259 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
