### PR TITLE
Set default value for waitapproval plugin config

### DIFF
--- a/pkg/app/pipedv1/plugin/waitapproval/go.mod
+++ b/pkg/app/pipedv1/plugin/waitapproval/go.mod
@@ -3,6 +3,7 @@ module github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/waitapproval
 go 1.25.0
 
 require (
+	github.com/creasty/defaults v1.6.0
 	github.com/pipe-cd/piped-plugin-sdk-go v0.1.0
 	github.com/stretchr/testify v1.10.0
 )
@@ -14,7 +15,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.11.0 // indirect
-	github.com/creasty/defaults v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect

--- a/pkg/app/pipedv1/plugin/waitapproval/options.go
+++ b/pkg/app/pipedv1/plugin/waitapproval/options.go
@@ -17,12 +17,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/creasty/defaults"
 )
 
 // WaitApprovalStageOptions contains configurable values for a WAIT_APPROVAL stage.
 type waitApprovalStageOptions struct {
 	Approvers      []string `json:"approvers,omitempty"`
-	MinApproverNum int      `json:"minApproverNum,omitempty"`
+	MinApproverNum int      `json:"minApproverNum,omitempty" default:"1"`
 }
 
 func (o waitApprovalStageOptions) validate() error {
@@ -40,6 +42,9 @@ func decode(data json.RawMessage) (waitApprovalStageOptions, error) {
 	var opts waitApprovalStageOptions
 	if err := json.Unmarshal(data, &opts); err != nil {
 		return waitApprovalStageOptions{}, fmt.Errorf("failed to unmarshal the config: %w", err)
+	}
+	if err := defaults.Set(&opts); err != nil {
+		return waitApprovalStageOptions{}, fmt.Errorf("failed to set defaults: %w", err)
 	}
 	if err := opts.validate(); err != nil {
 		return waitApprovalStageOptions{}, fmt.Errorf("failed to validate the config: %w", err)

--- a/pkg/app/pipedv1/plugin/waitapproval/options_test.go
+++ b/pkg/app/pipedv1/plugin/waitapproval/options_test.go
@@ -39,6 +39,15 @@ func TestDecode(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid config with default minApproverNum",
+			data: json.RawMessage(`{"approvers":["user1@example.com","user2@example.com"]}`),
+			expected: waitApprovalStageOptions{
+				Approvers:      []string{"user1@example.com", "user2@example.com"},
+				MinApproverNum: 1,
+			},
+			wantErr: false,
+		},
+		{
 			name:     "invalid config",
 			data:     json.RawMessage(`invalid`),
 			expected: waitApprovalStageOptions{},


### PR DESCRIPTION
**What this PR does**:

ssia

**Why we need it**:

pipedv0 wait approval stage config has `minApproversNum` default value set to 1, so we should keep the same behavior for waitapproval plugin

ref: https://pipecd.dev/docs-v0.54.x/user-guide/configuration-reference/#waitapprovalstageoptions

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
