### PR TITLE
CI: Deny dependency from plugins to pipe-cd/pipecd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,12 @@ linters-settings:
         deny:
           - pkg: "github.com/pipe-cd/pipecd/pkg/config$"
             desc: "Use github.com/pipe-cd/pipecd/pkg/configv1 instead."
+      plugin:
+        files:
+          - "**/pkg/app/pipedv1/plugin/**/*.go"
+        deny:
+          - pkg: "^github.com/pipe-cd/pipecd/(?!pkg/app/pipedv1/plugin).*"
+            desc: "Use github.com/pipe-cd/piped-plugin-sdk-go instead."
   gocritic:
     disabled-checks:
       - appendAssign


### PR DESCRIPTION
**What this PR does**:

Deny deps from files under `pipedv1/plugin/**` to outside them.

Examples: 
- Allow:
  -  github.com/pipe-cd/piped-plugin-sdk-go
  -  github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config
      - k8s -> tf is not denied in this rule, but not allowed
- Deny:
  - github.com/pipe-cd/pipecd/pkg/config
  - github.com/pipe-cd/pipecd/pkg/model

**Why we need it**:

This PR makes it easier to review and develop.
The plugins cannot depend on pipe-cd/pipecd except the SDK and its local modules for simplicity.


**Which issue(s) this PR fixes**:

Related to #5259 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
