### PR TITLE
Add support for configurable Plan Preview behavior in piped

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -535,6 +535,10 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			decrypter,
 			appManifestsCache,
 			cfg,
+			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
+			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
+			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
+			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
 			planpreview.WithLogger(input.Logger),
 		)
 		group.Go(func() error {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -526,6 +526,13 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			input.Logger.Info("successfully cleaned gitClient for plan-preview")
 		}()
 
+		ppOpts := []planpreview.Option{
+			planpreview.WithLogger(input.Logger),
+			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
+			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
+			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
+			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
+		}
 		h := planpreview.NewHandler(
 			gc,
 			apiClient,
@@ -535,11 +542,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			decrypter,
 			appManifestsCache,
 			cfg,
-			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
-			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
-			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
-			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
-			planpreview.WithLogger(input.Logger),
+			ppOpts...,
 		)
 		group.Go(func() error {
 			return h.Run(ctx)

--- a/pkg/app/piped/planpreview/handler.go
+++ b/pkg/app/piped/planpreview/handler.go
@@ -51,25 +51,33 @@ type Option func(*options)
 
 func WithWorkerNum(n int) Option {
 	return func(opts *options) {
-		opts.workerNum = n
+		if n > 0 {
+			opts.workerNum = n
+		}
 	}
 }
 
 func WithCommandQueueBufferSize(s int) Option {
 	return func(opts *options) {
-		opts.commandQueueBufferSize = s
+		if s > 0 {
+			opts.commandQueueBufferSize = s
+		}
 	}
 }
 
 func WithCommandCheckInterval(i time.Duration) Option {
 	return func(opts *options) {
-		opts.commandCheckInterval = i
+		if i > 0 {
+			opts.commandCheckInterval = i
+		}
 	}
 }
 
 func WithCommandHandleTimeout(t time.Duration) Option {
 	return func(opts *options) {
-		opts.commandHandleTimeout = t
+		if t > 0 {
+			opts.commandHandleTimeout = t
+		}
 	}
 }
 

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -500,6 +500,10 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			decrypter,
 			cfg,
 			pluginRegistry,
+			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
+			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
+			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
+			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
 			planpreview.WithLogger(input.Logger),
 		)
 		group.Go(func() error {

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -491,6 +491,13 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			input.Logger.Info("successfully cleaned gitClient for plan-preview")
 		}()
 
+		ppOpts := []planpreview.Option{
+			planpreview.WithLogger(input.Logger),
+			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
+			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
+			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
+			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
+		}
 		h := planpreview.NewHandler(
 			gc,
 			apiClient,
@@ -500,11 +507,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			decrypter,
 			cfg,
 			pluginRegistry,
-			planpreview.WithWorkerNum(cfg.PlanPreview.WorkerNum),
-			planpreview.WithCommandQueueBufferSize(cfg.PlanPreview.CommandQueueBufferSize),
-			planpreview.WithCommandCheckInterval(cfg.PlanPreview.CommandCheckInterval.Duration()),
-			planpreview.WithCommandHandleTimeout(cfg.PlanPreview.CommandHandleTimeout.Duration()),
-			planpreview.WithLogger(input.Logger),
+			ppOpts...,
 		)
 		group.Go(func() error {
 			return h.Run(ctx)

--- a/pkg/app/pipedv1/planpreview/handler.go
+++ b/pkg/app/pipedv1/planpreview/handler.go
@@ -51,25 +51,33 @@ type Option func(*options)
 
 func WithWorkerNum(n int) Option {
 	return func(opts *options) {
-		opts.workerNum = n
+		if n > 0 {
+			opts.workerNum = n
+		}
 	}
 }
 
 func WithCommandQueueBufferSize(s int) Option {
 	return func(opts *options) {
-		opts.commandQueueBufferSize = s
+		if s > 0 {
+			opts.commandQueueBufferSize = s
+		}
 	}
 }
 
 func WithCommandCheckInterval(i time.Duration) Option {
 	return func(opts *options) {
-		opts.commandCheckInterval = i
+		if i > 0 {
+			opts.commandCheckInterval = i
+		}
 	}
 }
 
 func WithCommandHandleTimeout(t time.Duration) Option {
 	return func(opts *options) {
-		opts.commandHandleTimeout = t
+		if t > 0 {
+			opts.commandHandleTimeout = t
+		}
 	}
 }
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -79,6 +79,8 @@ type PipedSpec struct {
 	SecretManagement *SecretManagement `json:"secretManagement,omitempty"`
 	// Optional settings for event watcher.
 	EventWatcher PipedEventWatcher `json:"eventWatcher"`
+	// Optional settings for plan-preview command handling.
+	PlanPreview PipedPlanPreview `json:"planPreview"`
 	// List of labels to filter all applications this piped will handle.
 	AppSelector map[string]string `json:"appSelector,omitempty"`
 }
@@ -139,6 +141,9 @@ func (s *PipedSpec) Validate() error {
 		}
 	}
 	if err := s.EventWatcher.Validate(); err != nil {
+		return err
+	}
+	if err := s.PlanPreview.Validate(); err != nil {
 		return err
 	}
 	for _, n := range s.Notifications.Receivers {
@@ -1210,4 +1215,31 @@ type PipedEventWatcherGitRepo struct {
 	// Patterns can be used like "foo/*.yaml".
 	// This is prioritized if both includes and this one are given.
 	Excludes []string `json:"excludes,omitempty"`
+}
+
+type PipedPlanPreview struct {
+	// Number of workers to handle plan-preview commands.
+	WorkerNum int `json:"workerNum,omitempty"`
+	// Channel buffer size used for plan-preview commands.
+	CommandQueueBufferSize int `json:"commandQueueBufferSize,omitempty"`
+	// Interval to fetch plan-preview commands.
+	CommandCheckInterval Duration `json:"commandCheckInterval,omitempty"`
+	// Timeout to handle each plan-preview command.
+	CommandHandleTimeout Duration `json:"commandHandleTimeout,omitempty"`
+}
+
+func (p *PipedPlanPreview) Validate() error {
+	if p.WorkerNum < 0 {
+		return errors.New("planPreview.workerNum must be greater than or equal to 0")
+	}
+	if p.CommandQueueBufferSize < 0 {
+		return errors.New("planPreview.commandQueueBufferSize must be greater than or equal to 0")
+	}
+	if p.CommandCheckInterval < 0 {
+		return errors.New("planPreview.commandCheckInterval must be greater than or equal to 0")
+	}
+	if p.CommandHandleTimeout < 0 {
+		return errors.New("planPreview.commandHandleTimeout must be greater than or equal to 0")
+	}
+	return nil
 }

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -1218,13 +1218,13 @@ type PipedEventWatcherGitRepo struct {
 }
 
 type PipedPlanPreview struct {
-	// Number of workers to handle plan-preview commands.
+	// WorkerNum is the number of worker goroutines processing plan-preview commands.
 	WorkerNum int `json:"workerNum,omitempty"`
-	// Channel buffer size used for plan-preview commands.
+	// CommandQueueBufferSize is the buffer size of the internal command channel.
 	CommandQueueBufferSize int `json:"commandQueueBufferSize,omitempty"`
-	// Interval to fetch plan-preview commands.
+	// CommandCheckInterval is how often to poll for new plan-preview commands.
 	CommandCheckInterval Duration `json:"commandCheckInterval,omitempty"`
-	// Timeout to handle each plan-preview command.
+	// CommandHandleTimeout is the default timeout for building each plan-preview result when the command does not specify one.
 	CommandHandleTimeout Duration `json:"commandHandleTimeout,omitempty"`
 }
 

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -361,6 +361,12 @@ func TestPipedConfig(t *testing.T) {
 						},
 					},
 				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
+				},
 			},
 			expectedError: nil,
 		},
@@ -374,6 +380,95 @@ func TestPipedConfig(t *testing.T) {
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
 				assert.Equal(t, tc.expectedSpec, cfg.spec)
 			}
+		})
+	}
+}
+
+func TestPipedPlanPreviewValidate(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		planPreview          PipedPlanPreview
+		wantErr              bool
+		wantPipedPlanPreview PipedPlanPreview
+	}{
+		{
+			name:    "negative workerNum",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				WorkerNum: -1,
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum: -1,
+			},
+		},
+		{
+			name:    "negative commandQueueBufferSize",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandQueueBufferSize: -1,
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandQueueBufferSize: -1,
+			},
+		},
+		{
+			name:    "negative commandCheckInterval",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandCheckInterval: Duration(-time.Second),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandCheckInterval: Duration(-time.Second),
+			},
+		},
+		{
+			name:    "negative commandHandleTimeout",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandHandleTimeout: Duration(-time.Minute),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandHandleTimeout: Duration(-time.Minute),
+			},
+		},
+		{
+			name:    "all zero",
+			wantErr: false,
+			planPreview: PipedPlanPreview{
+				WorkerNum:              0,
+				CommandQueueBufferSize: 0,
+				CommandCheckInterval:   Duration(0),
+				CommandHandleTimeout:   Duration(0),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum:              0,
+				CommandQueueBufferSize: 0,
+				CommandCheckInterval:   Duration(0),
+				CommandHandleTimeout:   Duration(0),
+			},
+		},
+		{
+			name:    "valid values",
+			wantErr: false,
+			planPreview: PipedPlanPreview{
+				WorkerNum:              5,
+				CommandQueueBufferSize: 20,
+				CommandCheckInterval:   Duration(5 * time.Second),
+				CommandHandleTimeout:   Duration(10 * time.Minute),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum:              5,
+				CommandQueueBufferSize: 20,
+				CommandCheckInterval:   Duration(5 * time.Second),
+				CommandHandleTimeout:   Duration(10 * time.Minute),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.planPreview.Validate()
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.wantPipedPlanPreview, tc.planPreview)
 		})
 	}
 }
