### PR TITLE
update control-plane docs for renamed Helm chart and container image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Note that if it's a new breaking change, make sure to complete the two latter qu
 
 PipeCD consists of several components and docs:
 
-- **cmd/pipecd**: A centralized component that manages deployment data and provides a gRPC API for connecting pipeds, as well as web functionalities such as authentication. [README.md](./cmd/pipecd/README.md)
+- **cmd/control-plane**: A centralized component that manages deployment data and provides a gRPC API for connecting pipeds, as well as web functionalities such as authentication. [README.md](./cmd/control-plane/README.md)
 - **cmd/piped**: piped is an agent component that runs in your cluster. [README.md](./cmd/piped/README.md)
 - **cmd/pipectl**: The command-line tool for PipeCD. [README.md](./cmd/pipectl/README.md)
 - **cmd/launcher**: The command executor that enables the remote upgrade feature of the piped agent. [README.md](./cmd/launcher/README.md)
@@ -182,9 +182,9 @@ When cleaning up, run `make kind-down` to stop and delete the registery and the 
 
 #### Run PipeCD Control Plane
 
-Run `make run/pipecd` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
+Run `make run/control-plane` to run PipeCD Control Plane using your local code changes. This will build and run PipeCD Control Plane.
 
-Run `make stop/pipecd` to stop PipeCD Control Plane.
+Run `make stop/control-plane` to stop PipeCD Control Plane.
 
 #### Port Forward
 

--- a/cmd/piped/README.md
+++ b/cmd/piped/README.md
@@ -19,7 +19,7 @@ For the full list of available commands, please see the Makefile at the root of 
 
 ## Setup Control Plane
 
-1. Prepare Control Plane that piped connects. If you want to run a control plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipecd#how-to-run-control-plane-locally).
+1. Prepare Control Plane that piped connects. If you want to run a control plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/tree/master/cmd/control-plane#how-to-run-control-plane-locally).
 
 2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and key for `piped-config.yaml`
 

--- a/cmd/pipedv1/README-usage-alpha.md
+++ b/cmd/pipedv1/README-usage-alpha.md
@@ -15,7 +15,7 @@ _This page might be moved to another place in the future._
 
 ## 1. Setup Control Plane
 
-1. Run a Control Plane that your piped will connect to. If you want to run a Control Plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/blob/master/cmd/pipecd/README.md#how-to-run-control-plane-locally).
+1. Run a Control Plane that your piped will connect to. If you want to run a Control Plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/blob/master/cmd/control-plane/README.md#how-to-run-control-plane-locally).
     - The Control Plane version must be v0.52.0 or later.
 
 2. Generate a new piped key/ID.

--- a/cmd/pipedv1/README.md
+++ b/cmd/pipedv1/README.md
@@ -22,7 +22,7 @@ For the full list of available commands, please see the Makefile at the root of 
 
 ## Setup Control Plane
 
-1. Prepare Control Plane that piped connects. If you want to run a control plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipecd#how-to-run-control-plane-locally).
+1. Prepare Control Plane that piped connects. If you want to run a control plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/tree/master/cmd/control-plane#how-to-run-control-plane-locally).
 
 2. Access to Control Plane console, go to Piped list page and add a new piped. Then, copy generated Piped ID and key for `piped-config.yaml`
 

--- a/docs/content/en/blog/plugin-arch-piped-alpha.md
+++ b/docs/content/en/blog/plugin-arch-piped-alpha.md
@@ -21,7 +21,7 @@ _If you want to know more about the plugin-arch piped internal, please read the 
 
 ## 1. Setup Control Plane
 
-1. Run a Control Plane that your piped will connect to. If you want to run a Control Plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/blob/master/cmd/pipecd/README.md#how-to-run-control-plane-locally).
+1. Run a Control Plane that your piped will connect to. If you want to run a Control Plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/control-plane/blob/master/cmd/pipecd/README.md#how-to-run-control-plane-locally).
     - The Control Plane version must be v0.52.0 or later.
 
 2. Generate a new piped key/ID.

