### PR TITLE
Handling stage timeout for plugin-arch piped

### DIFF
--- a/pkg/app/pipedv1/controller/planner.go
+++ b/pkg/app/pipedv1/controller/planner.go
@@ -464,11 +464,10 @@ func (p *planner) buildPipelineSyncStages(ctx context.Context, cfg *config.Gener
 		}
 
 		stagesCfgPerPlugin[plg] = append(stagesCfgPerPlugin[plg], &deployment.BuildPipelineSyncStagesRequest_StageConfig{
-			Name:    stageCfg.Name.String(),
-			Desc:    stageCfg.Desc,
-			Timeout: stageCfg.Timeout.Duration().String(),
-			Index:   int32(i),
-			Config:  stageCfg.With,
+			Name:   stageCfg.Name.String(),
+			Desc:   stageCfg.Desc,
+			Index:  int32(i),
+			Config: stageCfg.With,
 		})
 	}
 

--- a/pkg/configv1/application.go
+++ b/pkg/configv1/application.go
@@ -221,7 +221,7 @@ type DeploymentPipeline struct {
 type PipelineStage struct {
 	Name    model.Stage     `json:"name"`
 	Desc    string          `json:"desc,omitempty"`
-	Timeout Duration        `json:"timeout"`
+	Timeout Duration        `json:"timeout" default:"6h"`
 	With    json.RawMessage `json:"with" default:"{}"`
 	SkipOn  SkipOptions     `json:"skipOn,omitempty"`
 }


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

For the new pipedv1, the stage timeout (config via `pipeline.stages[].timeout`) will be handled by piped, not plugins. This configuration will be available for all stages.

Tested on dev with WAIT stage config duration set to 1h, while stage config timeout to 30s

```yaml
apiVersion: pipecd.dev/v1beta1
kind: Application
spec:
  name: timeout-test
  pipeline:
    stages:
      - name: WAIT
        timeout: 30s
        with:
          duration: 1h
```

<img width="1490" height="686" alt="Screenshot 2025-08-27 at 20 15 03" src="https://github.com/user-attachments/assets/4d5f6ebd-5299-4d55-a343-b8fd26735b0a" />


**Which issue(s) this PR fixes**:

Part of #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