@@ -1137,6 +1232,12 @@ func TestPipedSpecClone(t *testing.T) {
 						},
 					},
 				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
+				},
 			},
 			expectedSpec: &PipedSpec{
 				ProjectID:             "test-project",
@@ -1334,6 +1435,12 @@ func TestPipedSpecClone(t *testing.T) {
 							Includes:      []string{"event-watcher-dev.yaml", "event-watcher-stg.yaml"},
 						},
 					},
+				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
 				},
 			},
 			expectedError: nil,

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -243,3 +243,9 @@ spec:
         includes:
           - event-watcher-dev.yaml
           - event-watcher-stg.yaml
+
+  planPreview:
+    workerNum: 5
+    commandQueueBufferSize: 20
+    commandCheckInterval: 5s
+    commandHandleTimeout: 10m

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -64,6 +64,8 @@ type PipedSpec struct {
 	SecretManagement *SecretManagement `json:"secretManagement,omitempty"`
 	// Optional settings for event watcher.
 	EventWatcher PipedEventWatcher `json:"eventWatcher"`
+	// Optional settings for plan-preview command handling.
+	PlanPreview PipedPlanPreview `json:"planPreview"`
 	// List of labels to filter all applications this piped will handle.
 	AppSelector map[string]string `json:"appSelector,omitempty"`
 }
