### PR TITLE
chore(ci): update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/publish_image_chart.yaml
+++ b/.github/workflows/publish_image_chart.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   artifacts:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish_tool.yaml
+++ b/.github/workflows/publish_tool.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tool:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     timeout-minutes: 15
     permissions:
       packages: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "modules=$(find . -name go.mod -exec dirname {} \; | sort | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
 
   go:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     needs: list-go-modules
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What this PR does**:

CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
No.

- **How are users affected by this change**: N/A
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A 
