### PR TITLE
Ensure to cache plugin go mod in plugin release workflow

### DIFF
--- a/.github/workflows/plugin_release.yaml
+++ b/.github/workflows/plugin_release.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+          cache-dependency-path: ${{ inputs.path }}/go.sum
       - name: Determine Plugin Info
         run: echo "PLUGIN_NAME=$(basename ${{ inputs.path }})" >> $GITHUB_ENV
       - name: Build binary artifacts


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

To cache the plugin go mod instead of pipecd go mod

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
