### PR TITLE
ADD userguide/managingApp/customizing-deployment

### DIFF
--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/_index.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/_index.md
@@ -6,7 +6,7 @@ description: >
   This page describes how to customize an application's deployment pipeline with PipeCD defined stages.
 ---
 
-The previous section demonstrated how to use PipeCD supporting application kind's stages to build up a pipeline that defines how Piped should deploy your application. In this section, aside from the application kind specified stages, we will see some commonly defined pipeline stages, which can be used to build up a more fashionable deployment pipeline for your application.
+The previous section demonstrated how to use application kind-specific stages in PipeCD to build up a pipeline that defines how Piped should deploy your application. In this section, aside from the application kind-specific stages, we will see some commonly defined pipeline stages, which can be used to build up a more flexible deployment pipeline for your application.
 
 ![Deployment wait stage screenshot](/images/deployment-wait-stage.png)
 <p style="text-align: center;">

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/adding-a-manual-approval.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/adding-a-manual-approval.md
@@ -8,9 +8,9 @@ description: >
 
 While deploying an application to production environments, some teams require manual approvals before continuing.
 The manual approval stage enables you to control when the deployment is allowed to continue by requiring a specific person or team to approve.
-This stage is named by `WAIT_APPROVAL` and you can add it to your pipeline before some stages should be approved before they can be executed.
+This stage is called `WAIT_APPROVAL` and you can add it to your pipeline before stages that require approval before they can be executed.
 
-``` yaml
+```yaml
 apiVersion: pipecd.dev/v1beta1
 kind: Application
 spec:
@@ -18,7 +18,6 @@ spec:
     stages:
     - name: K8S_CANARY_ROLLOUT
     - name: WAIT_APPROVAL
-      timeout: 6h
       with:
         approvers:
         - user-abc
@@ -27,13 +26,13 @@ spec:
   plugins: {}
 ```
 
-As above example, the deployment requires an approval from `user-abc` before `K8S_PRIMARY_ROLLOUT` stage can be executed.
+In the above example, the deployment requires an approval from `user-abc` before `K8S_PRIMARY_ROLLOUT` stage can be executed.
 
-The value of user ID in the `approvers` list depends on your [SSO configuration](../../../managing-controlplane/auth/), it must be GitHub's user ID if your SSO was configured to use GitHub provider, it must be Gmail account if your SSO was configured to use Google provider.
+The value of user ID in the `approvers` list depends on your [SSO configuration](../../../managing-controlplane/auth/). It must be GitHub's user ID if your SSO was configured to use GitHub provider. It must be Gmail account if your SSO was configured to use Google provider.
 
 In case the `approvers` field was not configured, anyone in the project who has `Editor` or `Admin` role can approve the deployment pipeline.
 
-Also, it will end with failure when the time specified in `timeout` has elapsed. Default is `6h`.
+Also, it will end in failure when the time specified in `timeout` has elapsed. Default is `6h`.
 
 ![Screenshot of Wait Approval Stage](/images/deployment-wait-approval-stage.png)
 <p style="text-align: center;">

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/adding-a-wait-stage.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/adding-a-wait-stage.md
@@ -6,10 +6,10 @@ description: >
   This page describes how to add a WAIT stage.
 ---
 
-In addition to waiting for approvals from someones, the deployment pipeline can be configured to wait an amount of time before continuing.
-This can be done by adding the `WAIT` stage into the pipeline. This stage has one configurable field which is `duration` to configure how long should be waited.
+In addition to waiting for approvals from someone, the deployment pipeline can be configured to wait for a specified amount of time before continuing.
+This can be done by adding the `WAIT` stage into the pipeline. This stage has one configurable field `duration` to configure how long to wait.
 
-``` yaml
+```yaml
 apiVersion: pipecd.dev/v1beta1
 kind: Application
 spec:

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
@@ -6,14 +6,14 @@ description: >
   This page describes how to configure Automated Deployment Analysis feature.
 ---
 
-Automated Deployment Analysis (ADA) evaluates the impact of the deployment you are in the middle of by analyzing the metrics data, log entries, and the responses of the configured HTTP requests.
+Automated Deployment Analysis (ADA) evaluates the impact of the deployment during execution by analyzing the metrics data, log entries, and the responses of the configured HTTP requests.
 
 The analysis of the newly deployed application is often carried out in a manual, ad-hoc or statistically incorrect manner.
 ADA automates that and helps to build a robust deployment process.
 
 ADA is available as a stage in the pipeline specified in the application configuration file.
 
-ADA does the analysis by periodically performing queries against the [Analysis Provider](../../../../concepts/#analysis-provider) and evaluating the results to know the impact of the deployment. Then based on these evaluating results, the deployment can be rolled back immediately to minimize any negative impacts.
+ADA does the analysis by periodically performing queries against the [Analysis Provider](../../../../concepts/#analysis-provider) and evaluating the results to know the impact of the deployment. Then based on these evaluation results, the deployment can be rolled back immediately to minimize any negative impacts.
 
 The canonical use case for this stage is to determine if your canary deployment should proceed.
 
@@ -35,9 +35,11 @@ You can choose one of the four strategies to fit your use case.
 - `THRESHOLD`: A simple method to compare against a statically defined threshold (same as the typical analysis method up to `v0.18.0`).
 - `PREVIOUS`: A method to compare metrics with the last successful deployment.
 - `CANARY_BASELINE`: A method to compare the metrics between the Canary and Baseline variants.
-- `CANARY_PRIMARY`(not recommended): A method to compare the metrics between the Canary and Primary variants.
+- `CANARY_PRIMARY`: A method to compare the metrics between the Canary and Primary variants.
 
-`THRESHOLD` is the simplest strategy, so it's for you if you attempt to evaluate this feature.
+> **Note**: `CANARY_PRIMARY` is not recommended. Use `CANARY_BASELINE` instead.
+
+`THRESHOLD` is the simplest strategy, so it's recommended if you're just starting to evaluate this feature.
 
 `THRESHOLD` only checks if the query result falls within the statically specified range, whereas others evaluate by checking the deviation of two time-series data.
 
@@ -72,7 +74,7 @@ spec:
         k8sNamespace: default
 ```
 
