### PR TITLE
Fix lint on SDK

### DIFF
--- a/pkg/plugin/sdk/client.go
+++ b/pkg/plugin/sdk/client.go
@@ -247,7 +247,7 @@ func (c *Client) StageLogPersister() (StageLogPersister, error) {
 // Use this to persist the stage logs and make it viewable on the UI.
 // This method should be called only when the client is working with a specific stage, for example, when this client is passed as the ExecuteStage method's argument.
 // Otherwise, it will return nil.
-// deprecated: use StageLogPersister instead.
+// Deprecated: use StageLogPersister instead.
 func (c *Client) LogPersister() StageLogPersister {
 	return c.stageLogPersister
 }


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

Fix this lint error

```
INFO [runner] linters took 5.01125496s with stages: goanalysis_metalinter: 5.010460126s 
pkg/plugin/sdk/client.go:250:1: deprecatedComment: use `Deprecated: ` (note the casing) instead of `deprecated: ` (gocritic)
// deprecated: use StageLogPersister instead.
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
