### PR TITLE
actions-plan-preview: fix Details indent

### DIFF
--- a/tool/actions-plan-preview/planpreview.go
+++ b/tool/actions-plan-preview/planpreview.go
@@ -244,7 +244,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult, title string) str
 			for _, ppr := range app.PluginPlanResults {
 				fmt.Fprintf(&b, "  - %s(%s): %s\n", ppr.PluginName, ppr.DeployTarget, ppr.PlanSummary)
 			}
-			fmt.Fprint(&b, "  Details:\n")
+			fmt.Fprint(&b, "\n  Details:\n")
 			for _, ppr := range app.PluginPlanResults {
 				fmt.Fprintf(&b, "  - %s(%s):\n", ppr.PluginName, ppr.DeployTarget)
 

--- a/tool/actions-plan-preview/testdata/comment-plugin-one-success-app-multiple-plugins.txt
+++ b/tool/actions-plan-preview/testdata/comment-plugin-one-success-app-multiple-plugins.txt
@@ -11,6 +11,7 @@ Sync strategy: PIPELINE
   Summary:
   - kubernetes(dt-1): 2 resources will be added, 1 resource will be deleted and 5 resources will be changed
   - terraform(dt-2): 1 resource will be added, 2 resources will be deleted and 3 resources will be changed
+
   Details:
   - kubernetes(dt-1):
 <details>


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:


`Details` should be in a new line. It's broken now.
<img width="1448" height="1176" alt="image" src="https://github.com/user-attachments/assets/f399487a-b9b2-4bd4-b94d-a66abc4d11b7" />


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
