### PR TITLE
Migrate app config for analysis stage for v1

### DIFF
--- a/pkg/app/pipectl/cmd/migrate/application_config_test.go
+++ b/pkg/app/pipectl/cmd/migrate/application_config_test.go
@@ -334,6 +334,74 @@ func TestApplicationConfig_migrateApplicationConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "KubernetesApp with analysis stage",
+			inputConfig: map[string]interface{}{
+				"kind":       "KubernetesApp",
+				"apiVersion": "pipecd.dev/v1beta1",
+				"spec": map[string]interface{}{
+					"name":        "test-app",
+					"description": "Test application",
+					"labels": map[string]interface{}{
+						"env": "test",
+					},
+					"input": map[string]interface{}{
+						"namespace": "test",
+					},
+					"quickSync": map[string]interface{}{
+						"prune": true,
+					},
+					"service": map[string]interface{}{
+						"name": "test-service",
+					},
+					"pipeline": map[string]interface{}{
+						"stages": []interface{}{
+							map[string]interface{}{
+								"id":   "stage1",
+								"name": "ANALYSIS",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"kind":       "Application",
+				"apiVersion": "pipecd.dev/v1beta1",
+				"spec": map[string]interface{}{
+					"name":        "test-app",
+					"description": "Test application",
+					"labels": map[string]interface{}{
+						"env": "test",
+					},
+					"plugins": map[string]interface{}{
+						"kubernetes": map[string]interface{}{
+							"input": map[string]interface{}{
+								"namespace": "test",
+							},
+							"quickSync": map[string]interface{}{
+								"prune": true,
+							},
+							"service": map[string]interface{}{
+								"name": "test-service",
+							},
+						},
+						"analysis": map[string]interface{}{
+							"appCustomArgs": map[string]interface{}{
+								"k8sNamespace": "test",
+							},
+						},
+					},
+					"pipeline": map[string]interface{}{
+						"stages": []interface{}{
+							map[string]interface{}{
+								"id":   "stage1",
+								"name": "ANALYSIS",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does**:

Implement migration logic for analysis stage config in v0.
For backward capability, we set the value of `spec.input.namespace` for KubenetesApp under `plugins.analysis`.

**Why we need it**:

**Which issue(s) this PR fixes**:

Part of #5542 #6068

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
