### PR TITLE
Chore: Add local Codegen scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ build/plugin:
 	done
 	@echo "Plugins are built and copied to $(PLUGINS_BIN_DIR)"
 
+.PHONY: build/codegen
+build/codegen: CODEGEN_IMAGE_TAG ?= pipecd-local-codegen:latest
+build/codegen:
+	@echo "Building local codegen Docker image..."
+	docker build -t $(CODEGEN_IMAGE_TAG) ./tool/codegen
+	@echo "Successfully built $(CODEGEN_IMAGE_TAG)"
+
 .PHONY: push
 push/chart: BUCKET ?= charts.pipecd.dev
 push/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
@@ -259,6 +266,12 @@ update/copyright:
 gen/code:
 	# NOTE: Keep this container image as same as defined in .github/workflows/gen.yml
 	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh ghcr.io/pipe-cd/codegen@sha256:831f2dda2f56b1d12e90f88c0cb4168f51aa4eb5907b468e74bc42670939fff2 /repo # v0.50.0-215-g3f6a738
+
+.PHONY: gen/code-local
+gen/code-local: CODEGEN_IMAGE_TAG ?= pipecd-local-codegen:latest
+gen/code-local:
+	@echo "Running local codegen with image: $(CODEGEN_IMAGE_TAG)"
+	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh $(CODEGEN_IMAGE_TAG) /repo
 
 .PHONY: gen/test-tls
 gen/test-tls:

--- a/hack/local-codegen.sh
+++ b/hack/local-codegen.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The PipeCD Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Check if rebuild flag is provided
+REBUILD=""
+if [[ "${1:-}" == "--rebuild" ]]; then
+    REBUILD="true"
+fi
+
+echo "Generating code using local Docker image..."
+
+# Check if Docker is running
+if ! docker version >/dev/null 2>&1; then
+    echo "Error: Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+# If rebuild is requested or image doesn't exist, build it
+CODEGEN_IMAGE_TAG="pipecd-local-codegen:latest"
+if [[ "$REBUILD" == "true" ]] || ! docker image inspect "$CODEGEN_IMAGE_TAG" >/dev/null 2>&1; then
+    echo "Building codegen Docker image..."
+    make build/codegen
+fi
+
+echo "Running code generation..."
+make gen/code-local
+
+echo "Code generation completed successfully."


### PR DESCRIPTION
**What this PR does**:

Add script and build targets to build and run code generation locally using a local Docker image.

**Why we need it**:

Code generation currently requires pulling the image from GHCR and doesn't reflect local changes to codegen tools immediately. This creates friction for local development.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
