### PR TITLE
[terraform plugin] Comment out stage config unmarshaling logic for TERRAFORM_APPLY

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/config/config.go
+++ b/pkg/app/pipedv1/plugin/terraform/config/config.go
@@ -58,10 +58,6 @@ type TerraformPlanStageOptions struct {
 	ExitOnNoChanges bool `json:"exitOnNoChanges"`
 }
 
-// TerraformApplyStageOptions contains all configurable values for a TERRAFORM_APPLY stage.
-type TerraformApplyStageOptions struct {
-}
-
 // TerraformCommandFlags contains all additional flags will be used while executing terraform commands.
 type TerraformCommandFlags struct {
 	Shared []string `json:"shared"`

--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
@@ -32,13 +32,6 @@ func (p *Plugin) executeApplyStage(ctx context.Context, input *sdk.ExecuteStageI
 		return sdk.StageStatusFailure
 	}
 
-	// TODO: use stageConfig if this stage has any options in the future.
-	// stageConfig := config.TerraformApplyStageOptions{}
-	// if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {
-	// 	lp.Errorf("Failed to unmarshal stage config (%v)", err)
-	// 	return sdk.StageStatusFailure
-	// }
-
 	if err = cmd.Apply(ctx, lp); err != nil {
 		lp.Errorf("Failed to apply changes (%v)", err)
 		return sdk.StageStatusFailure

--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply.go
@@ -16,7 +16,6 @@ package deployment
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/provider"
@@ -33,11 +32,12 @@ func (p *Plugin) executeApplyStage(ctx context.Context, input *sdk.ExecuteStageI
 		return sdk.StageStatusFailure
 	}
 
-	stageConfig := config.TerraformApplyStageOptions{}
-	if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {
-		lp.Errorf("Failed to unmarshal stage config (%v)", err)
-		return sdk.StageStatusFailure
-	}
+	// TODO: use stageConfig if this stage has any options in the future.
+	// stageConfig := config.TerraformApplyStageOptions{}
+	// if err := json.Unmarshal(input.Request.StageConfig, &stageConfig); err != nil {
+	// 	lp.Errorf("Failed to unmarshal stage config (%v)", err)
+	// 	return sdk.StageStatusFailure
+	// }
 
 	if err = cmd.Apply(ctx, lp); err != nil {
 		lp.Errorf("Failed to apply changes (%v)", err)


### PR DESCRIPTION
**What this PR does**:

as title

**Why we need it**:

Currently, the `TERRAFORM_APPLY` stage doesn't have any options.
https://github.com/pipe-cd/pipecd/blob/96c15d8ad7499d96f80471a899e1305d8f08bcbd/pkg/app/pipedv1/plugin/terraform/config/config.go#L61-L63


So we don't need the logic for now. Also, it led the failure to execute `TERRAFORM_APPLY` as QuickSync 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
