### PR TITLE
restore NewNotifier() in pipedv1

### DIFF
--- a/pkg/app/pipedv1/notifier/notifier.go
+++ b/pkg/app/pipedv1/notifier/notifier.go
@@ -57,31 +57,31 @@ func NewNotifier(cfg *config.PipedSpec, logger *zap.Logger) (*Notifier, error) {
 	}
 
 	handlers := make([]handler, 0, len(cfg.Notifications.Routes))
-	// for _, route := range cfg.Notifications.Routes {
-	// 	// receiver, ok := receivers[route.Receiver]
-	// 	// if !ok {
-	// 	// 	return nil, fmt.Errorf("missing receiver %s that is used in route %s", route.Receiver, route.Name)
-	// 	// }
+	for _, route := range cfg.Notifications.Routes {
+		receiver, ok := receivers[route.Receiver]
+		if !ok {
+			return nil, fmt.Errorf("missing receiver %s that is used in route %s", route.Receiver, route.Name)
+		}
 
-	// 	var sd sender
-	// 	switch {
-	// 	case receiver.Slack != nil:
-	// 		slacksender, err := newSlackSender(receiver.Name, *receiver.Slack, cfg.WebAddress, logger)
-	// 		if err != nil {
-	// 			return nil, fmt.Errorf("failed to create slack sender: %w", err)
-	// 		}
-	// 		sd = slacksender
-	// 	case receiver.Webhook != nil:
-	// 		sd = newWebhookSender(receiver.Name, *receiver.Webhook, cfg.WebAddress, logger)
-	// 	default:
-	// 		continue
-	// 	}
+		var sd sender
+		switch {
+		case receiver.Slack != nil:
+			slacksender, err := newSlackSender(receiver.Name, *receiver.Slack, cfg.WebAddress, logger)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create slack sender: %w", err)
+			}
+			sd = slacksender
+		case receiver.Webhook != nil:
+			sd = newWebhookSender(receiver.Name, *receiver.Webhook, cfg.WebAddress, logger)
+		default:
+			continue
+		}
 
-	// 	handlers = append(handlers, handler{
-	// 		matcher: newMatcher(route),
-	// 		sender:  sd,
-	// 	})
-	// }
+		handlers = append(handlers, handler{
+			matcher: newMatcher(route),
+			sender:  sd,
+		})
+	}
 
 	return &Notifier{
 		config:      cfg,


### PR DESCRIPTION
**What this PR does**:

Uncomment to be the same as v0:
https://github.com/pipe-cd/pipecd/blob/efbe9c96961948a4a7db951d9cf4aaf1a66307ff/pkg/app/piped/notifier/notifier.go#L59-L86

**Why we need it**:


Although they are commented out in https://github.com/pipe-cd/pipecd/pull/5392, they are used in pipedv1 without the v0 config.

**Which issue(s) this PR fixes**:

Part of #5259 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
