### PR TITLE
Add stale time for fetching in settings-page

### DIFF
--- a/web/src/components/settings-page/api-key/index.tsx
+++ b/web/src/components/settings-page/api-key/index.tsx
@@ -84,10 +84,9 @@ export const APIKeyPage: FC = memo(function APIKeyPage() {
   );
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
 
-  const { data: keys = [], isLoading: loading } = useGetApiKeys(
-    { enabled: true },
-    { retry: false }
-  );
+  const { data: keys = [], isLoading: loading } = useGetApiKeys({
+    enabled: true,
+  });
   const { addToast } = useToast();
 
   const { mutateAsync: generateApiKey } = useGenerateApiKey();

--- a/web/src/components/settings-page/piped/index.tsx
+++ b/web/src/components/settings-page/piped/index.tsx
@@ -82,7 +82,7 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
 
   const { data: allPipeds } = useGetPipeds(
     { withStatus: true },
-    { refetchInterval: FETCH_INTERVAL }
+    { refetchInterval: FETCH_INTERVAL, retry: false, staleTime: FETCH_INTERVAL }
   );
 
   const { data: releasedVersions = [] } = useGetReleasedVersions({
@@ -91,7 +91,7 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
 
   const { data: breakingChangesNote } = useGetBreakingChanges(
     { projectId: projectDetail?.id ?? "" },
-    { enabled: !!projectDetail?.id, retry: false }
+    { enabled: !!projectDetail?.id }
   );
 
   const pipeds = useMemo(() => {

--- a/web/src/queries/api-keys/use-get-api-keys.tsx
+++ b/web/src/queries/api-keys/use-get-api-keys.tsx
@@ -16,6 +16,12 @@ export const useGetApiKeys = (
       const res = await APIKeysAPI.getAPIKeys({ options });
       return res.keysList;
     },
+    retry: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: 120000, // 2 minutes
+    cacheTime: 300000, // 5 minutes
     ...queryOption,
   });
 };

--- a/web/src/queries/pipeds/use-get-breaking-changes.tsx
+++ b/web/src/queries/pipeds/use-get-breaking-changes.tsx
@@ -17,6 +17,12 @@ export const useGetBreakingChanges = (
       });
       return notes;
     },
+    retry: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: 120000, // 2 minutes
+    cacheTime: 300000, // 5 minutes
     ...queryOption,
   });
 };

--- a/web/src/queries/pipeds/use-get-released-versions.tsx
+++ b/web/src/queries/pipeds/use-get-released-versions.tsx
@@ -14,6 +14,11 @@ export const useGetReleasedVersions = (
       const { versionsList } = await pipedsApi.listReleasedVersions();
       return versionsList;
     },
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: 120000, // 2 minutes
+    cacheTime: 300000, // 5 minutes
     ...queryOption,
   });
 };

--- a/web/src/queries/project/use-get-project.tsx
+++ b/web/src/queries/project/use-get-project.tsx
@@ -71,6 +71,12 @@ export const useGetProject = (
       userGroups: [],
       rbacRoles: [],
     },
+    retry: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: 120000, // 2 minutes
+    cacheTime: 300000, // 5 minutes
     ...queryOption,
   });
 };


### PR DESCRIPTION
**What this PR does**:
- Add staletime to force useQuery hook use cache in stale time

**Why we need it**:
- Reduce fetch when switching tabs fast and repeatedly in setting page

**Which issue(s) this PR fixes**:

Fixes #6246

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
