### PR TITLE
Redux replace setting pipeds

### DIFF
--- a/web/src/__fixtures__/dummy-piped.ts
+++ b/web/src/__fixtures__/dummy-piped.ts
@@ -1,4 +1,4 @@
-import { Piped, PipedKey } from "~/modules/pipeds";
+import { Piped, PipedKey } from "pipecd/web/model/piped_pb";
 import { createApplicationGitRepository, dummyRepo } from "./dummy-repo";
 import { createRandTimes, randomText, randomUUID } from "./utils";
 

--- a/web/src/components/application-detail-page/application-detail/index.test.tsx
+++ b/web/src/components/application-detail-page/application-detail/index.test.tsx
@@ -71,10 +71,6 @@ const baseState: Partial<AppState> = {
       [dummyPiped.id]: dummyPiped,
     },
     ids: [dummyPiped.id],
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
 };
 

--- a/web/src/components/application-form/application-form-manual-v0/index.test.tsx
+++ b/web/src/components/application-form/application-form-manual-v0/index.test.tsx
@@ -28,10 +28,6 @@ const baseState: Partial<AppState> = {
       [dummyPiped.id]: dummyPiped,
     },
     ids: [dummyPiped.id],
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
 };
 

--- a/web/src/components/application-form/application-form-manual-v1/index.test.tsx
+++ b/web/src/components/application-form/application-form-manual-v1/index.test.tsx
@@ -28,10 +28,6 @@ const baseState: Partial<AppState> = {
       [dummyPiped.id]: dummyPiped,
     },
     ids: [dummyPiped.id],
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
 };
 

--- a/web/src/components/application-form/application-form-v0/index.test.tsx
+++ b/web/src/components/application-form/application-form-v0/index.test.tsx
@@ -46,10 +46,6 @@ const baseState: Partial<AppState> = {
       [dummyPiped.id]: dummyPiped,
     },
     ids: [dummyPiped.id],
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
 };
 

--- a/web/src/components/application-form/application-form-v1/index.test.tsx
+++ b/web/src/components/application-form/application-form-v1/index.test.tsx
@@ -46,10 +46,6 @@ const baseState: Partial<AppState> = {
       [dummyPiped.id]: dummyPiped,
     },
     ids: [dummyPiped.id],
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
 };
 

