### PR TITLE
Remove helm remote git chart feature from kubernetes plugin

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/helm.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/helm.go
@@ -31,11 +31,6 @@ type InputHelmOptions struct {
 }
 
 type InputHelmChart struct {
-	// Git remote address where the chart is placing.
-	// Empty means the same repository.
-	GitRemote string `json:"gitRemote,omitempty"`
-	// The commit SHA or tag for remote git.
-	Ref string `json:"ref,omitempty"`
 	// Relative path from the repository root directory to the chart directory.
 	Path string `json:"path,omitempty"`
 

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader.go
@@ -16,7 +16,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -174,9 +173,6 @@ func (l *Loader) templateHelmChart(ctx context.Context, input LoaderInput) (stri
 	h := NewHelm(helmPath, input.Logger)
 
 	switch {
-	case input.HelmChart.GitRemote != "":
-		return "", errors.New("not implemented yet")
-
 	case input.HelmChart.Repository != "":
 		return h.TemplateRemoteChart(ctx, input.AppName, input.AppDir, input.Namespace, helmRemoteChart{
 			Repository: input.HelmChart.Repository,

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/loader_test.go
@@ -345,19 +345,6 @@ func TestLoader_templateHelmChart(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "helm chart from git remote",
-			input: LoaderInput{
-				AppName:     "test-app",
-				AppDir:      "testdata/testhelm/appconfdir",
-				Namespace:   "default",
-				HelmVersion: "3.16.1",
-				HelmChart:   &config.InputHelmChart{GitRemote: "https://github.com/test/repo.git"},
-				HelmOptions: &config.InputHelmOptions{},
-				Logger:      zap.NewNop(),
-			},
-			wantErr: true, // it's not implemented yet
-		},
-		{
 			name: "helm chart from repository",
 			input: LoaderInput{
 				AppName:     "test-app",


### PR DESCRIPTION
**What this PR does**:

SSIA

**Why we need it**:

Remove unused config for Helm GitRemoveChart feature. Pipedv0 supports that feature, but since Helm registry is more recommended now, we decided not to bring this feature to the k8s plugin.

**Which issue(s) this PR fixes**:

Follow #6162

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
