### PR TITLE
Fix scheduler status handling

### DIFF
--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -303,8 +303,8 @@ func (s *scheduler) Run(ctx context.Context) error {
 			break
 		}
 		if ps.Status == model.StageStatus_STAGE_SKIPPED {
-			statusReason = fmt.Sprintf("Stage %s was skipped", ps.Id)
-			continue // TODO
+			statusReason = fmt.Sprintf("Stage %s has been already skipped", ps.Id)
+			continue
 		}
 		if ps.Status == model.StageStatus_STAGE_EXITED {
 			deploymentStatus = model.DeploymentStatus_DEPLOYMENT_SUCCESS
@@ -489,6 +489,13 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		originalStatus = ps.Status
 	)
 
+	defer func() {
+		// Ensure reporting the status even if the stage is cancelled.
+		if err := s.reportStageStatus(context.Background(), ps.Id, finalStatus, ps.Requires); err != nil {
+			s.logger.Error("failed to report stage status", zap.Error(err))
+		}
+	}()
+
 	tds, err := s.targetDSP.Get(ctx, io.Discard)
 	if err != nil {
 		s.logger.Error("failed to get target deployment source", zap.String("stage-name", ps.Name), zap.Error(err))
@@ -532,6 +539,9 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 	// Update stage status to RUNNING if needed.
 	if model.CanUpdateStageStatus(ps.Status, model.StageStatus_STAGE_RUNNING) {
 		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_RUNNING, ps.Requires); err != nil {
+			if sig.Signal() == StopSignalCancel {
+				return model.StageStatus_STAGE_CANCELLED
+			}
 			return model.StageStatus_STAGE_FAILURE
 		}
 		originalStatus = model.StageStatus_STAGE_RUNNING
@@ -541,7 +551,6 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 	plugin, err := s.pluginRegistry.GetPluginClientByStageName(ps.Name)
 	if err != nil {
 		s.logger.Error("failed to find the plugin for the stage", zap.String("stage-name", ps.Name), zap.Error(err))
-		s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires)
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -549,9 +558,6 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 	stageConfig, stageConfigFound := s.genericApplicationConfig.GetStageConfigByte(ps.Index)
 	if !stageConfigFound {
 		s.logger.Error("Unable to find the stage configuration", zap.String("stage-name", ps.Name))
-		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires); err != nil {
-			s.logger.Error("failed to report stage status", zap.Error(err))
-		}
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -577,7 +583,6 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 	// otherwise, return the error.
 	if err != nil && ctx.Err() == nil {
 		s.logger.Error("failed to execute stage", zap.String("stage-name", ps.Name), zap.Error(err))
-		s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires)
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -596,7 +601,6 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		status == model.StageStatus_STAGE_EXITED ||
 		(status == model.StageStatus_STAGE_FAILURE && !sig.Terminated()) {
 
-		s.reportStageStatus(ctx, ps.Id, status, ps.Requires)
 		return status
 	}
 

--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -302,6 +302,15 @@ func (s *scheduler) Run(ctx context.Context) error {
 			statusReason = fmt.Sprintf("Failed while executing stage %s", ps.Id)
 			break
 		}
+		if ps.Status == model.StageStatus_STAGE_SKIPPED {
+			statusReason = fmt.Sprintf("Stage %s was skipped", ps.Id)
+			continue // TODO
+		}
+		if ps.Status == model.StageStatus_STAGE_EXITED {
+			deploymentStatus = model.DeploymentStatus_DEPLOYMENT_SUCCESS
+			statusReason = fmt.Sprintf("Deployment was exited before stage %s", ps.Id)
+			break
+		}
 
 		var (
 			result       model.StageStatus

--- a/pkg/app/pipedv1/controller/scheduler_test.go
+++ b/pkg/app/pipedv1/controller/scheduler_test.go
@@ -338,5 +338,5 @@ func TestExecuteStage_SignalCancelled(t *testing.T) {
 
 	handler.Cancel()
 	finalStatus := s.executeStage(sig, s.deployment.Stages[0])
-	assert.Equal(t, model.StageStatus_STAGE_FAILURE, finalStatus)
+	assert.Equal(t, model.StageStatus_STAGE_CANCELLED, finalStatus)
 }


### PR DESCRIPTION
**What this PR does**:

[1] Use `defer` to ensure reporting the status even if the stage is cancelled
[2] Handle Skipped/Exited before `executeStage` when the stage was already completed by a previous scheduler.


**Why we need it**:


[1] Without this PR, the following problems will occur:

A. The stage is marked as 'running' forever. (it should be 'cancelled')

![image](https://github.com/user-attachments/assets/3c49266f-f05c-4d5a-98ca-09cf36091303)


B. The stage is marked as 'failure' even if I cancelled. (it should be 'cancelled')

![image](https://github.com/user-attachments/assets/8d21b66d-aa33-4f22-a78b-5cccea48b414)


[2] To simplify status handling in executeStage.

**Which issue(s) this PR fixes**:

Part of #5259 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
