### PR TITLE
Make quickstart local storage volume off by default

### DIFF
--- a/quickstart/control-plane-values.yaml
+++ b/quickstart/control-plane-values.yaml
@@ -2,7 +2,7 @@ quickstart:
   enabled: true
 
 localStorageVolumes:
-  enabled: true
+  enabled: false
 
 config:
   data: |


### PR DESCRIPTION
**What this PR does**:

SSIA

**Why we need it**:

Since the current quickstart localstorage volume config only works well with a prepared kind cluster using `make up/kind-cluster`, it may block other use cases when quickstart is being used with
- a prepared k8s cluster on local that is not Kind (in my case, local use Docker for Mac k8s cluster)
- a prepared k8s cluster that is not local (test with autopilot k8s GKE cluster)

Note: This change only makes the default value for local storage volume config false, which means if the user wants (and prepares a kind cluster using make up/kind-cluster), they can use that by themselves.
For further improvement, we should change to using PV and PVC declarations and make the underlying config suit a generic K8s cluster, not only think about Kind.

ref: https://github.com/pipe-cd/pipecd/pull/6192#discussion_r2351487607

**Which issue(s) this PR fixes**:

Follow PR #6192

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
