### PR TITLE
fix: upgrade MinIO image to resolve crash on Apple Silicon (M3)

### DIFF
--- a/quickstart/manifests/control-plane.yaml
+++ b/quickstart/manifests/control-plane.yaml
@@ -793,7 +793,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio:RELEASE.2020-08-26T00-00-49Z
+          image: minio/minio:RELEASE.2024-11-07T00-52-20Z
           args:
           - server
           - /data
@@ -812,3 +812,4 @@ spec:
             - name: minio
               containerPort: 9000
               protocol: TCP
+              


### PR DESCRIPTION
Resolves #6380

**What this PR does / why we need it**:
The previous MinIO image tag (`RELEASE.2020...`) was outdated and lacked proper multi-arch support, causing crashes on ARM64 devices (like Mac M3) during local setup.

This PR updates the image to `RELEASE.2024-11-07T00-52-20Z`. This is a recent stable release that explicitly supports both `linux/amd64` and `linux/arm64`.

**Which issue(s) this PR fixes**:
Fixes #6380

**Special notes for your reviewer**:
Verified locally on Linux (AMD64) to ensure no regressions. The MinIO pod started successfully (`Running` status) with the new image.