### PR TITLE
Revert "Support ECS capacity provider strategy"

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/client.go
+++ b/pkg/app/piped/platformprovider/ecs/client.go
@@ -87,9 +87,6 @@ func (c *client) CreateService(ctx context.Context, service types.Service) (*typ
 	if service.DeploymentController == nil || service.DeploymentController.Type != types.DeploymentControllerTypeExternal {
 		return nil, fmt.Errorf("failed to create ECS service %s: deployment controller of type EXTERNAL is required", *service.ServiceName)
 	}
-	if service.LaunchType != "" && service.CapacityProviderStrategy != nil {
-		return nil, fmt.Errorf("failed to create ECS service %s: launch type and capacity provider strategy cannot be specified together", *service.ServiceName)
-	}
 	input := &ecs.CreateServiceInput{
 		Cluster:                       service.ClusterArn,
 		ServiceName:                   service.ServiceName,
@@ -106,12 +103,6 @@ func (c *client) CreateService(ctx context.Context, service types.Service) (*typ
 		Role:                          service.RoleArn,
 		SchedulingStrategy:            service.SchedulingStrategy,
 		Tags:                          service.Tags,
-	}
-	if service.LaunchType != "" {
-		input.LaunchType = service.LaunchType
-	}
-	if service.CapacityProviderStrategy != nil {
-		input.CapacityProviderStrategy = service.CapacityProviderStrategy
 	}
 	output, err := c.ecsClient.CreateService(ctx, input)
 	if err != nil {
@@ -145,9 +136,6 @@ func (c *client) PruneServiceTasks(ctx context.Context, service types.Service) e
 }
 
 func (c *client) UpdateService(ctx context.Context, service types.Service) (*types.Service, error) {
-	if service.LaunchType != "" && service.CapacityProviderStrategy != nil {
-		return nil, fmt.Errorf("failed to update ECS service %s: launch type and capacity provider strategy cannot be specified together", *service.ServiceName)
-	}
 	input := &ecs.UpdateServiceInput{
 		Cluster:              service.ClusterArn,
 		Service:              service.ServiceName,
@@ -162,10 +150,6 @@ func (c *client) UpdateService(ctx context.Context, service types.Service) (*typ
 	// If desiredCount is 0 or not set, keep current desiredCount because a user might use AutoScaling.
 	if service.DesiredCount != 0 {
 		input.DesiredCount = aws.Int32(service.DesiredCount)
-	}
-
-	if service.CapacityProviderStrategy != nil {
-		input.CapacityProviderStrategy = service.CapacityProviderStrategy
 	}
 
 	output, err := c.ecsClient.UpdateService(ctx, input)
@@ -257,9 +241,6 @@ func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskD
 	if taskDefinition.TaskDefinitionArn == nil {
 		return nil, fmt.Errorf("failed to create task set of task family %s: no task definition provided", *taskDefinition.Family)
 	}
-	if service.LaunchType != "" && service.CapacityProviderStrategy != nil {
-		return nil, fmt.Errorf("failed to create task set of task family %s: launch type and capacity provider strategy cannot be specified together", *taskDefinition.Family)
-	}
 
 	input := &ecs.CreateTaskSetInput{
 		Cluster:        service.ClusterArn,
@@ -270,18 +251,12 @@ func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskD
 		// If you specify the awsvpc network mode, the task is allocated an elastic network interface,
 		// and you must specify a NetworkConfiguration when run a task with the task definition.
 		NetworkConfiguration: service.NetworkConfiguration,
+		LaunchType:           service.LaunchType,
 		ServiceRegistries:    service.ServiceRegistries,
-	}
-	if service.LaunchType != "" {
-		input.LaunchType = service.LaunchType
-	}
-	if service.CapacityProviderStrategy != nil {
-		input.CapacityProviderStrategy = service.CapacityProviderStrategy
 	}
 	if targetGroup != nil {
 		input.LoadBalancers = []types.LoadBalancer{*targetGroup}
 	}
-
 	output, err := c.ecsClient.CreateTaskSet(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ECS task set %s: %w", *taskDefinition.TaskDefinitionArn, err)


### PR DESCRIPTION
Reverts pipe-cd/pipecd#6331

### Background

Follow PR #6384. We need to find an alternative way to support the capacity provider strategy, as enabling the ECS API to force the creation of a new deployment is necessary to make it happen.


> InvalidParameterException: When switching from launch type to capacity provider strategy on an existing service, or making a change to a capacity provider strategy on a service that is already using one, you must force a new deployment.
