### PR TITLE
Fix panic when Lambda manifest has no tags defined

### DIFF
--- a/pkg/app/piped/executor/lambda/lambda.go
+++ b/pkg/app/piped/executor/lambda/lambda.go
@@ -82,6 +82,9 @@ func loadFunctionManifest(in *executor.Input, functionManifestFile string, ds *d
 		return provider.FunctionManifest{}, false
 	}
 
+	if fm.Spec.Tags == nil {
+		fm.Spec.Tags = make(map[string]string)
+	}
 	fm.Spec.Tags[provider.LabelManagedBy] = provider.ManagedByPiped
 	fm.Spec.Tags[provider.LabelPiped] = in.PipedConfig.PipedID
 	fm.Spec.Tags[provider.LabelApplication] = in.Deployment.ApplicationId


### PR DESCRIPTION
**What this PR does**:

Fix panic when deploying Lambda functions with manifests that don't have tags defined in the spec.

**Why we need it**:

According to the [PipeCD documentation](https://pipecd.dev/docs-v0.50.x/user-guide/managing-application/defining-app-configuration/lambda/), the `tags` field is optional in Lambda function manifests ("Except the tags and the environments field, all others are required fields for the deployment to run").
However, the current implementation assumes that the `tags` field always exists, causing a panic with "assignment to entry in nil map" error when it's not defined.

Example manifest that causes the panic:

```yaml
apiVersion: pipecd.dev/v1beta1
kind: LambdaFunction
spec:
  name: example
  role: arn:aws:iam::0000000000:role/example
  image: example
  memory: 256
  timeout: 30
  environments:
    ENV: dev
```


Piped (v0.52.2) error log:

```
panic: assignment to entry in nil map [recovered]                                                                                                                         
    panic: assignment to entry in nil map                                                                                                                                 
                                                                                                                                                                          
goroutine 367730 [running]:                                                                                                                                               
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()                                                                                                      
    /home/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:398 +0x25                                                                                  
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0041a7380, {0x0, 0x0, 0xc00080e180?})                                                                          
    /home/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.28.0/trace/span.go:436 +0xa59                                                                                 
panic({0x24beec0?, 0x417ff90?})                                                                                                                                           
    /opt/hostedtoolcache/go/1.24.1/x64/src/runtime/panic.go:792 +0x132                                                                                                    
github.com/pipe-cd/pipecd/pkg/app/piped/executor/lambda.loadFunctionManifest(_, {_, _}, _)                                                                                
    /home/runner/work/pipecd/pipecd/pkg/app/piped/executor/lambda/lambda.go:85 +0x2c5                                                                                     
github.com/pipe-cd/pipecd/pkg/app/piped/executor/lambda.(*deployExecutor).ensureSync(0xc005ad3600, {0x2ca7548, 0xc006924000})                                             
    /home/runner/work/pipecd/pipecd/pkg/app/piped/executor/lambda/deploy.go:82 +0x7e                                                                                      
github.com/pipe-cd/pipecd/pkg/app/piped/executor/lambda.(*deployExecutor).Execute(0xc005ad3600, {0x2ca8010, 0xc00608da10})                                                
    /home/runner/work/pipecd/pipecd/pkg/app/piped/executor/lambda/deploy.go:68 +0x19e                                                                                     
github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*scheduler).executeStage(0xc0044e0008, {0x2ca8010, 0xc00608da10}, {{{}, {}, {}, 0x0}, 0x0, {0x0, 0x0, ...}, ...}, ...)
    /home/runner/work/pipecd/pipecd/pkg/app/piped/controller/scheduler.go:640 +0x1456                                                                                     
github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*scheduler).Run.func3()                                                                                               
    /home/runner/work/pipecd/pipecd/pkg/app/piped/controller/scheduler.go:350 +0x850                                                                                      
created by github.com/pipe-cd/pipecd/pkg/app/piped/controller.(*scheduler).Run in goroutine 367706                                                                        
    /home/runner/work/pipecd/pipecd/pkg/app/piped/controller/scheduler.go:339 +0x176

```

This prevents successful deployment of Lambda functions that don't explicitly define tags in their manifests, despite tags being an optional field per the specification.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Users can now deploy Lambda functions without explicitly defining the `tags` field in their function manifests. The deployment will no
  longer panic and PipeCD management tags will be properly added.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
