### PR TITLE
docs: move plugin configuration guides to plugins section

### DIFF
--- a/docs/content/en/docs-v1.0.x/plugins/_index.md
+++ b/docs/content/en/docs-v1.0.x/plugins/_index.md
@@ -14,6 +14,12 @@ description: >
 | [Kubernetes multi-cluster](kubernetes-multicluster/) | Deploy a single application to multiple Kubernetes clusters with one pipeline. | Alpha |
 | [ECS](ecs/) | Deploy applications to Amazon ECS using the `EXTERNAL` deployment controller | Alpha |
 
+This section contains configuration guides for the official PipeCD plugins.
+
+- [Kubernetes](./kubernetes/)
+- [Terraform](./terraform/)
+- [Analysis](./analysis/)
+
 In PipeCD v1, plugins handle deployments. `piped` runs each configured plugin as a separate process and communicates with it over gRPC, so which platforms your `piped` can deploy to depends on which plugins you configure. See more about [plugins](../concepts/#plugins).
 
 There are two types of plugins:

--- a/docs/content/en/docs-v1.0.x/plugins/analysis.md
+++ b/docs/content/en/docs-v1.0.x/plugins/analysis.md
@@ -1,12 +1,12 @@
 ---
-title: "Adding an analysis provider"
-linkTitle: "Adding analysis provider"
-weight: 6
+title: "Analysis Plugin"
+linkTitle: "Analysis"
+weight: 30
 description: >
   This page describes how to add an Analysis Provider to analyze the metrics of your deployment.
 ---
 
-To enable automated deployment analysis, you have to set the needed information for `piped` to connect to the [Analysis Provider](../../../concepts/#analysis-provider). See [managing applications](../managing-application/) for deployment and analysis features.
+To enable automated deployment analysis, you have to set the needed information for `piped` to connect to the Analysis Provider. See [managing applications](../user-guide/managing-application/) for deployment and analysis features.
 
 Currently, PipeCD supports the following providers:
 
@@ -35,7 +35,7 @@ spec:
               address: https://your-prometheus.dev
 ```
 
-To know more, see the full list of [configurable fields](configuration-reference/#analysisproviderprometheusconfig).
+To know more, see the full list of [configurable fields](../user-guide/managing-piped/configuration-reference/#analysisproviderprometheusconfig).
 
 ## Datadog
 
@@ -58,9 +58,9 @@ spec:
               applicationKeyFile: /etc/piped-secret/datadog-application-key
 ```
 
-To know more, see the full list of [configurable fields](configuration-reference/#analysisproviderdatadogconfig).
+To know more, see the full list of [configurable fields](../user-guide/managing-piped/configuration-reference/#analysisproviderdatadogconfig).
 
-If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
+If you choose `Helm` as the installation method, we recommend using `--set-file` to mount the key files while performing the [upgrading process](../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode).
 
 ```bash
 --set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \

--- a/docs/content/en/docs-v1.0.x/plugins/kubernetes.md
+++ b/docs/content/en/docs-v1.0.x/plugins/kubernetes.md
@@ -1,0 +1,31 @@
+---
+title: "Kubernetes Plugin"
+linkTitle: "Kubernetes"
+weight: 10
+description: >
+  How to configure the Kubernetes plugin.
+---
+
+The Kubernetes plugin enables PipeCD to manage Kubernetes application deployments.
+
+By default, piped deploys Kubernetes application to the cluster where the piped is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in [`deployTargets`](../user-guide/managing-piped/configuration-reference/#kubernetesplugin).
+
+Below is an example configuration for using the Kubernetes plugin:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  ...
+  plugins:
+    - name: kubernetes
+      port: 7001
+      url: https://github.com/pipe-cd/pipecd/releases/download/pkg%2Fapp%2Fpipedv1%2Fplugin%2Fkubernetes%2Fv0.1.0/kubernetes_v0.1.0_darwin_arm64
+      deployTargets:
+        - name: local
+          config:
+            kubectlVersion: 1.32.4
+            kubeConfigPath: /path/to/.kube/config
+```
+
+See [Configuration Reference for Kubernetes plugin](../user-guide/managing-piped/configuration-reference/#kubernetesplugin) for complete configuration details.

--- a/docs/content/en/docs-v1.0.x/plugins/terraform.md
+++ b/docs/content/en/docs-v1.0.x/plugins/terraform.md
@@ -1,0 +1,28 @@
+---
+title: "Terraform Plugin"
+linkTitle: "Terraform"
+weight: 20
+description: >
+  How to configure the Terraform plugin.
+---
+
+The Terraform plugin enables Piped to run Terraform-based deployments.
+A deploy target represents a Terraform execution environment (e.g., dev/prod workspace, shared variables, drift detection settings).
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  ...
+  plugins:
+    - name: terraform
+      port: 7002
+      url: https://github.com/.../terraform_v0.3.0_linux_amd64
+      deployTargets:
+        - name: tf-dev
+          config:
+            vars:
+              - "project=pipecd"
+```
+
+See [Configuration Reference for Terraform plugin](../user-guide/managing-piped/configuration-reference/#terraformplugin) for complete configuration details.

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuring-a-plugin.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuring-a-plugin.md
@@ -21,7 +21,7 @@ Currently, the official plugins maintained by the PipeCD Maintainers are:
 
 We are working towards releasing more plugins in the future.
 
->**Note:**  
+>**Note:**
 > We also have the [PipeCD Community Plugins repository](https://github.com/pipe-cd/community-plugins) for plugins made by the PipeCD Community.
 
 A plugin is added to the `piped` configuration inside the `spec.plugins` array and providing the plugin’s executable URL, the port it should run on, and any deploy targets that belong to it. For more details, see the [configuration reference for plugins](../configuration-reference/#plugins).
@@ -44,55 +44,4 @@ Check out the latest plugin releases on [GitHub](https://github.com/pipe-cd/pipe
 
 ---
 
-Now, we will see how you can configure plugins for different application types.
-
-## Configuring Kubernetes plugin
-
-The Kubernetes plugin enables PipeCD to manage Kubernetes application deployments.
-
-By default, `piped` deploys Kubernetes application to the cluster where the `piped` is running in. An external cluster can be connected by specifying the `masterURL` and `kubeConfigPath` in [`deployTargets`](../configuration-reference/#kubernetesplugin).
-
-<!-- And, the default resources (defined [here](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/platformprovider/kubernetes/resourcekey.go)) from all namespaces of the Kubernetes cluster will be watched for rendering the application state in realtime and detecting the configuration drift. In case you want to restrict piped to watch only a single namespace, let specify the namespace in the [KubernetesAppStateInformer](../configuration-reference/#kubernetesappstateinformer) field. You can also add other resources or exclude resources to/from the watching targets by that field. -->
-
-Below is an example configuration for using the Kubernetes plugin:
-
-``` yaml
-apiVersion: pipecd.dev/v1beta1
-kind: Piped
-spec:
-  ...
-  plugins:
-    - name: kubernetes
-      port: 7001
-      url: https://github.com/pipe-cd/pipecd/releases/download/pkg%2Fapp%2Fpipedv1%2Fplugin%2Fkubernetes%2Fv0.1.0/kubernetes_v0.1.0_darwin_arm64
-      deployTargets:
-        - name: local
-          config:
-            kubectlVersion: 1.32.4
-            kubeConfigPath: /path/to/.kube/config
-```
-
-See [Configuration Reference for Kubernetes plugin](../configuration-reference/#kubernetesplugin) for complete configuration details.
-
-## Configuring Terraform plugin
-
-The Terraform plugin enables `piped` to run Terraform-based deployments.
-A deploy target represents a Terraform execution environment (e.g., dev/prod workspace, shared variables, drift detection settings).
-
-``` yaml
-apiVersion: pipecd.dev/v1beta1
-kind: Piped
-spec:
-  ...
-  plugins:
-    - name: terraform
-      port: 7002
-      url: https://github.com/.../terraform_v0.3.0_linux_amd64
-      deployTargets:
-        - name: tf-dev
-          config:
-            vars:
-              - "project=pipecd"
-```
-
-See [Configuration Reference for Terraform plugin](../configuration-reference/#terraformplugin) for complete configuration details.
+> **Note:** Detailed configuration guides for specific plugins have been moved to the [Plugins](../../plugins/) section.


### PR DESCRIPTION
**What this PR does**:
Moves plugin-specific configuration guides out of the User Guide and into the new Plugins section. Specifically:
- Extracts the Kubernetes and Terraform plugin configuration sections from `user-guide/managing-piped/configuring-a-plugin.md` into dedicated pages under `plugins/`
- Moves `user-guide/managing-piped/adding-an-analysis-provider.md` to `plugins/analysis.md`
- Updates `plugins/_index.md` to link to the three new pages instead of showing a WIP placeholder
- Adds a redirect note in `configuring-a-plugin.md` pointing users to the new Plugins section

**Why we need it**:
The plugin documentation was scattered across the User Guide. Having dedicated pages under the Plugins section makes it easier for users to find plugin-specific configuration guides in one place.

**Which issue(s) this PR fixes**:
Fixes #6540

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: Plugin configuration guides are now located at `/docs-v1.0.x/plugins/` instead of inside the User Guide. A note in `configuring-a-plugin.md` directs users to the new location.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A