### PR TITLE
Remove deployment kind value from pipedv1 logic

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -105,7 +105,7 @@ func newPlanner(
 		zap.String("deployment-id", d.Id),
 		zap.String("app-id", d.ApplicationId),
 		zap.String("project-id", d.ProjectId),
-		zap.String("app-kind", d.Kind.String()),
+		zap.String("labels", d.GetLabelsString()),
 		zap.String("working-dir", workingDir),
 	)
 
@@ -173,8 +173,8 @@ func (p *planner) Run(ctx context.Context) error {
 		"Plan",
 		trace.WithAttributes(
 			attribute.String("application-id", p.deployment.ApplicationId),
-			attribute.String("kind", p.deployment.Kind.String()),
 			attribute.String("deployment-id", p.deployment.Id),
+			attribute.String("labels", p.deployment.GetLabelsString()),
 		))
 	defer span.End()
 

--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -91,7 +91,7 @@ func newScheduler(
 		zap.String("deployment-id", d.Id),
 		zap.String("app-id", d.ApplicationId),
 		zap.String("project-id", d.ProjectId),
-		zap.String("app-kind", d.Kind.String()),
+		zap.String("labels", d.GetLabelsString()),
 		zap.String("working-dir", workingDir),
 	)
 
@@ -265,8 +265,8 @@ func (s *scheduler) Run(ctx context.Context) error {
 		"Deploy",
 		trace.WithAttributes(
 			attribute.String("application-id", s.deployment.ApplicationId),
-			attribute.String("kind", s.deployment.Kind.String()),
 			attribute.String("deployment-id", s.deployment.Id),
+			attribute.String("labels", s.deployment.GetLabelsString()),
 		))
 	defer span.End()
 
@@ -325,8 +325,8 @@ func (s *scheduler) Run(ctx context.Context) error {
 		go func() {
 			_, span := s.tracer.Start(ctx, ps.Name, trace.WithAttributes(
 				attribute.String("application-id", s.deployment.ApplicationId),
-				attribute.String("kind", s.deployment.Kind.String()),
 				attribute.String("deployment-id", s.deployment.Id),
+				attribute.String("labels", s.deployment.GetLabelsString()),
 				attribute.String("stage-id", ps.Id),
 			))
 			defer span.End()
@@ -435,8 +435,8 @@ func (s *scheduler) Run(ctx context.Context) error {
 
 					_, span := s.tracer.Start(ctx, rbs.Name, trace.WithAttributes(
 						attribute.String("application-id", s.deployment.ApplicationId),
-						attribute.String("kind", s.deployment.Kind.String()),
 						attribute.String("deployment-id", s.deployment.Id),
+						attribute.String("labels", s.deployment.GetLabelsString()),
 						attribute.String("stage-id", rbs.Id),
 					))
 					defer span.End()

--- a/pkg/app/pipedv1/notifier/slack.go
+++ b/pkg/app/pipedv1/notifier/slack.go
@@ -212,7 +212,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		fields = []slackField{
 			{"Project", truncateText(d.ProjectId, 8), true},
 			{"Application", makeSlackLink(d.ApplicationName, fmt.Sprintf("%s/applications/%s?project=%s", webURL, d.ApplicationId, d.ProjectId)), true},
-			{"Kind", strings.ToLower(d.Kind.String()), true},
+			{"Labels", d.GetLabelsString(), true},
 			{"Deployment", makeSlackLink(truncateText(d.Id, 8), link), true},
 			{"Triggered By", d.TriggeredBy(), true},
 			{"Mention To Users", accountsStr, true},
@@ -262,7 +262,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		fields = []slackField{
 			{"Project", truncateText(d.ProjectId, 8), true},
 			{"Application", makeSlackLink(d.ApplicationName, fmt.Sprintf("%s/applications/%s?project=%s", webURL, d.ApplicationId, d.ProjectId)), true},
-			{"Kind", strings.ToLower(d.Kind.String()), true},
+			{"Labels", d.GetLabelsString(), true},
 			{"Deployment", makeSlackLink(truncateText(d.Id, 8), link), true},
 			{"Stage", s.Name, true},
 			{"Triggered By", d.TriggeredBy(), true},

--- a/pkg/app/pipedv1/trigger/deployment.go
+++ b/pkg/app/pipedv1/trigger/deployment.go
@@ -77,7 +77,6 @@ func buildDeployment(
 		ApplicationName: app.Name,
 		PipedId:         app.PipedId,
 		ProjectId:       app.ProjectId,
-		Kind:            app.Kind,
 		Trigger: &model.DeploymentTrigger{
 			Commit: &model.Commit{
 				Hash:      commit.Hash,

--- a/pkg/model/deployment_test.go
+++ b/pkg/model/deployment_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -722,6 +723,61 @@ func TestDeployment_GetDeployTargets(t *testing.T) {
 
 			got := tt.deployment.GetDeployTargets(tt.pluginName)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestDeployment_GetLabelsString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		deployment *Deployment
+		expected   string
+	}{
+		{
+			name:       "nil labels",
+			deployment: &Deployment{Labels: nil},
+			expected:   "",
+		},
+		{
+			name:       "empty labels",
+			deployment: &Deployment{Labels: map[string]string{}},
+			expected:   "",
+		},
+		{
+			name: "single label",
+			deployment: &Deployment{
+				Labels: map[string]string{
+					"env": "prod",
+				},
+			},
+			expected: "env=prod",
+		},
+		{
+			name: "multiple labels",
+			deployment: &Deployment{
+				Labels: map[string]string{
+					"env":     "prod",
+					"version": "v1.0.0",
+					"region":  "us-west-1",
+				},
+			},
+			expected: "env=prod,version=v1.0.0,region=us-west-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.deployment.GetLabelsString()
+			assert.Equal(t, len(tt.expected), len(result))
+			expectedParts := strings.Split(tt.expected, ",")
+			resultParts := strings.Split(result, ",")
+			sort.Strings(expectedParts)
+			sort.Strings(resultParts)
+			assert.Equal(t, expectedParts, resultParts)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

- Remove deployment kind value from Slack notifier (pipedv1)
- Remove deployment kind value from tracer log for planner and scheduler (pipedv1)
- Remove deployment kind value from trigger logic (pipedv1)

**Why we need it**:

Pipedv1 logic should not depended on deployment kind value

**Which issue(s) this PR fixes**:

Part of #5252 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
