### PR TITLE
fix: remove extra blank line in canary_test.go to satisfy gofmt

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/canary_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/canary_test.go
@@ -321,7 +321,6 @@ func TestPlugin_executeK8sMultiCanaryRolloutStage_WithoutCreateService(t *testin
 	assert.True(t, k8serrors.IsNotFound(err))
 }
 
-
 func TestPlugin_executeK8sMultiCanaryCleanStage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does**: Removes an extra blank line in `canary_test.go` that was causing the `gofmt` linter to fail in CI.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No user-facing change — test file formatting fix only.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A