### PR TITLE
bug(lambda): retain repository name for unknown git providers

### DIFF
--- a/pkg/app/piped/platformprovider/lambda/function.go
+++ b/pkg/app/piped/platformprovider/lambda/function.go
@@ -270,7 +270,6 @@ func FindArtifactVersions(fm FunctionManifest) ([]*model.ArtifactVersion, error)
 		default:
 			// TODO: Show repo name with commit link for other git provider
 			gitURL = ""
-			repoPath = ""
 		}
 
 		return []*model.ArtifactVersion{

--- a/pkg/app/piped/platformprovider/lambda/function_test.go
+++ b/pkg/app/piped/platformprovider/lambda/function_test.go
@@ -512,7 +512,7 @@ spec:
 				{
 					Kind:    model.ArtifactVersion_GIT_SOURCE,
 					Version: "dede7cdea5bbd3fdbcc4674bfcd2b2f9e0579603",
-					Name:    "",
+					Name:    "username/lambda-function-code",
 					Url:     "",
 				},
 			},


### PR DESCRIPTION
**What this PR does**:

In `pkg/app/piped/platformprovider/lambda/function.go`, the `FindArtifactVersions` function attempts to parse the Git URL to generate a commit hyperlink for Lambda Source Code deployments. If it encounters a Git host it doesn't instantly recognize (like AWS CodeCommit or an internal Git server), it formerly fell into a `default` case that completely wiped out both the `gitURL` hyperlink AND the `repoPath`. This PR removes the line zeroing out `repoPath`, safely retaining the parsed repository path as the artifact name fallback when the Git provider's hyperlink format is visually unknown.

**Why we need it**:

Zeroing out the `repoPath` caused the `ArtifactVersion.Name` to become empty, resulting in completely blank artifact layers surfacing within the PipeCD web UI. By safely preserving the `repoPath`, PipeCD can correctly identify and display the source repository path during deployments even if it can't hyperlink the commit hash itself. 

**Which issue(s) this PR fixes**:

Fixes #6666 

**Does this PR introduce a user-facing change?**:
Yes. 

- **How are users affected by this change**: 

Users loading AWS Lambda configurations backed by unknown / self-hosted Git providers will now see their repository correctly displayed in the PipeCD UI.

- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A
