### PR TITLE
Fix retrieving recent tag from git log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 build: build/go build/web
 
 .PHONY: build/go
-build/go: BUILD_VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
+build/go: BUILD_VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*.*')
 build/go: BUILD_COMMIT ?= $(shell git rev-parse HEAD)
 build/go: BUILD_DATE ?= $(shell date -u '+%Y%m%d-%H%M%S')
 build/go: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version
@@ -78,7 +78,7 @@ build/plugin:
 
 .PHONY: push
 push/chart: BUCKET ?= charts.pipecd.dev
-push/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7)
+push/chart: VERSION ?= $(shell git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*.*')
 push/chart: CREDENTIALS_FILE ?= ~/.config/gcloud/application_default_credentials.json
 push/chart:
 	@yq -i '.version = "${VERSION}" | .appVersion = "${VERSION}"' manifests/pipecd/Chart.yaml


### PR DESCRIPTION
**What this PR does**:

This PR fixes tag retrieving logic in the Makefile

**Why we need it**:

To avoid getting [the kubecon special tag](https://github.com/pipe-cd/pipecd/releases/tag/kubecon-jp-2025).

**Which issue(s) this PR fixes**:

Follows #5949 #5953

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
