### PR TITLE
ADD userguide/managingApp/rolling-back-a-deployment

### DIFF
--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/rolling-back-a-deployment.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/rolling-back-a-deployment.md
@@ -30,7 +30,7 @@ If a rollback is triggered, PipeCD adds a new `ROLLBACK` stage to the deployment
 
 ## Manual rollback
 
-If you need to roll back a deployment that has already completed, or want to intervene during a deployment which is in-progress, you can trigger a rollback manually from the Web UI by clicking the `Cancel with Rollback` button.
+If you need to roll back a deployment that has already completed, or want to intervene during a deployment which is in-progress, you can trigger a rollback manually from the Web UI. See [cancelling a deployment](./cancelling-a-deployment/) for details on how to cancel a deployment with rollback.
 
 ![Screenshot of rolling back a deployment](/images/rolled-back-deployment.png)
 <p style="text-align: center;">


### PR DESCRIPTION
**What this PR does**:

File by file commit from the bigger PR - https://github.com/pipe-cd/pipecd/pull/6345

Adds the “Rolling back a deployment” page under User Guide → Managing Application.

Related to https://github.com/pipe-cd/pipecd/issues/6395

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
