### PR TITLE
Pass ApplicationConfigFiilename when creating deploysource.DeploySource

### DIFF
--- a/pkg/app/pipedv1/deploysource/deploysource.go
+++ b/pkg/app/pipedv1/deploysource/deploysource.go
@@ -186,10 +186,11 @@ func (p *provider) prepare(ctx context.Context, lw io.Writer) (*DeploySource, er
 	}
 
 	return &DeploySource{
-		RepoDir:           repoDir,
-		AppDir:            appDir,
-		Revision:          p.revision,
-		ApplicationConfig: cfgFileContent,
+		RepoDir:                   repoDir,
+		AppDir:                    appDir,
+		Revision:                  p.revision,
+		ApplicationConfig:         cfgFileContent,
+		ApplicationConfigFilename: p.appGitPath.GetApplicationConfigFilename(),
 	}, nil
 }
 
@@ -205,9 +206,10 @@ func (p *provider) copy(lw io.Writer) (*DeploySource, error) {
 	}
 
 	return &DeploySource{
-		RepoDir:           dest,
-		AppDir:            filepath.Join(dest, p.appGitPath.Path),
-		Revision:          p.revision,
-		ApplicationConfig: p.source.ApplicationConfig,
+		RepoDir:                   dest,
+		AppDir:                    filepath.Join(dest, p.appGitPath.Path),
+		Revision:                  p.revision,
+		ApplicationConfig:         p.source.ApplicationConfig,
+		ApplicationConfigFilename: p.source.ApplicationConfigFilename,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We have to pass it because plugins need this.

**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
