### PR TITLE
Add timeout for build_tool and publish_tool jobs

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   tool:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       matrix:
         image:

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -13,6 +13,7 @@ env:
 jobs:
   tool:
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 15
     permissions:
       packages: write
     strategy:


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Some long CI jobs don't finish and become inefficient. Should not wait for these kind of jobs.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
