### PR TITLE
[ECS-Plugin]: Determine strategy for deployment

### DIFF
--- a/pkg/app/pipedv1/plugin/ecs/deployment/determine.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/determine.go
@@ -15,6 +15,8 @@
 package deployment
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -52,6 +54,74 @@ func parseContainerImage(image string) (img containerImage) {
 
 	img.name = last
 	return
+}
+
+// containerImages returns a map of container names to their images in the task definition that have both a name and an image set.
+func containerImages(taskDef types.TaskDefinition) map[string]string {
+	m := make(map[string]string, len(taskDef.ContainerDefinitions))
+	for _, c := range taskDef.ContainerDefinitions {
+		if c.Name == nil || c.Image == nil || *c.Image == "" {
+			continue
+		}
+		m[*c.Name] = *c.Image
+	}
+	return m
+}
+
+// determineStrategy compares the running and target task definitions and returns the appropriate sync strategy:
+//
+// Use PipelineSync if any container image added, removed, or changed.
+//
+// Use QuickSync if no image difference.
+func determineStrategy(running, target types.TaskDefinition) *sdk.DetermineStrategyResponse {
+	runningImages := containerImages(running)
+	targetImages := containerImages(target)
+
+	var changes []string
+
+	for name, targetImage := range targetImages {
+		runningImage, exists := runningImages[name]
+		if !exists {
+			changes = append(changes, fmt.Sprintf("added container %s with image %s", name, targetImage))
+			continue
+		}
+		if runningImage != targetImage {
+			ri := parseContainerImage(runningImage)
+			ti := parseContainerImage(targetImage)
+			if ri.name == ti.name {
+				riVer := ri.tag
+				if riVer == "" {
+					riVer = ri.digest
+				}
+				tiVer := ti.tag
+				if tiVer == "" {
+					tiVer = ti.digest
+				}
+				changes = append(changes, fmt.Sprintf("image %s from %s to %s", ri.name, riVer, tiVer))
+			} else {
+				changes = append(changes, fmt.Sprintf("image %s to %s", runningImage, targetImage))
+			}
+		}
+	}
+
+	for name := range runningImages {
+		if _, exists := targetImages[name]; !exists {
+			changes = append(changes, fmt.Sprintf("removed container %s", name))
+		}
+	}
+
+	if len(changes) > 0 {
+		sort.Strings(changes)
+		return &sdk.DetermineStrategyResponse{
+			Strategy: sdk.SyncStrategyPipelineSync,
+			Summary:  fmt.Sprintf("Sync progressively because of updating %s", strings.Join(changes, ", ")),
+		}
+	}
+
+	return &sdk.DetermineStrategyResponse{
+		Strategy: sdk.SyncStrategyQuickSync,
+		Summary:  "Quick sync because no container image change was detected",
+	}
 }
 
 // determineVersions extracts artifact versions from an ECS task definition.

--- a/pkg/app/pipedv1/plugin/ecs/deployment/determine_test.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/determine_test.go
@@ -90,6 +90,183 @@ func TestParseContainerImage(t *testing.T) {
 	}
 }
 
