### PR TITLE
add stageIndex and correct logPersisterTest write method

### DIFF
--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -300,6 +300,7 @@ func executeStage[Config, DeployTargetConfig, ApplicationConfigSpec any](
 	in := &ExecuteStageInput[ApplicationConfigSpec]{
 		Request: ExecuteStageRequest[ApplicationConfigSpec]{
 			StageName:               request.GetInput().GetStage().GetName(),
+			StageIndex:              int(request.GetInput().GetStage().GetIndex()),
 			StageConfig:             request.GetInput().GetStageConfig(),
 			RunningDeploymentSource: runningDeploymentSource,
 			TargetDeploymentSource:  targetDeploymentSource,
@@ -538,6 +539,8 @@ type ExecuteStageInput[ApplicationConfigSpec any] struct {
 type ExecuteStageRequest[ApplicationConfigSpec any] struct {
 	// The name of the stage to execute.
 	StageName string
+	// The index of the stage to execute.
+	StageIndex int
 	// Json encoded configuration of the stage.
 	StageConfig []byte
 

--- a/pkg/plugin/sdk/logpersister/logpersistertest/logpersister.go
+++ b/pkg/plugin/sdk/logpersister/logpersistertest/logpersister.go
@@ -38,7 +38,7 @@ func (lp TestLogPersister) StageLogPersister(deploymentID, stageID string) logpe
 func (lp TestLogPersister) Write(log []byte) (int, error) {
 	// Write the log to the test logger
 	lp.t.Log(string(log))
-	return 0, nil
+	return len(log), nil
 }
 func (lp TestLogPersister) Info(log string) {
 	lp.t.Log("INFO", log)


### PR DESCRIPTION
**What this PR does**: 
- add stageIndex per https://github.com/pipe-cd/pipecd/issues/5901 discussion
- make ```TestLogPersister``` Write method behaves the same as ```stageLogPersister```

**Why we need it**:
- the exec.Command will wire its output and error to the log persister. This will break when testing with the current implementation of ```TestLogPersister```

**Which issue(s) this PR fixes**:

Fixes # part of https://github.com/pipe-cd/pipecd/issues/5901

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
