### PR TITLE
added template for documentation issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation Issue
+about: Report an issue with the documentation
+labels: kind/documentation
+
+---
+<!-- Please only use this template for submitting documentation issues -->
+
+**Describe the issue**:
+
+**Relevant URLs**:


### PR DESCRIPTION
**What this PR does**:
This PR adds feature to specifically submit documentation issues. Additionally, a`kind/documentation` label will be added along with opening the documentation issue.

**Which issue(s) this PR fixes**:

Fixes #6484 