### PR TITLE
ADD userguide/managingApp/secret-management

### DIFF
--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/secret-management.md
@@ -103,24 +103,12 @@ data:
   password: "{{ .encryptedSecrets.password }}"
 ```
 
-- Configuring an ENV variable of a Lambda function to use an encrypted secret
-
-``` yaml
-apiVersion: pipecd.dev/v1beta1
-kind: LambdaFunction
-spec:
-  name: HelloFunction
-  environments:
-    KEY: "{{ .encryptedSecrets.key }}"
-```
-
 In all cases, `piped` decrypts the encrypted secrets and renders the decryption target files before using them to handle any deployment tasks.
 
 <!-- ## Examples
 
 - [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/kubernetes/secret-management)
 - [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/cloudrun/secret-management)
-- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/lambda/secret-management)
 - [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management)
 - [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/ecs/secret-management) -->
 


### PR DESCRIPTION
**What this PR does**:

File by file commit from the bigger PR - https://github.com/pipe-cd/pipecd/pull/6345

Adds the “Secret management” page under User Guide → Managing Application.

Related to https://github.com/pipe-cd/pipecd/issues/6395

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
