### PR TITLE
[Terraform plugin] Implemented Apply and Rollback stages

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+// TODO: add test
+func (p *Plugin) executeApplyStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
+	cmd, err := initTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
+	if err != nil {
+		return sdk.StageStatusFailure
+	}
+
+	lp := input.Client.LogPersister()
+
+	stageConfig := config.TerraformApplyStageOptions{}
+	if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {
+		lp.Errorf("Failed to unmarshal stage config (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	if err = cmd.Apply(ctx, lp); err != nil {
+		lp.Errorf("Failed to apply changes (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	lp.Success("Successfully applied changes")
+	return sdk.StageStatusSuccess
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
@@ -23,6 +23,7 @@ import (
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
+// TODO: add test
 func (p *Plugin) executePlanStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
 	cmd, err := initTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
@@ -112,11 +112,15 @@ func (p *Plugin) ExecuteStage(ctx context.Context, _ *config.Config, dts []*sdk.
 			Status: p.executePlanStage(ctx, input, dts),
 		}, nil
 	case stageApply:
-		panic("unimplemented")
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeApplyStage(ctx, input, dts),
+		}, nil
 	case stageRollback:
-		panic("unimplemented")
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeRollbackStage(ctx, input, dts),
+		}, nil
 	}
-	return nil, errors.New("unimplemented or unsupported stage")
+	return nil, errors.New("unsupported stage")
 }
 
 // FetchDefinedStages implements sdk.DeploymentPlugin.

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+// TODO: add test
+func (p *Plugin) executeRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
+	cmd, err := initTerraformCommand(ctx, input.Client, input.Request.RunningDeploymentSource, dts[0])
+	if err != nil {
+		return sdk.StageStatusFailure
+	}
+
+	lp := input.Client.LogPersister()
+
+	if err = cmd.Apply(ctx, lp); err != nil {
+		lp.Errorf("Failed to apply changes (%v)", err)
+		return sdk.StageStatusFailure
+	}
+
+	lp.Success("Successfully rolled back the changes")
+	return sdk.StageStatusSuccess
+}


### PR DESCRIPTION
**What this PR does**:

as title


I referred to pipedv0:
- apply: https://github.com/pipe-cd/pipecd/blob/c3edb9fa6cd2ae53e12b53e7b2fc80247d01dea7/pkg/app/piped/executor/terraform/deploy.go#L185-L219
- rollback: https://github.com/pipe-cd/pipecd/blob/c3edb9fa6cd2ae53e12b53e7b2fc80247d01dea7/pkg/app/piped/executor/terraform/rollback.go#L48-L115

**Why we need it**:

to support the stages in pipedv1 too.

**Which issue(s) this PR fixes**:

Part of #5992 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
