### PR TITLE
Rename live demo to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   A GitOps style continuous delivery platform that provides consistent deployment and operations experience for any applications
   <br/>
   <a href="https://pipecd.dev"><strong>Explore PipeCD docs »</strong></a>
-  <a href="https://play.pipecd.dev?project=play"><strong>Play with live demo »</strong></a>
+  <a href="https://play.pipecd.dev?project=play"><strong>Try on Playground »</strong></a>
 </p>
 
 #

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -16,7 +16,7 @@ linkTitle = "PipeCD"
 
 <div class="mx-auto">
 	<a class="btn btn-lg btn-primary mr-3 mb-4" target="_blank" href="https://play.pipecd.dev?project=play">
-		Live Demo <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+		Try on Playground <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://pipecd.dev/docs/quickstart/">
 		Quick Start <i class="fas fa-arrow-alt-circle-right ml-2"></i>


### PR DESCRIPTION
**What this PR does**:

Rename demo related docs to playground to make it less confusing.

**Why we need it**:

We have play.pipecd.dev mentioned as live demo, while demo.pipecd.dev used as dev. Should rename to make it less confusing 👀 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
