### PR TITLE
Update hugo setting for official site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -168,6 +168,10 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
   url = "/docs-dev/"
 
 [[params.versions]]
+  version = "v0.54.x"
+  url = "/docs-v0.54.x/"
+
+[[params.versions]]
   version = "v0.53.x"
   url = "/docs-v0.53.x/"
 

--- a/docs/main.go
+++ b/docs/main.go
@@ -28,7 +28,7 @@ import (
 const dir = "/public"
 
 // Don't update here manually. /hack/gen-release-docs.sh does.
-const latestPath = "/docs-v0.53.x/"
+const latestPath = "/docs-v0.54.x/"
 
 func main() {
 	var (


### PR DESCRIPTION
**What this PR does**:

missed fixes in #6228,  which is the result `make release version=v0.54.0`  

**Why we need it**:

**Which issue(s) this PR fixes**:

Follow #6228

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
