### PR TITLE
Get deploy targets by plugin name

### DIFF
--- a/pkg/app/pipedv1/livestatereporter/livestatereporter.go
+++ b/pkg/app/pipedv1/livestatereporter/livestatereporter.go
@@ -229,7 +229,7 @@ func (r *reporter) flush(ctx context.Context, app *model.Application, repo git.R
 			ApplicationId:   app.GetId(),
 			ApplicationName: app.GetName(),
 			DeploySource:    ds.ToPluginDeploySource(),
-			DeployTargets:   app.GetDeployTargets(),
+			DeployTargets:   app.GetDeployTargetsByPluginName(pluginClient.Name()),
 		})
 		if err != nil {
 			st, ok := status.FromError(err)

--- a/pkg/app/pipedv1/planpreview/builder.go
+++ b/pkg/app/pipedv1/planpreview/builder.go
@@ -287,7 +287,7 @@ func (b *builder) buildApp(ctx context.Context, worker int, command string, app 
 			ApplicationId:           app.Id,
 			ApplicationName:         app.Name,
 			PipedId:                 b.pipedCfg.PipedID,
-			DeployTargets:           app.GetDeployTargets(),
+			DeployTargets:           app.GetDeployTargetsByPluginName(plugin.Name()),
 			TargetDeploymentSource:  pluginTargetDS,
 			RunningDeploymentSource: pluginRunningDS,
 		})

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -94,6 +94,15 @@ func (a *Application) GetDeployTargets() []string {
 	return deployTargets
 }
 
+func (a *Application) GetDeployTargetsByPluginName(name string) []string {
+	dts, ok := a.DeployTargetsByPlugin[name]
+	if !ok {
+		return []string{}
+	}
+
+	return dts.GetDeployTargets()
+}
+
 func (a *Application) GetLabelsString() string {
 	labels := make([]string, 0, len(a.Labels))
 	for k, v := range a.Labels {


### PR DESCRIPTION
**What this PR does**:

as ttile

**Why we need it**:

When executing livestate or plan preview from pipedv1 side, the piped send the deploy targets which the plugin does not support.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
