### PR TITLE
bug(lambda): fix parseContainerImage to handle images with registry ports

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -206,12 +206,18 @@ func FindImageTag(fm FunctionManifest) (string, error) {
 }
 
 func parseContainerImage(image string) (name, tag string) {
-	parts := strings.Split(image, ":")
-	if len(parts) == 2 {
-		tag = parts[1]
+	paths := strings.Split(image, "/")
+	lastSegment := paths[len(paths)-1]
+
+	idx := strings.LastIndex(lastSegment, ":")
+	if idx == -1 {
+		name = lastSegment
+		tag = ""
+		return
 	}
-	paths := strings.Split(parts[0], "/")
-	name = paths[len(paths)-1]
+
+	name = lastSegment[:idx]
+	tag = lastSegment[idx+1:]
 	return
 }
 

--- a/pkg/app/piped/platformprovider/lambda/function_test.go
+++ b/pkg/app/piped/platformprovider/lambda/function_test.go
@@ -348,6 +348,28 @@ func TestFindArtifactVersions(t *testing.T) {
 		expectedErr bool
 	}{
 		{
+			name: "[From container image] ok: image with registry port",
+			input: []byte(`
+apiVersion: pipecd.dev/v1beta1
+kind: LambdaFunction
+spec:
+  name: SimpleFunction
+  image: localhost:5000/lambda-test:v0.0.1
+  role: arn:aws:iam::76xxxxxxx:role/lambda-role
+  memory: 512
+  timeout: 30
+`),
+			expected: []*model.ArtifactVersion{
+				{
+					Kind:    model.ArtifactVersion_CONTAINER_IMAGE,
+					Version: "v0.0.1",
+					Name:    "lambda-test",
+					Url:     "localhost:5000/lambda-test:v0.0.1",
+				},
+			},
+			expectedErr: false,
+		},
+		{
 			name: "[From container image] ok: using container image",
 			input: []byte(`
 apiVersion: pipecd.dev/v1beta1


### PR DESCRIPTION
**What this PR does**:

Updates `parseContainerImage` inside `pkg/app/piped/platformprovider/lambda/function.go` to use `strings.LastIndex` for separating the container image tag from the image name. It also adds unit tests to `TestFindArtifactVersions` for explicitly testing images with registry ports.

**Why we need it**:

The previous implementation naively split the image string by `:` to extract the image tag. If a user relies on a container image hosted in a registry that specifies a port (e.g., `localhost:5000/repo/image:tag`), the function incorrectly split the URI, resulting in a misparsed `name` and an empty `tag`. 

This addresses the exact same architectural duplication identified in the Cloud Run and ECS providers. Fixing this across the board ensures parity and defends against users deploying Lambda containers from custom registries.

**Which issue(s) this PR fixes**:

Fixes #6577 

**Does this PR introduce a user-facing change?**: yes

- **How are users affected by this change**: Users can now safely configure their Lambda function manifests to use container images hosted in external registries containing custom ports (e.g., `my-registry.com:8443/app:v1`).
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