@@ -111,6 +113,9 @@ func (s *PipedSpec) Validate() error {
 		}
 	}
 	if err := s.EventWatcher.Validate(); err != nil {
+		return err
+	}
+	if err := s.PlanPreview.Validate(); err != nil {
 		return err
 	}
 	for _, n := range s.Notifications.Receivers {
@@ -630,6 +635,33 @@ type PipedEventWatcherGitRepo struct {
 	// Patterns can be used like "foo/*.yaml".
 	// This is prioritized if both includes and this one are given.
 	Excludes []string `json:"excludes,omitempty"`
+}
+
+type PipedPlanPreview struct {
+	// Number of workers to handle plan-preview commands.
+	WorkerNum int `json:"workerNum,omitempty"`
+	// Channel buffer size used for plan-preview commands.
+	CommandQueueBufferSize int `json:"commandQueueBufferSize,omitempty"`
+	// Interval to fetch plan-preview commands.
+	CommandCheckInterval Duration `json:"commandCheckInterval,omitempty"`
+	// Timeout to handle each plan-preview command.
+	CommandHandleTimeout Duration `json:"commandHandleTimeout,omitempty"`
+}
+
+func (p *PipedPlanPreview) Validate() error {
+	if p.WorkerNum < 0 {
+		return errors.New("planPreview.workerNum must be greater than or equal to 0")
+	}
+	if p.CommandQueueBufferSize < 0 {
+		return errors.New("planPreview.commandQueueBufferSize must be greater than or equal to 0")
+	}
+	if p.CommandCheckInterval < 0 {
+		return errors.New("planPreview.commandCheckInterval must be greater than or equal to 0")
+	}
+	if p.CommandHandleTimeout < 0 {
+		return errors.New("planPreview.commandHandleTimeout must be greater than or equal to 0")
+	}
+	return nil
 }
 
 // PipedPlugin defines the plugin configuration for the piped.

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -638,13 +638,13 @@ type PipedEventWatcherGitRepo struct {
 }
 
 type PipedPlanPreview struct {
-	// Number of workers to handle plan-preview commands.
+	// WorkerNum is the number of worker goroutines processing plan-preview commands.
 	WorkerNum int `json:"workerNum,omitempty"`
-	// Channel buffer size used for plan-preview commands.
+	// CommandQueueBufferSize is the buffer size of the internal command channel.
 	CommandQueueBufferSize int `json:"commandQueueBufferSize,omitempty"`
-	// Interval to fetch plan-preview commands.
+	// CommandCheckInterval is how often to poll for new plan-preview commands.
 	CommandCheckInterval Duration `json:"commandCheckInterval,omitempty"`
-	// Timeout to handle each plan-preview command.
+	// CommandHandleTimeout is the default timeout for building each plan-preview result when the command does not specify one.
 	CommandHandleTimeout Duration `json:"commandHandleTimeout,omitempty"`
 }
 

--- a/pkg/configv1/piped_test.go
+++ b/pkg/configv1/piped_test.go
@@ -247,6 +247,12 @@ func TestPipedConfig(t *testing.T) {
 						},
 					},
 				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
