### PR TITLE
Update timeout for the build time workflow

### DIFF
--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   tool:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         image:


### PR DESCRIPTION
**What this PR does**:

The new VM runner needs more time to start up, so I updated the timeout to ensure a stable workflow.

**Why we need it**:

**Which issue(s) this PR fixes**:

Follow #6104 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
