### PR TITLE
Remove deprecated platform provider and cloud provider from trigger logic

### DIFF
--- a/pkg/app/pipedv1/controller/controllermetrics/metrics.go
+++ b/pkg/app/pipedv1/controller/controllermetrics/metrics.go
@@ -39,6 +39,7 @@ var (
 	)
 )
 
+// TODO: Update this function (remove platformProvider label value) when we redesign the deployment status metrics for plugin-arch piped.
 func UpdateDeploymentStatus(d *model.Deployment, status model.DeploymentStatus) {
 	for name, value := range model.DeploymentStatus_value {
 		if model.DeploymentStatus(value) == status {

--- a/pkg/app/pipedv1/trigger/deployment.go
+++ b/pkg/app/pipedv1/trigger/deployment.go
@@ -93,8 +93,6 @@ func buildDeployment(
 			StrategySummary: strategySummary,
 		},
 		GitPath:                   app.GitPath,
-		CloudProvider:             app.CloudProvider,
-		PlatformProvider:          app.PlatformProvider,
 		DeployTargetsByPlugin:     app.DeployTargetsByPlugin,
 		Labels:                    app.Labels,
 		Status:                    model.DeploymentStatus_DEPLOYMENT_PENDING,


### PR DESCRIPTION
**What this PR does**:

- Remove platform provider/cloud provider from pipedv1 trigger logic
- Add a todo reminder to remove the platform provider from the pipedv1 deployment metrics collector

**Why we need it**:

Should not using platform/cloud provider in pipedv1 logic

**Which issue(s) this PR fixes**:

Part of #5956

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
