### PR TITLE
docs: add 'Contributing to plugins' guide

### DIFF
--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins.md
@@ -1,9 +1,9 @@
 ---
-title: "Contributing to plugins"
-linkTitle: "Contributing to plugins"
+title: "Contribute to PipeCD plugins"
+linkTitle: "Contribute to PipeCD plugins"
 weight: 4
 description: >
-  This page describes how to contribute plugins for piped.
+  Learn how to create PipeCD plugins.
 ---
 
 PipeCD's plugin architecture allows anyone to extend piped's capabilities by creating custom plugins. This guide explains how to develop and contribute plugins.


### PR DESCRIPTION
- Add contributing-plugins.md with plugin architecture overview and development guidelines
- Apply changes to docs-dev and docs-v1.0.x
- Addresses #6124