### PR TITLE
Fix retrieving recent tag in web build

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "build": "PIPECD_VERSION=`git describe --tags --always --dirty --abbrev=7` webpack build --mode production --env htmlTemplate=./base.html --config ./webpack.config.js",
-    "dev": "PIPECD_VERSION=`git describe --tags --always --dirty --abbrev=7` webpack serve --env htmlTemplate=./base.html --config ./webpack.config.dev.js",
+    "build": "PIPECD_VERSION=`git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*.*'` webpack build --mode production --env htmlTemplate=./base.html --config ./webpack.config.js",
+    "dev": "PIPECD_VERSION=`git describe --tags --always --dirty --abbrev=7 --match 'v[0-9]*.*'` webpack serve --env htmlTemplate=./base.html --config ./webpack.config.dev.js",
     "test": "TZ=Asia/Tokyo jest --config jest.config.local.js",
     "test:coverage": "yarn test --coverage",
     "lint": "eslint --ext .ts,.tsx ./src",


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it:**

To avoid getting [the kubecon special tag](https://github.com/pipe-cd/pipecd/releases/tag/kubecon-jp-2025).

**Which issue(s) this PR fixes**:

Follows #5949 #5953 #6059

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
