### PR TITLE
Add deprecated note to pipelinestage id field

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -284,7 +284,7 @@ One of `yamlField` or `regex` is required.
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| id | string | The unique ID of the stage. | No |
+| id | string | The unique ID of the stage. This field is `deprecated`. | No |
 | name | string | One of the provided stage names. | Yes |
 | desc | string | The description about the stage. | No |
 | timeout | duration | The maximum time the stage can be taken to run. | No |


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

This field will not be supported as configurable field for plugin-arch pipecd

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
