### PR TITLE
[create by mistake] custom create kind cluster for cluster down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,11 +287,11 @@ release/docs:
 
 .PHONY: kind-up
 kind-up:
-	./hack/create-kind-cluster.sh pipecd
+	./hack/create-kind-cluster.sh pipecd up
 
 .PHONY: kind-down
 kind-down:
-	kind delete cluster --name pipecd
+	./hack/create-kind-cluster.sh pipecd down
 
 .PHONY: setup-envtest
 # Where to install the setup-envtest binary

--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -33,8 +33,22 @@ set -o nounset
 set -o pipefail
 
 CLUSTER=$1
+ACTION=$2
 REG_NAME='kind-registry'
 REG_PORT='5001'
+
+# Delete the cluster and the registry
+if [ "$ACTION" = "down" ]; then
+  kind delete cluster --name ${CLUSTER}
+  docker rm -f $REG_NAME 2>/dev/null
+  exit 0
+fi
+
+# Exit if the action is not valid
+if [ "$ACTION" != "up" ]; then
+  echo "Invalid mode: $ACTION"
+  exit 1
+fi
 
 # Create registry container unless it already exists
 echo "Creating local registry container..."


### PR DESCRIPTION
- **Release v0.53.0 (#6123)**
- **[bot] Publish quickstart manifests (#6132)**
- **Cloudrun stage base (#6115)**
- **chore(docs): migrate deprecated Hugo syntax for v0.148.2(latest) support (#6099)**
- **cleanup: remove SetUpdatedAt (#6127)**
- **Add up and down action to create-kind-cluster.sh script**
