### PR TITLE
Hide field kind in application form v1

### DIFF
--- a/web/src/components/application-form/application-form-v1/index.test.tsx
+++ b/web/src/components/application-form/application-form-v1/index.test.tsx
@@ -5,7 +5,6 @@ import userEvent from "@testing-library/user-event";
 import { dummyApplication } from "~/__fixtures__/dummy-application";
 import { server } from "~/mocks/server";
 import { dummyPiped } from "~/__fixtures__/dummy-piped";
-import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { act } from "react-dom/test-utils";
 import { ApplicationInfo } from "~/types/applications";
 
@@ -95,9 +94,6 @@ describe("ApplicationFormV1", () => {
       );
 
       // check
-      expect(screen.getByRole("textbox", { name: "Kind" })).toHaveValue(
-        APPLICATION_KIND_TEXT[dummyUnregisteredApplication.kind]
-      );
       expect(screen.getByRole("textbox", { name: "Path" })).toHaveValue(
         dummyUnregisteredApplication.path
       );

--- a/web/src/components/application-form/application-form-v1/index.tsx
+++ b/web/src/components/application-form/application-form-v1/index.tsx
@@ -14,7 +14,6 @@ import {
   StepContent,
 } from "@mui/material";
 import { FC, memo, useCallback, useState, useEffect, useMemo } from "react";
-import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { UI_TEXT_CANCEL, UI_TEXT_SAVE } from "~/constants/ui-text";
 import { sortFunc } from "~/utils/common";
 import { Autocomplete } from "@mui/material";
@@ -288,17 +287,6 @@ const ApplicationFormSuggestionV1: FC<Props> = ({
             <StepContent>
               {selectedApp && (
                 <Box>
-                  <TextField
-                    id={"kind"}
-                    label="Kind"
-                    margin="dense"
-                    fullWidth
-                    variant="outlined"
-                    value={APPLICATION_KIND_TEXT[selectedApp.kind]}
-                    slotProps={{
-                      htmlInput: { readOnly: true },
-                    }}
-                  />
                   <GroupTwoCol>
                     <TextField
                       id={"path"}


### PR DESCRIPTION
**What this PR does**:

Hide field `kind` in application form v1

**Why we need it**:

Field kind is deprecated in application using piped v1 so we should hide it in application form

**Which issue(s) this PR fixes**:

Fixes #6218 

**Does this PR introduce a user-facing change?**: no

- **How are users affected by this change**: no
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: no
