### PR TITLE
[k8s plugin] Implement ignoring istio virtual service on primary rollout stage

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/primary_test.go
@@ -98,6 +98,222 @@ func TestPlugin_executeK8sPrimaryRolloutStage(t *testing.T) {
 	assert.Equal(t, "simple", service.GetName())
 }
 
+func TestPlugin_executeK8sPrimaryRolloutStage_withIstio(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// initialize tool registry
+	testRegistry := toolregistrytest.NewTestToolRegistry(t)
+
+	// read the application config from the example file
+	appCfg := sdk.LoadApplicationConfigForTest[kubeConfigPkg.KubernetesApplicationSpec](t, filepath.Join("testdata", "primary_rollout_istio", "app.pipecd.yaml"), "kubernetes")
+
+	// initialize deploy target config and dynamic client for assertions with envtest
+	dtConfig, dynamicClient := setupTestDeployTargetConfigAndDynamicClient(t)
+
+	// install istio
+	installIstioCRDs(t, dtConfig)
+
+	// execute k8s sync stage
+	{
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_SYNC",
+				StageConfig: []byte(``),
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      filepath.Join("testdata", "primary_rollout_istio"),
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+
+		status := plugin.executeK8sSyncStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// check the existance of deployment, service, virutal service
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		verifyVirtualServiceRouting(t, dynamicClient, "traffic-test-vs", []expectedRoute{
+			{
+				host:   "traffic-test",
+				subset: "primary",
+				weight: 100,
+			},
+		})
+	}
+
+	// execute canary stage
+	{
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_CANARY_ROLLOUT",
+				StageConfig: []byte(`{"replicas": "100%"}`),
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      filepath.Join("testdata", "primary_rollout_istio"),
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+
+		status := plugin.executeK8sCanaryRolloutStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// check the existance of deployment, service, virutal service
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test-canary", metav1.GetOptions{})
+		assert.NoError(t, err)
+		verifyVirtualServiceRouting(t, dynamicClient, "traffic-test-vs", []expectedRoute{
+			{
+				host:   "traffic-test",
+				subset: "primary",
+				weight: 100,
+			},
+		})
+	}
+
+	// execute traffic routing stage
+	{
+		input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+			Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+				StageName:   "K8S_TRAFFIC_ROUTING",
+				StageConfig: []byte(`{"canary": "30%"}`),
+				TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+					ApplicationDirectory:      filepath.Join("testdata", "primary_rollout_istio"),
+					CommitHash:                "0123456789",
+					ApplicationConfig:         appCfg,
+					ApplicationConfigFilename: "app.pipecd.yaml",
+				},
+				Deployment: sdk.Deployment{
+					PipedID:       "piped-id",
+					ApplicationID: "app-id",
+				},
+			},
+			Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+			Logger: zaptest.NewLogger(t),
+		}
+
+		plugin := &Plugin{}
+
+		status := plugin.executeK8sTrafficRoutingStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+			{
+				Name:   "default",
+				Config: *dtConfig,
+			},
+		})
+
+		assert.Equal(t, sdk.StageStatusSuccess, status)
+
+		// check the existance of deployment, service, virutal service
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+		assert.NoError(t, err)
+		_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test-canary", metav1.GetOptions{})
+		assert.NoError(t, err)
+		verifyVirtualServiceRouting(t, dynamicClient, "traffic-test-vs", []expectedRoute{
+			{
+				host:   "traffic-test",
+				subset: "primary",
+				weight: 70,
+			},
+			{
+				host:   "traffic-test",
+				subset: "canary",
+				weight: 30,
+			},
+		})
+	}
+
+	// execute primary stage
+	input := &sdk.ExecuteStageInput[kubeConfigPkg.KubernetesApplicationSpec]{
+		Request: sdk.ExecuteStageRequest[kubeConfigPkg.KubernetesApplicationSpec]{
+			StageName:   "K8S_PRIMARY_ROLLOUT",
+			StageConfig: []byte(`{}`),
+			TargetDeploymentSource: sdk.DeploymentSource[kubeConfigPkg.KubernetesApplicationSpec]{
+				ApplicationDirectory:      filepath.Join("testdata", "primary_rollout_istio"),
+				CommitHash:                "0123456789",
+				ApplicationConfig:         appCfg,
+				ApplicationConfigFilename: "app.pipecd.yaml",
+			},
+			Deployment: sdk.Deployment{
+				PipedID:       "piped-id",
+				ApplicationID: "app-id",
+			},
+		},
+		Client: sdk.NewClient(nil, "kubernetes", "", "", logpersistertest.NewTestLogPersister(t), testRegistry),
+		Logger: zaptest.NewLogger(t),
+	}
+
+	plugin := &Plugin{}
+
+	status := plugin.executeK8sPrimaryRolloutStage(ctx, input, []*sdk.DeployTarget[kubeConfigPkg.KubernetesDeployTargetConfig]{
+		{
+			Name:   "default",
+			Config: *dtConfig,
+		},
+	})
+
+	assert.Equal(t, sdk.StageStatusSuccess, status)
+
+	// check the existance of deployment, service, virutal service
+	_, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}).Namespace("default").Get(ctx, "traffic-test", metav1.GetOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("default").Get(ctx, "traffic-test-canary", metav1.GetOptions{})
+	assert.NoError(t, err)
+	verifyVirtualServiceRouting(t, dynamicClient, "traffic-test-vs", []expectedRoute{
+		{
+			host:   "traffic-test",
+			subset: "primary",
+			weight: 70,
+		},
+		{
+			host:   "traffic-test",
+			subset: "canary",
+			weight: 30,
+		},
+	})
+}
+
 func TestPlugin_executeK8sPrimaryRolloutStage_withPrune(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/app.pipecd.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/app.pipecd.yaml
@@ -1,0 +1,34 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: primary-rollout-istio-test
+  description: Test data for primary rollout using Istio method
+  plugins:
+    kubernetes:
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+          - virtualservice.yaml
+        kubectlVersion: 1.32.2
+      service:
+        name: traffic-test
+      trafficRouting:
+        method: istio
+        istio:
+          editableRoutes: []
+          virtualService:
+            name: traffic-test-vs
+  pipeline:
+    stages:
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          replicas: 100%
+      - name: K8S_TRAFFIC_ROUTING
+        with:
+          canary: 30%
+      - name: K8S_PRIMARY_ROLLOUT
+      - name: K8S_TRAFFIC_ROUTING
+        with:
+          primary: 100%
+      - name: K8S_CANARY_CLEAN 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/deployment.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traffic-test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: traffic-test
+  template:
+    metadata:
+      labels:
+        app: traffic-test
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+      - name: traffic-test
+        image: nginx:1.22
+        ports:
+        - containerPort: 80 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/service.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: traffic-test
+spec:
+  selector:
+    app: traffic-test
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP 

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/virtualservice.yaml
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/testdata/primary_rollout_istio/virtualservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: traffic-test-vs
+spec:
+  hosts:
+  - traffic-test
+  http:
+  - route:
+    - destination:
+        host: traffic-test
+        subset: primary
+      weight: 100 


### PR DESCRIPTION
**What this PR does**:

Implemented the logic to ignore the virtual service from primary manifests.

This logic is implemented on the pipedv0.

https://github.com/pipe-cd/pipecd/blob/e1d78ff2e2c322c8f2b58c37a91fc9b614efdab1/pkg/app/piped/executor/kubernetes/primary.go#L57-L86

**Why we need it**:

**Which issue(s) this PR fixes**:

Part of #5764

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
