### PR TITLE
fix: update broken community meeting link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ Then, copy generated Piped ID and base64 key for `piped-config.yaml`
 
 Below is an exampled piped v0 configuration using the Kubernetes platform provider. Use the PipeD ID and base64 key you created in step 2 here.
 
-````yaml
+```yaml
   apiVersion: pipecd.dev/v1beta1
   kind: Piped
   spec:
@@ -264,7 +264,7 @@ Below is an exampled piped v0 configuration using the Kubernetes platform provid
 make run/piped \
 CONFIG_FILE=path/to/piped-config.yaml \
 INSECURE=true
-````
+```
 
 where the `CONFIG_FILE` is the path to your piped confiuration file and the `INSECURE` flag is set to `true` to allow `piped` to connect to the control plane without TLS verification.
 


### PR DESCRIPTION
**What this PR does**:
Updates the community meeting link in CONTRIBUTING.md to point to the CNCF Slack channel, as the previous Zoom link was outdated/broken.

**Why we need it**:
New contributors were being directed to a dead link, causing confusion.

**Which issue(s) this PR fixes**:
Fixes #6499

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: Contributors will find the correct meeting info.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A