### PR TITLE
Remove application kind from pipedv1 logic

### DIFF
--- a/pkg/app/pipedv1/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/pipedv1/appconfigreporter/appconfigreporter.go
@@ -276,14 +276,6 @@ func (r *Reporter) findOutOfSyncRegisteredApps(repoPath, repoID, headCommit stri
 }
 
 func (r *Reporter) isSynced(appInfo *model.ApplicationInfo, app *model.Application) bool {
-	if appInfo.Kind != app.Kind {
-		r.logger.Warn("kind in application config has been changed which isn't allowed",
-			zap.String("app-id", app.Id),
-			zap.String("repo-id", app.GitPath.Repo.Id),
-			zap.String("config-file-path", app.GitPath.GetApplicationConfigFilePath()),
-		)
-	}
-
 	// TODO: Make it possible to follow the ApplicationInfo field changes
 	if appInfo.Name != app.Name {
 		return false

--- a/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
@@ -394,6 +394,8 @@ spec:
 }
 
 func TestReporter_isSynced(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		appInfo  *model.ApplicationInfo
@@ -577,6 +579,8 @@ func TestReporter_isSynced(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := &Reporter{}
 			result := r.isSynced(tt.appInfo, tt.app)
 			if result != tt.expected {

--- a/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
@@ -392,3 +392,196 @@ spec:
 		})
 	}
 }
