### PR TITLE
fix prevent login path can access when already logged in

### DIFF
--- a/web/src/contexts/auth-context/auth-provider.tsx
+++ b/web/src/contexts/auth-context/auth-provider.tsx
@@ -3,19 +3,7 @@ import { AuthContext, AuthContextType } from "./auth-context";
 import { GetMeResponse } from "~~/api_client/service_pb";
 import { useGetMe } from "~/queries/me/use-get-me";
 import { useLocation } from "react-router-dom";
-import {
-  LOGIN_ENDPOINT,
-  LOGOUT_ENDPOINT,
-  PAGE_PATH_LOGIN,
-  STATIC_LOGIN_ENDPOINT,
-} from "~/constants/path";
-
-const PATH_PUBLIC = [
-  PAGE_PATH_LOGIN,
-  STATIC_LOGIN_ENDPOINT,
-  LOGIN_ENDPOINT,
-  LOGOUT_ENDPOINT,
-];
+import { PAGE_PATH_LOGIN } from "~/constants/path";
 
 export const AuthProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const path = useLocation();
@@ -25,7 +13,7 @@ export const AuthProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
 
   const { data, isInitialLoading } = useGetMe({
     retry: false,
-    enabled: !PATH_PUBLIC.includes(path.pathname),
+    meta: { preventGlobalError: path.pathname === PAGE_PATH_LOGIN },
   });
 
   useEffect(() => {

--- a/web/src/contexts/query-client-provider.tsx
+++ b/web/src/contexts/query-client-provider.tsx
@@ -33,16 +33,36 @@ const QueryClientWrap: FC<PropsWithChildren<unknown>> = ({ children }) => {
     [addToast]
   );
 
+  const handleQueryError = useCallback(
+    (err: unknown, query): void => {
+      if (query.meta && query.meta.preventGlobalError) {
+        return;
+      }
+      handleError(err);
+    },
+    [handleError]
+  );
+
+  const handleMutationError = useCallback(
+    (err: unknown, _variables, _context, mutation) => {
+      if (mutation.meta && mutation.meta.preventGlobalError) {
+        return;
+      }
+      handleError(err);
+    },
+    [handleError]
+  );
+
   const queryClient = useMemo(() => {
     return new QueryClient({
       queryCache: new QueryCache({
-        onError: handleError,
+        onError: handleQueryError,
       }),
       mutationCache: new MutationCache({
-        onError: handleError,
+        onError: handleMutationError,
       }),
     });
-  }, [handleError]);
+  }, [handleMutationError, handleQueryError]);
   return (
     <QueryClientProvider client={queryClient}>
       {children}


### PR DESCRIPTION
**What this PR does**:

- Trigger getMe Api in login page and prevent throw error message Unauthorized in login page.

**Why we need it**:

- when logged in , user still can navigate to login page by type /login in url address. Therefore, 
   - api getMe should be call in /login page to check token valid and redirect to "/"
   - should not show error message when api req failed.

**Which issue(s) this PR fixes**:

Partof #6260
Update PR #6261 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
