### PR TITLE
Update make run pipedv1 reflect command change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ run/piped: LOG_ENCODING ?= humanize
 run/piped: EXPERIMENTAL ?= false
 run/piped:
 ifeq ($(EXPERIMENTAL), true)
-	go run cmd/pipedv1/main.go piped --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE) --log-encoding=$(LOG_ENCODING)
+	go run cmd/pipedv1/main.go run --tools-dir=/tmp/piped-bin --config-file=$(CONFIG_FILE) --insecure=$(INSECURE) --log-encoding=$(LOG_ENCODING)
 else ifeq ($(LAUNCHER),true)
 	go run cmd/launcher/main.go launcher --config-file=$(CONFIG_FILE) --insecure=$(INSECURE) --log-encoding=$(LOG_ENCODING)
 else


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

Fix error command not found on running `make run/piped EXPERIMENTAL=true` (aka. run pipedv1 on local)

**Which issue(s) this PR fixes**:

Follow PR #6227

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
