### PR TITLE
Redux replace deployment detail page

### DIFF
--- a/web/src/__fixtures__/dummy-stage-log.ts
+++ b/web/src/__fixtures__/dummy-stage-log.ts
@@ -1,4 +1,4 @@
-import { LogBlock, LogSeverity } from "~/modules/stage-logs";
+import { LogBlock, LogSeverity } from "~~/model/logblock_pb";
 import { createRandTimes, randomWords } from "./utils";
 
 const logTimes = createRandTimes(3);

--- a/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.test.tsx
@@ -1,16 +1,10 @@
 import userEvent from "@testing-library/user-event";
-import { clearActiveStage } from "~/modules/active-stage";
-import { createActiveStageKey, LogSeverity } from "~/modules/stage-logs";
+import { LogSeverity } from "~~/model/logblock_pb";
 import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
-import { createStore, render, screen } from "~~/test-utils";
+import { render, screen } from "~~/test-utils";
 import { LogViewer } from ".";
 
 Element.prototype.scrollIntoView = jest.fn();
-
-const activeStageId = createActiveStageKey({
-  deploymentId: dummyDeployment.id,
-  stageId: dummyDeployment.stagesList[0].id,
-});
 
 const dummyLog = {
   stageId: dummyDeployment.stagesList[0].id,
@@ -26,42 +20,30 @@ const dummyLog = {
   deploymentId: dummyDeployment.id,
 };
 
+const activeStage = dummyDeployment.stagesList[0];
+
 it("should not appear in the document if activeState is null", () => {
-  render(<LogViewer />, {
-    initialState: {
-      deployments: {
-        ids: [dummyDeployment.id],
-        entities: {
-          [dummyDeployment.id]: dummyDeployment,
-        },
-      },
-      activeStage: null,
-    },
-  });
+  const changeActiveStage = jest.fn();
+  render(
+    <LogViewer
+      activeStage={null}
+      stageLog={dummyLog}
+      changeActiveStage={changeActiveStage}
+    />
+  );
 
   expect(screen.queryByTestId("log-viewer")).not.toBeInTheDocument();
 });
 
 it("should appear stage log in the document if activeState is exists", () => {
-  render(<LogViewer />, {
-    initialState: {
-      deployments: {
-        ids: [dummyDeployment.id],
-        entities: {
-          [dummyDeployment.id]: dummyDeployment,
-        },
-        skippable: {},
-      },
-      activeStage: {
-        deploymentId: dummyDeployment.id,
-        name: dummyDeployment.stagesList[0].name,
-        stageId: dummyDeployment.stagesList[0].id,
-      },
-      stageLogs: {
-        [activeStageId]: dummyLog,
-      },
-    },
-  });
+  render(
+    <LogViewer
+      activeStage={activeStage}
+      stageLog={dummyLog}
+      changeActiveStage={() => {}}
+    />,
+    {}
+  );
 
   expect(screen.queryByTestId("log-viewer")).toBeInTheDocument();
   expect(
@@ -70,33 +52,17 @@ it("should appear stage log in the document if activeState is exists", () => {
   expect(screen.queryByText("hello world")).toBeInTheDocument();
 });
 
-it("should dispatch clearActiveStage action if click `close log` button", () => {
-  const store = createStore({
-    deployments: {
-      ids: [dummyDeployment.id],
-      entities: {
-        [dummyDeployment.id]: dummyDeployment,
-      },
-      skippable: {},
-    },
-    activeStage: {
-      deploymentId: dummyDeployment.id,
-      name: dummyDeployment.stagesList[0].name,
-      stageId: dummyDeployment.stagesList[0].id,
-    },
-    stageLogs: {
-      [activeStageId]: dummyLog,
-    },
-  });
-  render(<LogViewer />, {
-    store,
-  });
+it("should clearActiveStage action if click `close log` button", () => {
+  const changeActiveStage = jest.fn();
+  render(
+    <LogViewer
+      activeStage={activeStage}
+      stageLog={dummyLog}
+      changeActiveStage={changeActiveStage}
+    />
+  );
 
   userEvent.click(screen.getByRole("button", { name: "close log" }));
 
-  expect(store.getActions()).toMatchObject([
-    {
-      type: clearActiveStage.type,
-    },
-  ]);
+  expect(changeActiveStage).toHaveBeenCalled();
 });

--- a/web/src/components/deployments-detail-page/log-viewer/log-line/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/log-line/index.tsx
@@ -8,7 +8,7 @@ import {
   DEFAULT_TEXT_COLOR,
   TERM_COLORS,
 } from "~/constants/term-colors";
-import { LogSeverity } from "~/modules/stage-logs";
+import { LogSeverity } from "~~/model/logblock_pb";
 import { parseLog } from "~/utils/parse-log";
 import dayjs from "dayjs";
 

--- a/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
@@ -2,7 +2,7 @@ import { FC, memo, useEffect, useRef } from "react";
 import { CircularProgress, Box } from "@mui/material";
 import { LogLine } from "../log-line";
 import { DEFAULT_BACKGROUND_COLOR } from "~/constants/term-colors";
-import { LogBlock } from "~/modules/stage-logs";
+import { LogBlock } from "~~/model/logblock_pb";
 
 export interface LogProps {
   logs: LogBlock.AsObject[];

--- a/web/src/components/deployments-detail-page/pipeline/index.test.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/index.test.tsx
@@ -1,28 +1,42 @@
-import { updateActiveStage } from "~/modules/active-stage";
 import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
-import { createStore, render } from "~~/test-utils";
 import { Pipeline } from ".";
+import { render, screen } from "~~/test-utils";
 
-it("should dispatch updateActiveState when first rendering", () => {
-  const store = createStore({
-    deployments: {
-      entities: {
-        [dummyDeployment.id]: dummyDeployment,
-      },
-      ids: [dummyDeployment.id],
-    },
+it("should render correct stage list", () => {
+  render(
+    <Pipeline
+      deployment={dummyDeployment}
+      activeStageInfo={null}
+      changeActiveStage={() => {}}
+    />
+  );
+
+  expect(screen.getByText("K8S_CANARY_ROLLOUT")).toBeInTheDocument();
+  expect(screen.getByText("K8S_TRAFFIC_ROUTING")).toBeInTheDocument();
+  expect(screen.getByText("K8S_CANARY_CLEAN")).toBeInTheDocument();
+});
+
+it("should call setActiveStage when click stage", () => {
+  const setActiveStage = jest.fn();
+
+  render(
+    <Pipeline
+      deployment={dummyDeployment}
+      activeStageInfo={null}
+      changeActiveStage={setActiveStage}
+    />
+  );
+
+  const stage = screen.getByText("K8S_CANARY_ROLLOUT");
+  stage.click();
+
+  const expectedStage = dummyDeployment.stagesList.find(
+    (item) => item.name === "K8S_CANARY_ROLLOUT"
+  );
+
+  expect(setActiveStage).toHaveBeenCalledWith({
+    deploymentId: dummyDeployment.id,
+    stageId: expectedStage?.id,
+    name: expectedStage?.name,
   });
-
-  render(<Pipeline deploymentId={dummyDeployment.id} />, { store });
-
-  expect(store.getActions()).toEqual([
-    {
-      type: updateActiveStage.type,
-      payload: {
-        name: dummyDeployment.stagesList[1].name,
-        stageId: dummyDeployment.stagesList[1].id,
-        deploymentId: dummyDeployment.id,
-      },
-    },
-  ]);
 });

--- a/web/src/components/deployments-detail-page/pipeline/pipeline-stage/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/pipeline-stage/index.tsx
@@ -88,10 +88,6 @@ export const PipelineStage: FC<PipelineStageProps> = memo(
     return (
       <Paper
         square
-        // className={clsx(classes.root, {
-        //   [classes.active]: active,
-        //   [classes.notStartedYet]: disabled,
-        // })}
         onClick={handleOnClick}
         sx={(theme) => ({
           flex: 1,

--- a/web/src/components/deployments-detail-page/pipeline/pipeline-stage/stage-status-icon/index.tsx
+++ b/web/src/components/deployments-detail-page/pipeline/pipeline-stage/stage-status-icon/index.tsx
@@ -7,7 +7,7 @@ import {
   Block,
 } from "@mui/icons-material";
 import { FC } from "react";
-import { StageStatus } from "~/modules/deployments";
+import { StageStatus } from "~~/model/deployment_pb";
 
 export interface StageStatusIconProps {
   status: StageStatus;

--- a/web/src/contexts/command-context/CommandStatusTracking.tsx
+++ b/web/src/contexts/command-context/CommandStatusTracking.tsx
@@ -1,0 +1,79 @@
+import { FC, memo, useEffect } from "react";
+import {
+  COMMAND_TYPE_TEXT,
+  useFetchCommand,
+} from "~/queries/commands/use-fetch-command";
+import { useToast } from "../toast-context";
+import { Command, CommandStatus } from "~~/model/command_pb";
+import { findMetadataByKey } from "~/utils/find-metadata-by-key";
+import { PAGE_PATH_DEPLOYMENTS } from "~/constants/path";
+
+type Props = {
+  commandId: string;
+  onComplete: (commandId: string) => void;
+  onFetched: (command: Command.AsObject) => void;
+};
+
+const METADATA_KEY = {
+  TRIGGERED_DEPLOYMENT_ID: "TriggeredDeploymentID",
+};
+
+const CommandStatusTracking: FC<Props> = ({
+  commandId,
+  onComplete,
+  onFetched,
+}: Props) => {
+  const { addToast } = useToast();
+  const { data: command, isSuccess } = useFetchCommand({ commandId });
+
+  // show toast when the command is successfully fetched and handled
+  useEffect(() => {
+    if (!isSuccess) return;
+    if (command === undefined) return;
+    if (command.status !== CommandStatus.COMMAND_SUCCEEDED) return;
+
+    switch (command.type) {
+      case Command.Type.SYNC_APPLICATION: {
+        const deploymentId = findMetadataByKey(
+          command.metadataMap,
+          METADATA_KEY.TRIGGERED_DEPLOYMENT_ID
+        );
+        addToast({
+          message: `Succeed "${COMMAND_TYPE_TEXT[command.type]}"`,
+          severity: "success",
+          to: deploymentId
+            ? `${PAGE_PATH_DEPLOYMENTS}/${deploymentId}`
+            : undefined,
+        });
+        break;
+      }
+      default:
+        addToast({
+          message: `Succeed "${COMMAND_TYPE_TEXT[command.type]}"`,
+          severity: "success",
+        });
+    }
+  }, [addToast, command, isSuccess]);
+
+  // Stop tracking the command when it is handled.
+  useEffect(() => {
+    if (
+      isSuccess &&
+      command?.status !== CommandStatus.COMMAND_NOT_HANDLED_YET
+    ) {
+      onComplete(commandId);
+    }
+  }, [command?.status, commandId, isSuccess, onComplete]);
+
+  useEffect(() => {
+    if (command) {
+      onFetched(command);
+    }
+  }, [command, onFetched]);
+
+  return null;
+};
+
+export default memo(CommandStatusTracking, (prev, next) => {
+  return prev.commandId === next.commandId;
+});

--- a/web/src/contexts/command-context/command-context.ts
+++ b/web/src/contexts/command-context/command-context.ts
@@ -1,0 +1,16 @@
+import React from "react";
+import { Command } from "~~/model/command_pb";
+
+export type CommandContextType = {
+  fetchedCommands: Record<string, Command.AsObject>;
+  commandIds?: Set<string>;
+  addCommand: (commandId: string) => void;
+  removeCommand: (commandId: string) => void;
+};
+
+export const CommandContext = React.createContext<CommandContextType>({
+  fetchedCommands: {},
+  commandIds: new Set<string>(),
+  addCommand: () => Promise.resolve(),
+  removeCommand: () => Promise.resolve(),
+});

--- a/web/src/contexts/command-context/command-provider.tsx
+++ b/web/src/contexts/command-context/command-provider.tsx
@@ -1,0 +1,58 @@
+import { FC, PropsWithChildren, useCallback, useState } from "react";
+import { CommandContext } from "./command-context";
+import CommandStatusTracking from "./CommandStatusTracking";
+import { Command } from "~~/model/command_pb";
+
+export const CommandProvider: FC<PropsWithChildren<unknown>> = ({
+  children,
+}) => {
+  const [commandIds, setCommandIds] = useState(new Set<string>());
+
+  const [fetchedCommands, setFetchedCommands] = useState<
+    Record<string, Command.AsObject>
+  >({});
+
+  const addCommand = useCallback((commandId: string): void => {
+    setCommandIds((prev) => new Set(prev).add(commandId));
+  }, []);
+
+  const removeCommand = useCallback((commandId: string): void => {
+    setCommandIds((prev) => {
+      const newIds = new Set(prev);
+      newIds.delete(commandId);
+      return newIds;
+    });
+    setFetchedCommands((prev) => {
+      const newFetchedCommands = { ...prev };
+      delete newFetchedCommands[commandId];
+      return newFetchedCommands;
+    });
+  }, []);
+
+  const saveFetchedCommand = useCallback((command: Command.AsObject): void => {
+    setFetchedCommands((prev) => ({
+      ...prev,
+      [command.id]: command,
+    }));
+  }, []);
+
+  return (
+    <CommandContext.Provider
+      value={{ fetchedCommands, addCommand, removeCommand, commandIds }}
+    >
+      {children}
+      {[...commandIds].map((commandId) => (
+        <CommandStatusTracking
+          commandId={commandId}
+          key={commandId}
+          onComplete={() => {
+            removeCommand(commandId);
+          }}
+          onFetched={(command) => {
+            saveFetchedCommand(command);
+          }}
+        />
+      ))}
+    </CommandContext.Provider>
+  );
+};

--- a/web/src/contexts/command-context/index.ts
+++ b/web/src/contexts/command-context/index.ts
@@ -1,0 +1,3 @@
+export * from "./command-context";
+export * from "./command-provider";
+export * from "./use-command";

--- a/web/src/contexts/command-context/use-command.tsx
+++ b/web/src/contexts/command-context/use-command.tsx
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { CommandContext, CommandContextType } from "./command-context";
+
+export const useCommand = (): CommandContextType => {
+  return useContext(CommandContext);
+};
+
+export default useCommand;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -11,6 +11,7 @@ import { CookiesProvider } from "react-cookie";
 import QueryClientWrap from "./contexts/query-client-provider";
 import { AuthProvider } from "./contexts/auth-context";
 import { ToastProvider } from "./contexts/toast-context/toast-provider";
+import { CommandProvider } from "./contexts/command-context";
 
 async function run(): Promise<void> {
   if (process.env.ENABLE_MOCK === "true") {
@@ -60,8 +61,10 @@ Happy PipeCD-ing 🙌
               <ToastProvider>
                 <QueryClientWrap>
                   <AuthProvider>
-                    <CssBaseline />
-                    <Routes />
+                    <CommandProvider>
+                      <CssBaseline />
+                      <Routes />
+                    </CommandProvider>
                   </AuthProvider>
                 </QueryClientWrap>
               </ToastProvider>

--- a/web/src/mocks/services/deployment.ts
+++ b/web/src/mocks/services/deployment.ts
@@ -1,4 +1,5 @@
 import {
+  CancelDeploymentResponse,
   GetDeploymentResponse,
   ListDeploymentsResponse,
 } from "pipecd/web/api_client/service_pb";
@@ -17,6 +18,11 @@ export const deploymentHandlers = [
   createHandler<ListDeploymentsResponse>("/ListDeployments", () => {
     const response = new ListDeploymentsResponse();
     response.setDeploymentsList([createDeploymentFromObject(dummyDeployment)]);
+    return response;
+  }),
+  createHandler<CancelDeploymentResponse>("/CancelDeployment", () => {
+    const response = new CancelDeploymentResponse();
+    response.setCommandId("123");
     return response;
   }),
 ];

--- a/web/src/queries/commands/use-fetch-command.ts
+++ b/web/src/queries/commands/use-fetch-command.ts
@@ -1,0 +1,38 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { getCommand } from "~/api/commands";
+import { Command, CommandStatus } from "~~/model/command_pb";
+
+const FETCH_COMMANDS_INTERVAL = 3000;
+
+export const COMMAND_TYPE_TEXT: Record<Command.Type, string> = {
+  [Command.Type.APPROVE_STAGE]: "Approve Stage",
+  [Command.Type.CANCEL_DEPLOYMENT]: "Cancel Deployment",
+  [Command.Type.SYNC_APPLICATION]: "Sync Application",
+  [Command.Type.UPDATE_APPLICATION_CONFIG]: "Update Application Config",
+  [Command.Type.BUILD_PLAN_PREVIEW]: "Build Plan Preview",
+  [Command.Type.CHAIN_SYNC_APPLICATION]: "Chain Sync Application",
+  [Command.Type.SKIP_STAGE]: "Skip Stage",
+  [Command.Type.RESTART_PIPED]: "Restart Piped",
+};
+
+export const useFetchCommand = ({
+  commandId,
+}: {
+  commandId: string;
+}): UseQueryResult<Command.AsObject> => {
+  return useQuery({
+    queryKey: ["command", commandId],
+    queryFn: async () => {
+      const { command } = await getCommand({ commandId });
+      return command;
+    },
+    refetchInterval(data) {
+      // If the command is not handled yet, we will refetch it every 5 seconds.
+      if (data?.status === CommandStatus.COMMAND_NOT_HANDLED_YET) {
+        return FETCH_COMMANDS_INTERVAL;
+      }
+      // Otherwise, we don't need to refetch.
+      return false;
+    },
+  });
+};

--- a/web/src/queries/deployment/use-approve-stage.ts
+++ b/web/src/queries/deployment/use-approve-stage.ts
@@ -1,0 +1,28 @@
+import {
+  useQueryClient,
+  useMutation,
+  UseMutationResult,
+} from "@tanstack/react-query";
+import * as deploymentsApi from "~/api/deployments";
+import { useCommand } from "~/contexts/command-context";
+
+export const useApproveStage = (): UseMutationResult<
+  string,
+  unknown,
+  { deploymentId: string; stageId: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  const { addCommand } = useCommand();
+
+  return useMutation({
+    mutationFn: async (payload) => {
+      const { commandId } = await deploymentsApi.approveStage(payload);
+      return commandId;
+    },
+    onSuccess: (commandId) => {
+      addCommand(commandId);
+      queryClient.invalidateQueries(["deployment"]);
+    },
+  });
+};

--- a/web/src/queries/deployment/use-cancel-deployment.ts
+++ b/web/src/queries/deployment/use-cancel-deployment.ts
@@ -1,0 +1,45 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import * as deploymentsApi from "~/api/deployments";
+import { useCommand } from "~/contexts/command-context";
+
+export const useCancelDeployment = (): UseMutationResult<
+  string,
+  unknown,
+  {
+    deploymentId: string;
+    forceRollback: boolean;
+    forceNoRollback: boolean;
+  },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  const { addCommand } = useCommand();
+
+  return useMutation({
+    mutationFn: async ({
+      deploymentId,
+      forceRollback,
+      forceNoRollback,
+    }: {
+      deploymentId: string;
+      forceRollback: boolean;
+      forceNoRollback: boolean;
+    }) => {
+      const { commandId } = await deploymentsApi.cancelDeployment({
+        deploymentId,
+        forceRollback,
+        forceNoRollback,
+      });
+      return commandId;
+    },
+    onSuccess: (commandId) => {
+      addCommand(commandId);
+      queryClient.invalidateQueries(["deployment"]);
+    },
+  });
+};
+// await thunkAPI.dispatch(fetchCommand(commandId));

--- a/web/src/queries/deployment/use-get-deployment-by-id.ts
+++ b/web/src/queries/deployment/use-get-deployment-by-id.ts
@@ -1,0 +1,23 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import * as deploymentsApi from "~/api/deployments";
+import { Deployment } from "pipecd/web/model/deployment_pb";
+
+export const useGetDeploymentById = (
+  { deploymentId }: { deploymentId: string },
+  queryOptions?: UseQueryOptions<Deployment.AsObject>
+): UseQueryResult<Deployment.AsObject> => {
+  return useQuery({
+    queryKey: ["deployment", "detail", { deploymentId }],
+    queryFn: async () => {
+      const { deployment } = await deploymentsApi.getDeployment({
+        deploymentId,
+      });
+      return deployment as Deployment.AsObject;
+    },
+    ...queryOptions,
+  });
+};

--- a/web/src/queries/deployment/use-skip-stage.ts
+++ b/web/src/queries/deployment/use-skip-stage.ts
@@ -1,0 +1,28 @@
+import {
+  useQueryClient,
+  useMutation,
+  UseMutationResult,
+} from "@tanstack/react-query";
+import * as deploymentsApi from "~/api/deployments";
+import { useCommand } from "~/contexts/command-context";
+
+export const useSkipStage = (): UseMutationResult<
+  string,
+  unknown,
+  { deploymentId: string; stageId: string },
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  const { addCommand } = useCommand();
+
+  return useMutation({
+    mutationFn: async (payload) => {
+      const { commandId } = await deploymentsApi.skipStage(payload);
+      return commandId;
+    },
+    onSuccess: (commandId) => {
+      addCommand(commandId);
+      queryClient.invalidateQueries(["deployment"]);
+    },
+  });
+};

--- a/web/src/queries/pipeds/use-get-piped-by-id.tsx
+++ b/web/src/queries/pipeds/use-get-piped-by-id.tsx
@@ -1,0 +1,38 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import * as pipedsApi from "~/api/piped";
+import { Piped } from "pipecd/web/model/piped_pb";
+import { useMemo } from "react";
+
+export const useGetPipedById = (
+  options: {
+    pipedId: string;
+    withStatus?: boolean;
+  },
+  queryOption: UseQueryOptions<Piped.AsObject[]> = {}
+): Omit<UseQueryResult<Piped.AsObject[]>, "data"> & {
+  data?: Piped.AsObject;
+} => {
+  const query = useQuery<Piped.AsObject[]>({
+    queryKey: ["pipeds", "list", { withStatus: options.withStatus }],
+    queryFn: async () => {
+      const { pipedsList } = await pipedsApi.getPipeds({
+        withStatus: true,
+      });
+
+      return pipedsList;
+    },
+    ...queryOption,
+  });
+  const piped = useMemo(() => {
+    return query.data?.find((p) => p.id === options.pipedId);
+  }, [options.pipedId, query.data]);
+
+  return {
+    ...query,
+    data: piped,
+  };
+};

--- a/web/src/queries/stage-logs/use-get-stage-logs.ts
+++ b/web/src/queries/stage-logs/use-get-stage-logs.ts
@@ -1,0 +1,87 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import { getStageLog } from "~/api/stage-log";
+import { StageLog } from "~/types/stage-log";
+import { Deployment, StageStatus } from "~~/model/deployment_pb";
+import { StatusCode } from "grpc-web";
+
+export const useGetStageLogs = (
+  options: {
+    deployment?: Deployment.AsObject;
+    offsetIndex: number;
+    retriedCount: number;
+    stageId: string;
+  },
+  queryOption: UseQueryOptions<StageLog> = {}
+): UseQueryResult<StageLog> => {
+  return useQuery({
+    queryKey: [
+      "stage-logs",
+      {
+        deploymentId: options.deployment?.id ?? "",
+        stageId: options.stageId,
+        offsetIndex: options.offsetIndex,
+        retriedCount: options.retriedCount,
+      },
+    ],
+    queryFn: async () => {
+      const { deployment, offsetIndex, retriedCount, stageId } = options || {};
+      const deploymentId = deployment?.id ?? "";
+
+      const initialLogs: StageLog = {
+        stageId,
+        deploymentId,
+        logBlocks: [],
+      };
+
+      if (!deployment) {
+        throw new Error(`Deployment: ${deploymentId} is not exists in state.`);
+      }
+
+      const stage = deployment.stagesList.find((stage) => stage.id === stageId);
+
+      if (!stage) {
+        throw new Error(
+          `Stage (ID: ${stageId}) is not found in application state.`
+        );
+      }
+
+      if (stage.status === StageStatus.STAGE_NOT_STARTED_YET) {
+        return initialLogs;
+      }
+
+      const response = await getStageLog({
+        deploymentId,
+        offsetIndex,
+        retriedCount,
+        stageId,
+      }).catch((e: { code: number }) => {
+        // If status is running and error code is NOT_FOUND, it is maybe first state of deployment log.
+        // So we ignore this error and then return initialLogs below code.
+        if (
+          e.code === StatusCode.NOT_FOUND &&
+          stage.status === StageStatus.STAGE_RUNNING
+        ) {
+          return;
+        }
+
+        throw e;
+      });
+
+      if (!response) {
+        return initialLogs;
+      }
+
+      return {
+        stageId,
+        deploymentId,
+        logBlocks: response.blocksList,
+      };
+    },
+
+    ...queryOption,
+  });
+};

--- a/web/src/types/deployment.ts
+++ b/web/src/types/deployment.ts
@@ -1,0 +1,3 @@
+import { PipelineStage } from "~~/model/deployment_pb";
+
+export type Stage = Required<PipelineStage.AsObject>;

--- a/web/src/types/stage-log.ts
+++ b/web/src/types/stage-log.ts
@@ -1,0 +1,7 @@
+import { LogBlock } from "~~/model/logblock_pb";
+
+export type StageLog = {
+  deploymentId: string;
+  stageId: string;
+  logBlocks: LogBlock.AsObject[];
+};

--- a/web/src/utils/find-default-active-stage-in-deployment.ts
+++ b/web/src/utils/find-default-active-stage-in-deployment.ts
@@ -1,0 +1,44 @@
+import { Stage } from "~/types/deployment";
+import { Deployment, StageStatus } from "~~/model/deployment_pb";
+
+enum PIPED_VERSION {
+  V0 = "v0",
+  V1 = "v1",
+}
+
+// Find stage that is running or latest
+export const findDefaultActiveStageInDeployment = (
+  deployment: Deployment.AsObject | undefined
+): Stage | null => {
+  if (!deployment) {
+    return null;
+  }
+
+  const pipedVersion = deployment.deployTargetsByPluginMap?.length
+    ? PIPED_VERSION.V1
+    : PIPED_VERSION.V0;
+
+  const stages = deployment.stagesList.filter((stage) => {
+    if (pipedVersion === PIPED_VERSION.V0) {
+      return (
+        stage.visible && stage.status !== StageStatus.STAGE_NOT_STARTED_YET
+      );
+    }
+
+    // For piped v1, field visible is not used.
+    if (pipedVersion === PIPED_VERSION.V1) {
+      return stage.status !== StageStatus.STAGE_NOT_STARTED_YET;
+    }
+    return false;
+  });
+
+  const runningStage = stages.find(
+    (stage) => stage.status === StageStatus.STAGE_RUNNING
+  );
+
+  if (runningStage) {
+    return runningStage;
+  }
+
+  return stages[stages.length - 1];
+};

--- a/web/src/utils/is-deployment-running.ts
+++ b/web/src/utils/is-deployment-running.ts
@@ -1,0 +1,21 @@
+import { DeploymentStatus } from "~~/model/deployment_pb";
+
+export const isDeploymentRunning = (
+  status: DeploymentStatus | undefined
+): boolean => {
+  if (status === undefined) {
+    return false;
+  }
+
+  switch (status) {
+    case DeploymentStatus.DEPLOYMENT_PENDING:
+    case DeploymentStatus.DEPLOYMENT_PLANNED:
+    case DeploymentStatus.DEPLOYMENT_ROLLING_BACK:
+    case DeploymentStatus.DEPLOYMENT_RUNNING:
+      return true;
+    case DeploymentStatus.DEPLOYMENT_CANCELLED:
+    case DeploymentStatus.DEPLOYMENT_FAILURE:
+    case DeploymentStatus.DEPLOYMENT_SUCCESS:
+      return false;
+  }
+};

--- a/web/src/utils/is-stage-running.ts
+++ b/web/src/utils/is-stage-running.ts
@@ -1,0 +1,15 @@
+import { StageStatus } from "~~/model/deployment_pb";
+
+export const isStageRunning = (status: StageStatus): boolean => {
+  switch (status) {
+    case StageStatus.STAGE_NOT_STARTED_YET:
+    case StageStatus.STAGE_RUNNING:
+      return true;
+    case StageStatus.STAGE_SUCCESS:
+    case StageStatus.STAGE_FAILURE:
+    case StageStatus.STAGE_CANCELLED:
+    case StageStatus.STAGE_SKIPPED:
+    case StageStatus.STAGE_EXITED:
+      return false;
+  }
+};


### PR DESCRIPTION
**What this PR does**:

- This MR depends on https://github.com/pipe-cd/pipecd/pull/5955
- Add commandContext for tracing command
- split util function from modules/deployment
- add query for get deployment by id, stage logs, command
- add mutation for cacnel deployment, approve stage, skip stage

**Why we need it**:

- remove redux module from deployment-detail pages

**Which issue(s) this PR fixes**:

Partof #5868

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
