### PR TITLE
Change z-index btn menu of application detail

### DIFF
--- a/web/src/components/application-detail-page/index.tsx
+++ b/web/src/components/application-detail-page/index.tsx
@@ -114,6 +114,7 @@ export const ApplicationDetailPage: FC = memo(function ApplicationDetailPage() {
           "&:hover": {
             backgroundColor: "grey",
           },
+          zIndex: 10,
         }}
         size="large"
       >


### PR DESCRIPTION
**What this PR does**:

- Change z-index of button Open menu in application detail page.

**Why we need it**:

- Button Open menu of application detail page is behind nodes graph. It should have higher z-index.

<img width="944" height="536" alt="CleanShot 2025-10-02 at 15 38 30" src="https://github.com/user-attachments/assets/a3321ff9-cebb-4191-bbbd-deaf851164de" />


**Which issue(s) this PR fixes**: 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: No
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: No
