### PR TITLE
feat: implement server side pagination for ListNotCompletedDeployments

### DIFF
--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -103,7 +103,6 @@ func (s *store) Lister() Lister {
 }
 
 func (s *store) sync(ctx context.Context) error {
-	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{})
 	if err != nil {
 		s.logger.Error("failed to list unhandled deployment", zap.Error(err))

--- a/pkg/app/pipedv1/apistore/deploymentstore/store.go
+++ b/pkg/app/pipedv1/apistore/deploymentstore/store.go
@@ -103,7 +103,6 @@ func (s *store) Lister() Lister {
 }
 
 func (s *store) sync(ctx context.Context) error {
-	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
 	resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{})
 	if err != nil {
 		s.logger.Error("failed to list unhandled deployment", zap.Error(err))


### PR DESCRIPTION
**What this PR does**:
Moves pagination logic to the server for ListNotCompletedDeployments

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1937

**Does this PR introduce a user-facing change?**:
No

- **How are users affected by this change**: Not affected, piped/pipedv1 still make a single RPC call.
- **Is this breaking change**:No
- **How to migrate (if breaking change)**:
