### PR TITLE
[k8s plugin] Implement helm registry login

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -97,39 +97,6 @@ type KubernetesVariantLabel struct {
 	BaselineValue string `json:"baselineValue" default:"baseline"`
 }
 
-type KubernetesDeployTargetConfig struct {
-	// The master URL of the kubernetes cluster.
-	// Empty means in-cluster.
-	MasterURL string `json:"masterURL,omitempty"`
-	// The path to the kubeconfig file.
-	// Empty means in-cluster.
-	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
-	// Version of kubectl will be used.
-	KubectlVersion string `json:"kubectlVersion"`
-	// Configuration for application resource informer.
-	AppStateInformer KubernetesAppStateInformer `json:"appStateInformer"`
-}
-
-// KubernetesAppStateInformer represents the configuration for application resource informer.
-type KubernetesAppStateInformer struct {
-	// Only watches the specified namespace.
-	// Empty means watching all namespaces.
-	Namespace string `json:"namespace,omitempty"`
-	// List of resources that should be added to the watching targets.
-	IncludeResources []KubernetesResourceMatcher `json:"includeResources,omitempty"`
-	// List of resources that should be ignored from the watching targets.
-	ExcludeResources []KubernetesResourceMatcher `json:"excludeResources,omitempty"`
-}
-
-// KubernetesResourceMatcher represents the matcher for a Kubernetes resource.
-type KubernetesResourceMatcher struct {
-	// The APIVersion of the kubernetes resource.
-	APIVersion string `json:"apiVersion,omitempty"`
-	// The kind name of the kubernetes resource.
-	// Empty means all kinds are matching.
-	Kind string `json:"kind,omitempty"`
-}
-
 // K8sResourcePatch represents a patch operation for a Kubernetes resource.
 type K8sResourcePatch struct {
 	// The target of the patch operation.

--- a/pkg/app/pipedv1/plugin/kubernetes/config/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/plugin.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+type KubernetesPluginConfig struct {
+	// List of helm chart repositories that should be added while starting up.
+	ChartRepositories []HelmChartRepository `json:"chartRepositories,omitempty"`
+	// List of helm chart registries that should be logged in while starting up.
+	ChartRegistries []HelmChartRegistry `json:"chartRegistries,omitempty"`
+}
+
+type HelmChartRepositoryType string
+
+const (
+	HTTPHelmChartRepository HelmChartRepositoryType = "HTTP"
+)
+
+type HelmChartRepository struct {
+	// The repository type. Only HTTP is supported.
+	Type HelmChartRepositoryType `json:"type" default:"HTTP"`
+
+	// Configuration for HTTP type.
+	// The name of the Helm chart repository.
+	Name string `json:"name,omitempty"`
+	// The address to the Helm chart repository.
+	Address string `json:"address,omitempty"`
+	// Username used for the repository backed by HTTP basic authentication.
+	Username string `json:"username,omitempty"`
+	// Password used for the repository backed by HTTP basic authentication.
+	Password string `json:"password,omitempty"`
+	// Whether to skip TLS certificate checks for the repository or not.
+	Insecure bool `json:"insecure"`
+}
+
+// HelmChartRegistryType represents the type of Helm chart registry.
+type HelmChartRegistryType string
+
+// The registry types that hosts Helm charts.
+const (
+	OCIHelmChartRegistry HelmChartRegistryType = "OCI"
+)
+
+// HelmChartRegistry represents the configuration for a Helm chart registry.
+type HelmChartRegistry struct {
+	// The registry type. Currently, only OCI is supported.
+	Type HelmChartRegistryType `json:"type" default:"OCI"`
+
+	// The address to the Helm chart registry.
+	Address string `json:"address"`
+	// Username used for the registry authentication.
+	Username string `json:"username,omitempty"`
+	// Password used for the registry authentication.
+	Password string `json:"password,omitempty"`
+}
+
+// KubernetesDeployTargetConfig represents the configuration for a Kubernetes deployment target.
+type KubernetesDeployTargetConfig struct {
+	// The master URL of the kubernetes cluster.
+	// Empty means in-cluster.
+	MasterURL string `json:"masterURL,omitempty"`
+	// The path to the kubeconfig file.
+	// Empty means in-cluster.
+	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
+	// Version of kubectl will be used.
+	KubectlVersion string `json:"kubectlVersion"`
+	// Configuration for application resource informer.
+	AppStateInformer KubernetesAppStateInformer `json:"appStateInformer"`
+}
+
+// KubernetesAppStateInformer represents the configuration for application resource informer.
+type KubernetesAppStateInformer struct {
+	// Only watches the specified namespace.
+	// Empty means watching all namespaces.
+	Namespace string `json:"namespace,omitempty"`
+	// List of resources that should be added to the watching targets.
+	IncludeResources []KubernetesResourceMatcher `json:"includeResources,omitempty"`
+	// List of resources that should be ignored from the watching targets.
+	ExcludeResources []KubernetesResourceMatcher `json:"excludeResources,omitempty"`
+}
+
+// KubernetesResourceMatcher represents the matcher for a Kubernetes resource.
+type KubernetesResourceMatcher struct {
+	// The APIVersion of the kubernetes resource.
+	APIVersion string `json:"apiVersion,omitempty"`
+	// The kind name of the kubernetes resource.
+	// Empty means all kinds are matching.
+	Kind string `json:"kind,omitempty"`
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/config/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/plugin.go
@@ -65,6 +65,11 @@ type HelmChartRegistry struct {
 	Password string `json:"password,omitempty"`
 }
 
+// IsOCI checks if the registry is an OCI registry.
+func (r *HelmChartRegistry) IsOCI() bool {
+	return r.Type == OCIHelmChartRegistry
+}
+
 // KubernetesDeployTargetConfig represents the configuration for a Kubernetes deployment target.
 type KubernetesDeployTargetConfig struct {
 	// The master URL of the kubernetes cluster.

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/plugin.go
@@ -43,7 +43,7 @@ type toolRegistry interface {
 	Helm(ctx context.Context, version string) (string, error)
 }
 
-var _ sdk.DeploymentPlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig, kubeconfig.KubernetesApplicationSpec] = (*Plugin)(nil)
+var _ sdk.DeploymentPlugin[kubeconfig.KubernetesPluginConfig, kubeconfig.KubernetesDeployTargetConfig, kubeconfig.KubernetesApplicationSpec] = (*Plugin)(nil)
 
 // FetchDefinedStages returns the defined stages for this plugin.
 func (p *Plugin) FetchDefinedStages() []string {
@@ -51,7 +51,7 @@ func (p *Plugin) FetchDefinedStages() []string {
 }
 
 // BuildPipelineSyncStages returns the stages for the pipeline sync strategy.
-func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	stages, err := buildPipelineStages(input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipeline stages: %w", err)
@@ -62,7 +62,7 @@ func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone,
 }
 
 // ExecuteStage executes the stage.
-func (p *Plugin) ExecuteStage(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.ExecuteStageResponse, error) {
+func (p *Plugin) ExecuteStage(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.ExecuteStageInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.ExecuteStageResponse, error) {
 	switch input.Request.StageName {
 	case StageK8sSync:
 		return &sdk.ExecuteStageResponse{
@@ -146,7 +146,7 @@ func (p *Plugin) loadManifests(ctx context.Context, deploy *sdk.Deployment, spec
 }
 
 // DetermineVersions determines the versions of the application.
-func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineVersionsInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.DetermineVersionsResponse, error) {
+func (p *Plugin) DetermineVersions(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, input *sdk.DetermineVersionsInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.DetermineVersionsResponse, error) {
 	logger := input.Logger
 
 	cfg, err := input.Request.DeploymentSource.AppConfig()
@@ -167,7 +167,7 @@ func (p *Plugin) DetermineVersions(ctx context.Context, _ *sdk.ConfigNone, input
 }
 
 // DetermineStrategy determines the strategy for the deployment.
-func (p *Plugin) DetermineStrategy(ctx context.Context, _ *sdk.ConfigNone, input *sdk.DetermineStrategyInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.DetermineStrategyResponse, error) {
+func (p *Plugin) DetermineStrategy(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, input *sdk.DetermineStrategyInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.DetermineStrategyResponse, error) {
 	logger := input.Logger
 	loader := provider.NewLoader(toolregistry.NewRegistry(input.Client.ToolRegistry()))
 
@@ -198,7 +198,7 @@ func (p *Plugin) DetermineStrategy(ctx context.Context, _ *sdk.ConfigNone, input
 }
 
 // BuildQuickSyncStages returns the stages for the quick sync strategy.
-func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
+func (p *Plugin) BuildQuickSyncStages(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, input *sdk.BuildQuickSyncStagesInput) (*sdk.BuildQuickSyncStagesResponse, error) {
 	return &sdk.BuildQuickSyncStagesResponse{
 		Stages: buildQuickSyncPipeline(input.Request.Rollback),
 	}, nil

--- a/pkg/app/pipedv1/plugin/kubernetes/go.mod
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/goccy/go-yaml v1.9.8
 	github.com/google/go-cmp v0.7.0
-	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250724013017-bc0f37a0cbad
+	github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250825120314-8f0eff883d49
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.22.0
@@ -60,7 +60,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce // indirect
+	github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/pkg/app/pipedv1/plugin/kubernetes/go.sum
+++ b/pkg/app/pipedv1/plugin/kubernetes/go.sum
@@ -429,8 +429,14 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce h1:zyYJ+lIC3oLya2ZoNL90TdDI6IkQVL7aptkT1f9I69U=
 github.com/pipe-cd/pipecd v0.52.1-0.20250722035702-5722fabb80ce/go.mod h1:5H0ydj0eUpGnJOesA2GPU3mTVlZEZDb8cNP7/lvNPTU=
+github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5 h1:1VM6ZkE2YfXqROq3lU8xrOV21MdJ257p19VX71E/nsU=
+github.com/pipe-cd/pipecd v0.52.1-0.20250731104149-f611ce3501c5/go.mod h1:5H0ydj0eUpGnJOesA2GPU3mTVlZEZDb8cNP7/lvNPTU=
 github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250724013017-bc0f37a0cbad h1:4zaaKmFnDwSmVU30Ns5KgbNuS3V9j0PuuxYbob4yD/0=
 github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250724013017-bc0f37a0cbad/go.mod h1:v+kzPB2Tom8uEIObY5Le0aBpVLtedwNhMsq2U+dovpg=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250825032242-edd551a6350d h1:Cs0kBcDE+5Do4Mf2QoTpNzyukwvWGLrlWmpK7M5CfNE=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250825032242-edd551a6350d/go.mod h1:JjOYv2tMx72fvLpe88KG8cvrlHiI5XKYeZBvdDO3g80=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250825120314-8f0eff883d49 h1:nEnlQzKlLykwfhaUFSNevF8/wWzFDpdS+VpDn/Rora0=
+github.com/pipe-cd/piped-plugin-sdk-go v0.0.0-20250825120314-8f0eff883d49/go.mod h1:JjOYv2tMx72fvLpe88KG8cvrlHiI5XKYeZBvdDO3g80=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/plugin.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	_ sdk.LivestatePlugin[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig, kubeconfig.KubernetesApplicationSpec] = (*Plugin)(nil)
-	_ sdk.Initializer[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig]                                           = (*Plugin)(nil)
+	_ sdk.LivestatePlugin[kubeconfig.KubernetesPluginConfig, kubeconfig.KubernetesDeployTargetConfig, kubeconfig.KubernetesApplicationSpec] = (*Plugin)(nil)
+	_ sdk.Initializer[kubeconfig.KubernetesPluginConfig, kubeconfig.KubernetesDeployTargetConfig]                                           = (*Plugin)(nil)
 )
 
 type Plugin struct {
@@ -43,7 +43,7 @@ type Plugin struct {
 }
 
 // Initialize implements sdk.Initializer.
-func (p *Plugin) Initialize(ctx context.Context, input *sdk.InitializeInput[sdk.ConfigNone, kubeconfig.KubernetesDeployTargetConfig]) error {
+func (p *Plugin) Initialize(ctx context.Context, input *sdk.InitializeInput[kubeconfig.KubernetesPluginConfig, kubeconfig.KubernetesDeployTargetConfig]) error {
 	var err error
 
 	p.initialized.Do(func() {
@@ -57,7 +57,7 @@ func (p *Plugin) Initialize(ctx context.Context, input *sdk.InitializeInput[sdk.
 }
 
 // GetLivestate implements sdk.LivestatePlugin.
-func (p *Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.GetLivestateResponse, error) {
+func (p *Plugin) GetLivestate(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, deployTargets []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec]) (*sdk.GetLivestateResponse, error) {
 	if len(deployTargets) != 1 {
 		return nil, fmt.Errorf("only 1 deploy target is allowed but got %d", len(deployTargets))
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -31,7 +31,7 @@ import (
 
 type initializer struct{}
 
-func (i *initializer) Initialize(ctx context.Context, input *sdk.InitializeInput[sdk.ConfigNone, config.KubernetesDeployTargetConfig]) error {
+func (i *initializer) Initialize(ctx context.Context, input *sdk.InitializeInput[config.KubernetesPluginConfig, config.KubernetesDeployTargetConfig]) error {
 	// Initialize the plugin with the given context and input.
 
 	toolregistry := toolregistry.NewRegistry(input.Client.ToolRegistry())

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -43,6 +43,8 @@ func (i *initializer) Initialize(ctx context.Context, input *sdk.InitializeInput
 
 	helm := provider.NewHelm(helmPath, input.Logger)
 
+	// TODO: Add and update helm chart repository
+
 	// Login to OCI registries
 	for _, registry := range input.Config.ChartRegistries {
 		if !registry.IsOCI() {

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -41,7 +41,7 @@ func (i *initializer) Initialize(ctx context.Context, input *sdk.InitializeInput
 		return err
 	}
 
-	helm := provider.NewHelm("", helmPath, input.Logger)
+	helm := provider.NewHelm(helmPath, input.Logger)
 
 	// Login to OCI registries
 	for _, registry := range input.Config.ChartRegistries {

--- a/pkg/app/pipedv1/plugin/kubernetes/main.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/main.go
@@ -43,10 +43,16 @@ func (i *initializer) Initialize(ctx context.Context, input *sdk.InitializeInput
 
 	helm := provider.NewHelm("", helmPath, input.Logger)
 
-	// TODO: set address, username, password from config
-	if err := helm.LoginToOCIRegistry(ctx, "", "", ""); err != nil {
-		input.Logger.Error("failed to login to helm oci registry", zap.Error(err))
-		return err
+	// Login to OCI registries
+	for _, registry := range input.Config.ChartRegistries {
+		if !registry.IsOCI() {
+			continue
+		}
+
+		if err := helm.LoginToOCIRegistry(ctx, registry.Address, registry.Username, registry.Password); err != nil {
+			input.Logger.Error("failed to login to helm oci registry", zap.String("address", registry.Address), zap.Error(err))
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
@@ -34,14 +34,12 @@ var (
 )
 
 type Helm struct {
-	version  string // TODO: Remove unused field
 	execPath string
 	logger   *zap.Logger
 }
 
-func NewHelm(version, path string, logger *zap.Logger) *Helm {
+func NewHelm(path string, logger *zap.Logger) *Helm {
 	return &Helm{
-		version:  version,
 		execPath: path,
 		logger:   logger,
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
@@ -34,7 +34,7 @@ var (
 )
 
 type Helm struct {
-	version  string
+	version  string // TODO: Remove unused field
 	execPath string
 	logger   *zap.Logger
 }
@@ -45,6 +45,29 @@ func NewHelm(version, path string, logger *zap.Logger) *Helm {
 		execPath: path,
 		logger:   logger,
 	}
+}
+
+func (h *Helm) LoginToOCIRegistry(ctx context.Context, address, username, password string) error {
+	args := []string{
+		"registry",
+		"login",
+		"-u",
+		username,
+		"-p",
+		password,
+		address,
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, h.execPath, args...)
+	cmd.Stderr = &stderr
+
+	h.logger.Info("login to oci registry", zap.String("address", address))
+	if err := cmd.Run(); err != nil {
+		h.logger.Error("failed to login to oci registry", zap.String("address", address), zap.Error(err))
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
 }
 
 func (h *Helm) TemplateLocalChart(ctx context.Context, appName, appDir, namespace, chartPath string, opts *config.InputHelmOptions) (string, error) {

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
@@ -44,7 +44,7 @@ func TestTemplateLocalChart(t *testing.T) {
 	helmPath, err := r.Helm(ctx, "3.16.1")
 	require.NoError(t, err)
 
-	helm := NewHelm("3.16.1", helmPath, zaptest.NewLogger(t))
+	helm := NewHelm(helmPath, zaptest.NewLogger(t))
 	out, err := helm.TemplateLocalChart(ctx, appName, appDir, "", chartPath, nil)
 	require.NoError(t, err)
 
@@ -70,7 +70,7 @@ func TestTemplateLocalChart_WithNamespace(t *testing.T) {
 	helmPath, err := r.Helm(ctx, "3.16.1")
 	require.NoError(t, err)
 
-	helm := NewHelm("3.16.1", helmPath, zaptest.NewLogger(t))
+	helm := NewHelm(helmPath, zaptest.NewLogger(t))
 	out, err := helm.TemplateLocalChart(ctx, appName, appDir, namespace, chartPath, nil)
 	require.NoError(t, err)
 

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/kustomize_test.go
@@ -69,7 +69,7 @@ func TestKustomizeTemplate_WithHelm(t *testing.T) {
 	require.NoError(t, err)
 
 	kustomize := NewKustomize("5.6.0", kustomizePath, zaptest.NewLogger(t))
-	helm := NewHelm("3.17.0", helmPath, zaptest.NewLogger(t))
+	helm := NewHelm(helmPath, zaptest.NewLogger(t))
 	out, err := kustomize.Template(ctx, appName, appDir, map[string]string{
 		"enable-helm": "",
 	}, helm)

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
@@ -171,7 +171,7 @@ func (l *Loader) templateHelmChart(ctx context.Context, input LoaderInput) (stri
 		return "", fmt.Errorf("failed to get helm tool: %w", err)
 	}
 
-	h := NewHelm(input.HelmVersion, helmPath, input.Logger)
+	h := NewHelm(helmPath, input.Logger)
 
 	switch {
 	case input.HelmChart.GitRemote != "":
@@ -196,7 +196,7 @@ func (l *Loader) templateKustomizeManifests(ctx context.Context, input LoaderInp
 		return "", fmt.Errorf("failed to get kustomize tool: %w", err)
 	}
 
-	h := NewHelm(input.HelmVersion, helmPath, input.Logger)
+	h := NewHelm(helmPath, input.Logger)
 
 	k := NewKustomize(input.KustomizeVersion, kustomizePath, input.Logger)
 


### PR DESCRIPTION
**What this PR does**:

Implement the feature to login to the OCI helm registry.

**Why we need it**:

We want to support the feature to use remote helm chart.

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipecd/issues/5764
Follow https://github.com/pipe-cd/pipecd/pull/6158

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
