### PR TITLE
[plugin planpreview] update SDK GetPlanPreviewResponse

### DIFF
--- a/pkg/plugin/sdk/go.mod
+++ b/pkg/plugin/sdk/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/creasty/defaults v1.6.0
-	github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce
+	github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0

--- a/pkg/plugin/sdk/go.sum
+++ b/pkg/plugin/sdk/go.sum
@@ -260,6 +260,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce h1:zyYJ+lIC3oLya2ZoNL90TdDI6IkQVL7aptkT1f9I69U=
 github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce/go.mod h1:5H0ydj0eUpGnJOesA2GPU3mTVlZEZDb8cNP7/lvNPTU=
+github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5 h1:1VM6ZkE2YfXqROq3lU8xrOV21MdJ257p19VX71E/nsU=
+github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5/go.mod h1:5H0ydj0eUpGnJOesA2GPU3mTVlZEZDb8cNP7/lvNPTU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/plugin/sdk/planpreview_test.go
+++ b/pkg/plugin/sdk/planpreview_test.go
@@ -27,6 +27,8 @@ import (
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/common"
 	"github.com/pipe-cd/pipecd/pkg/plugin/api/v1alpha1/planpreview"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockPlanPreviewPlugin struct {
@@ -70,7 +72,7 @@ spec: {}
 	tests := []struct {
 		name           string
 		request        *planpreview.GetPlanPreviewRequest
-		result         *GetPlanPreviewResponse
+		mockResp       *GetPlanPreviewResponse
 		err            error
 		expectedStatus codes.Code
 		expectErr      bool
@@ -87,10 +89,16 @@ spec: {}
 					ApplicationConfigFilename: "app-config-filename",
 				},
 			},
-			result: &GetPlanPreviewResponse{
-				Summary:  "summary",
-				NoChange: true,
-				Details:  []byte("details"),
+			mockResp: &GetPlanPreviewResponse{
+				Results: []PlanPreviewResult{
+					{
+						DeployTarget: "target1",
+						Summary:      "summary",
+						NoChange:     true,
+						Details:      []byte("details"),
+						DiffLanguage: "diff",
+					},
+				},
 			},
 			expectedStatus: codes.OK,
 		},
@@ -100,14 +108,14 @@ spec: {}
 				ApplicationId: "app1",
 				DeployTargets: []string{"target2"},
 			},
-			result:         &GetPlanPreviewResponse{},
+			mockResp:       &GetPlanPreviewResponse{},
 			expectErr:      true,
 			expectedStatus: codes.Internal,
 		},
 		{
 			name:           "error",
 			request:        &planpreview.GetPlanPreviewRequest{},
-			result:         &GetPlanPreviewResponse{},
+			mockResp:       &GetPlanPreviewResponse{},
 			err:            errors.New("some error"),
 			expectErr:      true,
 			expectedStatus: codes.Internal,
@@ -119,7 +127,7 @@ spec: {}
 			t.Parallel()
 
 			plugin := &mockPlanPreviewPlugin{
-				result: tt.result,
+				result: tt.mockResp,
 				err:    tt.err,
 			}
 			server := newTestPlanPreviewPluginServer(t, plugin)
@@ -133,9 +141,68 @@ spec: {}
 				t.Errorf("expected status %v, got %v", tt.expectedStatus, status.Code(err))
 			}
 
-			if response != nil && response.GetSummary() != tt.result.Summary {
-				t.Errorf("expected summary %v, got %v", tt.result.Summary, response.GetSummary())
+			if !tt.expectErr {
+				require.NotNil(t, response)
+				assert.Equal(t, tt.mockResp.toProto(), response)
 			}
+		})
+	}
+}
+
+func TestGetPlanPreviewResponse_toProto(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response *GetPlanPreviewResponse
+		expected *planpreview.GetPlanPreviewResponse
+	}{
+		{
+			name: "success",
+			response: &GetPlanPreviewResponse{
+				Results: []PlanPreviewResult{
+					{
+						DeployTarget: "target-1",
+						Summary:      "summary-1",
+						NoChange:     true,
+						Details:      []byte("details-1"),
+						DiffLanguage: "diff",
+					},
+					{
+						DeployTarget: "target-2",
+						Summary:      "summary-2",
+						NoChange:     false,
+						Details:      []byte("details-2"),
+						// not specify DiffLanguage
+					},
+				},
+			},
+			expected: &planpreview.GetPlanPreviewResponse{
+				Results: []*planpreview.PlanPreviewResult{
+					{
+						DeployTarget: "target-1",
+						Summary:      "summary-1",
+						NoChange:     true,
+						Details:      []byte("details-1"),
+						DiffLanguage: "diff",
+					},
+					{
+						DeployTarget: "target-2",
+						Summary:      "summary-2",
+						NoChange:     false,
+						Details:      []byte("details-2"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			response := tt.response.toProto()
+			assert.Equal(t, tt.expected, response)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

- Use repeated
- Add `DiffLanguage`
- Added missing `sdk.GetPlanPreviewRequest.DeployTargets`

**Why we need it**:

To reflect the followings:
- https://github.com/pipe-cd/pipecd/pull/6083
- https://github.com/pipe-cd/pipecd/pull/6082

**Which issue(s) this PR fixes**:

Part of #5985 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
