### PR TITLE
Support all kustomization files name

### DIFF
--- a/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/platformprovider/kubernetes/kubernetes.go
@@ -40,6 +40,4 @@ const (
 	IgnoreDriftDetectionTrue = "true"
 	UseReplaceEnabled        = "enabled"
 	UseServerSideApply       = "true"
-
-	kustomizationFileName = "kustomization.yaml"
 )

--- a/pkg/app/piped/platformprovider/kubernetes/loader.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader.go
@@ -221,8 +221,27 @@ func determineTemplatingMethod(input config.KubernetesDeploymentInput, appDirPat
 	if input.HelmChart != nil {
 		return TemplatingMethodHelm
 	}
-	if _, err := os.Stat(filepath.Join(appDirPath, kustomizationFileName)); err == nil {
+	if isKustomizationFileExists(appDirPath) {
 		return TemplatingMethodKustomize
 	}
 	return TemplatingMethodNone
+}
+
+// isKustomizationFileExists checks if a kustomization file exists in the given directory.
+// There are 3 files name considered as kustomization file:
+// - kustomization.yaml
+// - kustomization.yml
+// - Kustomization
+func isKustomizationFileExists(appDirPath string) bool {
+	recognizedKustomizationFileNames := []string{
+		"kustomization.yaml",
+		"kustomization.yml",
+		"Kustomization",
+	}
+	for _, fileName := range recognizedKustomizationFileNames {
+		if _, err := os.Stat(filepath.Join(appDirPath, fileName)); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/app/piped/platformprovider/kubernetes/loader_test.go
+++ b/pkg/app/piped/platformprovider/kubernetes/loader_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestSortManifests(t *testing.T) {
+	t.Parallel()
+
 	maker := func(name string, annotations map[string]string) Manifest {
 		m := Manifest{
 			Key: ResourceKey{Name: name},
@@ -73,6 +75,8 @@ func TestSortManifests(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			sortManifests(tc.manifests)
 			assert.Equal(t, tc.want, tc.manifests)
 		})
@@ -80,6 +84,8 @@ func TestSortManifests(t *testing.T) {
 }
 
 func TestDetermineTemplatingMethod(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		name       string
 		input      config.KubernetesDeploymentInput
@@ -109,6 +115,8 @@ func TestDetermineTemplatingMethod(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := determineTemplatingMethod(tc.input, tc.appDirPath)
 			if got != tc.want {
 				t.Errorf("determineTemplatingMethod() = %v, want %v", got, tc.want)


### PR DESCRIPTION
**What this PR does**:

Recognize all official kustomization file names, other than just `kustomization.yaml`

**Why we need it**:

Current pipecd logic only recognizes `kustomization.yaml` file as the config file for kustomize, while the official kustomize mentions that we should support three file names: `kustomization.yaml, kustomization.yml, Kustomization`

ref: https://github.com/kubernetes-sigs/kustomize/blob/7c04cbb23791c0675cfaa3806ef9b99d59698a98/api/konfig/general.go#L10-L16

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
