### PR TITLE
Auto-assign PR author on pull request creation

### DIFF
--- a/.github/workflows/auto-assign-pr.yaml
+++ b/.github/workflows/auto-assign-pr.yaml
@@ -1,0 +1,26 @@
+name: Auto-assign PR author
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assign PR author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              assignees: [prAuthor],
+            });


### PR DESCRIPTION
**What this PR does**:
Added .github/workflows/auto-assign-pr.yaml workflow that automatically assigns the PR author when a pull request is opened. 

**Why we need it**:
Improves PR tracking by ensuring the author is assigned from the start, making it easier to identify PR owners and manage reviews.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**: None
- **How are users affected by this change**:
- **Is this breaking change**: None
- **How to migrate (if breaking change)**: None
