### PR TITLE
Docs: Remove version selector from community and blog sections

### DIFF
--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -19,7 +19,7 @@
 				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
 			</li>
 			{{ end }}
-			{{ if and .Site.Params.versions (not .IsHome) }}
+			{{ if and .Site.Params.versions (not .IsHome) (ne .Section "community") (ne .Section "blog") }}
 			<li class="nav-item dropdown d-none d-lg-block">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>


### PR DESCRIPTION
**What this PR does**:
Removes version selector from community and blog sections 

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #6547 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
