### PR TITLE
V1 Fixing image path in Adding an application

### DIFF
--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/adding-an-application.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/adding-an-application.md
@@ -7,20 +7,20 @@ description: >
 ---
 
 An application is a collection of resources and configurations that are managed together.
-It represents the service which you are going to deploy. With PipeCD, all the application manifests and its application configuration (`app.pipecd.yaml`) must be committed into a directory of a Git repository. That directory is called as application directory.
+It represents the service which you are going to deploy. With PipeCD, all the application manifests and its application configuration (`app.pipecd.yaml`) must be committed into a directory of a Git repository. That directory is called the application directory.
 
 Each application is managed by exactly one `piped` instance. However, a single `piped` can manage multiple applications.
 
-Starting PipeCD V1, you can deploy virtually any application on your desired platform using plugins. See more about plugins. Currently, the PipeCD maintainers team maintains plugins for Kubernetes and Terraform.
+Starting PipeCD V1, you can deploy virtually any application on your desired platform using plugins. See more about [plugins](../../concepts/#plugins). Currently, the PipeCD maintainers team maintains plugins for Kubernetes and Terraform.
 
 ## Preparing the application configuration file
 
 You have to **prepare a configuration file** which contains your application configuration and store that file in the Git repository which your Piped is watching first to enable adding a new application this way. The application configuration file name must be suffixed by `.pipecd.yaml` because the `piped` agent periodically checks for files with this suffix.
 
-> Note: Make sure that your Application Repository is listed in your `piped` configuration file. See the [`piped` configuration reference](../managing-piped/configuration-reference/#gitrepository:~:text=No-,repositories,-%5B%5DRepository) for more details.
+>**Note**: Make sure that your Application Repository is listed in your `piped` configuration file. See the [`piped` configuration reference](../managing-piped/configuration-reference/#gitrepository:~:text=No-,repositories,-%5B%5DRepository) for more details.
 
-The application configuration depends on the [plugin](../../concepts/_index.md/#plugins) that you are using for your deployment. Below is an example of how an appliation configuration file (app.pipecd.yaml) will look like. Please see [Plguins]() and [defining application configuration]() for more details on how to configure your `app.pipecd.yaml` in accordance with the plugin that you plan to use.
-<!-- [Plguins](../../plugins) (Directory to be created alongside user-guide in the future) -->
+The application configuration depends on the plugin that you are using for your deployment. Below is an example of what an application configuration file (app.pipecd.yaml) will look like. Please see [Plugins](../../concepts/#plugins) and [Application Configuration](../../concepts/#application-configuration) for more details on how to configure your `app.pipecd.yaml` in accordance with the plugin that you plan to use.
+<!-- [Plugins](../../plugins) (Directory to be created alongside user-guide in the future) -->
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
@@ -46,18 +46,18 @@ Registering the application helps PipeCD know:
 
 You can register a new application from the web console (aka the Control Plane) by picking from a list of unused apps suggested by `pipeds` while scanning the git repositories connected to it.
 
-You can also use the `pipectl` command-line tool to confiure your application in the Control Plane. See adding a new application using [`pipectl`](../../command-line-tool/#adding-a-new-application).
+You can also use the `pipectl` command-line tool to configure your application in the Control Plane. See adding a new application using [`pipectl`](../../command-line-tool/#adding-a-new-application).
 
->**NOTE:**
+>**Note:**
 >Manually configuring the application on the Control Plane is not supported for PipeCD v1 deployments (deployment using plugins) as of now. We are working on this feature.
 
 <!-- To define your application deployment pipeline which contains the guideline to show Piped how to deploy your application, please visit [Defining app configuration](../defining-app-configuration/). -->
 
 Go to the PipeCD web console on application list page, click the `+ADD` button at the top left corner of the application list page and then switch to the `PIPED V1 ADD FROM SUGGESTIONS` tab.
 
-Select the Piped that you want to use and the deploy target that you want to deploy to. If you have configured your `piped` configuration file and the Application Repository correctly, all the applications in the target repository will be listed in the 'Select application to add' tab. Select the unregistered Applicatiom you want to deploy and click on 'SAVE'. Your application should now be successfully registered and deploying on PipeCD.
+Select the Piped that you want to use and the deploy target that you want to deploy to. If you have configured your `piped` configuration file and the Application Repository correctly, all the applications in the target repository will be listed in the 'Select application to add' tab. Select the unregistered Application you want to deploy and click on 'SAVE'. Your application should now be successfully registered and deploying on PipeCD.
 
-![Registering an Application from Suggestions: PipeCD v1](/images/add-from-suggestions-v1.png)
+![Registering an Application from Suggestions: PipeCD v1](/images/quickstart-adding-application-from-suggestions-v1.png)
 <p style="text-align: center;">
 Registering an Application from Suggestions
 </p>


### PR DESCRIPTION
**What this PR does**:
Correct the image path for “Registering an Application from Suggestions” along with some spelling and grammar changes.

**Why we need it**:
The image path for “Registering an Application from Suggestions” in
[Adding an application](https://pipecd.dev/docs-v1.0.x/user-guide/managing-application/adding-an-application/) is incorrect and points to a non-existent image, thus it does not render on the v1 docs page.


**Which issue(s) this PR fixes**:

Fixes #6436
Related to #6376 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