-In the `provider` field, put the name of the provider in Piped configuration prepared in the [Prerequisites](#prerequisites) section.
+In the `provider` field, specify the name of the provider in Piped configuration prepared in the [Prerequisites](#prerequisites) section.
 
 The `ANALYSIS` stage will continue to run for the period specified in the `duration` field.
 
@@ -86,7 +88,7 @@ The other strategies are basically the same, but there are slight differences. L
 
 #### PREVIOUS Strategy
 
-In the `PREVIOUS` strategy, Piped queries the analysis provider with the time range when the deployment was previously successful, and compares that metrics with the current metrics.
+In the `PREVIOUS` strategy, Piped queries the analysis provider with the time range from when the deployment was previously successful, and compares that metrics with the current metrics.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
@@ -114,7 +116,7 @@ spec:
 
 In the `THRESHOLD` strategy, we used `expected` to evaluate the deployment, but here we use `deviation` instead.
 
-The stage fails on deviation in the specified direction. In the above example, it fails if the current metrics is higher than the previous.
+The stage fails on deviation in the specified direction. In the above example, it fails if the current metrics are higher than the previous.
 
 #### CANARY strategy
 
@@ -158,7 +160,7 @@ The available built-in args currently are:
 |-|-|-|
 | Variant.Name | string | "canary", "baseline", or "primary" will be populated |
 
-Also, you can define the custom args using `baselineArgs` and `canaryArgs`, and refer them like `{{ .VariantCustom.Args.job }}`.
+Also, you can define the custom args using `baselineArgs` and `canaryArgs`, and reference them as `{{ .VariantCustom.Args.job }}`.
 
 ```yaml
           metrics:
@@ -181,7 +183,7 @@ However, we recommend that you compare it with Baseline that is a variant launch
 
 #### Comparison algorithm
 
-The metric comparison algorithm in PipeCD uses a nonparametric statistical test called [Mann-Whitney U test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) to check for a significant difference between two metrics collection (like Canary and Baseline, or the previous deployment and the current metrics).
+The metric comparison algorithm in PipeCD uses a nonparametric statistical test called [Mann-Whitney U test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) to check for a significant difference between two metric collections (like Canary and Baseline, or the previous deployment and the current metrics).
 
 ### Example pipelines
 
@@ -273,7 +275,7 @@ spec:
 
 The full list of configurable `ANALYSIS` stage fields are [here](../../../configuration-reference/#analysisstageoptions).
 
-See more the [example](https://github.com/pipe-cd/examples/blob/master/kubernetes/analysis-by-metrics/app.pipecd.yaml).
+See the [example](https://github.com/pipe-cd/examples/blob/master/kubernetes/analysis-by-metrics/app.pipecd.yaml) for more details.
 
 ## Analysis by logs
 
@@ -285,7 +287,7 @@ See more the [example](https://github.com/pipe-cd/examples/blob/master/kubernete
 
 ### [Optional] Analysis Template
 
-Analysis Templating is a feature that allows you to define some shared analysis configurations to be used by multiple applications. These templates must be placed at the `.pipe` directory at the root of the Git repository. Any application in that Git repository can use to the defined template by specifying the name of the template in the application configuration file.
+Analysis Templating is a feature that allows you to define some shared analysis configurations to be used by multiple applications. These templates must be placed at the `.pipe` directory at the root of the Git repository. Any application in that Git repository can use the defined template by specifying the name of the template in the application configuration file.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
@@ -303,7 +305,7 @@ spec:
         sum without(status) (rate(http_requests_total{job="{{ .App.Name }}"}[1m]))
 ```
 
-Once the AnalysisTemplate is defined, you can reference from the application configuration using the `template` field.
+Once the AnalysisTemplate is defined, you can reference it from the application configuration using the `template` field.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
@@ -333,7 +335,7 @@ The available built-in args are:
 | App.Name | string | Application Name. |
 | K8s.Namespace | string | The Kubernetes namespace where manifests will be applied. |
 
-Also, custom args is supported. Custom args placeholders can be defined as `{{ .AppCustomArgs.<name> }}`.
+Also, custom args are supported. Custom args placeholders can be defined as `{{ .AppCustomArgs.<name> }}`.
 
 Of course, it can be used in conjunction with [Variant args](#canary-strategy).
 

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/custom-sync.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/custom-sync.md
@@ -6,9 +6,9 @@ description: >
    Specific guide for configuring Custom Sync
 ---
 
-`CUSTOM_SYNC` is one stage in the pipeline and you can define scripts to deploy run in this stage.
+`CUSTOM_SYNC` is one stage in the pipeline and you can define scripts to run in this stage.
 
-> Note: This feature is marked as a deprecated feature and will be removed later.
+> **Note**: This feature is marked as a deprecated feature and will be removed later.
 
 ## How to configure Custom Sync
 
@@ -40,13 +40,13 @@ spec:
 
 ![Custom Sync](/images/custom-sync.png)
 
-Note:
+> **Note**:
+>
+> 1. You can use `CUSTOM_SYNC` with any current supporting application kind, but keep `alwaysUsePipeline` true to not run the application kind's default `QUICK_SYNC`.
+> 2. Only one `CUSTOM_SYNC` stage should be used in an application pipeline.
+> 3. The commands run with the environment variable `PATH` that refers `~/.piped/tools` at first.
 
-1. You can use `CUSTOM_SYNC` with any current supporting application kind, but keep `alwaysUsePipeline` true to not run the application kind's default `QUICK_SYNC`.
-2. Only one `CUSTOM_SYNC` stage should be used in an application pipeline.
-3. The commands run with the enviroment variable `PATH` that refers `~/.piped/tools` at first.
-
-The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX command available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). If you want to use your commands (`sam` in the above example), you can:
+The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX commands available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). If you want to use your commands (`sam` in the above example), you can:
 
 - Prepare your own environment container image then add [piped binary](https://github.com/pipe-cd/pipecd/releases) to it.
 - Build your own container image based on `ghcr.io/pipe-cd/piped` image.
@@ -58,7 +58,7 @@ When `autoRollback` is enabled, the deployment will be rolled back in the same w
 
 When the rolling back process is triggered in the pipeline including `CUSTOM_SYNC`, `CUSTOM_SYNC_ROLLBACK` stage will be added to the deployment pipeline.
 
-`CUSTOM_SYNC_ROLLBACK` is different from `ROLLBACK` that applications set defaultly, it runs the same commands as `CUSTOM_SYNC` in the runnning commit to reverts all the applied changes.
+`CUSTOM_SYNC_ROLLBACK` is different from `ROLLBACK` that applications set by default, it runs the same commands as `CUSTOM_SYNC` in the running commit to revert all the applied changes.
 
 ![Custom sync rollback](/images/custom-sync-rollback.png)
 

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/customizing-deployment/script-run.md
@@ -52,7 +52,7 @@ spec:
 
 You can define the command as `run`.
 
-Also, if you want to some values as variables, you can define them as `env`.
+Also, if you want to use some values as variables, you can define them as `env`.
 
 The commands run in the directory where this application configuration file exists.
 
@@ -60,7 +60,7 @@ The commands run in the directory where this application configuration file exis
 
 ### Execute the script file
 
-If your script is so long, you can separate the script as a file.
+If your script is too long, you can separate the script as a file.
 
 You can put the file with the app.pipecd.yaml in the same dir and then you can execute the script like this.
 
@@ -85,11 +85,11 @@ spec:
 └── script.sh
 ```
 
-## Builtin commands
+## Built-in commands
 
 Currently, you can use the commands which are installed in the environment for the piped.
 
-For example, If you are using the container platform and the offcial piped container image, you can use the command below:
+For example, if you use the container platform and the official piped container image, you can use the command below:
 
 - git
 - ssh
@@ -100,14 +100,14 @@ For example, If you are using the container platform and the offcial piped conta
 
 The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX commands available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)).
 
-If you want to use your commands, you can realize it with either step below.
+If you want to use your commands, you can achieve this with either step below.
 
 - Prepare your own environment container image then add [piped binary](https://github.com/pipe-cd/pipecd/releases) to it.
 - Build your own container image based on `ghcr.io/pipe-cd/piped` image.
 
 ## Default environment values
 
-You can use the envrionment values related to the deployment.
+You can use the environment values related to the deployment.
 
 | Name | Description | Example |
 |-|-|-|
@@ -121,7 +121,7 @@ You can use the envrionment values related to the deployment.
 |SR_SUMMARY| The summary of the deployment | Sync with the specified pipeline because piped received a command from user via web console or pipectl|
 |SR_CONTEXT_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
 |SR_LABELS_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABELS_ENV` and `SR_LABELS_TEAM` are registered.  | prd, server |
-|SR_IS_ROLLBACK| This is `true` if the deployment is rollbacking. Otherwise, this is `false`. | false |
+|SR_IS_ROLLBACK| This is `true` if the deployment is rolling back. Otherwise, this is `false`. | false |
 
 ### Use `SR_CONTEXT_RAW` with jq
 
@@ -140,7 +140,7 @@ You can use jq command to refer to the values from `SR_CONTEXT_RAW`.
 
 ## Rollback
 
-> Note: Currently, this feature is only for the application kind of KubernetesApp.
+>**Note**: Currently, this feature is only for the application kind of KubernetesApp.
 
 You can define the command as `onRollback` to execute when to rollback similar to `run`.
 
@@ -185,7 +185,7 @@ The command defined as `onRollback` is executed as `SCRIPT_RUN_ROLLBACK` stage a
 
 When there are multiple SCRIPT_RUN stages, they are executed in the same order as SCRIPT_RUN on the pipeline.
 
-Also, only for the executed SCRIPT_RUNs are rollbacked.
+Also, only the executed SCRIPT_RUNs are rolled back.
 
 For example, consider when deployment proceeds in the following order from 1 to 7.
 
@@ -201,7 +201,7 @@ For example, consider when deployment proceeds in the following order from 1 to 
 
 Then:
 
-- If 3 is canceled or fails while running, only SCRIPT_RUN of 3 will be rollbacked.
-- If 4 is canceled or fails while running, only SCRIPT_RUN of 3 will be rollbacked.
-- If 6 is canceled or fails while running, only SCRIPT_RUNs 3 and 5 will be rollbacked. The order of executing is 3 -> 5.
+- If 3 is canceled or fails while running, only SCRIPT_RUN of 3 will be rolled back.
+- If 4 is canceled or fails while running, only SCRIPT_RUN of 3 will be rolled back.
+- If 6 is canceled or fails while running, only SCRIPT_RUNs 3 and 5 will be rolled back. The order of executing is 3 -> 5.
 


### PR DESCRIPTION
**What this PR does**:

File by file commit from the bigger PR - https://github.com/pipe-cd/pipecd/pull/6345

Adds the “Customizing Deployment” section under User Guide → Managing Application.

Related to https://github.com/pipe-cd/pipecd/issues/6395
Source #6348 

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
