### PR TITLE
Prevent call api get me in login page

### DIFF
--- a/web/src/contexts/auth-context/auth-provider.tsx
+++ b/web/src/contexts/auth-context/auth-provider.tsx
@@ -2,14 +2,30 @@ import { FC, PropsWithChildren, useEffect, useState } from "react";
 import { AuthContext, AuthContextType } from "./auth-context";
 import { GetMeResponse } from "~~/api_client/service_pb";
 import { useGetMe } from "~/queries/me/use-get-me";
+import { useLocation } from "react-router-dom";
+import {
+  LOGIN_ENDPOINT,
+  LOGOUT_ENDPOINT,
+  PAGE_PATH_LOGIN,
+  STATIC_LOGIN_ENDPOINT,
+} from "~/constants/path";
+
+const PATH_PUBLIC = [
+  PAGE_PATH_LOGIN,
+  STATIC_LOGIN_ENDPOINT,
+  LOGIN_ENDPOINT,
+  LOGOUT_ENDPOINT,
+];
 
 export const AuthProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const path = useLocation();
   const [me, setMe] = useState<
     (GetMeResponse.AsObject & { isLogin: boolean }) | null
   >(null);
 
   const { data, isInitialLoading } = useGetMe({
     retry: false,
+    enabled: !PATH_PUBLIC.includes(path.pathname),
   });
 
   useEffect(() => {


### PR DESCRIPTION
**What this PR does**:
- Prevent hook getMe when user in login page

**Why we need it**:
- When user in login page, hook getMe is trigger => show message Unauthorized. This hook should only trigger when user is logged in. 
<img width="604" height="400" alt="CleanShot 2025-09-22 at 14 21 14@2x" src="https://github.com/user-attachments/assets/54b6e112-cff2-49c1-ae23-ad4a036dabeb" />

**Which issue(s) this PR fixes**:

Fixes #6260

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
