### PR TITLE
Remove commander from protoc gen auth template

### DIFF
--- a/tool/codegen/protoc-gen-auth/file.go
+++ b/tool/codegen/protoc-gen-auth/file.go
@@ -52,9 +52,8 @@ func NewRBACAuthorizer(
 	projects map[string]config.ControlPlaneProject,
 	logger *zap.Logger,
 ) rpcauth.RBACAuthorizer {
-	w := datastore.WebCommander
 	return &authorizer{
-		projectStore:     datastore.NewProjectStore(ds, w),
+		projectStore:     datastore.NewProjectStore(ds),
 		rbacCache:        memorycache.NewTTLCache(ctx, 10*time.Minute, 5*time.Minute),
 		projectsInConfig: projects,
 		logger:           logger.Named("authorizer"),


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

We will remove FileDB support, so the commander is not needed.

**Which issue(s) this PR fixes**:

Part of #5652

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