--- a/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -65,7 +65,7 @@ See [ConfigurationReference](../../../user-guide/managing-controlplane/configura
 After all, install the Control Plane as bellow:
 
 ``` console
-helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/latest_version >}} --namespace={NAMESPACE} \
+helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/control-plane --version {{< blocks/latest_version >}} --namespace={NAMESPACE} \
   --set-file config.data=path-to-control-plane-configuration-file \
   --set-file secret.encryptionKey.data=path-to-encryption-key-file \
   --set-file secret.firestoreServiceAccount.data=path-to-service-account-file \
@@ -102,7 +102,7 @@ __Caution__: In case of using `MySQL` as Control Plane's datastore, please note 
 
 ### 3. Accessing the PipeCD web
 
-If your installation was including an [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L7), the PipeCD web can be accessed by the ingress's IP address or domain.
+If your installation was including an [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/control-plane/values.yaml#L7), the PipeCD web can be accessed by the ingress's IP address or domain.
 Otherwise, private PipeCD web can be accessed by using `kubectl port-forward` to expose the installed Control Plane on your localhost:
 
 ``` console
@@ -134,7 +134,7 @@ For more about adding a new project in detail, please read the following [docs](
 To upgrade the PipeCD Control Plane, preparations and commands remain as you do when installing PipeCD Control Plane. Only need to change the version flag in command to the specified version you want to upgrade your PipeCD Control Plane to.
 
 ``` console
-helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {NEW_VERSION} --namespace={NAMESPACE} \
+helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/control-plane --version {NEW_VERSION} --namespace={NAMESPACE} \
   --set-file config.data=path-to-control-plane-configuration-file \
   --set-file secret.encryptionKey.data=path-to-encryption-key-file \
   --set-file secret.firestoreServiceAccount.data=path-to-service-account-file \
@@ -147,7 +147,7 @@ This part provides guidance for a production hardened deployment of the control 
 
 - Publishing the control plane
 
-    You can allow external access to the control plane by enabling the [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L7) configuration.
+    You can allow external access to the control plane by enabling the [ingress](https://github.com/pipe-cd/pipecd/blob/master/manifests/control-plane/values.yaml#L7) configuration.
 
 - End-to-End TLS
 
@@ -158,7 +158,7 @@ This part provides guidance for a production hardened deployment of the control 
     ``` console
     openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN={YOUR_DOMAIN}"
     ```
-    Those key and cert can be configured via [`secret.internalTLSKey.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L118) and [`secret.internalTLSCert.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/pipecd/values.yaml#L121).
+    Those key and cert can be configured via [`secret.internalTLSKey.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/control-plane/values.yaml#L118) and [`secret.internalTLSCert.data`](https://github.com/pipe-cd/pipecd/blob/master/manifests/control-plane/values.yaml#L121).
 
     To enable internal tls connection, please set the `gateway.internalTLS.enabled` parameter to be `true`.
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/README.md
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/README.md
@@ -21,7 +21,7 @@ git pull
 
 **Prepare the PipeCD Control Plane**
 
-Please refer to [pipe-cd/pipecd/cmd/pipecd/README.md](../../../../../cmd/pipecd/README.md) to set up the Control Plane in your local environment.
+Please refer to [pipe-cd/pipecd/cmd/control-plane/README.md](../../../../../cmd/control-plane/README.md) to set up the Control Plane in your local environment.
 
 **Prepare two k8s clusters**
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -40,7 +40,7 @@ The manifests directory contains raw Kubernetes manifests files. The 2 files are
 For `control-plane.yaml`
 
 ```shell
-$ helm template pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version v0.48.6 -n pipecd -f quickstart/control-plane-values.yaml
+$ helm template pipecd oci://ghcr.io/pipe-cd/chart/control-plane --version v0.48.6 -n pipecd -f quickstart/control-plane-values.yaml
 ```
 
 For `piped.yaml`


### PR DESCRIPTION
What this PR does:
Updates the control-plane documentation to reflect the recently renamed Helm chart and container image.

Why we need it:
The documentation needs to refer to updated chart and image after this PR (https://github.com/pipe-cd/pipecd/pull/6020)  gets merged

Which issue(s) this PR fixes:#5858
