### PR TITLE
fix title logview deployemnt detail is transparent

### DIFF
--- a/web/src/components/deployments-detail-page/log-viewer/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/index.tsx
@@ -135,13 +135,8 @@ export const LogViewer: FC = memo(function LogViewer() {
         }}
       >
         <Divider />
-        <Toolbar
-          variant="dense"
-          // className={classes.toolbar}
-          sx={{ background: "background.default" }}
-        >
+        <Toolbar variant="dense" sx={{ backgroundColor: "background.default" }}>
           <Box
-            // className={classes.toolbarLeft}
             sx={{
               flex: 1,
               display: "flex",


### PR DESCRIPTION
**What this PR does**:
- Make background of logview title not transparent.

<img width="1920" height="903" alt="CleanShot 2025-07-21 at 13 44 54" src="https://github.com/user-attachments/assets/61c4276a-8f71-425a-b0d6-495a504f0cea" />


**Why we need it**:
- Background of logview title of deployment detail page should not be transparent.

**Which issue(s) this PR fixes**:

Fixes #5988

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
