### PR TITLE
[Terraform plugin] implemented DetermineVersions()

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
@@ -20,8 +20,10 @@ import (
 	"slices"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"go.uber.org/zap"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
 )
 
 // Stage names for Terraform plugin.
@@ -101,7 +103,21 @@ func (p *Plugin) DetermineStrategy(ctx context.Context, _ *config.Config, input 
 
 // DetermineVersions implements sdk.DeploymentPlugin.
 func (p *Plugin) DetermineVersions(ctx context.Context, _ *config.Config, input *sdk.DetermineVersionsInput[config.ApplicationConfigSpec]) (*sdk.DetermineVersionsResponse, error) {
-	panic("unimplemented")
+	files, err := provider.LoadTerraformFiles(input.Request.DeploymentSource.ApplicationDirectory)
+	if err != nil {
+		input.Logger.Error("failed to load Terraform files", zap.Error(err))
+		return nil, err
+	}
+
+	versions, err := provider.FindArtifactVersions(files)
+	if err != nil || len(versions) == 0 {
+		input.Logger.Warn("unable to determine target versions", zap.Error(err))
+		versions = []sdk.ArtifactVersion{{Version: "unknown"}}
+	}
+
+	return &sdk.DetermineVersionsResponse{
+		Versions: versions,
+	}, nil
 }
 
 // ExecuteStage implements sdk.DeploymentPlugin.

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
-	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
 func Test_FetchDefinedStages(t *testing.T) {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_no_modules/main.tf
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_no_modules/main.tf
@@ -1,0 +1,19 @@
+resource "docker_container" "helloworld" {
+  name = "gcr.io/pipecd/helloworld:${var.image_version}"
+  ports {
+    internal = 9376
+    external = "${var.external_port}"
+  }
+}
+
+variable "external_port" {
+    default = 80
+}
+
+variable "image_version" {
+  default = "latest"
+}
+
+output "container" {
+  value = docker_image.helloworld
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld/main.tf
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld/main.tf
@@ -1,0 +1,19 @@
+resource "docker_container" "helloworld" {
+  name = "gcr.io/pipecd/helloworld:${var.image_version}"
+  ports {
+    internal = 9376
+    external = "${var.external_port}"
+  }
+}
+
+variable "external_port" {
+    default = 80
+}
+
+variable "image_version" {
+  default = "latest"
+}
+
+output "container" {
+  value = docker_image.helloworld
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld_01.tf
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld_01.tf
@@ -1,0 +1,9 @@
+provider "docker" {
+}
+
+module "helloworld_01" {
+  source = "helloworld"
+  version = "v1.0.0"
+  image_version = "v1.0.0"
+  external_port = 8080
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld_02.tf
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/testdata/versions_success/helloworld_02.tf
@@ -1,0 +1,9 @@
+provider "docker" {
+}
+
+module "helloworld_02" {
+  source = "helloworld"
+  version = "v0.9.0"
+  image_version = "v0.9.0"
+  external_port = 8081
+}

--- a/pkg/app/pipedv1/plugin/terraform/provider/module.go
+++ b/pkg/app/pipedv1/plugin/terraform/provider/module.go
@@ -111,11 +111,11 @@ func LoadTerraformFiles(dir string) ([]File, error) {
 
 // FindArtifactVersions parses artifact versions from Terraform files.
 // For Terraform, module version is an artifact version.
-func FindArtifactVersions(tfs []File) ([]*sdk.ArtifactVersion, error) {
-	versions := make([]*sdk.ArtifactVersion, 0)
+func FindArtifactVersions(tfs []File) ([]sdk.ArtifactVersion, error) {
+	versions := make([]sdk.ArtifactVersion, 0)
 	for _, tf := range tfs {
 		for _, m := range tf.Modules {
-			versions = append(versions, &sdk.ArtifactVersion{
+			versions = append(versions, sdk.ArtifactVersion{
 				Version: m.Version,
 				Name:    m.Name,
 				URL:     m.Source,

--- a/pkg/app/pipedv1/plugin/terraform/provider/module_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/provider/module_test.go
@@ -134,13 +134,13 @@ func TestFindArticatVersions(t *testing.T) {
 	testcases := []struct {
 		name        string
 		moduleDir   string
-		expected    []*sdk.ArtifactVersion
+		expected    []sdk.ArtifactVersion
 		expectedErr bool
 	}{
 		{
 			name:      "single module",
 			moduleDir: "./testdata/single_module",
-			expected: []*sdk.ArtifactVersion{
+			expected: []sdk.ArtifactVersion{
 				{
 					Name:    "helloworld",
 					URL:     "helloworld",
@@ -152,7 +152,7 @@ func TestFindArticatVersions(t *testing.T) {
 		{
 			name:      "single module with optional field",
 			moduleDir: "./testdata/single_module_optional",
-			expected: []*sdk.ArtifactVersion{
+			expected: []sdk.ArtifactVersion{
 				{
 					Name:    "helloworld",
 					URL:     "helloworld",
@@ -164,7 +164,7 @@ func TestFindArticatVersions(t *testing.T) {
 		{
 			name:      "multi modules",
 			moduleDir: "./testdata/multi_modules",
-			expected: []*sdk.ArtifactVersion{
+			expected: []sdk.ArtifactVersion{
 				{
 					Name:    "helloworld_01",
 					URL:     "helloworld",


### PR DESCRIPTION
**What this PR does**:

as title

cf. 
- determineVersions in pipedv0: [planner/terraform/terraform.go](https://github.com/pipe-cd/pipecd/blob/b097a63df2c88435b5706e89171ec15b2a7f0756/pkg/app/piped/planner/terraform/terraform.go#L79-L94)
- the test files are copied from [provider/testdata/multi_modules_with_multi_files](https://github.com/pipe-cd/pipecd/blob/facdebe82186edaecab303b0a485b9d6ee7e852b/pkg/app/pipedv1/plugin/terraform/provider/testdata/multi_modules_with_multi_files).

**Why we need it**:

to show the module versions for Terraform

**Which issue(s) this PR fixes**:

Part of #5992 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
