### PR TITLE
[stage plugins] SDK: add MetadataKeyStageApprovedUsers and DeploymentSource.SharedConfigDirectory

### DIFF
--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -31,6 +31,10 @@ import (
 const (
 	// MetadataKeyStageDisplay is the key of the stage metadata to be displayed on the deployment detail UI.
 	MetadataKeyStageDisplay = model.MetadataKeyStageDisplay
+	// MetadataKeyStageApprovedUsers is the key of the metadata of who approved the stage.
+	// It will be displayed in the DEPLOYMENT_APPROVED notification.
+	// e.g. user-1,user-2
+	MetadataKeyStageApprovedUsers = "pipecd/stage-approved-users"
 
 	listStageCommandsInterval = 5 * time.Second
 )

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -34,7 +34,7 @@ const (
 	// MetadataKeyStageApprovedUsers is the key of the metadata of who approved the stage.
 	// It will be displayed in the DEPLOYMENT_APPROVED notification.
 	// e.g. user-1,user-2
-	MetadataKeyStageApprovedUsers = "pipecd/stage-approved-users"
+	MetadataKeyStageApprovedUsers = model.MetadataKeyStageApprovedUsers
 
 	listStageCommandsInterval = 5 * time.Second
 )

--- a/pkg/plugin/sdk/deployment_source.go
+++ b/pkg/plugin/sdk/deployment_source.go
@@ -37,6 +37,8 @@ type DeploymentSource[Spec any] struct {
 	// ApplicationConfigFilename is the name of the file that contains the application configuration.
 	// The plugins can use this to avoid mistakenly reading this file as a manifest to deploy.
 	ApplicationConfigFilename string
+	// SharedConfigDirectory is the directory where the shared configuration in the repository is located.
+	SharedConfigDirectory string
 }
 
 // newDeploymentSource converts the common.DeploymentSource to the internal representation.
@@ -55,6 +57,7 @@ func newDeploymentSource[Spec any](pluginName string, source *common.DeploymentS
 		CommitHash:                source.GetCommitHash(),
 		ApplicationConfig:         cfg.Spec,
 		ApplicationConfigFilename: source.GetApplicationConfigFilename(),
+		SharedConfigDirectory:     source.GetSharedConfigDirectory(),
 	}, nil
 }
 

--- a/pkg/plugin/sdk/go.mod
+++ b/pkg/plugin/sdk/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/creasty/defaults v1.6.0
-	github.com/pipe-cd/pipecd v0.52.1-0.20250704040938-472e02fa6fa1
+	github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0
@@ -60,7 +60,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/pkg/plugin/sdk/go.sum
+++ b/pkg/plugin/sdk/go.sum
@@ -258,8 +258,8 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/pipe-cd/pipecd v0.52.1-0.20250704040938-472e02fa6fa1 h1:lTqbUL+MNEt2E33M2t/a3DshSbesS15NjJNcDKAyeyU=
-github.com/pipe-cd/pipecd v0.52.1-0.20250704040938-472e02fa6fa1/go.mod h1:C+fumClBzVt98cmdH5nyxNXek2jtNLrYu34yAMuAZJY=
+github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce h1:zyYJ+lIC3oLya2ZoNL90TdDI6IkQVL7aptkT1f9I69U=
+github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce/go.mod h1:5H0ydj0eUpGnJOesA2GPU3mTVlZEZDb8cNP7/lvNPTU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -440,8 +440,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
**What this PR does**:

- Added `MetadataKeyStageApprovedUsers` const
- Added `DeploymentSource.SharedConfigDirectory`


**Why we need it**:

- To persist the approved users
- To pass the analysisTemplate in `.pipe/` to a. plugin

**Which issue(s) this PR fixes**:

Part of #5367 
Follows #6036 (analysis), #6033 (notifier)

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
