### PR TITLE
Add --match opion for `git describe` for `build/chart`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build/web:
 	yarn --cwd web build
 
 .PHONY: build/chart
-build/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
+build/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*.*')
 build/chart:
 	mkdir -p .artifacts
 ifndef MOD


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

When creating the tag whose format is not semantic version, `build/chart` fails because helm chart supports only semantic versioning.
So we decided to allow only semantic versioned one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
