### PR TITLE
fixed the 404 link for pprof guide in faq section

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/using-pprof-in-piped.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/using-pprof-in-piped.md
@@ -4,8 +4,6 @@ linkTitle: "Using Pprof in Piped"
 weight: 10
 description: >
   This guide is for developers who want to use pprof for performance profiling in Piped.
-aliases:
-  - /docs-dev/managing-piped/using-pprof-in-piped/
 ---
 
 Piped provides built-in support for pprof, a tool for visualization and analysis of profiling data. It's a part of the standard Go library.


### PR DESCRIPTION
**What this PR does**:
This PR fixes the 404 link error which was resulted as the result of incorrect path.

**Why we need it**:
To fix the 404 error

**Which issue(s) this PR fixes**:

Fixes #6503