### PR TITLE
[PipeCD-DataStore] fix: nil pointer dereference in UpdatePluginMetadata

### DIFF
--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -264,6 +264,9 @@ func (s *deploymentStore) UpdatePluginMetadata(ctx context.Context, id string, p
 		if d.MetadataV2.Plugins == nil {
 			d.MetadataV2.Plugins = make(map[string]*model.DeploymentMetadata_KeyValues)
 		}
+		if d.MetadataV2.Plugins[pluginName] == nil {
+			d.MetadataV2.Plugins[pluginName] = &model.DeploymentMetadata_KeyValues{}
+		}
 		d.MetadataV2.Plugins[pluginName] = &model.DeploymentMetadata_KeyValues{
 			KeyValues: mergeMetadata(d.MetadataV2.Plugins[pluginName].KeyValues, metadata),
 		}


### PR DESCRIPTION
**What this PR does**: Check if `d.MetadataV2.Plugins[pluginName] == nil` before accessing it:
```go
  if d.MetadataV2.Plugins[pluginName] == nil {
      d.MetadataV2.Plugins[pluginName] = &model.DeploymentMetadata_KeyValues{}
  }
```

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #6610

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
