### PR TITLE
Fix go version of Terraform plugin to 1.24.1

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/go.mod
+++ b/pkg/app/pipedv1/plugin/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform
 
-go 1.24.2
+go 1.24.1
 
 require (
 	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250702080240-3ef0619b560c


### PR DESCRIPTION
**What this PR does**:

fix by `go mod edit -go=1.24.1 `

**Why we need it**:

To use the same version as other plugins.

**Which issue(s) this PR fixes**:

Part of #5992 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
