### PR TITLE
Rename pipedv1 subcommand from piped to run

### DIFF
--- a/manifests/pipedv1-exp/templates/_helpers.tpl
+++ b/manifests/pipedv1-exp/templates/_helpers.tpl
@@ -166,7 +166,7 @@ A set of args for Launcher.
 A set of args for Piped.
 */}}
 {{- define "piped.pipedArgs" -}}
-- piped
+- run
 - --config-file=/etc/piped-config/{{ .Values.config.fileName }}
 - --metrics={{ .Values.args.metrics }}
 - --log-encoding={{ .Values.args.logEncoding }}

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -117,7 +117,7 @@ func NewCommand() *cobra.Command {
 		maxRecvMsgSize:    1024 * 1024 * 10, // 10MB
 	}
 	cmd := &cobra.Command{
-		Use:   "piped",
+		Use:   "run",
 		Short: "Start running piped.",
 		RunE:  cli.WithContext(p.run),
 	}


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

The PR changes the piped execution command as bellow

old
```bash
Usage:
  piped [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  piped       Start running piped.
  version     Print the information of current binary.
```

new
```bash
Usage:
  piped [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  run         Start running piped.    <-- this was changed
  version     Print the information of current binary.
```

This means the piped running command changes from `piped piped --flags` to `piped run --flags`.

Tested the helm chart using my locally built chart usingthe  following commands

```bash
$ make build/chart MOD=pipedv1-exp VERSION=v1.0.0-rc4
$ helm template pipedv1-exp .artifacts/pipedv1-exp-v1.0.0-rc4.tgz --version=v1.0.0-rc4 --namespace=pipecd --create-namespace --set-file config.data=.dev/in-cluster-pipedv1-config.yaml > .dev/piped-template-OUT.yaml
$ less .dev/piped-template-OUT.yaml
...
    spec:
      serviceAccountName: pipedv1-exp
      containers:
        - name: piped
          imagePullPolicy: IfNotPresent
          image: "ghcr.io/pipe-cd/pipedv1-exp:v1.0.0-rc4"
          args:
            - run
            - --config-file=/etc/piped-config/piped-config.yaml
            - --metrics=true
            - --log-encoding=humanize
            - --log-level=info
            - --add-login-user-to-passwd=false
            - --insecure=false
...
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
