### PR TITLE
[Analysis Plugin] Add Found flag to `GetApplicationSharedObject()` to distinguish NotFound

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/grpcapi/plugin_api.go
+++ b/pkg/app/pipedv1/cmd/piped/grpcapi/plugin_api.go
@@ -26,6 +26,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type PluginAPI struct {
@@ -164,6 +166,9 @@ func (a *PluginAPI) GetApplicationSharedObject(ctx context.Context, req *service
 		PluginName:    req.PluginName,
 		Key:           req.Key,
 	})
+	if status.Code(err) == codes.NotFound {
+		return nil, status.Error(codes.NotFound, "the requested application shared object was not found")
+	}
 	if err != nil {
 		a.Logger.Error("failed to get application shared object",
 			zap.String("applicationID", req.ApplicationId),

--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/plugin/pipedservice"
@@ -204,16 +206,19 @@ func (c *Client) GetDeploymentSharedMetadata(ctx context.Context, key string) (s
 }
 
 // GetApplicationSharedObject gets the application object which is shared across deployments.
-func (c *Client) GetApplicationSharedObject(ctx context.Context, key string) ([]byte, error) {
+func (c *Client) GetApplicationSharedObject(ctx context.Context, key string) (obj []byte, found bool, err error) {
 	resp, err := c.base.GetApplicationSharedObject(ctx, &pipedservice.GetApplicationSharedObjectRequest{
 		ApplicationId: c.applicationID,
 		PluginName:    c.pluginName,
 		Key:           key,
 	})
-	if err != nil {
-		return nil, err
+	if status.Code(err) == codes.NotFound {
+		return nil, false, nil
 	}
-	return resp.Object, nil
+	if err != nil {
+		return nil, false, err
+	}
+	return resp.Object, true, nil
 }
 
 // PutApplicationSharedObject stores the application object which is shared across deployments.


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

To distinguish 
- when the result does not exist yet
- when failed to get 

https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/apistore/analysisresultstore/store.go#L56-L71

**Which issue(s) this PR fixes**:

Part of #6068 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
