### PR TITLE
[terraform plugin] fix: do not use logPersister in livestate and planpreview

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
@@ -26,12 +26,12 @@ import (
 
 // TODO: add test
 func (p *Plugin) executeApplyStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
+	lp := input.Client.LogPersister()
 	cmd, err := provider.NewTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
 	if err != nil {
+		lp.Errorf("Failed to initialize Terraform command (%v)", err)
 		return sdk.StageStatusFailure
 	}
-
-	lp := input.Client.LogPersister()
 
 	stageConfig := config.TerraformApplyStageOptions{}
 	if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
@@ -26,12 +26,12 @@ import (
 
 // TODO: add test
 func (p *Plugin) executePlanStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
+	lp := input.Client.LogPersister()
 	cmd, err := provider.NewTerraformCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
 	if err != nil {
+		lp.Errorf("Failed to initialize Terraform command (%v)", err)
 		return sdk.StageStatusFailure
 	}
-
-	lp := input.Client.LogPersister()
 
 	stageConfig := config.TerraformPlanStageOptions{}
 	if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
@@ -35,6 +35,7 @@ func (p *Plugin) executeRollbackStage(ctx context.Context, input *sdk.ExecuteSta
 
 	cmd, err := provider.NewTerraformCommand(ctx, input.Client, rds, dts[0])
 	if err != nil {
+		lp.Errorf("Failed to initialize Terraform command (%v)", err)
 		return sdk.StageStatusFailure
 	}
 

--- a/pkg/app/pipedv1/plugin/terraform/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/livestate/plugin.go
@@ -15,6 +15,7 @@
 package livestate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -46,7 +47,8 @@ func (p *Plugin) GetLivestate(ctx context.Context, _ *sdk.ConfigNone, dts []*sdk
 		return nil, err
 	}
 
-	planResult, err := cmd.Plan(ctx, input.Client.LogPersister())
+	buf := &bytes.Buffer{}
+	planResult, err := cmd.Plan(ctx, buf)
 	if err != nil {
 		input.Logger.Error("Failed to execute plan", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
**What this PR does**:

**Why we need it**:

To avoid a nil panic of logpersister.
The client.LogPersister() is nil in livestate and planpreview.


**Note:** 

Client.LogPersister() should not exist in LivestatePlugin and PlanPreviewPlugin since they're not exist there.
To avoid unintended nil panic like this PR, we should have a better way like defining a new client for livestate/planpreview.



**Which issue(s) this PR fixes**:

Related to #5992 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
