### PR TITLE
[SDK] add unit types to use in config types

### DIFF
--- a/pkg/plugin/sdk/unit/duration.go
+++ b/pkg/plugin/sdk/unit/duration.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type Duration time.Duration
+
+func (d Duration) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch raw := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(raw))
+		return nil
+	case string:
+		value, err := time.ParseDuration(raw)
+		if err != nil {
+			return err
+		}
+		*d = Duration(value)
+		return nil
+	default:
+		return fmt.Errorf("invalid duration: %v", string(b))
+	}
+}

--- a/pkg/plugin/sdk/unit/duration.go
+++ b/pkg/plugin/sdk/unit/duration.go
@@ -20,16 +20,22 @@ import (
 	"time"
 )
 
+// Duration represents a time duration that can be marshaled/unmarshaled as a string in JSON.
+// It supports both numeric values (interpreted as nanoseconds) and string values (e.g., "5m", "1h30m").
 type Duration time.Duration
 
+// Duration returns the time.Duration value.
 func (d Duration) Duration() time.Duration {
 	return time.Duration(d)
 }
 
+// MarshalJSON marshals the Duration to a JSON string representation (e.g., "5m30s").
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(d).String())
 }
 
+// UnmarshalJSON unmarshals a JSON value to Duration.
+// It accepts both numeric values (interpreted as nanoseconds) and string values (e.g., "5m", "1h30m").
 func (d *Duration) UnmarshalJSON(b []byte) error {
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/pkg/plugin/sdk/unit/duration_test.go
+++ b/pkg/plugin/sdk/unit/duration_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuration(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    Duration
+		expected time.Duration
+	}{
+		{
+			name:     "zero duration",
+			input:    Duration(0),
+			expected: 0,
+		},
+		{
+			name:     "one second",
+			input:    Duration(time.Second),
+			expected: time.Second,
+		},
+		{
+			name:     "one minute",
+			input:    Duration(time.Minute),
+			expected: time.Minute,
+		},
+		{
+			name:     "complex duration",
+			input:    Duration(2*time.Hour + 30*time.Minute + 15*time.Second),
+			expected: 2*time.Hour + 30*time.Minute + 15*time.Second,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Duration()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDurationMarshal(t *testing.T) {
+	type wrapper struct {
+		Duration Duration
+	}
+
+	testcases := []struct {
+		name     string
+		input    wrapper
+		expected string
+	}{
+		{
+			name: "zero duration",
+			input: wrapper{
+				Duration: Duration(0),
+			},
+			expected: `{"Duration":"0s"}`,
+		},
+		{
+			name: "one second",
+			input: wrapper{
+				Duration: Duration(time.Second),
+			},
+			expected: `{"Duration":"1s"}`,
+		},
+		{
+			name: "one minute",
+			input: wrapper{
+				Duration: Duration(time.Minute),
+			},
+			expected: `{"Duration":"1m0s"}`,
+		},
+		{
+			name: "one hour",
+			input: wrapper{
+				Duration: Duration(time.Hour),
+			},
+			expected: `{"Duration":"1h0m0s"}`,
+		},
+		{
+			name: "complex duration",
+			input: wrapper{
+				Duration: Duration(2*time.Hour + 30*time.Minute + 15*time.Second),
+			},
+			expected: `{"Duration":"2h30m15s"}`,
+		},
+		{
+			name: "milliseconds",
+			input: wrapper{
+				Duration: Duration(500 * time.Millisecond),
+			},
+			expected: `{"Duration":"500ms"}`,
+		},
+		{
+			name: "microseconds",
+			input: wrapper{
+				Duration: Duration(100 * time.Microsecond),
+			},
+			expected: `{"Duration":"100µs"}`,
+		},
+		{
+			name: "nanoseconds",
+			input: wrapper{
+				Duration: Duration(50),
+			},
+			expected: `{"Duration":"50ns"}`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(got))
+		})
+	}
+}
+
+func TestDurationUnmarshal(t *testing.T) {
+	type wrapper struct {
+		Duration Duration
+	}
+
+	testcases := []struct {
+		name        string
+		input       string
+		expected    *wrapper
+		expectedErr bool
+	}{
+		{
+			name:  "duration as float64 nanoseconds",
+			input: `{"Duration": 1000000000}`,
+			expected: &wrapper{
+				Duration: Duration(time.Second),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "duration as string seconds",
+			input: `{"Duration": "1s"}`,
+			expected: &wrapper{
+				Duration: Duration(time.Second),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "duration as string minutes",
+			input: `{"Duration": "5m"}`,
+			expected: &wrapper{
+				Duration: Duration(5 * time.Minute),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "duration as string hours",
+			input: `{"Duration": "2h"}`,
+			expected: &wrapper{
+				Duration: Duration(2 * time.Hour),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "complex duration string",
+			input: `{"Duration": "2h30m45s"}`,
+			expected: &wrapper{
+				Duration: Duration(2*time.Hour + 30*time.Minute + 45*time.Second),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "duration with milliseconds",
+			input: `{"Duration": "1.5s"}`,
+			expected: &wrapper{
+				Duration: Duration(1500 * time.Millisecond),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "duration with microseconds",
+			input: `{"Duration": "100us"}`,
+			expected: &wrapper{
+				Duration: Duration(100 * time.Microsecond),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "zero duration as float64",
+			input: `{"Duration": 0}`,
+			expected: &wrapper{
+				Duration: Duration(0),
+			},
+			expectedErr: false,
+		},
+		{
+			name:  "zero duration as string",
+			input: `{"Duration": "0s"}`,
+			expected: &wrapper{
+				Duration: Duration(0),
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "invalid duration string",
+			input:       `{"Duration": "invalid"}`,
+			expected:    nil,
+			expectedErr: true,
+		},
+		{
+			name:        "invalid type bool",
+			input:       `{"Duration": true}`,
+			expected:    nil,
+			expectedErr: true,
+		},
+		{
+			name:        "invalid type array",
+			input:       `{"Duration": [1, 2, 3]}`,
+			expected:    nil,
+			expectedErr: true,
+		},
+		{
+			name:        "invalid type object",
+			input:       `{"Duration": {"value": 1}}`,
+			expected:    nil,
+			expectedErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := &wrapper{}
+			err := json.Unmarshal([]byte(tc.input), got)
+			assert.Equal(t, tc.expectedErr, err != nil)
+			if tc.expected != nil {
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/plugin/sdk/unit/percentage.go
+++ b/pkg/plugin/sdk/unit/percentage.go
@@ -21,11 +21,15 @@ import (
 	"strings"
 )
 
+// Percentage represents a percentage value that can be represented with or without a % suffix.
+// It stores both the numeric value and whether it originally had a % suffix.
 type Percentage struct {
 	Number    int  `json:",omitempty"`
 	HasSuffix bool `json:",omitempty"`
 }
 
+// String returns the string representation of the percentage.
+// If HasSuffix is true, it includes the % suffix.
 func (p Percentage) String() string {
 	s := strconv.FormatInt(int64(p.Number), 10)
 	if p.HasSuffix {
@@ -34,14 +38,18 @@ func (p Percentage) String() string {
 	return s
 }
 
+// Int returns the numeric value of the percentage.
 func (p Percentage) Int() int {
 	return p.Number
 }
 
+// MarshalJSON marshals the Percentage to a JSON string representation.
 func (p Percentage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.String())
 }
 
+// UnmarshalJSON unmarshals a JSON string to Percentage.
+// It accepts both plain numbers (e.g., "50") and percentage strings (e.g., "50%").
 func (p *Percentage) UnmarshalJSON(b []byte) error {
 	raw := strings.Trim(string(b), `"`)
 	percentage := Percentage{

--- a/pkg/plugin/sdk/unit/percentage.go
+++ b/pkg/plugin/sdk/unit/percentage.go
@@ -1,0 +1,61 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Percentage struct {
+	Number    int  `json:",omitempty"`
+	HasSuffix bool `json:",omitempty"`
+}
+
+func (p Percentage) String() string {
+	s := strconv.FormatInt(int64(p.Number), 10)
+	if p.HasSuffix {
+		return s + "%"
+	}
+	return s
+}
+
+func (p Percentage) Int() int {
+	return p.Number
+}
+
+func (p Percentage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
+func (p *Percentage) UnmarshalJSON(b []byte) error {
+	raw := strings.Trim(string(b), `"`)
+	percentage := Percentage{
+		HasSuffix: false,
+	}
+	if strings.HasSuffix(raw, "%") {
+		percentage.HasSuffix = true
+		raw = strings.TrimSuffix(raw, "%")
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid percentage: %w", err)
+	}
+	percentage.Number = int(value)
+	*p = percentage
+	return nil
+}

--- a/pkg/plugin/sdk/unit/percentage_test.go
+++ b/pkg/plugin/sdk/unit/percentage_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercentageMarshal(t *testing.T) {
+	type wrapper struct {
+		Percentage Percentage
+	}
+
+	testcases := []struct {
+		name     string
+		input    wrapper
+		expected string
+	}{
+		{
+			name: "normal number",
+			input: wrapper{
+				Percentage{
+					Number:    10,
+					HasSuffix: false,
+				},
+			},
+			expected: `{"Percentage":"10"}`,
+		},
+		{
+			name: "percentage number",
+			input: wrapper{
+				Percentage{
+					Number:    15,
+					HasSuffix: true,
+				},
+			},
+			expected: `{"Percentage":"15%"}`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(got))
+		})
+	}
+}
+
+func TestPercentageUnmarshal(t *testing.T) {
+	type wrapper struct {
+		Percentage Percentage
+	}
+
+	testcases := []struct {
+		name        string
+		input       string
+		expected    *wrapper
+		expectedErr bool
+	}{
+		{
+			name:  "normal number",
+			input: `{"Percentage": 10}`,
+			expected: &wrapper{
+				Percentage{
+					Number: 10,
+				},
+			},
+		},
+		{
+			name:  "normal number by string",
+			input: `{"Percentage": "10"}`,
+			expected: &wrapper{
+				Percentage{
+					Number: 10,
+				},
+			},
+		},
+		{
+			name:  "percentage number",
+			input: `{"Percentage": "10%"}`,
+			expected: &wrapper{
+				Percentage{
+					Number:    10,
+					HasSuffix: true,
+				},
+			},
+		},
+		{
+			name:        "wrong string format",
+			input:       `{"Percentage": "1a%"}`,
+			expected:    nil,
+			expectedErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := &wrapper{}
+			err := json.Unmarshal([]byte(tc.input), got)
+			assert.Equal(t, tc.expectedErr, err != nil)
+			if tc.expected != nil {
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestPercentageString(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    Percentage
+		expected string
+	}{
+		{
+			name: "without suffix",
+			input: Percentage{
+				Number:    10,
+				HasSuffix: false,
+			},
+			expected: "10",
+		},
+		{
+			name: "with suffix",
+			input: Percentage{
+				Number:    25,
+				HasSuffix: true,
+			},
+			expected: "25%",
+		},
+		{
+			name: "zero without suffix",
+			input: Percentage{
+				Number:    0,
+				HasSuffix: false,
+			},
+			expected: "0",
+		},
+		{
+			name: "zero with suffix",
+			input: Percentage{
+				Number:    0,
+				HasSuffix: true,
+			},
+			expected: "0%",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.String()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestPercentageInt(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    Percentage
+		expected int
+	}{
+		{
+			name: "without suffix",
+			input: Percentage{
+				Number:    10,
+				HasSuffix: false,
+			},
+			expected: 10,
+		},
+		{
+			name: "with suffix",
+			input: Percentage{
+				Number:    25,
+				HasSuffix: true,
+			},
+			expected: 25,
+		},
+		{
+			name: "zero",
+			input: Percentage{
+				Number:    0,
+				HasSuffix: false,
+			},
+			expected: 0,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Int()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/plugin/sdk/unit/replicas.go
+++ b/pkg/plugin/sdk/unit/replicas.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type Replicas struct {
+	Number       int
+	IsPercentage bool
+}
+
+func (r Replicas) String() string {
+	s := strconv.FormatInt(int64(r.Number), 10)
+	if r.IsPercentage {
+		return s + "%"
+	}
+	return s
+}
+
+func (r Replicas) Calculate(total, defaultValue int) int {
+	if r.Number == 0 {
+		return defaultValue
+	}
+	if !r.IsPercentage {
+		return r.Number
+	}
+	num := float64(r.Number*total) / 100.0
+	return int(math.Ceil(num))
+}
+
+func (r Replicas) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+func (r *Replicas) UnmarshalJSON(b []byte) error {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch raw := v.(type) {
+	case float64:
+		*r = Replicas{
+			Number:       int(raw),
+			IsPercentage: false,
+		}
+		return nil
+	case string:
+		replicas := Replicas{
+			IsPercentage: false,
+		}
+		if strings.HasSuffix(raw, "%") {
+			replicas.IsPercentage = true
+			raw = strings.TrimSuffix(raw, "%")
+		}
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			return fmt.Errorf("invalid replicas: %v", err)
+		}
+		replicas.Number = value
+		*r = replicas
+		return nil
+	default:
+		return fmt.Errorf("invalid replicas: %v", string(b))
+	}
+}

--- a/pkg/plugin/sdk/unit/replicas.go
+++ b/pkg/plugin/sdk/unit/replicas.go
@@ -22,11 +22,15 @@ import (
 	"strings"
 )
 
+// Replicas represents a replica count that can be either an absolute number or a percentage.
+// When IsPercentage is true, Number represents a percentage value.
 type Replicas struct {
 	Number       int
 	IsPercentage bool
 }
 
+// String returns the string representation of the replicas.
+// If IsPercentage is true, it includes the % suffix.
 func (r Replicas) String() string {
 	s := strconv.FormatInt(int64(r.Number), 10)
 	if r.IsPercentage {
@@ -35,6 +39,10 @@ func (r Replicas) String() string {
 	return s
 }
 
+// Calculate returns the actual replica count based on the total replicas.
+// If the replica is a percentage, it calculates the ceiling of (Number * total / 100).
+// If Number is 0, it returns the defaultValue.
+// If IsPercentage is false, it returns the Number directly.
 func (r Replicas) Calculate(total, defaultValue int) int {
 	if r.Number == 0 {
 		return defaultValue
@@ -46,10 +54,13 @@ func (r Replicas) Calculate(total, defaultValue int) int {
 	return int(math.Ceil(num))
 }
 
+// MarshalJSON marshals the Replicas to a JSON string representation.
 func (r Replicas) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.String())
 }
 
+// UnmarshalJSON unmarshals a JSON value to Replicas.
+// It accepts numeric values, string numbers (e.g., "5"), and percentage strings (e.g., "50%").
 func (r *Replicas) UnmarshalJSON(b []byte) error {
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/pkg/plugin/sdk/unit/replicas_test.go
+++ b/pkg/plugin/sdk/unit/replicas_test.go
@@ -1,0 +1,281 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicasMarshal(t *testing.T) {
+	type wrapper struct {
+		Replicas Replicas
+	}
+
+	testcases := []struct {
+		name     string
+		input    wrapper
+		expected string
+	}{
+		{
+			name: "normal number",
+			input: wrapper{
+				Replicas{
+					Number:       1,
+					IsPercentage: false,
+				},
+			},
+			expected: "{\"Replicas\":\"1\"}",
+		},
+		{
+			name: "percentage number",
+			input: wrapper{
+				Replicas{
+					Number:       1,
+					IsPercentage: true,
+				},
+			},
+			expected: "{\"Replicas\":\"1%\"}",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(got))
+		})
+	}
+}
+
+func TestReplicasUnmarshal(t *testing.T) {
+	type wrapper struct {
+		Replicas Replicas
+	}
+
+	testcases := []struct {
+		name        string
+		input       string
+		expected    *wrapper
+		expectedErr error
+	}{
+		{
+			name:  "normal number",
+			input: "{\"Replicas\": 1}",
+			expected: &wrapper{
+				Replicas{
+					Number:       1,
+					IsPercentage: false,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "normal number by string",
+			input: "{\"Replicas\":\"1\"}",
+			expected: &wrapper{
+				Replicas{
+					Number:       1,
+					IsPercentage: false,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:  "percentage number",
+			input: "{\"Replicas\":\"1%\"}",
+			expected: &wrapper{
+				Replicas{
+					Number:       1,
+					IsPercentage: true,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "wrong string format",
+			input:       "{\"Replicas\":\"1a%\"}",
+			expected:    nil,
+			expectedErr: fmt.Errorf("invalid replicas: strconv.Atoi: parsing \"1a\": invalid syntax"),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := &wrapper{}
+			err := json.Unmarshal([]byte(tc.input), got)
+			assert.Equal(t, tc.expectedErr, err)
+			if tc.expected != nil {
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestReplicasString(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    Replicas
+		expected string
+	}{
+		{
+			name: "normal number",
+			input: Replicas{
+				Number:       5,
+				IsPercentage: false,
+			},
+			expected: "5",
+		},
+		{
+			name: "percentage number",
+			input: Replicas{
+				Number:       50,
+				IsPercentage: true,
+			},
+			expected: "50%",
+		},
+		{
+			name: "zero replicas",
+			input: Replicas{
+				Number:       0,
+				IsPercentage: false,
+			},
+			expected: "0",
+		},
+		{
+			name: "zero percentage",
+			input: Replicas{
+				Number:       0,
+				IsPercentage: true,
+			},
+			expected: "0%",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.String()
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestReplicasCalculate(t *testing.T) {
+	testcases := []struct {
+		name         string
+		input        Replicas
+		total        int
+		defaultValue int
+		expected     int
+	}{
+		{
+			name: "zero number returns default",
+			input: Replicas{
+				Number:       0,
+				IsPercentage: false,
+			},
+			total:        10,
+			defaultValue: 3,
+			expected:     3,
+		},
+		{
+			name: "zero percentage returns default",
+			input: Replicas{
+				Number:       0,
+				IsPercentage: true,
+			},
+			total:        10,
+			defaultValue: 5,
+			expected:     5,
+		},
+		{
+			name: "normal number",
+			input: Replicas{
+				Number:       7,
+				IsPercentage: false,
+			},
+			total:        10,
+			defaultValue: 3,
+			expected:     7,
+		},
+		{
+			name: "50 percent of 10",
+			input: Replicas{
+				Number:       50,
+				IsPercentage: true,
+			},
+			total:        10,
+			defaultValue: 3,
+			expected:     5,
+		},
+		{
+			name: "50 percent of 3 (rounds up)",
+			input: Replicas{
+				Number:       50,
+				IsPercentage: true,
+			},
+			total:        3,
+			defaultValue: 1,
+			expected:     2,
+		},
+		{
+			name: "33 percent of 10 (rounds up)",
+			input: Replicas{
+				Number:       33,
+				IsPercentage: true,
+			},
+			total:        10,
+			defaultValue: 1,
+			expected:     4,
+		},
+		{
+			name: "25 percent of 10",
+			input: Replicas{
+				Number:       25,
+				IsPercentage: true,
+			},
+			total:        10,
+			defaultValue: 1,
+			expected:     3,
+		},
+		{
+			name: "10 percent of 3 (rounds up to 1)",
+			input: Replicas{
+				Number:       10,
+				IsPercentage: true,
+			},
+			total:        3,
+			defaultValue: 0,
+			expected:     1,
+		},
+		{
+			name: "100 percent",
+			input: Replicas{
+				Number:       100,
+				IsPercentage: true,
+			},
+			total:        7,
+			defaultValue: 1,
+			expected:     7,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Calculate(tc.total, tc.defaultValue)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/plugin/sdk/unit/replicas_test.go
+++ b/pkg/plugin/sdk/unit/replicas_test.go
@@ -41,7 +41,7 @@ func TestReplicasMarshal(t *testing.T) {
 					IsPercentage: false,
 				},
 			},
-			expected: "{\"Replicas\":\"1\"}",
+			expected: `{"Replicas":"1"}`,
 		},
 		{
 			name: "percentage number",
@@ -51,7 +51,7 @@ func TestReplicasMarshal(t *testing.T) {
 					IsPercentage: true,
 				},
 			},
-			expected: "{\"Replicas\":\"1%\"}",
+			expected: `{"Replicas":"1%"}`,
 		},
 	}
 	for _, tc := range testcases {
@@ -76,7 +76,7 @@ func TestReplicasUnmarshal(t *testing.T) {
 	}{
 		{
 			name:  "normal number",
-			input: "{\"Replicas\": 1}",
+			input: `{"Replicas": 1}`,
 			expected: &wrapper{
 				Replicas{
 					Number:       1,
@@ -87,7 +87,7 @@ func TestReplicasUnmarshal(t *testing.T) {
 		},
 		{
 			name:  "normal number by string",
-			input: "{\"Replicas\":\"1\"}",
+			input: `{"Replicas":"1"}`,
 			expected: &wrapper{
 				Replicas{
 					Number:       1,
@@ -98,7 +98,7 @@ func TestReplicasUnmarshal(t *testing.T) {
 		},
 		{
 			name:  "percentage number",
-			input: "{\"Replicas\":\"1%\"}",
+			input: `{"Replicas":"1%"}`,
 			expected: &wrapper{
 				Replicas{
 					Number:       1,
@@ -109,7 +109,7 @@ func TestReplicasUnmarshal(t *testing.T) {
 		},
 		{
 			name:        "wrong string format",
-			input:       "{\"Replicas\":\"1a%\"}",
+			input:       `{"Replicas":"1a%"}`,
 			expected:    nil,
 			expectedErr: fmt.Errorf("invalid replicas: strconv.Atoi: parsing \"1a\": invalid syntax"),
 		},


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

They are used generally in the platform provider's specific configs in pipedv0, and are useful to define config types.
And I want to use them in the Kubernetes plugin.

In the current implementation of the Kubernetes plugin, we use `pkg/configv1`, but it's not a good way to import it.
https://github.com/pipe-cd/pipecd/blob/f39124f9ff935a5bdbb7ee9489a7ba74a4d00ceb/pkg/app/pipedv1/plugin/kubernetes/config/baseline.go#L17-L25

**Which issue(s) this PR fixes**:

Part of #5530 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
