### PR TITLE
ci(docs): add link checker to existing CI to prevent broken docs links

### DIFF
--- a/.github/workflows/link_checker.yaml
+++ b/.github/workflows/link_checker.yaml
@@ -1,0 +1,57 @@
+name: link_checker
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - master
+      - "release-v*"
+      - "feat/*"
+    paths:
+      - "docs/**"
+      - "**/*.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  link-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine files to check
+        id: files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin master --depth=1
+            # Only check markdown files changed in this PR (avoids legacy broken links blocking PRs)
+            changed=$(git diff --name-only origin/master...HEAD | grep -E '^docs/.*\.md$' | xargs)
+            if [ -n "$changed" ]; then
+              echo "targets=$changed" >> $GITHUB_OUTPUT
+              echo "skip=false" >> $GITHUB_OUTPUT
+            else
+              echo "No docs markdown files changed."
+              echo "skip=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            # On master push, do a full health check across all docs
+            echo "targets=docs/content/**/*.md docs/README.md *.md" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Link Checker
+        if: steps.files.outputs.skip != 'true'
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --verbose --no-progress --config .lychee.toml ${{ steps.files.outputs.targets }}
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,72 @@
+# Resolve root-relative links (e.g. /images/...) against docs/static
+root_dir = "docs/static"
+
+max_retries = 3
+timeout = 30
+max_concurrency = 10
+
+# Only accept successful responses and standard redirects.
+# Known-flaky domains are excluded below instead of blanket-accepting error codes.
+accept = ["200..=204", "300..=307"]
+
+# Do not check internal files
+offline = false
+
+exclude_path = [
+    "node_modules/",
+    "vendor/"
+]
+
+exclude = [
+    # Local/loopback/private addresses
+    'http://localhost(:\d+)?',
+    'http://127\.0\.0\.1(:\d+)?',
+
+    # Example/placeholder domains
+    'http(s)?://example\.com',
+    'http(s)?://.*\.example\.com',
+    'https://github.com/org/.*',
+    'https://github.com/your-org/.*',
+    'https://github.com/yourname/.*',
+
+    # GitHub edit and issue-creation links (dynamic, not real pages)
+    'https://github.com/pipe-cd/pipecd/edit/.*',
+    'https://github.com/pipe-cd/pipecd/issues/new.*',
+
+    # Social media (rate-limit / block automated checkers)
+    'https://twitter\.com/.*',
+    'https://x\.com/.*',
+    'https://linkedin\.com/.*',
+    'https://medium\.com/.*',
+
+    # CI / badge services
+    'https://codecov\.io/.*',
+    'https://goreportcard\.com/.*',
+
+    # Known flaky domains that block or rate-limit automated checkers
+    'https://www\.mysql\.com/.*',
+    'https://dev\.mysql\.com/.*',
+    'https://www\.npmjs\.com/.*',
+    'https://npmjs\.org/.*',
+    'https://www\.weave\.works/.*',
+    'https://exploringjs\.com/.*',
+    'https://travis-ci\.com/.*',
+    'https://pipecd\.dev/.*',
+
+    # Hugo local relative links and paths (resolved dynamically, not physical files)
+    '^/',
+    '^#',
+    '^Adding-.*',
+    '^getting-started.*',
+    '^architecture/.*',
+    '^community/.*',
+    '^concepts/.*',
+    '^configuration/.*',
+    '^contribution-guidelines/.*',
+    '^faq/.*',
+    '^installation/.*',
+    '^operator-manual/.*',
+    '^reference/.*',
+    '^tutorials/.*',
+    '^user-guide/.*',
+]


### PR DESCRIPTION
Fixes #6549

Adds a lightweight link-checking step using `lychee-action` to the existing CI workflow that runs only when docs or README files change. It relies on a custom `.lychee.toml` configuration to ignore localhost, social networks, active repository edit links, and Hugo's internal relative routing paths to avoid false positives. 

The action is pinned to its latest SHA (`8646ba30`) equivalent to `v2.8.0` following the repository's existing security conventions.

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: No, this is purely a CI pipeline enhancement for maintainers.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A
