### PR TITLE
Add check for divergent branches error

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -293,10 +293,26 @@ func (r *repo) CheckoutPullRequest(ctx context.Context, number int, branch strin
 // Pull fetches from and integrate with a local branch.
 func (r *repo) Pull(ctx context.Context, branch string) error {
 	out, err := r.runGitCommand(ctx, "pull", r.remote, branch)
-	if err != nil {
-		return formatCommandError(err, out)
+
+	if err == nil {
+		return nil
 	}
-	return nil
+
+	if strings.Contains(string(out), "divergent branches") {
+		// need to use --force to move the remote-ref to the new commit
+		// when the update is a non-fast-forward one like divergent branches
+		out, err := r.runGitCommand(ctx, "fetch", r.remote, branch, "--force")
+		if err != nil {
+			return formatCommandError(err, out)
+		}
+		// because we want our local to exactly replicate the remote
+		out, err = r.runGitCommand(ctx, "reset", "--hard", "FETCH_HEAD")
+		if err != nil {
+			return formatCommandError(err, out)
+		}
+		return nil
+	}
+	return formatCommandError(err, out)
 }
 
 // MergeRemoteBranch merges all commits until the given one

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -292,13 +292,13 @@ func (r *repo) CheckoutPullRequest(ctx context.Context, number int, branch strin
 
 // Pull fetches from and integrate with a local branch.
 func (r *repo) Pull(ctx context.Context, branch string) error {
-	out, err := r.runGitCommand(ctx, "pull", r.remote, branch)
+	out, err := r.runGitCommand(ctx, "pull", "--ff-only", r.remote, branch)
 
 	if err == nil {
 		return nil
 	}
-
-	if strings.Contains(string(out), "divergent branches") {
+	// Handle "divergent branches" error, caused by amending the remote
+	if strings.Contains(string(out), "Diverging branches") {
 		// need to use --force to move the remote-ref to the new commit
 		// when the update is a non-fast-forward one like divergent branches
 		out, err := r.runGitCommand(ctx, "fetch", r.remote, branch, "--force")

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -298,7 +298,7 @@ func (r *repo) Pull(ctx context.Context, branch string) error {
 		return nil
 	}
 	// Handle "divergent branches" error, caused by amending the remote
-	if strings.Contains(string(out), "Diverging branches") {
+	if strings.Contains(string(out), "Not possible to fast-forward") {
 		// need to use --force to move the remote-ref to the new commit
 		// when the update is a non-fast-forward one like divergent branches
 		out, err := r.runGitCommand(ctx, "fetch", r.remote, branch, "--force")


### PR DESCRIPTION
**What this PR does**:

Fixes the error in piped when the last commit is amended and force pushed which used to cause a divergent branches error. 

**Why we need it**:

Because otherwise whenever an emergency amend commit is made to the tracked repo, piped would raise an error and the control plane would hang while syncing.

**Which issue(s) this PR fixes**:

Fixes #6016 

**Does this PR introduce a user-facing change?**:

No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
