### PR TITLE
Fix typo: enviroment → environment

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/custom-sync.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/custom-sync.md
@@ -43,7 +43,7 @@ spec:
 Note:
 1. You can use `CUSTOM_SYNC` with any current supporting application kind, but keep `alwaysUsePipeline` true to not run the application kind's default `QUICK_SYNC`.
 2. Only one `CUSTOM_SYNC` stage should be used in an application pipeline.
-3. The commands run with the enviroment variable `PATH` that refers `~/.piped/tools` at first.
+3. The commands run with the environment variable `PATH` that refers `~/.piped/tools` at first.
 
 The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX command available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). If you want to use your commands (`sam` in the above example), you can:
 

--- a/docs/content/en/docs-v0.55.x/user-guide/managing-application/customizing-deployment/custom-sync.md
+++ b/docs/content/en/docs-v0.55.x/user-guide/managing-application/customizing-deployment/custom-sync.md
@@ -43,7 +43,7 @@ spec:
 Note:
 1. You can use `CUSTOM_SYNC` with any current supporting application kind, but keep `alwaysUsePipeline` true to not run the application kind's default `QUICK_SYNC`.
 2. Only one `CUSTOM_SYNC` stage should be used in an application pipeline.
-3. The commands run with the enviroment variable `PATH` that refers `~/.piped/tools` at first.
+3. The commands run with the environment variable `PATH` that refers `~/.piped/tools` at first.
 
 The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX command available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). If you want to use your commands (`sam` in the above example), you can:
 


### PR DESCRIPTION
## Summary
Fixes a spelling typo (“enviroment” → “environment”) in Custom Sync documentation.

## Changes
- Corrected the typo in `docs-dev` and the latest released docs (`docs-v0.55.x`)

**Does this PR introduce a user-facing change?**:
- No