### PR TITLE
feat(cloudrun): implement DetermineVersions for v1 plugin architectur…

### DIFF
--- a/pkg/app/pipedv1/plugin/cloudrun/config/application.go
+++ b/pkg/app/pipedv1/plugin/cloudrun/config/application.go
@@ -27,6 +27,10 @@ type CloudRunDeploymentInput struct {
 	// The name of service manifest file placing in application directory.
 	// Default is service.yaml
 	ServiceManifestFile string `json:"serviceManifestFile"`
+
+	//The full container image path to be deployed to Cloud Run.
+	Image string `json:"image"`
+
 }
 
 // CloudRunSyncStageOptions contains all configurable values for a CLOUDRUN_SYNC stage.

--- a/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin_test.go
@@ -161,3 +161,46 @@ func Test_buildPipelineStages(t *testing.T) {
 		})
 	}
 }
+
+func TestImageVersionExtraction(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{
+			name:     "GCR Standard Tag",
+			image:    "gcr.io/pipecd/webapp:v1.2.3",
+			expected: "v1.2.3",
+		},
+		{
+			name:     "Image Digest (SHA)",
+			image:    "gcr.io/pipecd/webapp@sha256:45b23dee08af",
+			expected: "sha256:45b23dee08af",
+		},
+		{
+			name:     "Registry with Port",
+			image:    "localhost:5000/pipecd/webapp:v1.0.0",
+			expected: "v1.0.0",
+		},
+		{
+			name:     "Untagged Image",
+			image:    "gcr.io/pipecd/webapp",
+			expected: "latest",
+		},
+		{
+			name:     "Empty String",
+			image:    "",
+			expected: "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ImageVersionExtraction(tc.image)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:
* Implements the `DetermineVersions` lifecycle method for the new Cloud Run v1 plugin.
* Adds a robust `ImageVersionExtraction` helper function to handle diverse container image formats environments.
* Updates the `CloudRunDeploymentInput` struct in `application.go` to include the `image` field required for version determination.
* Includes comprehensive unit tests in `plugin_test.go` to verify the extraction logic against various real-world image strings.

**Why we need it**:
The v1 plugin architecture requires explicit logic to identify artifact versions for the Control Plane. This implementation allows PipeCD to correctly populate the "Version" column in the Deployment UI, which is a core requirement for the Cloud Run v1 migration.

**Which issue(s) this PR fixes**:
Fixes #6114

**Does this PR introduce a user-facing change?**:
Yes.

* **How are users affected by this change**: Users must now specify the `image` field within the `input` section of their Cloud Run application configuration. This enables PipeCD to track and display the specific container version being deployed.
* **Is this breaking change**: No, as this is part of the initial migration to the v1 plugin architecture.
* **How to migrate (if breaking change)**: N/A.