### PR TITLE
[Docs]: Correcting command to run piped as a standalone binary 

### DIFF
--- a/docs/content/en/docs-v1.0.x/migrating-from-v0-to-v1/_index.md
+++ b/docs/content/en/docs-v1.0.x/migrating-from-v0-to-v1/_index.md
@@ -263,13 +263,13 @@ curl -Lo ./piped https://github.com/pipe-cd/pipecd/releases/download/pipedv1%2Fe
 chmod +x ./piped
 
 # Run piped binary
-./piped piped --config-file=<PATH_TO_PIPEDV1_CONFIG_FILE> --tools-dir=/tmp/piped-bin
+./piped run --config-file=<PATH_TO_PIPEDV1_CONFIG_FILE> --tools-dir=/tmp/piped-bin
 ```
 
 If your Control Plane is running locally, append the `--insecure=true` flag to skip TLS certificate verification:
 
 ```bash
-./piped piped --config-file=<PATH_TO_PIPEDV1_CONFIG_FILE> --tools-dir=/tmp/piped-bin --insecure=true
+./piped run --config-file=<PATH_TO_PIPEDV1_CONFIG_FILE> --tools-dir=/tmp/piped-bin --insecure=true
 ```
 
 ### Option 3 - Run `pipedv1` as a Container


### PR DESCRIPTION
**What this PR does**:
Use the right command to run piped as a standalone binary, the current documents uses the wrong command

**Why we need it**:

**Which issue(s) this PR fixes**:
#6545 

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
