### PR TITLE
[Terraform Plugin] implemented GetLiveState()

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
@@ -19,13 +19,14 @@ import (
 	"encoding/json"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
 // TODO: add test
 func (p *Plugin) executeApplyStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
-	cmd, err := initTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
+	cmd, err := provider.NewTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
 	if err != nil {
 		return sdk.StageStatusFailure
 	}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
@@ -19,13 +19,14 @@ import (
 	"encoding/json"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
 // TODO: add test
 func (p *Plugin) executePlanStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
-	cmd, err := initTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
+	cmd, err := provider.NewTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
 	if err != nil {
 		return sdk.StageStatusFailure
 	}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
@@ -39,10 +39,10 @@ const (
 // Plugin implements sdk.DeploymentPlugin for Terraform.
 type Plugin struct{}
 
-var _ sdk.DeploymentPlugin[config.Config, config.DeployTargetConfig, config.ApplicationConfigSpec] = (*Plugin)(nil)
+var _ sdk.DeploymentPlugin[sdk.ConfigNone, config.DeployTargetConfig, config.ApplicationConfigSpec] = (*Plugin)(nil)
 
 // BuildPipelineSyncStages implements sdk.DeploymentPlugin.
-func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *config.Config, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	reqStages := input.Request.Stages
 	out := make([]sdk.PipelineStage, 0, len(reqStages)+1)
 
@@ -71,7 +71,7 @@ func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *config.Config, 
 }
 
 // BuildQuickSyncStages implements sdk.DeploymentPlugin.
-func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *config.Config, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
+func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
 	stages := make([]sdk.QuickSyncStage, 0, 2)
 	stages = append(stages, sdk.QuickSyncStage{
 		Name:               stageApply,
@@ -97,12 +97,12 @@ func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *config.Config, inp
 
 // DetermineStrategy implements sdk.DeploymentPlugin.
 // It returns (nil, nil) because this plugin does not have specific logic for DetermineStrategy.
-func (p *Plugin) DetermineStrategy(ctx context.Context, _ *config.Config, input *sdk.DetermineStrategyInput[config.ApplicationConfigSpec]) (*sdk.DetermineStrategyResponse, error) {
+func (p *Plugin) DetermineStrategy(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineStrategyInput[config.ApplicationConfigSpec]) (*sdk.DetermineStrategyResponse, error) {
 	return nil, nil
 }
 
 // DetermineVersions implements sdk.DeploymentPlugin.
-func (p *Plugin) DetermineVersions(ctx context.Context, _ *config.Config, input *sdk.DetermineVersionsInput[config.ApplicationConfigSpec]) (*sdk.DetermineVersionsResponse, error) {
+func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineVersionsInput[config.ApplicationConfigSpec]) (*sdk.DetermineVersionsResponse, error) {
 	files, err := provider.LoadTerraformFiles(input.Request.DeploymentSource.ApplicationDirectory)
 	if err != nil {
 		input.Logger.Error("failed to load Terraform files", zap.Error(err))
@@ -121,7 +121,7 @@ func (p *Plugin) DetermineVersions(ctx context.Context, _ *config.Config, input 
 }
 
 // ExecuteStage implements sdk.DeploymentPlugin.
-func (p *Plugin) ExecuteStage(ctx context.Context, _ *config.Config, dts []*sdk.DeployTarget[config.DeployTargetConfig], input *sdk.ExecuteStageInput[config.ApplicationConfigSpec]) (*sdk.ExecuteStageResponse, error) {
+func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk.DeployTarget[config.DeployTargetConfig], input *sdk.ExecuteStageInput[config.ApplicationConfigSpec]) (*sdk.ExecuteStageResponse, error) {
 	switch input.Request.StageName {
 	case stagePlan:
 		return &sdk.ExecuteStageResponse{

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
@@ -32,7 +33,7 @@ func (p *Plugin) executeRollbackStage(ctx context.Context, input *sdk.ExecuteSta
 		return sdk.StageStatusFailure
 	}
 
-	cmd, err := initTerraformCommand(ctx, input.Client, rds, dts[0])
+	cmd, err := provider.NewTerraformCommand(ctx, input.Client, rds, dts[0])
 	if err != nil {
 		return sdk.StageStatusFailure
 	}

--- a/pkg/app/pipedv1/plugin/terraform/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/livestate/plugin.go
@@ -1,0 +1,97 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livestate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
+)
+
+var (
+	_ sdk.LivestatePlugin[sdk.ConfigNone, config.DeployTargetConfig, config.ApplicationConfigSpec] = (*Plugin)(nil)
+)
+
+type Plugin struct {
+}
+
+// GetLivestate implements sdk.LivestatePlugin.
+func (p *Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk.DeployTarget[config.DeployTargetConfig], input *sdk.GetLivestateInput[config.ApplicationConfigSpec]) (*sdk.GetLivestateResponse, error) {
+	if len(dts) != 1 {
+		return nil, fmt.Errorf("only 1 deploy target is allowed but got %d", len(dts))
+	}
+	dt := dts[0]
+
+	cmd, err := provider.NewTerraformCommand(ctx, input.Client, input.Request.DeploymentSource, dt)
+	if err != nil {
+		input.Logger.Error("Failed to initialize Terraform command", zap.Error(err))
+		return nil, err
+	}
+
+	planResult, err := cmd.Plan(ctx, input.Client.LogPersister())
+	if err != nil {
+		input.Logger.Error("Failed to execute plan", zap.Error(err))
+		return nil, err
+	}
+
+	syncState, err := makeSyncState(planResult, input.Request.DeploymentSource.CommitHash)
+	if err != nil {
+		input.Logger.Error("Failed to make sync state", zap.Error(err))
+		return nil, err
+	}
+
+	return &sdk.GetLivestateResponse{
+		// Currently, LiveState is not supported in this plugin.
+		SyncState: syncState,
+	}, nil
+}
+
+func makeSyncState(r provider.PlanResult, commit string) (sdk.ApplicationSyncState, error) {
+	if r.NoChanges() {
+		return sdk.ApplicationSyncState{
+			Status:      sdk.ApplicationSyncStateSynced,
+			ShortReason: "",
+			Reason:      "",
+		}, nil
+	}
+
+	total := r.Imports + r.Adds + r.Destroys + r.Changes
+	shortReason := fmt.Sprintf("There are %d manifests that are not synced (%d imports, %d adds, %d deletes, %d changes)", total, r.Imports, r.Adds, r.Destroys, r.Changes)
+	if len(commit) >= 7 {
+		commit = commit[:7]
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual live state:\n\n", commit))
+	b.WriteString("--- Actual   (LiveState)\n+++ Expected (Git)\n\n")
+
+	details, err := r.Render()
+	if err != nil {
+		return sdk.ApplicationSyncState{}, err
+	}
+	b.WriteString(details)
+
+	return sdk.ApplicationSyncState{
+		Status:      sdk.ApplicationSyncStateOutOfSync,
+		ShortReason: shortReason,
+		Reason:      b.String(),
+	}, nil
+}

--- a/pkg/app/pipedv1/plugin/terraform/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/livestate/plugin_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livestate
+
+import (
+	"fmt"
+	"testing"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
+)
+
+func TestMakeSyncState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		result  provider.PlanResult
+		commit  string
+		want    sdk.ApplicationSyncState
+		wantErr bool
+	}{
+		{
+			name: "no changes",
+			result: provider.PlanResult{
+				Imports:  0,
+				Adds:     0,
+				Changes:  0,
+				Destroys: 0,
+			},
+			commit: "commit1",
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateSynced,
+				ShortReason: "",
+				Reason:      "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "has changes",
+			result: provider.PlanResult{
+				Imports:    1,
+				Adds:       2,
+				Changes:    3,
+				Destroys:   4,
+				PlanOutput: "Terraform will perform the following actions:\nsome changes\nPlan: 1 to import, 2 to add, 3 to change, 4 to destroy.",
+			},
+			commit: "1234567890abcdef",
+			want: sdk.ApplicationSyncState{
+				Status:      sdk.ApplicationSyncStateOutOfSync,
+				ShortReason: "There are 10 manifests that are not synced (1 imports, 2 adds, 4 deletes, 3 changes)",
+				Reason: fmt.Sprintf("Diff between the defined state in Git at commit 1234567 and actual live state:\n\n" +
+					"--- Actual   (LiveState)\n" +
+					"+++ Expected (Git)\n\n" +
+					"some changes\nPlan: 1 to import, 2 to add, 3 to change, 4 to destroy.\n"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid plan output",
+			result: provider.PlanResult{
+				Imports:    1,
+				Adds:       1,
+				Changes:    1,
+				Destroys:   1,
+				PlanOutput: "<invalid plan output> Terraform will perform the following actions:",
+			},
+			commit:  "1234567890abcdef",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := makeSyncState(tt.result, tt.commit)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/main.go
+++ b/pkg/app/pipedv1/plugin/terraform/main.go
@@ -20,12 +20,14 @@ import (
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/deployment"
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/livestate"
 )
 
 func main() {
 	plugin, err := sdk.NewPlugin(
 		"0.0.1",
 		sdk.WithDeploymentPlugin(&deployment.Plugin{}),
+		sdk.WithLivestatePlugin(&livestate.Plugin{}),
 	)
 	if err != nil {
 		log.Fatalln(err)

--- a/pkg/app/pipedv1/plugin/terraform/provider/initialize_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/provider/initialize_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deployment
+package provider
 
 import (
 	"testing"

--- a/pkg/app/pipedv1/plugin/terraform/provider/terraform.go
+++ b/pkg/app/pipedv1/plugin/terraform/provider/terraform.go
@@ -88,7 +88,7 @@ type Terraform struct {
 	options options
 }
 
-func NewTerraform(execPath, dir string, opts ...Option) *Terraform {
+func newTerraform(execPath, dir string, opts ...Option) *Terraform {
 	opt := options{}
 	for _, o := range opts {
 		o(&opt)
@@ -101,7 +101,7 @@ func NewTerraform(execPath, dir string, opts ...Option) *Terraform {
 	}
 }
 
-func (t *Terraform) Version(ctx context.Context) (string, error) {
+func (t *Terraform) version(ctx context.Context) (string, error) {
 	args := []string{"version"}
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir
@@ -115,7 +115,7 @@ func (t *Terraform) Version(ctx context.Context) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func (t *Terraform) Init(ctx context.Context, w io.Writer) error {
+func (t *Terraform) init(ctx context.Context, w io.Writer) error {
 	args := []string{
 		"init",
 	}
@@ -135,7 +135,7 @@ func (t *Terraform) Init(ctx context.Context, w io.Writer) error {
 	return cmd.Run()
 }
 
-func (t *Terraform) SelectWorkspace(ctx context.Context, workspace string) error {
+func (t *Terraform) selectWorkspace(ctx context.Context, workspace string) error {
 	args := []string{
 		"workspace",
 		"select",


### PR DESCRIPTION
**What this PR does**:

- moved `initialize.go` to the `provider` package to call it from not only `deployment`.
- implemented livestateplugin.  cf.:

    https://github.com/pipe-cd/pipecd/blob/5be3da35d9dda6b2f8c30c8d05c1076166c67d57/pkg/app/piped/driftdetector/terraform/detector.go#L255-L320

LiveState is not supported as pipedv0

**Why we need it**:

to support driftdetection for terraform in pipedv1 too.

**Which issue(s) this PR fixes**:

Part of #5992 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
