### PR TITLE
[ECS-Plugin] Setting default value for config

### DIFF
--- a/pkg/app/pipedv1/plugin/ecs/config/application.go
+++ b/pkg/app/pipedv1/plugin/ecs/config/application.go
@@ -35,8 +35,7 @@ type ECSDeploymentInput struct {
 
 	// ServiceDefinitionFile is the name of service definition file placing in application directory
 	// e.g., "servicedef.json" or "ecs/servicedef.yaml"
-	// Default: servicedef.json
-	ServiceDefinitionFile string `json:"serviceDefinitionFile,omitempty" default:"servicedef.json"`
+	ServiceDefinitionFile string `json:"serviceDefinitionFile,omitempty"`
 
 	// RunStandaloneTask indicates whether to run the task as a standalone task without creating/updating an ECS service.
 	// If true, the plugin will run the task directly without managing it through an ECS service.


### PR DESCRIPTION
**What this PR does**: 
- Setting default value for config
- Remove default value of ServiceDefinitionFile (no need for default value of this field because it will affect StandAloneTask mode) 

**Why we need it**:
- For example, if launch type is not specified in manifest, the value of launch type will be empty, ECS will try to use EC2 instead of fargate mode 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
