### PR TITLE
fix: update-copyright script for linux compatibility

### DIFF
--- a/hack/update-copyright.sh
+++ b/hack/update-copyright.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2026 The PipeCD Authors.
+# Copyright 2024 The PipeCD Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does**:
Fixed the `update-copyright.sh` to work correctly: 
- Removing `-Z` from grep (using newline-separated output)  
- Adding cross-platform for `sed -i` (mac vs Linux)

**Why we need it**: The script `grep -rlZ` which causing all filenames to concatenate into one string. Also, the script used macOS `sed -i ''` which is not working on linux.

Before:
<img width="1034" height="552" alt="Screenshot 2026-01-25 152804" src="https://github.com/user-attachments/assets/cb348508-2147-42fa-997d-e6ccb9143578" />

After:
<img width="687" height="546" alt="Screenshot 2026-01-25 153250" src="https://github.com/user-attachments/assets/da7c00f2-5b00-452f-a39e-f4fad3e26e89" />

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: NA
- **Is this breaking change**: NO
- **How to migrate (if breaking change)**: NA