### PR TITLE
fix(ci): fix failing site publish

### DIFF
--- a/docs/layouts/docs-v0.53.x/list.html
+++ b/docs/layouts/docs-v0.53.x/list.html
@@ -19,11 +19,11 @@
 	</header>
 	{{ .Content }}
         {{ partial "section-index.html" . }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (site.Config.Services.GoogleAnalytics.ID)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (site.Config.Services.Disqus.Shortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}


### PR DESCRIPTION
**What this PR does**:

fixes site publish by updating `docs-v0.53.x` changes

**Why we need it**:

publish site CI is failing