### PR TITLE
added duplciate-check:

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -142,6 +142,42 @@
     ]
   },
   {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "GitPath.Repo.Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "GitPath.Path",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "GitPath.ConfigFilename",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
     "collectionGroup": "Command",
     "queryScope": "COLLECTION",
     "fields": [

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -166,6 +166,42 @@ func TestParseIndexes(t *testing.T) {
 			},
 		},
 		{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "GitPath.Repo.Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "GitPath.Path",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "GitPath.ConfigFilename",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
 			CollectionGroup: "Command",
 			QueryScope:      "COLLECTION",
 			Fields: []field{

--- a/pkg/app/server/grpcapi/api_test.go
+++ b/pkg/app/server/grpcapi/api_test.go
@@ -21,9 +21,190 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
+	"github.com/pipe-cd/pipecd/pkg/datastore"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+type mockPipedStore struct {
+	apiPipedStore
+	getFunc func(ctx context.Context, id string) (*model.Piped, error)
+}
+
+func (m *mockPipedStore) Get(ctx context.Context, id string) (*model.Piped, error) {
+	return m.getFunc(ctx, id)
+}
+
+type mockApplicationStore struct {
+	apiApplicationStore
+	listFunc func(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error)
+	addFunc  func(ctx context.Context, app *model.Application) error
+}
+
+func (m *mockApplicationStore) List(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error) {
+	return m.listFunc(ctx, opts)
+}
+
+func (m *mockApplicationStore) Add(ctx context.Context, app *model.Application) error {
+	return m.addFunc(ctx, app)
+}
+
+func TestAddApplication(t *testing.T) {
+	testcases := []struct {
+		name         string
+		req          *apiservice.AddApplicationRequest
+		piped        *model.Piped
+		existingApps []*model.Application
+		expectErr    bool
+		expectedCode codes.Code
+	}{
+		{
+			name: "ok: no duplicates",
+			req: &apiservice.AddApplicationRequest{
+				Name:    "app-1",
+				PipedId: "piped-1",
+				GitPath: &model.ApplicationGitPath{
+					Repo:           &model.ApplicationGitRepository{Id: "repo-1"},
+					Path:           "path-1",
+					ConfigFilename: "app.yaml",
+				},
+				Kind:             model.ApplicationKind_KUBERNETES,
+				PlatformProvider: "provider-1",
+			},
+			piped: &model.Piped{
+				Id:        "piped-1",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-1",
+						Remote: "https://github.com/org/repo",
+						Branch: "master",
+					},
+				},
+			},
+			existingApps: []*model.Application{},
+			expectErr:    false,
+		},
+		{
+			name: "error: duplicate found",
+			req: &apiservice.AddApplicationRequest{
+				Name:    "app-1",
+				PipedId: "piped-1",
+				GitPath: &model.ApplicationGitPath{
+					Repo:           &model.ApplicationGitRepository{Id: "repo-1"},
+					Path:           "path-1",
+					ConfigFilename: "app.yaml",
+				},
+				Kind:             model.ApplicationKind_KUBERNETES,
+				PlatformProvider: "provider-1",
+			},
+			piped: &model.Piped{
+				Id:        "piped-1",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-1",
+						Remote: "https://github.com/org/repo",
+						Branch: "master",
+					},
+				},
+			},
+			existingApps: []*model.Application{
+				{
+					Id:      "existing-1",
+					Name:    "app-1",
+					PipedId: "piped-1",
+					GitPath: &model.ApplicationGitPath{
+						Repo:           &model.ApplicationGitRepository{Id: "repo-1"},
+						Path:           "path-1",
+						ConfigFilename: "app.yaml",
+					},
+				},
+			},
+			expectErr:    true,
+			expectedCode: codes.AlreadyExists,
+		},
+		{
+			name: "ok: same name different path",
+			req: &apiservice.AddApplicationRequest{
+				Name:    "app-1",
+				PipedId: "piped-1",
+				GitPath: &model.ApplicationGitPath{
+					Repo:           &model.ApplicationGitRepository{Id: "repo-1"},
+					Path:           "path-2",
+					ConfigFilename: "app.yaml",
+				},
+				Kind:             model.ApplicationKind_KUBERNETES,
+				PlatformProvider: "provider-1",
+			},
+			piped: &model.Piped{
+				Id:        "piped-1",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-1",
+						Remote: "https://github.com/org/repo",
+						Branch: "master",
+					},
+				},
+			},
+			existingApps: []*model.Application{},
+			expectErr:    false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := &mockPipedStore{
+				getFunc: func(ctx context.Context, id string) (*model.Piped, error) {
+					return tc.piped, nil
+				},
+			}
+			as := &mockApplicationStore{
+				listFunc: func(ctx context.Context, opts datastore.ListOptions) ([]*model.Application, string, error) {
+					// Verify filters
+					filters := make(map[string]interface{})
+					for _, f := range opts.Filters {
+						filters[f.Field] = f.Value
+					}
+					assert.Equal(t, "project-1", filters["ProjectId"])
+					assert.Equal(t, tc.req.GitPath.Repo.Id, filters["GitPath.Repo.Id"])
+					assert.Equal(t, tc.req.GitPath.Path, filters["GitPath.Path"])
+					assert.Equal(t, tc.req.GitPath.ConfigFilename, filters["GitPath.ConfigFilename"])
+
+					return tc.existingApps, "", nil
+				},
+				addFunc: func(ctx context.Context, app *model.Application) error {
+					return nil
+				},
+			}
+
+			api := &API{
+				pipedStore:       ps,
+				applicationStore: as,
+				logger:           zap.NewNop(),
+			}
+
+			ctx := rpcauth.ContextWithAPIKey(context.Background(), &model.APIKey{
+				ProjectId: "project-1",
+				Role:      model.APIKey_READ_WRITE,
+			})
+
+			_, err := api.AddApplication(ctx, tc.req)
+			if tc.expectErr {
+				assert.Error(t, err)
+				s, ok := status.FromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expectedCode, s.Code())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestRequireAPIKey(t *testing.T) {
 	testcases := []struct {

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -24,6 +24,10 @@ CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, U
 ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX application_piped_id_updated_at_desc ON Application (PipedId, UpdatedAt DESC);
 
+-- index on `GitPath.Repo.Id` ASC, `GitPath.Path` ASC, `GitPath.ConfigFilename` ASC and `UpdatedAt` DESC
+ALTER TABLE Application ADD COLUMN GitPath_Repo_Id VARCHAR(50) GENERATED ALWAYS AS (IFNULL(data->>"$.git_path.repo.id", "")) VIRTUAL NOT NULL, ADD COLUMN GitPath_Path VARCHAR(255) GENERATED ALWAYS AS (IFNULL(data->>"$.git_path.path", "")) VIRTUAL NOT NULL, ADD COLUMN GitPath_ConfigFilename VARCHAR(50) GENERATED ALWAYS AS (IFNULL(data->>"$.git_path.config_filename", "")) VIRTUAL NOT NULL;
+CREATE INDEX application_gitpath_unique_check ON Application (ProjectId, GitPath_Repo_Id, GitPath_Path, GitPath_ConfigFilename, UpdatedAt DESC);
+
 -- TODO: Should remove this statement after few releases.
 DROP INDEX application_piped_id ON Application;
 

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -193,8 +193,14 @@ func refineOrdersField(orders []datastore.Order) []datastore.Order {
 		switch order.Field {
 		case "SyncState.Status":
 			order.Field = "SyncState_Status"
+		case "GitPath.Repo.Id":
+			order.Field = "GitPath_Repo_Id"
+		case "GitPath.Path":
+			order.Field = "GitPath_Path"
+		case "GitPath.ConfigFilename":
+			order.Field = "GitPath_ConfigFilename"
 		default:
-			break
+
 		}
 		out[i] = order
 	}
@@ -207,8 +213,14 @@ func refineFiltersField(filters []datastore.ListFilter) []datastore.ListFilter {
 		switch filter.Field {
 		case "SyncState.Status":
 			filter.Field = "SyncState_Status"
+		case "GitPath.Repo.Id":
+			filter.Field = "GitPath_Repo_Id"
+		case "GitPath.Path":
+			filter.Field = "GitPath_Path"
+		case "GitPath.ConfigFilename":
+			filter.Field = "GitPath_ConfigFilename"
 		default:
-			break
+
 		}
 		out[i] = filter
 	}

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -129,6 +129,30 @@ func TestBuildFindQuery(t *testing.T) {
 			expectedQuery: "SELECT Data FROM Project WHERE SyncState_Status = ?",
 		},
 		{
+			name: "query with GitPath filter field name in where clause",
+			kind: "Application",
+			listOptions: datastore.ListOptions{
+				Filters: []datastore.ListFilter{
+					{
+						Field:    "GitPath.Repo.Id",
+						Operator: datastore.OperatorEqual,
+						Value:    "repo-1",
+					},
+					{
+						Field:    "GitPath.Path",
+						Operator: datastore.OperatorEqual,
+						Value:    "path-1",
+					},
+					{
+						Field:    "GitPath.ConfigFilename",
+						Operator: datastore.OperatorEqual,
+						Value:    "app.yaml",
+					},
+				},
+			},
+			expectedQuery: "SELECT Data FROM Application WHERE GitPath_Repo_Id = ? AND GitPath_Path = ? AND GitPath_ConfigFilename = ?",
+		},
+		{
 			name: "query with multi filters",
 			kind: "Project",
 			listOptions: datastore.ListOptions{


### PR DESCRIPTION
This PR implements a backend-side duplicate check for application registration. It ensures that no two applications within the same project can point to the exact same Git repository path and configuration file (RepoId, 
Path
, 
ConfigFilename
).

Key changes include:

Modified 
AddApplication
 gRPC handler to validate uniqueness of 
GitPath
 before creation.
Updated MySQL schema with virtual columns for 
GitPath
 fields (git_path.repo.id, git_path.path, git_path.config_filename) to support efficient indexing.
Added a composite unique index for 
GitPath
 fields in MySQL.
Added a composite index for 
GitPath
 fields in Firestore (
indexes.json
).
Updated MySQL query builder (
query.go
) to map 
GitPath
 filters to the new virtual columns.
Added usage of 
GitPath
 filters in the 
AddApplication
 handler instead of relying on client-side checks or name-only uniqueness.
 
 Solves #3806 