### PR TITLE
fixed numbering of subheading in installing-controlplane-on-k8s section

### DIFF
--- a/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -129,7 +129,7 @@ Once a new project has been registered, a static admin (username, password) will
 
 For more about adding a new project in detail, please read the following [docs](../../../user-guide/managing-controlplane/adding-a-project/).
 
-### 4'. Upgrade Control Plane version
+### 5. Upgrade Control Plane version
 
 To upgrade the PipeCD Control Plane, preparations and commands remain as you do when installing PipeCD Control Plane. Only need to change the version flag in command to the specified version you want to upgrade your PipeCD Control Plane to.
 


### PR DESCRIPTION
**What this PR does**:
This PR fixes the incorrect numbering in the installing-controlplane-on-k8s section. Earlier it was 4', while it should have 5.

**Why we need it**:
To fix bug

**Which issue(s) this PR fixes**:

Fixes #6504 
