### PR TITLE
added additional flag for base64 encoding under pipectl encrypt

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -355,6 +355,9 @@ You can encrypt it the same way you do [from the web](../managing-application/se
       --input-file={PATH_TO_SECRET_FILE}
   ```
 
+Optional encoding:
+- `--use-base64-encoding` to base64-encode the plaintext before encrypting.
+
 Note: The docs for pipectl available command is maybe outdated, we suggest users use the `help` command for the updated usage while using pipectl.
 
 ### Generating an application config (app.pipecd.yaml)


### PR DESCRIPTION
**What this PR does**:
This PR adds a short note that pipectl encrypt supports an optional --use-base64-encoding flag (base64-encodes plaintext before encrypting).

**Why we need it**:
This fixes the docs gap where the flag existed but wasn’t mentioned in the CLI guide, which is why users wouldn’t know to use it.

**Which issue(s) this PR fixes**:

Fixes #6509 
