### PR TITLE
bug(ecs): fix parseContainerImage to handle images with registry ports

### DIFF
--- a/pkg/app/piped/platformprovider/ecs/task.go
+++ b/pkg/app/piped/platformprovider/ecs/task.go
@@ -54,12 +54,18 @@ func FindImageTag(taskDefinition types.TaskDefinition) (string, error) {
 }
 
 func parseContainerImage(image string) (name, tag string) {
-	parts := strings.Split(image, ":")
-	if len(parts) == 2 {
-		tag = parts[1]
+	paths := strings.Split(image, "/")
+	lastSegment := paths[len(paths)-1]
+
+	idx := strings.LastIndex(lastSegment, ":")
+	if idx == -1 {
+		name = lastSegment
+		tag = ""
+		return
 	}
-	paths := strings.Split(parts[0], "/")
-	name = paths[len(paths)-1]
+
+	name = lastSegment[:idx]
+	tag = lastSegment[idx+1:]
 	return
 }
 

--- a/pkg/app/piped/platformprovider/ecs/task_test.go
+++ b/pkg/app/piped/platformprovider/ecs/task_test.go
@@ -93,6 +93,42 @@ func TestFindArtifactVersions(t *testing.T) {
 		expectedErr bool
 	}{
 		{
+			name: "image with registry port",
+			input: []byte(`
+{
+	"family": "nginx-canary-fam-1",
+	"compatibilities": [
+		"FARGATE"
+	],
+	"networkMode": "awsvpc",
+	"memory": 512,
+	"cpu": 256,
+	"containerDefinitions" : [
+		{
+			"image": "localhost:5000/pipecd/helloworld:v1.0.0",
+			"name": "helloworld",
+			"portMappings": [ 
+				{ 
+				"containerPort": 80,
+				"hostPort": 9085,
+				"protocol": "tcp"
+				}
+			]
+		}
+	]
+}
+`),
+			expected: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "v1.0.0",
+					Name:    "helloworld",
+					Url:     "localhost:5000/pipecd/helloworld:v1.0.0",
+				},
+			},
+			expectedErr: false,
+		},
+		{
 			name: "ok",
 			input: []byte(`
 {


### PR DESCRIPTION
**What this PR does**:
Updates [parseContainerImage](cci:1://file:///Users/zyzz_mohit/.gemini/antigravity/brain/6d991304-edb0-4d42-a61a-e4fa4bf780ce/Gsoc-practice/pipecd/pkg/app/piped/platformprovider/ecs/task.go:55:0-69:1) inside [pkg/app/piped/platformprovider/ecs/task.go](cci:7://file:///Users/zyzz_mohit/.gemini/antigravity/brain/6d991304-edb0-4d42-a61a-e4fa4bf780ce/Gsoc-practice/pipecd/pkg/app/piped/platformprovider/ecs/task.go:0:0-0:0) to use `strings.LastIndex` for separating the container image tag from the image name. It also adds unit tests to [TestFindArtifactVersions](cci:1://file:///Users/zyzz_mohit/.gemini/antigravity/brain/6d991304-edb0-4d42-a61a-e4fa4bf780ce/Gsoc-practice/pipecd/pkg/app/piped/platformprovider/ecs/task_test.go:85:0-323:1) for explicitly testing images with registry ports.

**Why we need it**:
The previous implementation naively split the image string by `:` to extract the image tag. If a user relies on a container image hosted in a registry that specifies a port (e.g., `localhost:5000/repo/image:tag`), the function incorrectly split the URI, resulting in a misparsed `name` and an empty [tag](cci:1://file:///Users/zyzz_mohit/.gemini/antigravity/brain/6d991304-edb0-4d42-a61a-e4fa4bf780ce/Gsoc-practice/pipecd/pkg/app/pipedv1/plugin/ecs/deployment/plugin.go:58:0-69:1). 

This is the exact same architectural flaw recently identified and fixed in the Cloud Run provider ([pkg/app/piped/platformprovider/cloudrun/servicemanifest.go](cci:7://file:///Users/zyzz_mohit/.gemini/antigravity/brain/6d991304-edb0-4d42-a61a-e4fa4bf780ce/Gsoc-practice/pipecd/pkg/app/piped/platformprovider/cloudrun/servicemanifest.go:0:0-0:0)). Because AWS ECS frequently utilizes custom Docker registries with ports, this is a necessary defensive fix mapping to real-world use cases.

**Which issue(s) this PR fixes**:

Fixes #6575

**Does this PR introduce a user-facing change?**:
Yes

- **How are users affected by this change**: Users can now safely configure their ECS task definitions to use container images hosted in external registries containing custom ports (e.g., `my-registry.com:8443/app:v1`).
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
