### PR TITLE
[planpreview] Fix to avoid nil panic when executing plan preview

### DIFF
--- a/pkg/plugin/api/v1alpha1/client.go
+++ b/pkg/plugin/api/v1alpha1/client.go
@@ -49,10 +49,11 @@ func NewClient(ctx context.Context, name string, address string, opts ...rpcclie
 	}
 
 	return &client{
-		DeploymentServiceClient: deployment.NewDeploymentServiceClient(conn),
-		LivestateServiceClient:  livestate.NewLivestateServiceClient(conn),
-		conn:                    conn,
-		name:                    name,
+		DeploymentServiceClient:  deployment.NewDeploymentServiceClient(conn),
+		LivestateServiceClient:   livestate.NewLivestateServiceClient(conn),
+		PlanPreviewServiceClient: planpreview.NewPlanPreviewServiceClient(conn),
+		conn:                     conn,
+		name:                     name,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:

as title.

Fixed four points
- set the value for named return variable `result`
- abort nil runningDS when execting determineStrategy
- pass runningDS as nil to plugin side
- init PlanPreviewServiceClient

**Why we need it**:

We want to make plan preview work in pipedv1.

**Which issue(s) this PR fixes**:

Follow #6221

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
