### PR TITLE
Add PluginClient.Name()

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -362,7 +362,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 		rpcclient.WithInsecure(),
 	}
 	for _, plg := range cfg.Plugins {
-		cli, err := pluginapi.NewClient(ctx, net.JoinHostPort("localhost", strconv.Itoa(plg.Port)), options...)
+		cli, err := pluginapi.NewClient(ctx, plg.Name, net.JoinHostPort("localhost", strconv.Itoa(plg.Port)), options...)
 		if err != nil {
 			input.Logger.Error("failed to create client to connect plugin", zap.String("plugin", plg.Name), zap.Error(err))
 			return err

--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -234,8 +234,7 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 		if err != nil {
 			st, ok := status.FromError(err)
 			if ok && st.Code() == codes.Unimplemented {
-				// TODO: show plugin name
-				r.logger.Info("plugin does not support livestate feature")
+				r.logger.Info(fmt.Sprintf("plugin '%s' does not support livestate feature", pluginClient.Name()))
 				continue
 			}
 

--- a/pkg/plugin/api/v1alpha1/client.go
+++ b/pkg/plugin/api/v1alpha1/client.go
@@ -28,15 +28,18 @@ type PluginClient interface {
 	deployment.DeploymentServiceClient
 	livestate.LivestateServiceClient
 	Close() error
+	Name() string
 }
 
 type client struct {
 	deployment.DeploymentServiceClient
 	livestate.LivestateServiceClient
 	conn *grpc.ClientConn
+
+	name string
 }
 
-func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption) (PluginClient, error) {
+func NewClient(ctx context.Context, name string, address string, opts ...rpcclient.DialOption) (PluginClient, error) {
 	conn, err := rpcclient.DialContext(ctx, address, opts...)
 	if err != nil {
 		return nil, err
@@ -46,9 +49,14 @@ func NewClient(ctx context.Context, address string, opts ...rpcclient.DialOption
 		DeploymentServiceClient: deployment.NewDeploymentServiceClient(conn),
 		LivestateServiceClient:  livestate.NewLivestateServiceClient(conn),
 		conn:                    conn,
+		name:                    name,
 	}, nil
 }
 
 func (c *client) Close() error {
 	return c.conn.Close()
+}
+
+func (c *client) Name() string {
+	return c.name
 }


### PR DESCRIPTION
**What this PR does**:

- add Name() to PluginClient
- show the name in livestatereporter log

**Why we need it**:

- more helpful log
- to be used in the plan-preview feature too

**Which issue(s) this PR fixes**:

Part of #5259 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
