### PR TITLE
fix: prevent nil pointer dereference in eventwatcher re-clone

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -198,12 +198,14 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 				w.logger.Info("Try to re-clone because it's more likely to be unable to pull the next time too",
 					zap.String("repo-id", repoCfg.RepoID),
 				)
-				repo, err = w.cloneRepo(ctx, repoCfg)
+				newRepo, err := w.cloneRepo(ctx, repoCfg)
 				if err != nil {
 					w.logger.Error("failed to re-clone repository",
 						zap.String("repo-id", repoCfg.RepoID),
 						zap.Error(err),
 					)
+				} else {
+					repo = newRepo
 				}
 				continue
 			}

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -194,12 +194,14 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 				w.logger.Info("Try to re-clone because it's more likely to be unable to pull the next time too",
 					zap.String("repo-id", repoCfg.RepoID),
 				)
-				repo, err = w.cloneRepo(ctx, repoCfg)
+				newRepo, err := w.cloneRepo(ctx, repoCfg)
 				if err != nil {
 					w.logger.Error("failed to re-clone repository",
 						zap.String("repo-id", repoCfg.RepoID),
 						zap.Error(err),
 					)
+				} else {
+					repo = newRepo
 				}
 				continue
 			}


### PR DESCRIPTION
**What this PR does**:

Fix nil pointer dereference in event watcher when repository re-clone fails.

**Why we need it**:

During the GitHub service disruption on 2025-11-18 (https://www.githubstatus.com/incidents/5q7nmlxz30sk), piped crashed with a nil pointer panic:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x20cc9fc]

  goroutine 1769 [running]:
    github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher.(*watcher).run(
      0xc0003f2000,
      {0x2ca7548, 0xc00070a640},
      {0x2cb7570, 0xc005c93b00},
      {{0xc000058738, 0x13}, {0xc0000574d0, 0x2c}, {0xc0004f726a, ...}},
    )
      /home/runner/work/pipecd/pipecd/pkg/app/piped/eventwatcher/eventwatcher.go:185 +0x41c
  created by github.com/pipe-cd/pipecd/pkg/app/piped/eventwatcher.(*watcher).Run in goroutine 112
      /home/runner/work/pipecd/pipecd/pkg/app/piped/eventwatcher/eventwatcher.go:145 +0x2ea
```

When `repo.Pull()` fails, the event watcher tries to re-clone the repository. However, the original code had a bug:
```
repo, err = w.cloneRepo(ctx, repoCfg)  // repo becomes nil if this fails
if err != nil {
    w.logger.Error("failed to re-clone repository", ...)
    // continues with repo == nil, causing panic on next iteration
}
```

This fix ensures the repo variable is only updated when re-cloning succeeds:
```
newRepo, err := w.cloneRepo(ctx, repoCfg)
if err != nil {
    w.logger.Error("failed to re-clone repository", ...)
} else {
    repo = newRepo  // Only update on success
}
```

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
Piped no longer crashes during git service disruptions. The event watcher continues retrying instead of panicking.

- **Is this breaking change**:
No
