### PR TITLE
Remove 'replace' of the SDK in k8s and wait plugins

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -16,8 +16,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
 require (
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/pkg/app/pipedv1/plugin/kubernetes/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.sum
@@ -429,6 +429,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8 h1:n1MCeA8Obd+hGK2x0ajU1lLInAcfOZXIFT+/mhjoNzk=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/wait/go.mod
+++ b/pkg/app/pipedv1/plugin/wait/go.mod
@@ -8,8 +8,6 @@ require (
 	go.uber.org/zap v1.19.1
 )
 
-replace github.com/pipe-cd/piped-plugin-sdk-go => ../../../../plugin/sdk
-
 require (
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/pkg/app/pipedv1/plugin/wait/go.sum
+++ b/pkg/app/pipedv1/plugin/wait/go.sum
@@ -211,6 +211,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pipe-cd/pipecd v0.52.0 h1:/WRzHs4hqeYRJBvu0ask6UAO7qBlvPgN1ulBdA1VjgE=
 github.com/pipe-cd/pipecd v0.52.0/go.mod h1:Hi4d3mndTeY+hPB4YbN9aIgvP00EBV0CM+NQgyEwn98=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8 h1:n1MCeA8Obd+hGK2x0ajU1lLInAcfOZXIFT+/mhjoNzk=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250624100230-4dd9b8f9b0b8/go.mod h1:WpVRto2ZLgFRJ4VOk8gtTChHNCrGa4UjRhGN81TCl2E=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

- Make the plugins depend on the published SDK, not the local one.
   - I think this `replace` was a temporary solution when splitting the go.mod.
   - I guess this is the cause of https://github.com/pipe-cd/pipecd/actions/runs/16065019520/job/45337800981?pr=6000.
- To make consistency with other plugins



**Which issue(s) this PR fixes**:

Part of #5867 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
