### PR TITLE
Update release version list API to support modules release pattern

### DIFF
--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -1953,6 +1953,12 @@ func (a *WebAPI) ListReleasedVersions(ctx context.Context, req *webservice.ListR
 		if *release.Prerelease || *release.Draft {
 			continue
 		}
+		// Ignore module's release.
+		// Eg. pkg/app/pipedv1/plugin/kubernetes/v0.1.0
+		if !semver.IsValid(*release.TagName) {
+			continue
+		}
+
 		versions = append(versions, *release.TagName)
 	}
 


### PR DESCRIPTION
**What this PR does**:

SSIA

**Why we need it**:

The current upgrade piped version via UI feature uses the release versions list API provided by the PipeCD control plane.
From now on, the PipeCD project release will contain not only the PipeCD release version but also the plugin's releases, which requires updating the release versions list API filter logic to keep this feature behavior as expected.

Here is the semver IsValid behavior test I referred to when updating the filter logic
https://go.dev/play/p/qMuj-rlM9Br

**Which issue(s) this PR fixes**:

Related to #4980 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
