### PR TITLE
docs: fix broken configuration reference links

### DIFF
--- a/docs/content/en/docs-v1.0.x/user-guide/managing-application/triggering-a-deployment.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-application/triggering-a-deployment.md
@@ -24,7 +24,7 @@ You can configure when PipeCD triggers a new deployment. The following trigger t
 - `onOutOfSync`: Triggers a deployment when the application enters an OUT_OF_SYNC state.
 - `onChain`: Triggers a deployment when the application is part of a deployment chain.
 
-For the full list of options, see [Configuration reference](../../configuration-reference/#deploymenttrigger).
+For the full list of options, see [Configuration reference](./configuration-reference.md/#deploymenttrigger).
 
 After a deployment is triggered, it is added to a queue and handled by the appropriate `piped`. At this stage, the deployment pipeline is not yet decided.
 `piped` ensures that only one deployment runs per application at a time. If no deployment is currently running, `piped` selects a queued deployment and plans its pipeline.
@@ -35,7 +35,7 @@ For example:
 - If a merged pull request updates a Deployment's container image or updates a mounted ConfigMap or Secret, `piped` decides to use the specified pipeline for a progressive deployment.
 - If a merged pull request only updates the `replicas` number, `piped` decides to use a quick sync to scale the resources.
 
-You can configure `piped` to use the [QuickSync](../../../concepts/#sync-strategy) or the specified pipeline based on the commit message by configuring [CommitMatcher](../../configuration-reference/#commitmatcher) in the application configuration.
+You can configure `piped` to use the [QuickSync](../../../concepts/#sync-strategy) or the specified pipeline based on the commit message by configuring [CommitMatcher](./configuration-reference.md/#commitmatcher) in the application configuration.
 
 After the planning, the deployment will be executed as per the decided pipeline. The deployment execution including the state of each stage as well as their logs can be viewed in real time on the deployment details page on the Web UI.
 


### PR DESCRIPTION
**What this PR does**:
Fixes broken links in the Triggering a Deployment documentation page.
The links pointing to the configuration reference were using an incorrect relative path which resulted in a 404.
The issue suggested updating the path to `../configuration-reference/`, but since both files are located in the same managing-application directory, the correct relative path is `./configuration-reference/`

**Why we need it**:
Without this fix, users navigating from the deployment trigger documentation to the configuration reference encounter broken links.

**Which issue(s) this PR fixes**:
Fixes #6579 

**Does this PR introduce a user-facing change?**:
Yes (documentation improvement)

- **How are users affected by this change**:
  Users can correctly navigate to the configuration reference from the deployment trigger documentation.
- **Is this breaking change**:
  No
- **How to migrate (if breaking change)**:
  