### PR TITLE
[Stage Plugins] Make the UI compatible with skip and approval of pipedv1 

### DIFF
--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -167,6 +167,18 @@ func (s *deploymentStore) Add(ctx context.Context, d *model.Deployment) error {
 	if d.UpdatedAt == 0 {
 		d.UpdatedAt = now
 	}
+
+	// To make compatibility with pipedv0 and pipedv1 on the UI.
+	// TODO: Add "If the piped is v0," condition
+	for _, s := range d.Stages {
+		switch s.Name {
+		case model.StageAnalysis.String():
+			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_SKIP
+		case model.StageWaitApproval.String():
+			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_NONE
+		}
+	}
+
 	if err := d.Validate(); err != nil {
 		return err
 	}

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -175,7 +175,7 @@ func (s *deploymentStore) Add(ctx context.Context, d *model.Deployment) error {
 		case model.StageAnalysis.String():
 			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_SKIP
 		case model.StageWaitApproval.String():
-			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_NONE
+			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_APPROVE
 		}
 	}
 

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -169,13 +169,15 @@ func (s *deploymentStore) Add(ctx context.Context, d *model.Deployment) error {
 	}
 
 	// To make compatibility with pipedv0 and pipedv1 on the UI.
-	// TODO: Add "If the piped is v0," condition
-	for _, s := range d.Stages {
-		switch s.Name {
-		case model.StageAnalysis.String():
-			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_SKIP
-		case model.StageWaitApproval.String():
-			s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_APPROVE
+	// TODO: Remove this block after ending support of pipedv0.
+	if len(d.DeployTargetsByPlugin) == 0 {
+		for _, s := range d.Stages {
+			switch s.Name {
+			case model.StageAnalysis.String():
+				s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_SKIP
+			case model.StageWaitApproval.String():
+				s.AvailableOperation = model.ManualOperation_MANUAL_OPERATION_APPROVE
+			}
 		}
 	}
 

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -36,6 +36,7 @@ import { ManualOperation } from "~~/model/deployment_pb";
 
 const INITIAL_HEIGHT = 400;
 const TOOLBAR_HEIGHT = 48;
+const ANALYSIS_STAGE_NAME = "ANALYSIS";
 
 function useActiveStageLog(): [Stage | null, StageLog | null] {
   return useShallowEqualSelector<[Stage | null, StageLog | null]>((state) => {
@@ -147,8 +148,11 @@ export const LogViewer: FC = memo(function LogViewer() {
               alignItems: "center",
             }}
           >
-            {activeStage.availableOperation ===
-              ManualOperation.MANUAL_OPERATION_SKIP &&
+            {/* TODO: Remove stageName condition after finishing deployments which are made 
+                      while the server does not inject availableOperation */}
+            {(activeStage.name === ANALYSIS_STAGE_NAME ||
+              activeStage.availableOperation ===
+                ManualOperation.MANUAL_OPERATION_SKIP) &&
               activeStage.status === StageStatus.STAGE_RUNNING && (
                 <Button
                   // className={classes.skipButton}

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -147,7 +147,8 @@ export const LogViewer: FC = memo(function LogViewer() {
               alignItems: "center",
             }}
           >
-            {activeStage.availableOperation === ManualOperation.MANUAL_OPERATION_SKIP &&
+            {activeStage.availableOperation ===
+              ManualOperation.MANUAL_OPERATION_SKIP &&
               activeStage.status === StageStatus.STAGE_RUNNING && (
                 <Button
                   // className={classes.skipButton}

--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -32,10 +32,10 @@ import {
 } from "~/modules/deployments";
 import { selectStageLogById, StageLog } from "~/modules/stage-logs";
 import { Log } from "./log";
+import { ManualOperation } from "~~/model/deployment_pb";
 
 const INITIAL_HEIGHT = 400;
 const TOOLBAR_HEIGHT = 48;
-const ANALYSIS_STAGE_NAME = "ANALYSIS";
 
 function useActiveStageLog(): [Stage | null, StageLog | null] {
   return useShallowEqualSelector<[Stage | null, StageLog | null]>((state) => {
@@ -147,7 +147,7 @@ export const LogViewer: FC = memo(function LogViewer() {
               alignItems: "center",
             }}
           >
-            {activeStage.name === ANALYSIS_STAGE_NAME &&
+            {activeStage.availableOperation === ManualOperation.MANUAL_OPERATION_SKIP &&
               activeStage.status === StageStatus.STAGE_RUNNING && (
                 <Button
                   // className={classes.skipButton}

--- a/web/src/components/deployments-detail-page/pipeline/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.tsx
@@ -244,8 +244,9 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
                       }),
                     })}
                   >
-                    {stage.availableOperation === ManualOperation.MANUAL_OPERATION_APPROVE &&
-                      stage.status === StageStatus.STAGE_RUNNING ? (
+                    {stage.availableOperation ===
+                      ManualOperation.MANUAL_OPERATION_APPROVE &&
+                    stage.status === StageStatus.STAGE_RUNNING ? (
                       <ApprovalStage
                         id={stage.id}
                         name={stage.name}

--- a/web/src/components/deployments-detail-page/pipeline/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.tsx
@@ -25,8 +25,8 @@ import {
 import { fetchStageLog } from "~/modules/stage-logs";
 import { ApprovalStage } from "./approval-stage";
 import { PipelineStage } from "./pipeline-stage";
+import { ManualOperation } from "~~/model/deployment_pb";
 
-const WAIT_APPROVAL_NAME = "WAIT_APPROVAL";
 const STAGE_HEIGHT = 56;
 const APPROVED_STAGE_HEIGHT = 66;
 
@@ -244,8 +244,8 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
                       }),
                     })}
                   >
-                    {stage.name === WAIT_APPROVAL_NAME &&
-                    stage.status === StageStatus.STAGE_RUNNING ? (
+                    {stage.availableOperation === ManualOperation.MANUAL_OPERATION_APPROVE &&
+                      stage.status === StageStatus.STAGE_RUNNING ? (
                       <ApprovalStage
                         id={stage.id}
                         name={stage.name}

--- a/web/src/components/deployments-detail-page/pipeline/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.tsx
@@ -27,6 +27,7 @@ import { ApprovalStage } from "./approval-stage";
 import { PipelineStage } from "./pipeline-stage";
 import { ManualOperation } from "~~/model/deployment_pb";
 
+const WAIT_APPROVAL_NAME = "WAIT_APPROVAL";
 const STAGE_HEIGHT = 56;
 const APPROVED_STAGE_HEIGHT = 66;
 
@@ -244,8 +245,11 @@ export const Pipeline: FC<PipelineProps> = memo(function Pipeline({
                       }),
                     })}
                   >
-                    {stage.availableOperation ===
-                      ManualOperation.MANUAL_OPERATION_APPROVE &&
+                    {/* TODO: Remove stageName condition after finishing deployments which are made 
+                         while the server does not inject availableOperation */}
+                    {(stage.name === WAIT_APPROVAL_NAME ||
+                      stage.availableOperation ===
+                        ManualOperation.MANUAL_OPERATION_APPROVE) &&
                     stage.status === StageStatus.STAGE_RUNNING ? (
                       <ApprovalStage
                         id={stage.id}


### PR DESCRIPTION
**What this PR does**:

- UI: Judge by `availableOperation` to show the skip/approval button
- server:  Add `availableOperation` to pipedv0 Analysis/WaitApproval stages


Note: 
- We need to pass metadata of `Approvers`, `ApprovedBy`, and `SkippedBy` from WaitApproval/Analysis stage.
   - we need refactoring of the const values


**Why we need it**:

To enable skip/approval of both pipedv0 and pipedv1


**Which issue(s) this PR fixes**:

Part of #5367 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
