### PR TITLE
Add setup-go-workspace and teardown-go-workspace commands to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 
 # Go
 /vendor
+go.work
+go.work.sum
 
 # nodejs
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -319,3 +319,20 @@ setup-local-oidc:
 .PHONY: delete-local-oidc
 delete-local-oidc:
 	docker compose -f ./hack/oidc/docker-compose.yml down
+
+# Go workspace commands
+# These commands are used to manage go workspace.
+# It is useful when you want to develop SDK and test it in other modules.
+.PHONY: setup-go-workspace
+setup-go-workspace: MODULES ?= $(shell find . -name go.mod | while read -r dir; do dirname "$$dir"; done | paste -sd, -) # comma separated list of modules. eg: MODULES=.,pkg/plugin/sdk
+setup-go-workspace:
+	@echo "Setting up go workspace..."
+	go work init || true # ignore error if go workspace is already initialized
+	@for module in $(shell echo $(MODULES) | tr ',' ' '); do \
+		echo "Setting up module: $$module"; \
+		go work use $$module; \
+	done
+
+.PHONY: teardown-go-workspace
+teardown-go-workspace:
+	rm -f go.work go.work.sum


### PR DESCRIPTION
**What this PR does**:

This PR adds utility target `setup-go-workspace` and `teadown-go-workspace` to Makefile

**Why we need it**:

When we develop a plugin SDK, sometimes we want to test in the development version before merging it.

**Which issue(s) this PR fixes**:

No issue about this PR

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