+
+func TestReporter_isSynced(t *testing.T) {
+	tests := []struct {
+		name     string
+		appInfo  *model.ApplicationInfo
+		app      *model.Application
+		expected bool
+	}{
+		{
+			name: "should return true when all fields match",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "should return false when name differs",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			app: &model.Application{
+				Name:        "different-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when description differs",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "different description",
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when labels have different length",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when labels have different values",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v2.0.0",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when labels have different keys",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":   "prod",
+					"build": "v1.0.0",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when appInfo has nil labels but app has empty labels",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels:      nil,
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels:      map[string]string{},
+			},
+			expected: false,
+		},
+		{
+			name: "should return false when labels have same keys but different values",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+					"region":  "us-west-1",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+					"region":  "us-east-1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "should return true when labels have same keys and values in different order",
+			appInfo: &model.ApplicationInfo{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+					"region":  "us-west-1",
+				},
+			},
+			app: &model.Application{
+				Name:        "test-app",
+				Description: "test description",
+				Labels: map[string]string{
+					"region":  "us-west-1",
+					"version": "v1.0.0",
+					"env":     "prod",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reporter{}
+			result := r.isSynced(tt.appInfo, tt.app)
+			if result != tt.expected {
+				t.Errorf("isSynced() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/pipedv1/appconfigreporter/appconfigreporter_test.go
@@ -516,7 +516,7 @@ func TestReporter_isSynced(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "should return false when appInfo has nil labels but app has empty labels",
+			name: "should return true when appInfo has nil labels but app has empty labels",
 			appInfo: &model.ApplicationInfo{
 				Name:        "test-app",
 				Description: "test description",
@@ -527,7 +527,7 @@ func TestReporter_isSynced(t *testing.T) {
 				Description: "test description",
 				Labels:      map[string]string{},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "should return false when labels have same keys but different values",

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -252,7 +252,8 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 		ApplicationId: app.Id,
 		PipedId:       app.PipedId,
 		ProjectId:     app.ProjectId,
-		Kind:          app.Kind,
+		// TODO: Remove this field when we find a way to implement StateView component for application state.
+		Kind: app.Kind,
 		ApplicationLiveState: &model.ApplicationLiveState{
 			Resources: resourceStates,
 		},

--- a/pkg/app/pipedv1/notifier/slack.go
+++ b/pkg/app/pipedv1/notifier/slack.go
@@ -232,7 +232,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		fields = []slackField{
 			{"Project", truncateText(app.ProjectId, 8), true},
 			{"Application", makeSlackLink(app.Name, link), true},
-			{"Kind", strings.ToLower(app.Kind.String()), true},
+			{"Labels", app.GetLabelsString(), true},
 			{"Mention To Users", accountsStr, true},
 			{"Mention To Groups", groupsStr, true},
 		}

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -98,6 +98,14 @@ func (a *Application) SetUpdatedAt(t int64) {
 	a.UpdatedAt = t
 }
 
+func (a *Application) GetLabelsString() string {
+	labels := make([]string, 0, len(a.Labels))
+	for k, v := range a.Labels {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(labels, ",")
+}
+
 func (ak ApplicationKind) CompatiblePlatformProviderType() PlatformProviderType {
 	switch ak {
 	case ApplicationKind_KUBERNETES:

--- a/pkg/model/application_test.go
+++ b/pkg/model/application_test.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +24,8 @@ import (
 )
 
 func TestMakeApplicationURL(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name          string
 		baseURL       string
@@ -43,6 +47,8 @@ func TestMakeApplicationURL(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := MakeApplicationURL(tc.baseURL, tc.applicationID)
 			assert.Equal(t, tc.expected, got)
 		})
@@ -50,6 +56,8 @@ func TestMakeApplicationURL(t *testing.T) {
 }
 
 func TestApplication_ContainLabels(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name   string
 		app    *Application
@@ -93,6 +101,8 @@ func TestApplication_ContainLabels(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := tc.app.ContainLabels(tc.labels)
 			assert.Equal(t, tc.want, got)
 		})
@@ -100,6 +110,8 @@ func TestApplication_ContainLabels(t *testing.T) {
 }
 
 func TestCompatiblePlatformProviderType(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		kind     ApplicationKind
@@ -139,6 +151,8 @@ func TestCompatiblePlatformProviderType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := tt.kind.CompatiblePlatformProviderType()
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -146,6 +160,8 @@ func TestCompatiblePlatformProviderType(t *testing.T) {
 }
 
 func TestIsOutOfSync(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		app      *Application
@@ -170,6 +186,8 @@ func TestIsOutOfSync(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := tt.app.IsOutOfSync()
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -177,6 +195,8 @@ func TestIsOutOfSync(t *testing.T) {
 }
 
 func TestHasChanged(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		current  ApplicationSyncState
@@ -211,6 +231,8 @@ func TestHasChanged(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := tt.current.HasChanged(tt.next)
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -218,6 +240,8 @@ func TestHasChanged(t *testing.T) {
 }
 
 func TestGetApplicationConfigFilename(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		gitPath      ApplicationGitPath
@@ -237,12 +261,16 @@ func TestGetApplicationConfigFilename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actualName := tt.gitPath.GetApplicationConfigFilename()
 			assert.Equal(t, tt.expectedName, actualName)
 		})
 	}
 }
 func TestMergeApplicationSyncState(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		states   []*ApplicationSyncState
@@ -308,6 +336,8 @@ func TestMergeApplicationSyncState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := MergeApplicationSyncState(tt.states)
 			assert.Equal(t, tt.expected.Status, actual.Status)
 			assert.Equal(t, tt.expected.ShortReason, actual.ShortReason)
@@ -318,6 +348,8 @@ func TestMergeApplicationSyncState(t *testing.T) {
 }
 
 func TestApplication_GetLabelsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		app      *Application
@@ -353,64 +385,19 @@ func TestApplication_GetLabelsString(t *testing.T) {
 			},
 			expected: "env=prod,version=v1.0.0,region=us-west-1",
 		},
-		{
-			name: "labels with special characters",
-			app: &Application{
-				Labels: map[string]string{
-					"app-name": "my-app",
-					"version":  "v1.0.0-beta",
-					"env":      "staging",
-				},
-			},
-			expected: "app-name=my-app,version=v1.0.0-beta,env=staging",
-		},
-		{
-			name: "labels with empty values",
-			app: &Application{
-				Labels: map[string]string{
-					"env":     "prod",
-					"version": "",
-					"region":  "us-west-1",
-				},
-			},
-			expected: "env=prod,version=,region=us-west-1",
-		},
-		{
-			name: "labels with spaces",
-			app: &Application{
-				Labels: map[string]string{
-					"app name": "my app",
-					"version":  "v1.0.0",
-				},
-			},
-			expected: "app name=my app,version=v1.0.0",
-		},
-		{
-			name: "labels with equals sign in value",
-			app: &Application{
-				Labels: map[string]string{
-					"config": "key=value",
-					"env":    "prod",
-				},
-			},
-			expected: "config=key=value,env=prod",
-		},
-		{
-			name: "labels with comma in value",
-			app: &Application{
-				Labels: map[string]string{
-					"tags": "tag1,tag2,tag3",
-					"env":  "prod",
-				},
-			},
-			expected: "tags=tag1,tag2,tag3,env=prod",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.app.GetLabelsString()
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, len(tt.expected), len(result))
+			expectedParts := strings.Split(tt.expected, ",")
+			resultParts := strings.Split(result, ",")
+			sort.Strings(expectedParts)
+			sort.Strings(resultParts)
+			assert.Equal(t, expectedParts, resultParts)
 		})
 	}
 }

--- a/pkg/model/application_test.go
+++ b/pkg/model/application_test.go
@@ -316,3 +316,101 @@ func TestMergeApplicationSyncState(t *testing.T) {
 		})
 	}
 }
+
+func TestApplication_GetLabelsString(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      *Application
+		expected string
+	}{
+		{
+			name:     "nil labels",
+			app:      &Application{Labels: nil},
+			expected: "",
+		},
+		{
+			name:     "empty labels",
+			app:      &Application{Labels: map[string]string{}},
+			expected: "",
+		},
+		{
+			name: "single label",
+			app: &Application{
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			expected: "env=prod",
+		},
+		{
+			name: "multiple labels",
+			app: &Application{
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+					"region":  "us-west-1",
+				},
+			},
+			expected: "env=prod,version=v1.0.0,region=us-west-1",
+		},
+		{
+			name: "labels with special characters",
+			app: &Application{
+				Labels: map[string]string{
+					"app-name": "my-app",
+					"version":  "v1.0.0-beta",
+					"env":      "staging",
+				},
+			},
+			expected: "app-name=my-app,version=v1.0.0-beta,env=staging",
+		},
+		{
+			name: "labels with empty values",
+			app: &Application{
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "",
+					"region":  "us-west-1",
+				},
+			},
+			expected: "env=prod,version=,region=us-west-1",
+		},
+		{
+			name: "labels with spaces",
+			app: &Application{
+				Labels: map[string]string{
+					"app name": "my app",
+					"version":  "v1.0.0",
+				},
+			},
+			expected: "app name=my app,version=v1.0.0",
+		},
+		{
+			name: "labels with equals sign in value",
+			app: &Application{
+				Labels: map[string]string{
+					"config": "key=value",
+					"env":    "prod",
+				},
+			},
+			expected: "config=key=value,env=prod",
+		},
+		{
+			name: "labels with comma in value",
+			app: &Application{
+				Labels: map[string]string{
+					"tags": "tag1,tag2,tag3",
+					"env":  "prod",
+				},
+			},
+			expected: "tags=tag1,tag2,tag3,env=prod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.app.GetLabelsString()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

- Remove application Kind value from app config reporter logic (pipedv1)
- Remove application Kind value from Slack notifier logic (pipedv1) - using application Labels instead
- Add TODO note to remove application Kind value from LiveStateReporter logic (pipedv1) - currently the UI is using that value to render the correct StateView component (ref: https://github.com/pipe-cd/pipecd/issues/5252#issuecomment-2456527867)

**Why we need it**:

The pipedv1 logic should not depend on the application Kind value.

**Which issue(s) this PR fixes**:

Part of #5252

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