--- a/web/src/components/applications-page/edit-application-drawer/index.test.tsx
+++ b/web/src/components/applications-page/edit-application-drawer/index.test.tsx
@@ -32,10 +32,6 @@ const initialState = {
     entities: {
       [dummyPiped.id]: dummyPiped,
     },
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
   },
   applications: {
     loading: false,

--- a/web/src/components/deployments-detail-page/index.test.tsx
+++ b/web/src/components/deployments-detail-page/index.test.tsx
@@ -25,10 +25,6 @@ describe("DeploymentDetailPage", () => {
       pipeds: {
         entities: { [dummyPiped.id]: dummyPiped },
         ids: [dummyPiped.id],
-        registeredPiped: null,
-        updating: false,
-        releasedVersions: [],
-        breakingChangesNote: "",
       },
     });
 

--- a/web/src/components/insight-page/statistic-information/piped-count.tsx
+++ b/web/src/components/insight-page/statistic-information/piped-count.tsx
@@ -6,7 +6,7 @@ import {
   TooltipComponent,
 } from "echarts/components";
 import { FC, useEffect, useMemo } from "react";
-import { Piped } from "~/modules/pipeds";
+import { Piped } from "pipecd/web/model/piped_pb";
 import { GaugeChart } from "echarts/charts";
 import { CanvasRenderer } from "echarts/renderers";
 import useEChartState from "~/hooks/useEChartState";

--- a/web/src/components/settings-page/piped/components/add-piped-dialog/index.tsx
+++ b/web/src/components/settings-page/piped/components/add-piped-dialog/index.tsx
@@ -2,36 +2,33 @@ import { Dialog } from "@mui/material";
 import { useFormik } from "formik";
 import { FC, memo, useCallback } from "react";
 import { ADD_PIPED_SUCCESS } from "~/constants/toast-text";
-import { unwrapResult, useAppDispatch } from "~/hooks/redux";
-import { addPiped } from "~/modules/pipeds";
-import { addToast } from "~/modules/toasts";
 import { PipedForm, PipedFormValues, validationSchema } from "../piped-form";
 import useProjectName from "~/contexts/auth-context/use-project-name";
+import { useAddPiped } from "~/queries/pipeds/use-add-piped";
+import { useToast } from "~/contexts/toast-context";
 
 export interface AddPipedDrawerProps {
   open: boolean;
   onClose: () => void;
+  onSuccess: (data: { id: string; key: string }) => void;
 }
 
 export const AddPipedDialog: FC<AddPipedDrawerProps> = memo(
-  function AddPipedDialog({ open, onClose }) {
-    const dispatch = useAppDispatch();
+  function AddPipedDialog({ open, onClose, onSuccess }) {
+    const { mutateAsync: addPiped } = useAddPiped();
+    const { addToast } = useToast();
     const projectName = useProjectName();
 
     const formik = useFormik<PipedFormValues>({
       initialValues: { name: "", desc: "" },
       validationSchema,
       validateOnMount: true,
-      async onSubmit(values) {
-        await dispatch(addPiped(values))
-          .then(unwrapResult)
-          .then(() => {
-            dispatch(
-              addToast({ message: ADD_PIPED_SUCCESS, severity: "success" })
-            );
-            onClose();
-          })
-          .catch(() => undefined);
+      onSubmit(values) {
+        addPiped(values).then((res) => {
+          addToast({ message: ADD_PIPED_SUCCESS, severity: "success" });
+          formik.resetForm();
+          onSuccess({ id: res.id, key: res.key });
+        });
       },
     });
 

--- a/web/src/components/settings-page/piped/index.tsx
+++ b/web/src/components/settings-page/piped/index.tsx
@@ -21,8 +21,7 @@ import {
   Update as UpgradeIcon,
 } from "@mui/icons-material";
 import Alert from "@mui/material/Alert";
-import { createSelector } from "@reduxjs/toolkit";
-import { FC, memo, useCallback, useEffect, useState } from "react";
+import { FC, memo, useCallback, useMemo, useState } from "react";
 import { TextWithCopyButton } from "~/components/text-with-copy-button";
 import {
   UI_TEXT_ADD,
@@ -32,22 +31,7 @@ import {
   UI_TEXT_UPGRADE,
 } from "~/constants/ui-text";
 import { REQUEST_PIPED_RESTART_SUCCESS } from "~/constants/toast-text";
-import { useAppDispatch, useAppSelector } from "~/hooks/redux";
-import { useInterval } from "~/hooks/use-interval";
-import {
-  clearRegisteredPipedInfo,
-  disablePiped,
-  enablePiped,
-  restartPiped,
-  fetchPipeds,
-  fetchReleasedVersions,
-  fetchBreakingChanges,
-  Piped,
-  RegisteredPiped,
-  selectAllPipeds,
-} from "~/modules/pipeds";
-import { addToast } from "~/modules/toasts";
-import { AppState } from "~/store";
+import { Piped } from "pipecd/web/model/piped_pb";
 import { AddPipedDialog } from "./components/add-piped-dialog";
 import { EditPipedDialog } from "./components/edit-piped-dialog";
 import { FilterValues, PipedFilter } from "./components/piped-filter";
@@ -55,25 +39,14 @@ import { PipedTableRow } from "./components/piped-table-row";
 import { UpgradePipedDialog } from "./components/upgrade-dialog";
 import { TableCellNoWrap } from "../styles";
 import { useGetProject } from "~/queries/project/use-get-project";
-
-const filterValue = (
-  _: AppState,
-  filterValue: FilterValues
-): boolean | undefined => filterValue.enabled;
-
-const selectFilteredPipeds = createSelector(
-  [selectAllPipeds, filterValue],
-  (pipeds, enabled) => {
-    switch (enabled) {
-      case true:
-        return pipeds.filter((piped) => piped.disabled === false);
-      case false:
-        return pipeds.filter((piped) => piped.disabled);
-      default:
-        return pipeds;
-    }
-  }
-);
+import { useToast } from "~/contexts/toast-context";
+import { useGetPipeds } from "~/queries/pipeds/use-get-pipeds";
+import { useGetReleasedVersions } from "~/queries/pipeds/use-get-released-versions";
+import { useGetBreakingChanges } from "~/queries/pipeds/use-get-breaking-changes";
+import { useAddNewPipedKey } from "~/queries/pipeds/use-add-new-piped-key";
+import { useDisablePiped } from "~/queries/pipeds/use-disable-piped";
+import { useEnablePiped } from "~/queries/pipeds/use-enable-piped";
+import { useRestartPiped } from "~/queries/pipeds/use-restart-piped";
 
 const OLD_KEY_ALERT_MESSAGE =
   "The old key is still there.\nDo not forget to delete it once you update your Piped to use this new key.";
@@ -83,75 +56,86 @@ const FETCH_INTERVAL = 30000;
 export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   const [openFilter, setOpenFilter] = useState(false);
   const [isOpenForm, setIsOpenForm] = useState(false);
-  const [editPipedId, setEditPipedId] = useState<string | null>(null);
+  const [editPiped, setEditPiped] = useState<Piped.AsObject | null>(null);
+  const [isUpgradeDialogOpen, setIsUpgradeDialogOpen] = useState(false);
+  const [registeredPiped, setRegisteredPiped] = useState<{
+    id: string;
+    key: string;
+    isNewKey: boolean;
+  } | null>(null);
   const [filterValues, setFilterValues] = useState<FilterValues>({
     enabled: true,
   });
-  const dispatch = useAppDispatch();
+
+  const { addToast } = useToast();
+
   const { data: projectDetail } = useGetProject();
-  const pipeds = useAppSelector<Piped.AsObject[]>((state) =>
-    selectFilteredPipeds(state, filterValues)
+
+  const { mutateAsync: addNewPipedKey } = useAddNewPipedKey();
+
+  const { mutateAsync: restartPiped } = useRestartPiped();
+
+  const { mutateAsync: disablePiped } = useDisablePiped();
+
+  const { mutateAsync: enablePiped } = useEnablePiped();
+
+  const { data: allPipeds } = useGetPipeds(
+    { withStatus: true },
+    { refetchInterval: FETCH_INTERVAL }
   );
 
-  useEffect(() => {
-    dispatch(fetchReleasedVersions());
-  }, [dispatch]);
+  const { data: releasedVersions = [] } = useGetReleasedVersions();
 
-  useEffect(() => {
-    if (projectDetail?.id) {
-      dispatch(fetchBreakingChanges({ projectId: projectDetail.id }));
-    }
-  }, [dispatch, projectDetail?.id]);
-
-  const releasedVersions = useAppSelector<string[]>(
-    (state) => state.pipeds.releasedVersions
+  const { data: breakingChangesNote } = useGetBreakingChanges(
+    { projectId: projectDetail?.id ?? "" },
+    { enabled: !!projectDetail?.id }
   );
 
-  const breakingChangesNote = useAppSelector<string | null>(
-    (state) => state.pipeds.breakingChangesNote
-  );
+  const pipeds = useMemo(() => {
+    return (
+      allPipeds?.filter((piped) => {
+        if (filterValues.enabled === true) return !piped.disabled;
+        if (filterValues.enabled === false) return piped.disabled;
+        return true;
+      }) ?? []
+    );
+  }, [allPipeds, filterValues.enabled]);
+
   // TODO: Remove this console.log
   console.log("[DEBUG]", breakingChangesNote);
 
-  const [isUpgradeDialogOpen, setIsUpgradeDialogOpen] = useState(false);
-  const handleUpgradeDialogClose = (): void => setIsUpgradeDialogOpen(false);
-
-  const registeredPiped = useAppSelector<RegisteredPiped | null>(
-    (state) => state.pipeds.registeredPiped
-  );
+  const handleUpgradeDialogClose = (): void => {
+    setIsUpgradeDialogOpen(false);
+  };
 
   const handleDisable = useCallback(
     (id: string) => {
-      dispatch(disablePiped({ pipedId: id })).then(() => {
-        dispatch(fetchPipeds(true));
-      });
+      disablePiped({ pipedId: id });
     },
-    [dispatch]
-  );
-  const handleEnable = useCallback(
-    (id: string) => {
-      dispatch(enablePiped({ pipedId: id })).then(() => {
-        dispatch(fetchPipeds(true));
-      });
-    },
-    [dispatch]
-  );
-  const handleRestart = useCallback(
-    (id: string) => {
-      dispatch(restartPiped({ pipedId: id })).then(() => {
-        dispatch(
-          addToast({
-            message: REQUEST_PIPED_RESTART_SUCCESS,
-            severity: "success",
-          })
-        );
-      });
-    },
-    [dispatch]
+    [disablePiped]
   );
 
-  const handleEdit = useCallback((id: string) => {
-    setEditPipedId(id);
+  const handleEnable = useCallback(
+    (id: string) => {
+      enablePiped({ pipedId: id });
+    },
+    [enablePiped]
+  );
+
+  const handleRestart = useCallback(
+    (id: string) => {
+      restartPiped({ pipedId: id }).then(() => {
+        addToast({
+          message: REQUEST_PIPED_RESTART_SUCCESS,
+          severity: "success",
+        });
+      });
+    },
+    [addToast, restartPiped]
+  );
+
+  const handleEdit = useCallback((piped: Piped.AsObject) => {
+    setEditPiped(piped);
   }, []);
 
   const handleClose = useCallback(() => {
@@ -159,17 +143,30 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   }, []);
 
   const handleClosePipedInfo = useCallback(() => {
-    dispatch(clearRegisteredPipedInfo());
-    dispatch(fetchPipeds(true));
-  }, [dispatch]);
-
-  const handleEditClose = useCallback(() => {
-    setEditPipedId(null);
+    setRegisteredPiped(null);
   }, []);
 
-  useInterval(() => {
-    dispatch(fetchPipeds(true));
-  }, FETCH_INTERVAL);
+  const handleEditClose = useCallback(() => {
+    setEditPiped(null);
+  }, []);
+
+  const handleSuccessAddedPiped = (data: { id: string; key: string }): void => {
+    setIsOpenForm(false);
+    setRegisteredPiped({ ...data, isNewKey: false });
+  };
+
+  const handleAddNewKey = useCallback(
+    (piped: Piped.AsObject) => {
+      addNewPipedKey({ pipedId: piped.id }).then((key) => {
+        setRegisteredPiped({
+          id: piped.id,
+          key,
+          isNewKey: true,
+        });
+      });
+    },
+    [addNewPipedKey]
+  );
 
   return (
     <>
@@ -225,7 +222,8 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
               {pipeds.map((piped) => (
                 <PipedTableRow
                   key={piped.id}
-                  pipedId={piped.id}
+                  piped={piped}
+                  onAddNewKey={handleAddNewKey}
                   onEdit={handleEdit}
                   onDisable={handleDisable}
                   onEnable={handleEnable}
@@ -240,14 +238,21 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
           <PipedFilter values={filterValues} onChange={setFilterValues} />
         )}
       </Box>
-      <AddPipedDialog open={isOpenForm} onClose={handleClose} />
-      <EditPipedDialog pipedId={editPipedId} onClose={handleEditClose} />
+      <AddPipedDialog
+        open={isOpenForm}
+        onSuccess={handleSuccessAddedPiped}
+        onClose={handleClose}
+      />
+
+      <EditPipedDialog piped={editPiped} onClose={handleEditClose} />
+
       <UpgradePipedDialog
         open={isUpgradeDialogOpen}
         pipeds={pipeds}
         releasedVersions={releasedVersions}
         onClose={handleUpgradeDialogClose}
       />
+
       <Dialog fullWidth open={Boolean(registeredPiped)}>
         <DialogTitle>
           {registeredPiped?.isNewKey

--- a/web/src/modules/pipeds/index.test.ts
+++ b/web/src/modules/pipeds/index.test.ts
@@ -1,20 +1,9 @@
 import { dummyPiped } from "~/__fixtures__/dummy-piped";
-import {
-  pipedsSlice,
-  clearRegisteredPipedInfo,
-  addPiped,
-  fetchPipeds,
-  addNewPipedKey,
-  editPiped,
-} from "./";
+import { pipedsSlice, fetchPipeds } from "./";
 
 const baseState = {
   entities: {},
   ids: [],
-  registeredPiped: null,
-  updating: false,
-  releasedVersions: [],
-  breakingChangesNote: "",
 };
 
 describe("pipedsSlice reducer", () => {
@@ -24,46 +13,6 @@ describe("pipedsSlice reducer", () => {
         type: "TEST_ACTION",
       })
     ).toEqual(baseState);
-  });
-
-  it(`should handle ${clearRegisteredPipedInfo.type}`, () => {
-    expect(
-      pipedsSlice.reducer(
-        {
-          ...baseState,
-          registeredPiped: {
-            id: "piped-1",
-            key: "piped-key",
-            isNewKey: false,
-          },
-        },
-        {
-          type: clearRegisteredPipedInfo.type,
-        }
-      )
-    ).toEqual(baseState);
-  });
-
-  describe("addPiped", () => {
-    it(`should handle ${addPiped.fulfilled.type}`, () => {
-      expect(
-        pipedsSlice.reducer(baseState, {
-          type: addPiped.fulfilled.type,
-          payload: {
-            id: "piped-1",
-            key: "piped-key",
-            isNewKey: false,
-          },
-        })
-      ).toEqual({
-        ...baseState,
-        registeredPiped: {
-          id: "piped-1",
-          key: "piped-key",
-          isNewKey: false,
-        },
-      });
-    });
   });
 
   describe("fetchPipeds", () => {
@@ -77,70 +26,6 @@ describe("pipedsSlice reducer", () => {
         ...baseState,
         entities: { [dummyPiped.id]: dummyPiped },
         ids: [dummyPiped.id],
-      });
-    });
-  });
-
-  describe("recreatePipedKey", () => {
-    it(`should handle ${addNewPipedKey.fulfilled.type}`, () => {
-      expect(
-        pipedsSlice.reducer(baseState, {
-          type: addNewPipedKey.fulfilled.type,
-          payload: "add-new-piped-key",
-          meta: {
-            arg: {
-              pipedId: "piped-1",
-            },
-          },
-        })
-      ).toEqual({
-        ...baseState,
-        registeredPiped: {
-          id: "piped-1",
-          key: "add-new-piped-key",
-          isNewKey: true,
-        },
-      });
-    });
-  });
-
-  describe("editPiped", () => {
-    it(`should handle ${editPiped.pending.type}`, () => {
-      expect(
-        pipedsSlice.reducer(baseState, {
-          type: editPiped.pending.type,
-        })
-      ).toEqual({
-        ...baseState,
-        updating: true,
-      });
-    });
-
-    it(`should handle ${editPiped.rejected.type}`, () => {
-      expect(
-        pipedsSlice.reducer(
-          { ...baseState, updating: true },
-          {
-            type: editPiped.rejected.type,
-          }
-        )
-      ).toEqual({
-        ...baseState,
-        updating: false,
-      });
-    });
-
-    it(`should handle ${editPiped.fulfilled.type}`, () => {
-      expect(
-        pipedsSlice.reducer(
-          { ...baseState, updating: true },
-          {
-            type: editPiped.fulfilled.type,
-          }
-        )
-      ).toEqual({
-        ...baseState,
-        updating: false,
       });
     });
   });

--- a/web/src/modules/pipeds/index.ts
+++ b/web/src/modules/pipeds/index.ts
@@ -8,12 +8,6 @@ import { Piped } from "pipecd/web/model/piped_pb";
 import type { AppState } from "~/store";
 import * as pipedsApi from "~/api/piped";
 
-export interface RegisteredPiped {
-  id: string;
-  key: string;
-  isNewKey: boolean;
-}
-
 const MODULE_NAME = "pipeds";
 
 const pipedsAdapter = createEntityAdapter<Piped.AsObject>({});
@@ -29,24 +23,6 @@ export const selectPipedIds = (state: AppState): EntityId[] =>
 export const selectAllPipeds = (state: AppState): Piped.AsObject[] =>
   selectAll(state.pipeds);
 
-export const fetchReleasedVersions = createAsyncThunk<string[]>(
-  `${MODULE_NAME}/fetchReleasedVersions`,
-  async () => {
-    const { versionsList } = await pipedsApi.listReleasedVersions();
-    return versionsList;
-  }
-);
-
-export const fetchBreakingChanges = createAsyncThunk<
-  string,
-  { projectId: string }
->(`${MODULE_NAME}/fetchBreakingChanges`, async (props) => {
-  const { notes } = await pipedsApi.listBreakingChanges({
-    projectId: props.projectId,
-  });
-  return notes;
-});
-
 export const fetchPipeds = createAsyncThunk<Piped.AsObject[], boolean>(
   `${MODULE_NAME}/fetchList`,
   async (withStatus: boolean) => {
@@ -56,125 +32,16 @@ export const fetchPipeds = createAsyncThunk<Piped.AsObject[], boolean>(
   }
 );
 
-export const addPiped = createAsyncThunk<
-  RegisteredPiped,
-  { name: string; desc: string }
->(`${MODULE_NAME}/add`, async (props) => {
-  const res = await pipedsApi.registerPiped({
-    desc: props.desc,
-    name: props.name,
-  });
-  return { ...res, isNewKey: false };
-});
-
-export const disablePiped = createAsyncThunk<void, { pipedId: string }>(
-  `${MODULE_NAME}/disable`,
-  async ({ pipedId }) => {
-    await pipedsApi.disablePiped({ pipedId });
-  }
-);
-
-export const enablePiped = createAsyncThunk<void, { pipedId: string }>(
-  `${MODULE_NAME}/enable`,
-  async ({ pipedId }) => {
-    await pipedsApi.enablePiped({ pipedId });
-  }
-);
-
-export const restartPiped = createAsyncThunk<void, { pipedId: string }>(
-  `${MODULE_NAME}/restart`,
-  async ({ pipedId }) => {
-    await pipedsApi.restartPiped({ pipedId });
-  }
-);
-
-export const addNewPipedKey = createAsyncThunk<string, { pipedId: string }>(
-  `${MODULE_NAME}/addNewKey`,
-  async ({ pipedId }) => {
-    const { key } = await pipedsApi.recreatePipedKey({ id: pipedId });
-    return key;
-  }
-);
-
-export const deleteOldKey = createAsyncThunk<void, { pipedId: string }>(
-  `${MODULE_NAME}/deleteOldKey`,
-  async ({ pipedId }) => {
-    await pipedsApi.deleteOldPipedKey({ pipedId });
-  }
-);
-
-export const editPiped = createAsyncThunk<
-  void,
-  { pipedId: string; name: string; desc: string }
->(`${MODULE_NAME}/edit`, async ({ pipedId, name, desc }) => {
-  await pipedsApi.updatePiped({
-    pipedId,
-    name,
-    desc,
-  });
-});
-
-export const updatePipedDesiredVersion = createAsyncThunk<
-  void,
-  { version: string; pipedIds: string[] }
->(`${MODULE_NAME}/updatePipedDesiredVersion`, async ({ version, pipedIds }) => {
-  await pipedsApi.updatePipedDesiredVersion({
-    version,
-    pipedIdsList: pipedIds,
-  });
-});
-
 export const pipedsSlice = createSlice({
   name: MODULE_NAME,
-  initialState: pipedsAdapter.getInitialState<{
-    registeredPiped: RegisteredPiped | null;
-    updating: boolean;
-    releasedVersions: string[];
-    breakingChangesNote: string;
-  }>({
-    registeredPiped: null,
-    updating: false,
-    releasedVersions: [],
-    breakingChangesNote: "",
-  }),
-  reducers: {
-    clearRegisteredPipedInfo(state) {
-      state.registeredPiped = null;
-    },
-  },
+  initialState: pipedsAdapter.getInitialState({}),
+  reducers: {},
   extraReducers: (builder) => {
-    builder
-      .addCase(addPiped.fulfilled, (state, action) => {
-        state.registeredPiped = action.payload;
-      })
-      .addCase(fetchPipeds.fulfilled, (state, action) => {
-        pipedsAdapter.removeAll(state);
-        pipedsAdapter.addMany(state, action.payload);
-      })
-      .addCase(addNewPipedKey.fulfilled, (state, action) => {
-        state.registeredPiped = {
-          id: action.meta.arg.pipedId,
-          key: action.payload,
-          isNewKey: true,
-        };
-      })
-      .addCase(editPiped.pending, (state) => {
-        state.updating = true;
-      })
-      .addCase(editPiped.rejected, (state) => {
-        state.updating = false;
-      })
-      .addCase(editPiped.fulfilled, (state) => {
-        state.updating = false;
-      })
-      .addCase(fetchReleasedVersions.fulfilled, (state, action) => {
-        state.releasedVersions = action.payload;
-      })
-      .addCase(fetchBreakingChanges.fulfilled, (state, action) => {
-        state.breakingChangesNote = action.payload;
-      });
+    builder.addCase(fetchPipeds.fulfilled, (state, action) => {
+      pipedsAdapter.removeAll(state);
+      pipedsAdapter.addMany(state, action.payload);
+    });
   },
 });
 
-export const { clearRegisteredPipedInfo } = pipedsSlice.actions;
 export { Piped, PipedKey } from "pipecd/web/model/piped_pb";

--- a/web/src/queries/pipeds/use-add-new-piped-key.ts
+++ b/web/src/queries/pipeds/use-add-new-piped-key.ts
@@ -1,0 +1,26 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useAddNewPipedKey = (): UseMutationResult<
+  string,
+  unknown,
+  {
+    pipedId: string;
+  },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId }) => {
+      const { key } = await pipedsApi.recreatePipedKey({ id: pipedId });
+      return key;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds", "list"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-add-piped.ts
+++ b/web/src/queries/pipeds/use-add-piped.ts
@@ -1,0 +1,27 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useAddPiped = (): UseMutationResult<
+  { id: string; key: string },
+  unknown,
+  { name: string; desc: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      const res = await pipedsApi.registerPiped({
+        desc: data.desc,
+        name: data.name,
+      });
+      return res;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds", "list"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-delete-old-piped-key.ts
+++ b/web/src/queries/pipeds/use-delete-old-piped-key.ts
@@ -1,0 +1,25 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useDeleteOldPipedKey = (): UseMutationResult<
+  void,
+  unknown,
+  {
+    pipedId: string;
+  },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId }) => {
+      await pipedsApi.deleteOldPipedKey({ pipedId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds", "list"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-disable-piped.ts
+++ b/web/src/queries/pipeds/use-disable-piped.ts
@@ -1,0 +1,23 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useDisablePiped = (): UseMutationResult<
+  void,
+  unknown,
+  { pipedId: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId }) => {
+      await pipedsApi.disablePiped({ pipedId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-edit-piped.ts
+++ b/web/src/queries/pipeds/use-edit-piped.ts
@@ -1,0 +1,27 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useEditPiped = (): UseMutationResult<
+  void,
+  unknown,
+  { pipedId: string; name: string; desc: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId, name, desc }) => {
+      await pipedsApi.updatePiped({
+        pipedId,
+        name,
+        desc,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds", "list"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-enable-piped.ts
+++ b/web/src/queries/pipeds/use-enable-piped.ts
@@ -1,0 +1,23 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useEnablePiped = (): UseMutationResult<
+  void,
+  unknown,
+  { pipedId: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId }) => {
+      await pipedsApi.enablePiped({ pipedId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-get-breaking-changes.tsx
+++ b/web/src/queries/pipeds/use-get-breaking-changes.tsx
@@ -1,0 +1,22 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useGetBreakingChanges = (
+  options: { projectId: string },
+  queryOption: UseQueryOptions<string> = {}
+): UseQueryResult<string> => {
+  return useQuery({
+    queryKey: ["pipeds", "breakingChanges", options],
+    queryFn: async () => {
+      const { notes } = await pipedsApi.listBreakingChanges({
+        projectId: options.projectId,
+      });
+      return notes;
+    },
+    ...queryOption,
+  });
+};

--- a/web/src/queries/pipeds/use-get-released-versions.tsx
+++ b/web/src/queries/pipeds/use-get-released-versions.tsx
@@ -1,0 +1,19 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useGetReleasedVersions = (
+  queryOption: UseQueryOptions<string[]> = {}
+): UseQueryResult<string[]> => {
+  return useQuery({
+    queryKey: ["pipeds", "releasedVersions"],
+    queryFn: async () => {
+      const { versionsList } = await pipedsApi.listReleasedVersions();
+      return versionsList;
+    },
+    ...queryOption,
+  });
+};

--- a/web/src/queries/pipeds/use-restart-piped.ts
+++ b/web/src/queries/pipeds/use-restart-piped.ts
@@ -1,0 +1,23 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useRestartPiped = (): UseMutationResult<
+  void,
+  unknown,
+  { pipedId: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pipedId }) => {
+      await pipedsApi.restartPiped({ pipedId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-update-piped-desired-version.ts
+++ b/web/src/queries/pipeds/use-update-piped-desired-version.ts
@@ -1,0 +1,26 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+
+export const useUpdatePipedDesiredVersion = (): UseMutationResult<
+  void,
+  unknown,
+  { version: string; pipedIds: string[] },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      await pipedsApi.updatePipedDesiredVersion({
+        version: data.version,
+        pipedIdsList: data.pipedIds,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["pipeds", "list"]);
+    },
+  });
+};


### PR DESCRIPTION
**What this PR does**:

- This MR depends on https://github.com/pipe-cd/pipecd/pull/5941
- remove functions in modules/pipeds
- add query for get breaking changes and released versions
- add mutation for add, disable, enable, restart piped
- add mutation for update piped desired version
- add mutaiton for add new, delete old piped key.
- remove unused state in module/pipeds
- update tests affected

**Why we need it**:

- remove redux module from settings/pipeds page

**Which issue(s) this PR fixes**:

Partof #5868

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
