### PR TITLE
Enable ssh configration for pipedv1

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -167,7 +167,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	// Register all metrics.
 	registry := registerMetrics(cfg.PipedID, cfg.ProjectID, p.launcherVersion)
 
-	// // Configure SSH config if needed.
+	// Configure SSH config if needed.
 	if cfg.Git.ShouldConfigureSSHConfig() {
 		tempFile, err := git.AddSSHConfig(cfg.Git)
 		if err != nil {

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -169,10 +169,12 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	// // Configure SSH config if needed.
 	if cfg.Git.ShouldConfigureSSHConfig() {
-		if _, err := git.AddSSHConfig(cfg.Git); err != nil {
+		tempFile, err := git.AddSSHConfig(cfg.Git)
+		if err != nil {
 			input.Logger.Error("failed to configure ssh-config", zap.Error(err))
 			return err
 		}
+		defer os.Remove(tempFile)
 		input.Logger.Info("successfully configured ssh-config")
 	}
 

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -168,13 +168,13 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	registry := registerMetrics(cfg.PipedID, cfg.ProjectID, p.launcherVersion)
 
 	// // Configure SSH config if needed.
-	// if cfg.Git.ShouldConfigureSSHConfig() {
-	// 	if err := git.AddSSHConfig(cfg.Git); err != nil {
-	// 		input.Logger.Error("failed to configure ssh-config", zap.Error(err))
-	// 		return err
-	// 	}
-	// 	input.Logger.Info("successfully configured ssh-config")
-	// }
+	if cfg.Git.ShouldConfigureSSHConfig() {
+		if _, err := git.AddSSHConfig(cfg.Git); err != nil {
+			input.Logger.Error("failed to configure ssh-config", zap.Error(err))
+			return err
+		}
+		input.Logger.Info("successfully configured ssh-config")
+	}
 
 	pipedKey, err := cfg.LoadPipedKey()
 	if err != nil {

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
@@ -185,7 +184,91 @@ func (s *PipedSpec) LoadPipedKey() ([]byte, error) {
 	return nil, errors.New("either pipedKeyFile or pipedKeyData must be set")
 }
 
-type PipedGit = config.PipedGit
+type PipedGit struct {
+	// The username that will be configured for `git` user.
+	// Default is "piped".
+	Username string `json:"username,omitempty"`
+	// The email that will be configured for `git` user.
+	// Default is "pipecd.dev@gmail.com".
+	Email string `json:"email,omitempty"`
+	// Where to write ssh config file.
+	// Default is "$HOME/.ssh/config".
+	SSHConfigFilePath string `json:"sshConfigFilePath,omitempty"`
+	// The host name.
+	// e.g. github.com, gitlab.com
+	// Default is "github.com".
+	Host string `json:"host,omitempty"`
+	// The hostname or IP address of the remote git server.
+	// e.g. github.com, gitlab.com
+	// Default is the same value with Host.
+	HostName string `json:"hostName,omitempty"`
+	// The path to the private ssh key file.
+	// This will be used to clone the source code of the specified git repositories.
+	SSHKeyFile string `json:"sshKeyFile,omitempty"`
+	// Base64 encoded string of ssh-key.
+	SSHKeyData string `json:"sshKeyData,omitempty"`
+	// Base64 encoded string of password.
+	// This will be used to clone the source repo with https basic auth.
+	Password string `json:"password,omitempty"`
+}
+
+func (g PipedGit) ShouldConfigureSSHConfig() bool {
+	return g.SSHKeyData != "" || g.SSHKeyFile != ""
+}
+
+func (g PipedGit) LoadSSHKey() ([]byte, error) {
+	if g.SSHKeyData != "" && g.SSHKeyFile != "" {
+		return nil, errors.New("only either sshKeyFile or sshKeyData can be set")
+	}
+	if g.SSHKeyData != "" {
+		return base64.StdEncoding.DecodeString(g.SSHKeyData)
+	}
+	if g.SSHKeyFile != "" {
+		return os.ReadFile(g.SSHKeyFile)
+	}
+	return nil, errors.New("either sshKeyFile or sshKeyData must be set")
+}
+
+func (g *PipedGit) Validate() error {
+	isPassword := g.Password != ""
+	isSSH := g.ShouldConfigureSSHConfig()
+	if isSSH && isPassword {
+		return errors.New("cannot configure both sshKeyData or sshKeyFile and password authentication")
+	}
+	if isSSH && (g.SSHKeyData != "" && g.SSHKeyFile != "") {
+		return errors.New("only either sshKeyFile or sshKeyData can be set")
+	}
+	if isPassword && (g.Username == "" || g.Password == "") {
+		return errors.New("both username and password must be set")
+	}
+	return nil
+}
+
+func (g *PipedGit) Mask() {
+	if len(g.SSHConfigFilePath) != 0 {
+		g.SSHConfigFilePath = maskString
+	}
+	if len(g.SSHKeyFile) != 0 {
+		g.SSHKeyFile = maskString
+	}
+	if len(g.SSHKeyData) != 0 {
+		g.SSHKeyData = maskString
+	}
+	if len(g.Password) != 0 {
+		g.Password = maskString
+	}
+}
+
+func (g *PipedGit) DecodedPassword() (string, error) {
+	if len(g.Password) == 0 {
+		return "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(g.Password)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
 
 type PipedRepository struct {
 	// Unique identifier for this repository.

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
@@ -184,91 +185,7 @@ func (s *PipedSpec) LoadPipedKey() ([]byte, error) {
 	return nil, errors.New("either pipedKeyFile or pipedKeyData must be set")
 }
 
-type PipedGit struct {
-	// The username that will be configured for `git` user.
-	// Default is "piped".
-	Username string `json:"username,omitempty"`
-	// The email that will be configured for `git` user.
-	// Default is "pipecd.dev@gmail.com".
-	Email string `json:"email,omitempty"`
-	// Where to write ssh config file.
-	// Default is "$HOME/.ssh/config".
-	SSHConfigFilePath string `json:"sshConfigFilePath,omitempty"`
-	// The host name.
-	// e.g. github.com, gitlab.com
-	// Default is "github.com".
-	Host string `json:"host,omitempty"`
-	// The hostname or IP address of the remote git server.
-	// e.g. github.com, gitlab.com
-	// Default is the same value with Host.
-	HostName string `json:"hostName,omitempty"`
-	// The path to the private ssh key file.
-	// This will be used to clone the source code of the specified git repositories.
-	SSHKeyFile string `json:"sshKeyFile,omitempty"`
-	// Base64 encoded string of ssh-key.
-	SSHKeyData string `json:"sshKeyData,omitempty"`
-	// Base64 encoded string of password.
-	// This will be used to clone the source repo with https basic auth.
-	Password string `json:"password,omitempty"`
-}
-
-func (g PipedGit) ShouldConfigureSSHConfig() bool {
-	return g.SSHKeyData != "" || g.SSHKeyFile != ""
-}
-
-func (g PipedGit) LoadSSHKey() ([]byte, error) {
-	if g.SSHKeyData != "" && g.SSHKeyFile != "" {
-		return nil, errors.New("only either sshKeyFile or sshKeyData can be set")
-	}
-	if g.SSHKeyData != "" {
-		return base64.StdEncoding.DecodeString(g.SSHKeyData)
-	}
-	if g.SSHKeyFile != "" {
-		return os.ReadFile(g.SSHKeyFile)
-	}
-	return nil, errors.New("either sshKeyFile or sshKeyData must be set")
-}
-
-func (g *PipedGit) Validate() error {
-	isPassword := g.Password != ""
-	isSSH := g.ShouldConfigureSSHConfig()
-	if isSSH && isPassword {
-		return errors.New("cannot configure both sshKeyData or sshKeyFile and password authentication")
-	}
-	if isSSH && (g.SSHKeyData != "" && g.SSHKeyFile != "") {
-		return errors.New("only either sshKeyFile or sshKeyData can be set")
-	}
-	if isPassword && (g.Username == "" || g.Password == "") {
-		return errors.New("both username and password must be set")
-	}
-	return nil
-}
-
-func (g *PipedGit) Mask() {
-	if len(g.SSHConfigFilePath) != 0 {
-		g.SSHConfigFilePath = maskString
-	}
-	if len(g.SSHKeyFile) != 0 {
-		g.SSHKeyFile = maskString
-	}
-	if len(g.SSHKeyData) != 0 {
-		g.SSHKeyData = maskString
-	}
-	if len(g.Password) != 0 {
-		g.Password = maskString
-	}
-}
-
-func (g *PipedGit) DecodedPassword() (string, error) {
-	if len(g.Password) == 0 {
-		return "", nil
-	}
-	decoded, err := base64.StdEncoding.DecodeString(g.Password)
-	if err != nil {
-		return "", err
-	}
-	return string(decoded), nil
-}
+type PipedGit = config.PipedGit
 
 type PipedRepository struct {
 	// Unique identifier for this repository.

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	configv1 "github.com/pipe-cd/pipecd/pkg/configv1"
 )
 
 const (
@@ -48,7 +48,7 @@ type sshConfig struct {
 	IdentityFile string
 }
 
-func AddSSHConfig(cfg config.PipedGit) (string, error) {
+func AddSSHConfig(cfg configv1.PipedGit) (string, error) {
 	cfgPath := cfg.SSHConfigFilePath
 	if cfgPath == "" {
 		home, err := os.UserHomeDir()
@@ -105,7 +105,7 @@ func AddSSHConfig(cfg config.PipedGit) (string, error) {
 	return sshKeyFile.Name(), nil
 }
 
-func generateSSHConfig(cfg config.PipedGit, sshKeyFile string) (string, error) {
+func generateSSHConfig(cfg configv1.PipedGit, sshKeyFile string) (string, error) {
 	var (
 		buffer bytes.Buffer
 		data   = sshConfig{

--- a/pkg/git/ssh_config_test.go
+++ b/pkg/git/ssh_config_test.go
@@ -19,19 +19,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pipe-cd/pipecd/pkg/config"
+	configv1 "github.com/pipe-cd/pipecd/pkg/configv1"
 )
 
 func TestGenerateSSHConfig(t *testing.T) {
 	testcases := []struct {
 		name        string
-		cfg         config.PipedGit
+		cfg         configv1.PipedGit
 		expected    string
 		expectedErr error
 	}{
 		{
 			name: "default",
-			cfg: config.PipedGit{
+			cfg: configv1.PipedGit{
 				SSHKeyFile: "/tmp/piped-secret/ssh-key",
 			},
 			expected: `
@@ -46,7 +46,7 @@ Host github.com
 		},
 		{
 			name: "host is configured",
-			cfg: config.PipedGit{
+			cfg: configv1.PipedGit{
 				Host:       "gitlab.com",
 				SSHKeyFile: "/tmp/piped-secret/ssh-key",
 			},
@@ -62,7 +62,7 @@ Host gitlab.com
 		},
 		{
 			name: "host and hostname are configured",
-			cfg: config.PipedGit{
+			cfg: configv1.PipedGit{
 				Host:       "gitlab.com",
 				HostName:   "gitlab.com",
 				SSHKeyFile: "/tmp/piped-secret/ssh-key",


### PR DESCRIPTION
**What this PR does**:

as title
To realize this, we decided to define a type alias for `configv1.PipedGit` in `pkg/config`.


Currently, it's ok because `configv1.PipedGit` and `config.PipedGit` are the same definition.

```go
// in pkg/config
type PipedGit = configv1.PipedGit
```

⚠️ We need to consider the backward capability for v0 when fixing `configv1.PipedGit`. 
We decided to do it to fix the config easily in the future, and we will support only pipedv1.

**Why we need it**:

The current pipedv1 can't clone git repo with ssh.

**Which issue(s) this PR fixes**:

Part of #5259

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