+func TestDetermineStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		running types.TaskDefinition
+		target  types.TaskDefinition
+		want    *sdk.DetermineStrategyResponse
+	}{
+		{
+			name: "no change -> QuickSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyQuickSync,
+				Summary:  "Quick sync because no container image change was detected",
+			},
+		},
+		{
+			name: "image tag updated -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.25")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating image nginx from 1.21 to 1.25",
+			},
+		},
+		{
+			name: "image replaced with different name -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("apache:2.4")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating image nginx:1.21 to apache:2.4",
+			},
+		},
+		{
+			name: "container added -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+					{Name: aws.String("sidecar"), Image: aws.String("redis:7.0")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating added container sidecar with image redis:7.0",
+			},
+		},
+		{
+			name: "container removed -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+					{Name: aws.String("sidecar"), Image: aws.String("redis:7.0")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating removed container sidecar",
+			},
+		},
+		{
+			name: "multiple containers, only one image changed -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+					{Name: aws.String("sidecar"), Image: aws.String("redis:7.0")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.25")},
+					{Name: aws.String("sidecar"), Image: aws.String("redis:7.0")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating image nginx from 1.21 to 1.25",
+			},
+		},
+		{
+			name:    "empty running task definition -> all containers treated as added",
+			running: types.TaskDefinition{},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx:1.21")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating added container app with image nginx:1.21",
+			},
+		},
+		{
+			name:    "both empty -> QuickSync",
+			running: types.TaskDefinition{},
+			target:  types.TaskDefinition{},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyQuickSync,
+				Summary:  "Quick sync because no container image change was detected",
+			},
+		},
+		// Digest image cases
+		{
+			name: "added container with digest image -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx@sha256:abcdef1234567890")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating added container app with image nginx@sha256:abcdef1234567890",
+			},
+		},
+		{
+			name: "digest updated -> PipelineSync",
+			running: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx@sha256:aaaa")},
+				},
+			},
+			target: types.TaskDefinition{
+				ContainerDefinitions: []types.ContainerDefinition{
+					{Name: aws.String("app"), Image: aws.String("nginx@sha256:bbbb")},
+				},
+			},
+			want: &sdk.DetermineStrategyResponse{
+				Strategy: sdk.SyncStrategyPipelineSync,
+				Summary:  "Sync progressively because of updating image nginx from sha256:aaaa to sha256:bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineStrategy(tt.running, tt.target)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestDetermineVersions(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/app/pipedv1/plugin/ecs/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/plugin.go
@@ -124,14 +124,50 @@ func (p *ECSPlugin) DetermineVersions(
 }
 
 // DetermineStrategy determines the strategy to deploy the resources.
+//
+// Use PipelineSync if any container image added, removed, or changed.
+//
+// Use QuickSync if no image difference.
 func (p *ECSPlugin) DetermineStrategy(
 	ctx context.Context,
 	cfg *ecsconfig.ECSPluginConfig,
 	input *sdk.DetermineStrategyInput[ecsconfig.ECSApplicationSpec],
 ) (*sdk.DetermineStrategyResponse, error) {
-	// Use quick sync as the default strategy for ECS deployment.
-	return &sdk.DetermineStrategyResponse{
-		Strategy: sdk.SyncStrategyQuickSync,
-		Summary:  "Use quick sync strategy for ECS deployment (work as ECS_SYNC stage)",
-	}, nil
+	targetAppCfg, err := input.Request.TargetDeploymentSource.AppConfig()
+	if err != nil {
+		input.Logger.Error("failed to load target application config", zap.Error(err))
+		return nil, err
+	}
+
+	taskDefFile := targetAppCfg.Spec.Input.TaskDefinitionFile
+
+	targetTaskDef, err := provider.LoadTaskDefinition(
+		input.Request.TargetDeploymentSource.ApplicationDirectory,
+		taskDefFile,
+	)
+	if err != nil {
+		input.Logger.Error("failed to load target task definition", zap.Error(err))
+		return nil, err
+	}
+
+	if input.Request.RunningDeploymentSource.ApplicationDirectory == "" {
+		return &sdk.DetermineStrategyResponse{
+			Strategy: sdk.SyncStrategyPipelineSync,
+			Summary:  "Sync with the specified pipeline (no running deployment source)",
+		}, nil
+	}
+
+	runningTaskDef, err := provider.LoadTaskDefinition(
+		input.Request.RunningDeploymentSource.ApplicationDirectory,
+		taskDefFile,
+	)
+	if err != nil {
+		input.Logger.Warn("failed to load running task definition, falling back to pipeline sync", zap.Error(err))
+		return &sdk.DetermineStrategyResponse{
+			Strategy: sdk.SyncStrategyPipelineSync,
+			Summary:  "Sync with the specified pipeline (unable to load running task definition)",
+		}, nil
+	}
+
+	return determineStrategy(runningTaskDef, targetTaskDef), nil
 }


### PR DESCRIPTION
**What this PR does**:  Implements `DetermineStrategy` for the ECS plugin

**Why we need it**: compares the container images between the running and target task definitions to choose the appropriate sync strategy:
- Any image added, removed, or changed: PipelineSync (canary/progressive deployment)
- No image difference: QuickSync

**Which issue(s) this PR fixes**: Previously DetermineStrategy always returned QuickSync, which caused the pipeline configured by users to be silently bypassed on every deployment

Fixes # Part of #6443 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
