### PR TITLE
[plugin planpreview] Copied from pipedv0 and partially modified

### DIFF
--- a/pkg/app/pipedv1/planpreview/builder.go
+++ b/pkg/app/pipedv1/planpreview/builder.go
@@ -1,0 +1,413 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreview
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pipe-cd/pipecd/pkg/app/piped/deploysource"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/planner"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/planner/registry"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/trigger"
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
+	"github.com/pipe-cd/pipecd/pkg/backoff"
+	"github.com/pipe-cd/pipecd/pkg/cache"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/git"
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/regexpool"
+)
+
+const (
+	workspacePattern    = "plan-preview-builder-*"
+	defaultWorkerAppNum = 3
+	maxWorkerNum        = 100
+)
+
+var (
+	defaultPlannerRegistry = registry.DefaultRegistry()
+)
+
+type lastTriggeredCommitGetter interface {
+	Get(ctx context.Context, applicationID string) (string, error)
+}
+
+type Builder interface {
+	Build(ctx context.Context, id string, cmd model.Command_BuildPlanPreview) ([]*model.ApplicationPlanPreviewResult, error)
+}
+
+type builder struct {
+	gitClient         gitClient
+	apiClient         apiClient
+	applicationLister applicationLister
+	commitGetter      lastTriggeredCommitGetter
+	secretDecrypter   secretDecrypter
+	appManifestsCache cache.Cache
+	regexPool         *regexpool.Pool
+	pipedCfg          *config.PipedSpec
+	logger            *zap.Logger
+
+	workingDir string
+	repoCfg    config.PipedRepository
+}
+
+func newBuilder(
+	gc gitClient,
+	ac apiClient,
+	al applicationLister,
+	cg lastTriggeredCommitGetter,
+	sd secretDecrypter,
+	amc cache.Cache,
+	rp *regexpool.Pool,
+	cfg *config.PipedSpec,
+	logger *zap.Logger,
+) *builder {
+
+	return &builder{
+		gitClient:         gc,
+		apiClient:         ac,
+		applicationLister: al,
+		commitGetter:      cg,
+		secretDecrypter:   sd,
+		appManifestsCache: amc,
+		regexPool:         rp,
+		pipedCfg:          cfg,
+		logger:            logger.Named("plan-preview-builder"),
+	}
+}
+
+func (b *builder) Build(ctx context.Context, id string, cmd model.Command_BuildPlanPreview) (results []*model.ApplicationPlanPreviewResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("an unexpected panic occurred (%v)", r)
+			b.logger.Error("unexpected panic", zap.Error(err))
+		}
+	}()
+
+	return b.build(ctx, id, cmd)
+}
+
+func (b *builder) build(ctx context.Context, id string, cmd model.Command_BuildPlanPreview) ([]*model.ApplicationPlanPreviewResult, error) {
+	logger := b.logger.With(zap.String("command", id))
+	logger.Info(fmt.Sprintf("start building planpreview result for command %s", id))
+
+	// Ensure the existence of the working directory.
+	workingDir, err := os.MkdirTemp("", workspacePattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create working directory (%w)", err)
+	}
+	defer os.RemoveAll(workingDir)
+	b.workingDir = workingDir
+
+	// Find the registered repository in Piped config and validate the command's payload against it.
+	repoCfg, ok := b.pipedCfg.GetRepository(cmd.RepositoryId)
+	if !ok {
+		return nil, fmt.Errorf("repository %s was not found in Piped config", cmd.RepositoryId)
+	}
+	if repoCfg.Branch != cmd.BaseBranch {
+		return nil, fmt.Errorf("base branch of repository %s was not matched, requested %s, expected %s", cmd.RepositoryId, cmd.BaseBranch, repoCfg.Branch)
+	}
+	b.repoCfg = repoCfg
+
+	// List all applications that belong to this Piped
+	// and are placed in the given repository.
+	apps := b.listApplications(repoCfg)
+	if len(apps) == 0 {
+		logger.Info(fmt.Sprintf("there is no target application for command %s", id))
+		return nil, nil
+	}
+
+	// Prepare source code at the head commit.
+	// This clones the base branch and merges the head branch into it for correct data.
+	// Because new changes might be added into the base branch after the head branch had checked out.
+	repo, err := b.cloneHeadCommit(ctx, cmd.HeadBranch, cmd.HeadCommit)
+	if err != nil {
+		return nil, err
+	}
+
+	// We added a merge commit so the commit ID was changed.
+	mergedCommit, err := repo.GetLatestCommit(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find all applications that should be triggered.
+	triggerApps, failedResults := b.findTriggerApps(ctx, repo, apps, mergedCommit.Hash)
+	results := failedResults
+
+	if len(triggerApps) == 0 {
+		return results, nil
+	}
+
+	// Plan the trigger applications for more detailed feedback.
+	var (
+		numApps  = len(triggerApps)
+		appCh    = make(chan *model.Application, numApps)
+		resultCh = make(chan *model.ApplicationPlanPreviewResult, numApps)
+	)
+	// Optimize the number of workers.
+	numWorkers := numApps / defaultWorkerAppNum
+	if numWorkers < 1 {
+		numWorkers = numApps
+	}
+	if numWorkers > maxWorkerNum {
+		numWorkers = maxWorkerNum
+	}
+
+	// Start some workers to speed up building time.
+	logger.Info(fmt.Sprintf("start %d workers for building plan-preview results for %d applications", numWorkers, numApps))
+	for w := 0; w < numWorkers; w++ {
+		go func(wid int) {
+			logger.Info("app worker for plan-preview started", zap.Int("worker", wid))
+			for app := range appCh {
+				resultCh <- b.buildApp(ctx, wid, id, app, repo, mergedCommit.Hash)
+			}
+			logger.Info("app worker for plan-preview stopped", zap.Int("worker", wid))
+		}(w)
+	}
+
+	// Add all applications into the channel for start handling.
+	for i := 0; i < numApps; i++ {
+		appCh <- triggerApps[i]
+	}
+	close(appCh)
+
+	// Wait and collect all results.
+	for i := 0; i < numApps; i++ {
+		r := <-resultCh
+		results = append(results, r)
+	}
+
+	logger.Info("successfully collected plan-preview results of all applications")
+	return results, nil
+}
+
+func (b *builder) buildApp(ctx context.Context, worker int, command string, app *model.Application, repo git.Repo, mergedCommit string) *model.ApplicationPlanPreviewResult {
+	logger := b.logger.With(
+		zap.Int("worker", worker),
+		zap.String("command", command),
+		zap.String("app-id", app.Id),
+		zap.String("app-name", app.Name),
+		zap.String("app-kind", app.Kind.String()),
+	)
+
+	logger.Info("will decide sync strategy for an application")
+
+	r := model.MakeApplicationPlanPreviewResult(*app)
+
+	var preCommit string
+	// Find the commit of the last successful deployment.
+	if deploy, err := b.getMostRecentlySuccessfulDeployment(ctx, app.Id); err == nil {
+		preCommit = deploy.Trigger.Commit.Hash
+	} else if status.Code(err) != codes.NotFound {
+		r.Error = fmt.Sprintf("failed while finding the last successful deployment (%v)", err)
+		return r
+	}
+
+	targetDSP := deploysource.NewProvider(
+		b.workingDir,
+		deploysource.NewLocalSourceCloner(repo, "target", mergedCommit),
+		*app.GitPath,
+		b.secretDecrypter,
+	)
+
+	strategy, err := b.plan(ctx, app, targetDSP, preCommit)
+	if err != nil {
+		r.Error = fmt.Sprintf("failed while planning, %v", err)
+		return r
+	}
+	r.SyncStrategy = strategy
+
+	logger.Info("successfully decided sync strategy for a application", zap.String("strategy", strategy.String()))
+
+	var buf bytes.Buffer
+	var dr *diffResult
+
+	switch app.Kind {
+	case model.ApplicationKind_KUBERNETES:
+		dr, err = b.kubernetesDiff(ctx, app, targetDSP, preCommit, &buf)
+	case model.ApplicationKind_TERRAFORM:
+		dr, err = b.terraformDiff(ctx, app, targetDSP, &buf)
+	case model.ApplicationKind_CLOUDRUN:
+		dr, err = b.cloudrundiff(ctx, app, targetDSP, preCommit, &buf)
+	case model.ApplicationKind_ECS:
+		dr, err = b.ecsdiff(ctx, app, targetDSP, preCommit, &buf)
+	case model.ApplicationKind_LAMBDA:
+		dr, err = b.lambdadiff(ctx, app, targetDSP, preCommit, &buf)
+	default:
+		dr = &diffResult{
+			summary: fmt.Sprintf("%s application is not implemented yet (coming soon)", app.Kind.String()),
+		}
+	}
+
+	if dr != nil {
+		r.PlanSummary = []byte(dr.summary)
+		r.NoChange = dr.noChange
+	}
+	r.PlanDetails = buf.Bytes()
+
+	if err != nil {
+		r.Error = fmt.Sprintf("failed while calculating diff, %v", err)
+		return r
+	}
+
+	return r
+}
+
+type diffResult struct {
+	summary  string
+	noChange bool
+}
+
+func (b *builder) cloneHeadCommit(ctx context.Context, headBranch, headCommit string) (git.Repo, error) {
+	dir, err := os.MkdirTemp(b.workingDir, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory %w", err)
+	}
+
+	var (
+		remote     = b.repoCfg.Remote
+		baseBranch = b.repoCfg.Branch
+	)
+	repo, err := b.gitClient.Clone(ctx, b.repoCfg.RepoID, remote, baseBranch, dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone git repository %s at branch %s", b.repoCfg.RepoID, baseBranch)
+	}
+
+	mergeCommitMessage := fmt.Sprintf("Plan-preview: merged %s commit from %s branch into %s base branch", headCommit, headBranch, baseBranch)
+	if err := repo.MergeRemoteBranch(ctx, headBranch, headCommit, mergeCommitMessage); err != nil {
+		return nil, fmt.Errorf("detected conflicts between commit %s at %s branch and the base branch %s (%w)", headCommit, headBranch, baseBranch, err)
+	}
+
+	return repo, nil
+}
+
+func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult) {
+	d := trigger.NewOnCommitDeterminer(repo, headCommit, b.commitGetter, b.logger)
+	determine := func(app *model.Application) (bool, error) {
+		appCfg, err := config.LoadApplication(repo.GetPath(), app.GitPath.GetApplicationConfigFilePath(), app.Kind)
+		if err != nil {
+			return false, err
+		}
+		return d.ShouldTrigger(ctx, app, appCfg)
+	}
+
+	for _, app := range apps {
+		shouldTrigger, err := determine(app)
+		if shouldTrigger {
+			triggerApps = append(triggerApps, app)
+			continue
+		}
+		if err == nil {
+			continue
+		}
+
+		r := model.MakeApplicationPlanPreviewResult(*app)
+		r.Error = fmt.Sprintf("failed while determining the application should be triggered or not, %v", err)
+		failedResults = append(failedResults, r)
+	}
+	return
+}
+
+func (b *builder) plan(ctx context.Context, app *model.Application, targetDSP deploysource.Provider, lastSuccessfulCommit string) (strategy model.SyncStrategy, err error) {
+	p, ok := defaultPlannerRegistry.Planner(app.Kind)
+	if !ok {
+		err = fmt.Errorf("application kind %s is not supported yet", app.Kind.String())
+		return
+	}
+
+	in := planner.Input{
+		ApplicationID:   app.Id,
+		ApplicationName: app.Name,
+		GitPath:         *app.GitPath,
+		Trigger: model.DeploymentTrigger{
+			Commit: &model.Commit{
+				Branch: b.repoCfg.Branch,
+				Hash:   targetDSP.Revision(),
+			},
+			Commander: "pipectl",
+		},
+		TargetDSP:                      targetDSP,
+		MostRecentSuccessfulCommitHash: lastSuccessfulCommit,
+		PipedConfig:                    b.pipedCfg,
+		AppManifestsCache:              b.appManifestsCache,
+		RegexPool:                      b.regexPool,
+		Logger:                         b.logger,
+	}
+
+	if lastSuccessfulCommit != "" {
+		in.RunningDSP = deploysource.NewProvider(
+			b.workingDir,
+			deploysource.NewGitSourceCloner(b.gitClient, b.repoCfg, "running", lastSuccessfulCommit),
+			*app.GitPath,
+			b.secretDecrypter,
+		)
+	}
+
+	out, err := p.Plan(ctx, in)
+	if err != nil {
+		return
+	}
+
+	strategy = out.SyncStrategy
+	return
+}
+
+func (b *builder) listApplications(repo config.PipedRepository) []*model.Application {
+	apps := b.applicationLister.List()
+	out := make([]*model.Application, 0, len(apps))
+
+	for _, app := range apps {
+		if app.GitPath.Repo.Id != repo.RepoID {
+			continue
+		}
+		if app.GitPath.Repo.Remote != repo.Remote {
+			continue
+		}
+		if app.GitPath.Repo.Branch != repo.Branch {
+			continue
+		}
+		out = append(out, app)
+	}
+
+	return out
+}
+
+func (b *builder) getMostRecentlySuccessfulDeployment(ctx context.Context, applicationID string) (*model.ApplicationDeploymentReference, error) {
+	retry := pipedservice.NewRetry(3)
+
+	deploy, err := retry.Do(ctx, func() (interface{}, error) {
+		resp, err := b.apiClient.GetApplicationMostRecentDeployment(ctx, &pipedservice.GetApplicationMostRecentDeploymentRequest{
+			ApplicationId: applicationID,
+			Status:        model.DeploymentStatus_DEPLOYMENT_SUCCESS,
+		})
+		if err != nil {
+			return nil, backoff.NewError(err, pipedservice.Retriable(err))
+		}
+		return resp.Deployment, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return deploy.(*model.ApplicationDeploymentReference), nil
+}

--- a/pkg/app/pipedv1/planpreview/builder_test.go
+++ b/pkg/app/pipedv1/planpreview/builder_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type fakeApplicationLister struct {
+	apps []*model.Application
+}
+
+func (l *fakeApplicationLister) List() []*model.Application {
+	return l.apps
+}
+
+func TestListApplications(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		repo     config.PipedRepository
+		apps     []*model.Application
+		expected []*model.Application
+	}{
+		{
+			name: "no applications",
+			repo: config.PipedRepository{
+				RepoID: "repo-1",
+				Remote: "git@github.com:org/repo-1.git",
+				Branch: "main",
+			},
+			apps:     []*model.Application{},
+			expected: []*model.Application{},
+		},
+		{
+			name: "filter by repository configuration",
+			repo: config.PipedRepository{
+				RepoID: "repo-1",
+				Remote: "git@github.com:org/repo-1.git",
+				Branch: "main",
+			},
+			apps: []*model.Application{
+				{
+					Id: "app-1",
+					GitPath: &model.ApplicationGitPath{
+						Repo: &model.ApplicationGitRepository{
+							Id:     "repo-1",
+							Remote: "git@github.com:org/repo-1.git",
+							Branch: "main",
+						},
+					},
+				},
+				{
+					Id: "app-2",
+					GitPath: &model.ApplicationGitPath{
+						Repo: &model.ApplicationGitRepository{
+							Id:     "repo-2", // Different repo ID
+							Remote: "git@github.com:org/repo-1.git",
+							Branch: "main",
+						},
+					},
+				},
+				{
+					Id: "app-3",
+					GitPath: &model.ApplicationGitPath{
+						Repo: &model.ApplicationGitRepository{
+							Id:     "repo-1",
+							Remote: "git@github.com:org/repo-2.git", // Different remote
+							Branch: "main",
+						},
+					},
+				},
+				{
+					Id: "app-4",
+					GitPath: &model.ApplicationGitPath{
+						Repo: &model.ApplicationGitRepository{
+							Id:     "repo-1",
+							Remote: "git@github.com:org/repo-1.git",
+							Branch: "develop", // Different branch
+						},
+					},
+				},
+			},
+			expected: []*model.Application{
+				{
+					Id: "app-1",
+					GitPath: &model.ApplicationGitPath{
+						Repo: &model.ApplicationGitRepository{
+							Id:     "repo-1",
+							Remote: "git@github.com:org/repo-1.git",
+							Branch: "main",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &builder{
+				applicationLister: &fakeApplicationLister{
+					apps: tc.apps,
+				},
+			}
+
+			got := b.listApplications(tc.repo)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/planpreview/handler.go
+++ b/pkg/app/pipedv1/planpreview/handler.go
@@ -1,0 +1,298 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	metrics "github.com/pipe-cd/pipecd/pkg/app/piped/planpreview/planpreviewmetrics"
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
+	"github.com/pipe-cd/pipecd/pkg/cache"
+	"github.com/pipe-cd/pipecd/pkg/config"
+	"github.com/pipe-cd/pipecd/pkg/git"
+	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/regexpool"
+)
+
+const (
+	defaultWorkerNum              = 3
+	defaultCommandQueueBufferSize = 10
+	defaultCommandCheckInterval   = 5 * time.Second
+	defaultCommandHandleTimeout   = 5 * time.Minute
+)
+
+type options struct {
+	workerNum              int
+	commandQueueBufferSize int
+	commandCheckInterval   time.Duration
+	commandHandleTimeout   time.Duration
+	logger                 *zap.Logger
+}
+
+type Option func(*options)
+
+func WithWorkerNum(n int) Option {
+	return func(opts *options) {
+		opts.workerNum = n
+	}
+}
+
+func WithCommandQueueBufferSize(s int) Option {
+	return func(opts *options) {
+		opts.commandQueueBufferSize = s
+	}
+}
+
+func WithCommandCheckInterval(i time.Duration) Option {
+	return func(opts *options) {
+		opts.commandCheckInterval = i
+	}
+}
+
+func WithCommandHandleTimeout(t time.Duration) Option {
+	return func(opts *options) {
+		opts.commandHandleTimeout = t
+	}
+}
+
+func WithLogger(l *zap.Logger) Option {
+	return func(opts *options) {
+		opts.logger = l
+	}
+}
+
+type gitClient interface {
+	Clone(ctx context.Context, repoID, remote, branch, destination string) (git.Repo, error)
+}
+
+type apiClient interface {
+	GetApplicationMostRecentDeployment(ctx context.Context, req *pipedservice.GetApplicationMostRecentDeploymentRequest, opts ...grpc.CallOption) (*pipedservice.GetApplicationMostRecentDeploymentResponse, error)
+}
+
+type applicationLister interface {
+	List() []*model.Application
+}
+
+type commandLister interface {
+	ListBuildPlanPreviewCommands() []model.ReportableCommand
+}
+
+type secretDecrypter interface {
+	Decrypt(string) (string, error)
+}
+
+type Handler struct {
+	gitClient     gitClient
+	commandLister commandLister
+
+	commandCh    chan model.ReportableCommand
+	prevCommands map[string]struct{}
+
+	options        *options
+	builderFactory func() Builder
+	logger         *zap.Logger
+}
+
+func NewHandler(
+	gc gitClient,
+	ac apiClient,
+	cl commandLister,
+	al applicationLister,
+	cg lastTriggeredCommitGetter,
+	sd secretDecrypter,
+	appManifestsCache cache.Cache,
+	cfg *config.PipedSpec,
+	opts ...Option,
+) *Handler {
+
+	opt := &options{
+		workerNum:              defaultWorkerNum,
+		commandQueueBufferSize: defaultCommandQueueBufferSize,
+		commandCheckInterval:   defaultCommandCheckInterval,
+		commandHandleTimeout:   defaultCommandHandleTimeout,
+		logger:                 zap.NewNop(),
+	}
+	for _, o := range opts {
+		o(opt)
+	}
+
+	h := &Handler{
+		gitClient:     gc,
+		commandLister: cl,
+		commandCh:     make(chan model.ReportableCommand, opt.commandQueueBufferSize),
+		prevCommands:  map[string]struct{}{},
+		options:       opt,
+		logger:        opt.logger.Named("plan-preview-handler"),
+	}
+
+	regexPool := regexpool.DefaultPool()
+	h.builderFactory = func() Builder {
+		return newBuilder(gc, ac, al, cg, sd, appManifestsCache, regexPool, cfg, h.logger)
+	}
+
+	return h
+}
+
+// Run starts running Handler until the given context has done.
+func (h *Handler) Run(ctx context.Context) error {
+	h.logger.Info("start running planpreview handler")
+
+	startWorker := func(ctx context.Context, cmdCh <-chan model.ReportableCommand) {
+		h.logger.Info("started a worker for handling plan-preview command")
+		for {
+			select {
+			case cmd := <-cmdCh:
+				h.handleCommand(ctx, cmd)
+
+			case <-ctx.Done():
+				h.logger.Info("a worker has been stopped")
+				return
+			}
+		}
+	}
+
+	h.logger.Info(fmt.Sprintf("spawn %d worker to handle commands", h.options.workerNum))
+	for i := 0; i < h.options.workerNum; i++ {
+		go startWorker(ctx, h.commandCh)
+	}
+
+	commandTicker := time.NewTicker(h.options.commandCheckInterval)
+	defer commandTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Info("planpreview handler has been stopped")
+			return nil
+
+		case <-commandTicker.C:
+			h.enqueueNewCommands(ctx)
+		}
+	}
+}
+
+func (h *Handler) enqueueNewCommands(ctx context.Context) {
+	h.logger.Debug("fetching unhandled commands to enqueue")
+
+	commands := h.commandLister.ListBuildPlanPreviewCommands()
+	if len(commands) == 0 {
+		h.logger.Debug("there is no command to enqueue")
+		return
+	}
+
+	news := make([]model.ReportableCommand, 0, len(commands))
+	cmds := make(map[string]struct{}, len(commands))
+	for _, cmd := range commands {
+		cmds[cmd.Id] = struct{}{}
+		if _, ok := h.prevCommands[cmd.Id]; !ok {
+			news = append(news, cmd)
+		}
+	}
+
+	h.logger.Info("fetched unhandled commands to enqueue",
+		zap.Any("pre-commands", h.prevCommands),
+		zap.Any("commands", cmds),
+		zap.Int("news", len(news)),
+	)
+
+	if len(news) == 0 {
+		h.logger.Info("there is no new command to enqueue")
+		return
+	}
+
+	h.prevCommands = cmds
+	metrics.ReceivedCommands(len(news))
+	h.logger.Info(fmt.Sprintf("will enqueue %d new commands", len(news)))
+
+	for _, cmd := range news {
+		select {
+		case h.commandCh <- cmd:
+			h.logger.Info("queued a new new command", zap.String("command", cmd.Id))
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (h *Handler) handleCommand(ctx context.Context, cmd model.ReportableCommand) {
+	start := time.Now()
+	logger := h.logger.With(
+		zap.String("command", cmd.Id),
+	)
+	logger.Info("received a plan-preview command to handle")
+
+	result := &model.PlanPreviewCommandResult{
+		CommandId: cmd.Id,
+		PipedId:   cmd.PipedId,
+	}
+
+	reportError := func(err error) {
+		metrics.HandledCommand(metrics.StatusFailure, time.Since(start))
+
+		result.Error = err.Error()
+		output, err := json.Marshal(result)
+		if err != nil {
+			logger.Error("failed to marshal command result", zap.Error(err))
+		}
+
+		if err := cmd.Report(ctx, model.CommandStatus_COMMAND_FAILED, nil, output); err != nil {
+			logger.Error("failed to report command status", zap.Error(err))
+			return
+		}
+		logger.Info("successfully reported a failure command")
+	}
+
+	if cmd.BuildPlanPreview == nil {
+		reportError(fmt.Errorf("malformed command"))
+		return
+	}
+
+	timeout := time.Duration(cmd.BuildPlanPreview.Timeout) * time.Second
+	if timeout == 0 {
+		timeout = h.options.commandHandleTimeout
+	}
+	buildCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	b := h.builderFactory()
+	appResults, err := b.Build(buildCtx, cmd.Id, *cmd.BuildPlanPreview)
+	if err != nil {
+		reportError(err)
+		return
+	}
+
+	result.Results = appResults
+	output, err := json.Marshal(result)
+	if err != nil {
+		reportError(fmt.Errorf("failed to marshal command result (%w)", err))
+		return
+	}
+
+	if err := cmd.Report(ctx, model.CommandStatus_COMMAND_SUCCEEDED, nil, output); err != nil {
+		metrics.HandledCommand(metrics.StatusFailure, time.Since(start))
+		logger.Error("failed to report command status", zap.Error(err))
+		return
+	}
+
+	metrics.HandledCommand(metrics.StatusSuccess, time.Since(start))
+	logger.Info("successfully reported a success command")
+}

--- a/pkg/app/pipedv1/planpreview/handler.go
+++ b/pkg/app/pipedv1/planpreview/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	metrics "github.com/pipe-cd/pipecd/pkg/app/piped/planpreview/planpreviewmetrics"
+	metrics "github.com/pipe-cd/pipecd/pkg/app/pipedv1/planpreview/planpreviewmetrics"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin"
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
-	"github.com/pipe-cd/pipecd/pkg/cache"
-	"github.com/pipe-cd/pipecd/pkg/config"
+	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/git"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/regexpool"
@@ -118,8 +118,8 @@ func NewHandler(
 	al applicationLister,
 	cg lastTriggeredCommitGetter,
 	sd secretDecrypter,
-	appManifestsCache cache.Cache,
 	cfg *config.PipedSpec,
+	pluginRegistry plugin.PluginRegistry,
 	opts ...Option,
 ) *Handler {
 
@@ -145,7 +145,7 @@ func NewHandler(
 
 	regexPool := regexpool.DefaultPool()
 	h.builderFactory = func() Builder {
-		return newBuilder(gc, ac, al, cg, sd, appManifestsCache, regexPool, cfg, h.logger)
+		return newBuilder(gc, ac, al, cg, sd, regexPool, cfg, pluginRegistry, h.logger)
 	}
 
 	return h

--- a/pkg/app/pipedv1/planpreview/handler_test.go
+++ b/pkg/app/pipedv1/planpreview/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The PipeCD Authors.
+// Copyright 2025 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/app/pipedv1/planpreview/handler_test.go
+++ b/pkg/app/pipedv1/planpreview/handler_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreview
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+type testCommandLister struct {
+	commands []model.Command
+}
+
+func (l *testCommandLister) ListBuildPlanPreviewCommands() []model.ReportableCommand {
+	out := make([]model.ReportableCommand, 0, len(l.commands))
+	for i := range l.commands {
+		out = append(out, model.ReportableCommand{
+			Command: &l.commands[i],
+			Report: func(ctx context.Context, status model.CommandStatus, metadata map[string]string, output []byte) error {
+				return nil
+			},
+		})
+	}
+	return out
+}
+
+type testBuilder struct {
+	recorder func(id string)
+}
+
+func (b *testBuilder) Build(ctx context.Context, id string, cmd model.Command_BuildPlanPreview) ([]*model.ApplicationPlanPreviewResult, error) {
+	b.recorder(id)
+	return nil, nil
+}
+
+func TestHandler(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cl := &testCommandLister{}
+	handledCommands := make([]string, 0)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	handler := NewHandler(nil, nil, cl, nil, nil, nil, nil, nil,
+		WithWorkerNum(2),
+		// Use a long interval because we will directly call enqueueNewCommands function in this test.
+		WithCommandCheckInterval(time.Hour),
+	)
+	handler.builderFactory = func() Builder {
+		return &testBuilder{
+			recorder: func(id string) {
+				defer wg.Done()
+				mu.Lock()
+				defer mu.Unlock()
+				handledCommands = append(handledCommands, id)
+				sort.Strings(handledCommands)
+			},
+		}
+	}
+	go handler.Run(ctx)
+
+	// CommandLister returns no command,
+	// then there is no new command.
+	handler.enqueueNewCommands(ctx)
+
+	require.Equal(t, []string{}, handledCommands)
+
+	// CommandLister returns 2 commands: 1, 2.
+	// both of them will be considered as new commands.
+	wg.Add(2)
+	cl.commands = []model.Command{
+		{
+			Id:               "1",
+			Type:             model.Command_BUILD_PLAN_PREVIEW,
+			BuildPlanPreview: &model.Command_BuildPlanPreview{},
+		},
+		{
+			Id:               "2",
+			Type:             model.Command_BUILD_PLAN_PREVIEW,
+			BuildPlanPreview: &model.Command_BuildPlanPreview{},
+		},
+	}
+	handler.enqueueNewCommands(ctx)
+	wg.Wait()
+	require.Equal(t, []string{"1", "2"}, handledCommands)
+
+	// CommandLister returns the same command list
+	// so no new command will be added.
+	handler.enqueueNewCommands(ctx)
+	require.Equal(t, []string{"1", "2"}, handledCommands)
+
+	// CommandLister returns commands: 2, 3.
+	// then 3 will be considered as a new command.
+	wg.Add(1)
+	cl.commands = []model.Command{
+		{
+			Id:               "2",
+			Type:             model.Command_BUILD_PLAN_PREVIEW,
+			BuildPlanPreview: &model.Command_BuildPlanPreview{},
+		},
+		{
+			Id:               "3",
+			Type:             model.Command_BUILD_PLAN_PREVIEW,
+			BuildPlanPreview: &model.Command_BuildPlanPreview{},
+		},
+	}
+	handler.enqueueNewCommands(ctx)
+	wg.Wait()
+	require.Equal(t, []string{"1", "2", "3"}, handledCommands)
+}

--- a/pkg/app/pipedv1/planpreview/planpreviewmetrics/metrics.go
+++ b/pkg/app/pipedv1/planpreview/planpreviewmetrics/metrics.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreviewmetrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	statusKey = "status"
+)
+
+type Status string
+
+const (
+	StatusSuccess Status = "success"
+	StatusFailure Status = "failure"
+)
+
+var (
+	commandReceivedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "plan_preview_command_received_total",
+			Help: "Total number of plan-preview commands received at piped.",
+		},
+	)
+	commandHandledTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "plan_preview_command_handled_total",
+			Help: "Total number of plan-preview commands handled at piped.",
+		},
+		[]string{statusKey},
+	)
+
+	commandHandlingSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "plan_preview_command_handling_seconds",
+			Help:    "Histogram of handling seconds of plan-preview commands.",
+			Buckets: []float64{1, 10, 30, 60, 120, 300, 600},
+		},
+		[]string{statusKey},
+	)
+)
+
+func ReceivedCommands(n int) {
+	commandReceivedTotal.Add(float64(n))
+}
+
+func HandledCommand(s Status, d time.Duration) {
+	commandHandledTotal.With(prometheus.Labels{
+		statusKey: string(s),
+	}).Inc()
+
+	commandHandlingSeconds.With(prometheus.Labels{
+		statusKey: string(s),
+	}).Observe(d.Seconds())
+}
+
+func Register(r prometheus.Registerer) {
+	r.MustRegister(
+		commandReceivedTotal,
+		commandHandledTotal,
+		commandHandlingSeconds,
+	)
+}


### PR DESCRIPTION
**What this PR does**:

as a part of piped-side planpreview,

- `planpreviewmetrics/metrics.go`: copied from pipedv0. 9d0ef855824c75b032af3087f6bb03a1a601d86c
- `handler.go`, `handler_test.go`, `builder.go`: 
    1. copied from pipedv0: b5bf0ac4150a32bf8f7764c233e7b3ae3da27cd7
    2. modify with TODO in builder: b5c56828892784c74acaf1f6a6cea88fc0d704d3
- `builder_test.go`: add
- `piped.go` call the handler

TODO: I need to update `builder.go` and `controller/planner.go`

**Why we need it**:

To support planpreview in pipedv1 too.

**Which issue(s) this PR fixes**:

Part of #5985 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
