### PR TITLE
Fix broken All Categories / All Tags links in docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -16,8 +16,6 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
-
 # Highlighting config
 pygmentsCodeFences = true
 pygmentsUseClasses = false


### PR DESCRIPTION
### **What this PR does**

* Enables Hugo taxonomy pages for **categories** and **tags**
* Fixes broken **All Categories** and **All Tags** links so they navigate correctly

---

### **Why we need it**

* Currently, clicking **All Categories** or **All Tags** does nothing
* The taxonomy list pages (`/categories`, `/tags`) were not generated due to disabled config

---

### **Which issue(s) this PR fixes**

Fixes #6468

---

### **Does this PR introduce a user-facing change?**

Yes

* **How are users affected by this change**:
  Users can now properly view all categories and tags instead of staying on the same page.

* **Is this breaking change**:
  No

* **How to migrate (if breaking change)**:
  Not applicable

---

<img width="1440" height="849" alt="Image" src="https://github.com/user-attachments/assets/bb60558b-6746-4f02-9f61-76e2fc95f005" />

<img width="1440" height="861" alt="Image" src="https://github.com/user-attachments/assets/4283bb07-1f54-45f3-9997-6690993f0d0e" />