+				},
 			},
 			expectedError: nil,
 		},
@@ -260,6 +266,95 @@ func TestPipedConfig(t *testing.T) {
 				assert.Equal(t, tc.expectedAPIVersion, cfg.APIVersion)
 				assert.Equal(t, tc.expectedSpec, cfg.Spec)
 			}
+		})
+	}
+}
+
+func TestPipedPlanPreviewValidate(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		planPreview          PipedPlanPreview
+		wantErr              bool
+		wantPipedPlanPreview PipedPlanPreview
+	}{
+		{
+			name:    "negative workerNum",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				WorkerNum: -1,
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum: -1,
+			},
+		},
+		{
+			name:    "negative commandQueueBufferSize",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandQueueBufferSize: -1,
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandQueueBufferSize: -1,
+			},
+		},
+		{
+			name:    "negative commandCheckInterval",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandCheckInterval: Duration(-time.Second),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandCheckInterval: Duration(-time.Second),
+			},
+		},
+		{
+			name:    "negative commandHandleTimeout",
+			wantErr: true,
+			planPreview: PipedPlanPreview{
+				CommandHandleTimeout: Duration(-time.Minute),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				CommandHandleTimeout: Duration(-time.Minute),
+			},
+		},
+		{
+			name:    "all zero",
+			wantErr: false,
+			planPreview: PipedPlanPreview{
+				WorkerNum:              0,
+				CommandQueueBufferSize: 0,
+				CommandCheckInterval:   Duration(0),
+				CommandHandleTimeout:   Duration(0),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum:              0,
+				CommandQueueBufferSize: 0,
+				CommandCheckInterval:   Duration(0),
+				CommandHandleTimeout:   Duration(0),
+			},
+		},
+		{
+			name:    "valid values",
+			wantErr: false,
+			planPreview: PipedPlanPreview{
+				WorkerNum:              5,
+				CommandQueueBufferSize: 20,
+				CommandCheckInterval:   Duration(5 * time.Second),
+				CommandHandleTimeout:   Duration(10 * time.Minute),
+			},
+			wantPipedPlanPreview: PipedPlanPreview{
+				WorkerNum:              5,
+				CommandQueueBufferSize: 20,
+				CommandCheckInterval:   Duration(5 * time.Second),
+				CommandHandleTimeout:   Duration(10 * time.Minute),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.planPreview.Validate()
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.wantPipedPlanPreview, tc.planPreview)
 		})
 	}
 }
@@ -765,6 +860,12 @@ func TestPipedSpecClone(t *testing.T) {
 						},
 					},
 				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
+				},
 			},
 			expectedSpec: &PipedSpec{
 				ProjectID:             "test-project",
@@ -854,6 +955,12 @@ func TestPipedSpecClone(t *testing.T) {
 							Includes:      []string{"event-watcher-dev.yaml", "event-watcher-stg.yaml"},
 						},
 					},
+				},
+				PlanPreview: PipedPlanPreview{
+					WorkerNum:              5,
+					CommandQueueBufferSize: 20,
+					CommandCheckInterval:   Duration(5 * time.Second),
+					CommandHandleTimeout:   Duration(10 * time.Minute),
 				},
 			},
 			expectedError: nil,

--- a/pkg/configv1/testdata/piped/piped-config.yaml
+++ b/pkg/configv1/testdata/piped/piped-config.yaml
@@ -201,3 +201,9 @@ spec:
         includes:
           - event-watcher-dev.yaml
           - event-watcher-stg.yaml
+
+  planPreview:
+    workerNum: 5
+    commandQueueBufferSize: 20
+    commandCheckInterval: 5s
+    commandHandleTimeout: 10m


### PR DESCRIPTION
**What this PR does**:
Adds a configurable `planPreview` section to piped config (`PipedSpec` in both `pkg/config` and `pkg/configv1`).

These values are validated and then passed to `planpreview.NewHandler` using existing options:
- `WithWorkerNum`
- `WithCommandQueueBufferSize`
- `WithCommandCheckInterval`
- `WithCommandHandleTimeout`

The configuration is applied in both piped entrypoints (`pkg/app/piped/cmd/piped` and `pkg/app/pipedv1/cmd/piped`).

Also includes tests to ensure:
- YAML parsing works correctly
- Invalid (negative) values fail validation

**Why we need it**: 
Currently plan preview behavior can only be tuned internally (mainly in tests).
This change allows to configure things like worker count, queue size, and timing directly from piped config.

### **Fixes Issue #5916**

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: 
  - Users can optionally add a `spec.planPreview` block in piped YAML:
    - `workerNum`
    - `commandQueueBufferSize`
    - `commandCheckInterval`
    - `commandHandleTimeout` (duration format like `5s`, `10m`)
  - If not provided, existing default behavior remains unchanged
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
