### PR TITLE
Improve `make run/pipecd` execution speed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,60 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+.DS_Store
+
+# Binaries
+.artifacts
+
+# docs
+docs
+
+examples
+
+# Go
+/vendor
+
+# nodejs
+node_modules
+
+# web
+web/node_modules
+web/dist
+web/.env
+web/.cache
+web/coverage
+pkg/app/web/.env
+
+# IDE config files
+.ijwb
+.idea
+
+.dev
+
+# Terraform workspace
+.terraform
+.terraform-credentials
+
+.rendered-manifests
+
+# manfiests
+manifests/*
+
+# gomock generated reflect files
+gomock_reflect_*/
+
+# Cache
+.cache
+
+# hack
+hack/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -47,7 +47,7 @@ pkg/app/web/.env
 
 .rendered-manifests
 
-# manfiests
+# manifests
 manifests/*
 
 # gomock generated reflect files

--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,6 @@ run/pipecd: BUILD_LDFLAGS_PREFIX := -X github.com/pipe-cd/pipecd/pkg/version
 run/pipecd: BUILD_OPTS ?= -ldflags "$(BUILD_LDFLAGS_PREFIX).version=$(BUILD_VERSION) $(BUILD_LDFLAGS_PREFIX).gitCommit=$(BUILD_COMMIT) $(BUILD_LDFLAGS_PREFIX).buildDate=$(BUILD_DATE) -w"
 run/pipecd: CONTROL_PLANE_VALUES ?= ./quickstart/control-plane-values.yaml
 run/pipecd:
-	@echo "Building go binary of Control Plane..."
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(BUILD_ENV) go build $(BUILD_OPTS) -o ./.artifacts/pipecd ./cmd/pipecd
-
-	@echo "Building web static files..."
-	yarn --cwd web build
-
 	@echo "Building docker image and pushing it to local registry..."
 	docker build -f cmd/pipecd/Dockerfile -t localhost:5001/pipecd:$(BUILD_VERSION) .
 	docker push localhost:5001/pipecd:$(BUILD_VERSION)

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -10,7 +10,9 @@ RUN apk add --no-cache make git
 COPY web/package.json web/yarn.lock ./web/
 RUN yarn --cwd web install --prefer-offline
 
-COPY . .
+COPY .git ./.git
+COPY web ./web
+COPY Makefile .
 RUN make build/web
 
 # pipecd builder
@@ -24,7 +26,9 @@ WORKDIR /app
 COPY go.* ./
 RUN go mod download
 
-COPY . ./
+COPY pkg/ ./pkg/
+COPY cmd/ ./cmd/
+COPY Makefile .
 
 RUN make build/go MOD=pipecd BUILD_OS=${TARGETOS} BUILD_ARCH=${TARGETARCH}
 

--- a/cmd/pipecd/Dockerfile
+++ b/cmd/pipecd/Dockerfile
@@ -5,11 +5,12 @@ FROM --platform=$BUILDPLATFORM node:20.19.0-alpine3.21 AS web
 
 WORKDIR /app
 
-COPY . .
-
 RUN apk add --no-cache make git
 
-RUN make update/web-deps
+COPY web/package.json web/yarn.lock ./web/
+RUN yarn --cwd web install --prefer-offline
+
+COPY . .
 RUN make build/web
 
 # pipecd builder


### PR DESCRIPTION
**What this PR does**:

1. Optimize dockerfile:
- COPY only what is necessary for each RUN command:
  - only `web/package.json` and `web/yarn.lock` are necessary for `yarn install`
  - only `.git`, `web/`, `Makefile` are necessary for `make build/web`
  - only `pkg/` and `cmd/` are necessary for `make go/build`

- Add `.dockerignore`: to ignore unnecessary file in Dockerfile COPY. After this change. Because the files to be COPYed already limited so only `web/node_modules` (and some `web/...`) are relevant, but I still keep this file (based on gitignore content + `web/node_modules`, `examples`, `docs`)

2. Remove local build in `make run/pipecd`

**Why we need it**: 🐰 We have much faster `make run/pipecd` execution time during development 🐰 

1. Optimize dockerfile:

- Utilize the docker image layer cache -> speed up build process
  - Before: if any file changes, either in web or go, all the build command: `update/web-deps`, `go mod download`, `build/web`, `build/go` be executed all over again -> this really takes time
  - After: if the dependency files are not changes, then the build command is cached and don't have executed again. For example:

|when to execute `make run/pipecd`|what will happen|
|---|---|
|first time|<img width="596" height="114" alt="Image" src="https://github.com/user-attachments/assets/f4fd141f-3560-44e5-b875-e98c57f08347" />|
|subsequent build when: some web files change|only trigger `build/web`, other builds already cached<br><br><img width="987" height="866" alt="Image" src="https://github.com/user-attachments/assets/a55a7d02-d326-4f3d-96f5-99eee57cb1ac" />|
|subsequent build when:: only go files change|only trigger `build/go`, other builds already cached <img width="991" height="857" alt="Image" src="https://github.com/user-attachments/assets/bd3f2bfc-def8-41cb-8238-d6e514330344" />|

- It also speed up docker build time by not copy unnecessary files `web/node_modules`.

Copy consumed time Before >90 sec|Copy consumed time After: almost ~0 sec
---|---
<img width="1261" height="928" alt="image" src="https://github.com/user-attachments/assets/f41bad3b-493e-4e61-b0b8-29830c066591" />|<img width="992" height="331" alt="image" src="https://github.com/user-attachments/assets/cd27bc8b-3f09-466f-a2df-25a1d99041cd" />

2. Remove local build in `make run/pipecd`

- There is no usage for local build here because the [go build](https://github.com/pipe-cd/pipecd/blob/e7ec5c4fe30ed3acc63fad108d6bde4835939bbe/cmd/pipecd/Dockerfile#L28) and [web build](https://github.com/pipe-cd/pipecd/blob/e7ec5c4fe30ed3acc63fad108d6bde4835939bbe/cmd/pipecd/Dockerfile#L12-L13) already done in Dockerfile.
  - `go build`: execute very fast. We can keep here because it can fail fast if go source is valid or not (for example if we import a package but not use), but I decided to remove it as well because we can use other command to confirm on local like `make build/go`.
  - `web build`: it take around ~13 seconds in my local
    - <img width="738" height="238" alt="image" src="https://github.com/user-attachments/assets/5ae57f6e-0f7d-4c00-952f-4f288b4e4276" />


**Which issue(s) this PR fixes**:

It is one of the approaches improving local development

Fixes #6152 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No 
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
