### PR TITLE
[Plugins] Replace configv1 unit types with SDK unit types

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/baseline.go
@@ -14,7 +14,7 @@
 
 package config
 
-import config "github.com/pipe-cd/pipecd/pkg/configv1"
+import "github.com/pipe-cd/piped-plugin-sdk-go/unit"
 
 // K8sBaselineRolloutStageOptions contains all configurable values for a K8S_BASELINE_ROLLOUT stage.
 type K8sBaselineRolloutStageOptions struct {
@@ -22,7 +22,7 @@ type K8sBaselineRolloutStageOptions struct {
 	// An integer value can be specified to indicate an absolute value of pod number.
 	// Or a string suffixed by "%" to indicate an percentage value compared to the pod number of PRIMARY.
 	// Default is 1 pod.
-	Replicas config.Replicas `json:"replicas"`
+	Replicas unit.Replicas `json:"replicas"`
 	// Suffix that should be used when naming the BASELINE variant's resources.
 	// Default is "baseline".
 	Suffix string `json:"suffix" default:"baseline"`

--- a/pkg/app/pipedv1/plugin/kubernetes/config/canary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/canary.go
@@ -14,7 +14,7 @@
 
 package config
 
-import config "github.com/pipe-cd/pipecd/pkg/configv1"
+import "github.com/pipe-cd/piped-plugin-sdk-go/unit"
 
 // K8sCanaryRolloutStageOptions contains all configurable values for a K8S_CANARY_ROLLOUT stage.
 type K8sCanaryRolloutStageOptions struct {
@@ -22,7 +22,7 @@ type K8sCanaryRolloutStageOptions struct {
 	// An integer value can be specified to indicate an absolute value of pod number.
 	// Or a string suffixed by "%" to indicate an percentage value compared to the pod number of PRIMARY.
 	// Default is 1 pod.
-	Replicas config.Replicas `json:"replicas"`
+	Replicas unit.Replicas `json:"replicas"`
 	// Suffix that should be used when naming the CANARY variant's resources.
 	// Default is "canary".
 	Suffix string `json:"suffix" default:"canary"`

--- a/pkg/app/pipedv1/plugin/kubernetes/config/traffic.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/traffic.go
@@ -14,7 +14,7 @@
 
 package config
 
-import config "github.com/pipe-cd/pipecd/pkg/configv1"
+import "github.com/pipe-cd/piped-plugin-sdk-go/unit"
 
 type KubernetesTrafficRoutingMethod string
 
@@ -62,11 +62,11 @@ type K8sTrafficRoutingStageOptions struct {
 	// "primary" or "canary" or "baseline" can be populated.
 	All string `json:"all"`
 	// The percentage of traffic should be routed to PRIMARY variant.
-	Primary config.Percentage `json:"primary"`
+	Primary unit.Percentage `json:"primary"`
 	// The percentage of traffic should be routed to CANARY variant.
-	Canary config.Percentage `json:"canary"`
+	Canary unit.Percentage `json:"canary"`
 	// The percentage of traffic should be routed to BASELINE variant.
-	Baseline config.Percentage `json:"baseline"`
+	Baseline unit.Percentage `json:"baseline"`
 }
 
 // Percentages returns the primary, canary, and baseline percentages from the K8sTrafficRoutingStageOptions.

--- a/pkg/app/pipedv1/plugin/kubernetes/config/traffic_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/traffic_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/piped-plugin-sdk-go/unit"
 )
 
 func TestDetermineKubernetesTrafficRoutingMethod(t *testing.T) {
@@ -110,9 +110,9 @@ func TestK8sTrafficRoutingStageOptions_Percentages(t *testing.T) {
 		{
 			name: "custom split with all percentages",
 			opts: K8sTrafficRoutingStageOptions{
-				Primary:  config.Percentage{Number: 50},
-				Canary:   config.Percentage{Number: 30},
-				Baseline: config.Percentage{Number: 20},
+				Primary:  unit.Percentage{Number: 50},
+				Canary:   unit.Percentage{Number: 30},
+				Baseline: unit.Percentage{Number: 20},
 			},
 			wantPrimary:  50,
 			wantCanary:   30,
@@ -121,8 +121,8 @@ func TestK8sTrafficRoutingStageOptions_Percentages(t *testing.T) {
 		{
 			name: "custom split with only primary and canary",
 			opts: K8sTrafficRoutingStageOptions{
-				Primary: config.Percentage{Number: 80},
-				Canary:  config.Percentage{Number: 20},
+				Primary: unit.Percentage{Number: 80},
+				Canary:  unit.Percentage{Number: 20},
 			},
 			wantPrimary:  80,
 			wantCanary:   20,
@@ -139,8 +139,8 @@ func TestK8sTrafficRoutingStageOptions_Percentages(t *testing.T) {
 			name: "invalid 'all' value should use percentages",
 			opts: K8sTrafficRoutingStageOptions{
 				All:     "invalid",
-				Primary: config.Percentage{Number: 60},
-				Canary:  config.Percentage{Number: 40},
+				Primary: unit.Percentage{Number: 60},
+				Canary:  unit.Percentage{Number: 40},
 			},
 			wantPrimary:  60,
 			wantCanary:   40,

--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/goccy/go-yaml v1.9.8
 	github.com/google/go-cmp v0.7.0
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250612023157-bc4c32dc15cb
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0

--- a/pkg/app/pipedv1/plugin/wait/go.mod
+++ b/pkg/app/pipedv1/plugin/wait/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/pipe-cd/pipecd v0.52.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250612023157-bc4c32dc15cb
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 )

--- a/pkg/app/pipedv1/plugin/wait/options.go
+++ b/pkg/app/pipedv1/plugin/wait/options.go
@@ -18,12 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/piped-plugin-sdk-go/unit"
 )
 
 // WaitStageOptions contains configurable values for a WAIT stage.
 type WaitStageOptions struct {
-	Duration config.Duration `json:"duration,omitempty"`
+	Duration unit.Duration `json:"duration,omitempty"`
 }
 
 func (o WaitStageOptions) validate() error {

--- a/pkg/app/pipedv1/plugin/wait/options_test.go
+++ b/pkg/app/pipedv1/plugin/wait/options_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/piped-plugin-sdk-go/unit"
 )
 
 func TestDecode(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDecode(t *testing.T) {
 			name: "valid config",
 			data: json.RawMessage(`{"duration":"1m"}`),
 			expected: WaitStageOptions{
-				Duration: config.Duration(1 * time.Minute),
+				Duration: unit.Duration(1 * time.Minute),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We don't want to import `pkg/configv1` from plugins

**Which issue(s) this PR fixes**:

Follows #5959 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
