### PR TITLE
[Pipedv1] Scan preinstalled tools

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry.go
+++ b/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry.go
@@ -50,6 +50,11 @@ func newToolRegistry(toolsDir string) (*toolRegistry, error) {
 		return nil, fmt.Errorf("failed to create the tools directory: %w", err)
 	}
 
+	installedTools, err := loadPreinstalledTools(toolsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load installed tools: %w", err)
+	}
+
 	tmpDir, err := os.MkdirTemp("", "tool-registry")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a temporary directory: %w", err)
@@ -57,8 +62,22 @@ func newToolRegistry(toolsDir string) (*toolRegistry, error) {
 	return &toolRegistry{
 		toolsDir:       toolsDir,
 		tmpDir:         tmpDir,
-		installedTools: make(map[string]struct{}),
+		installedTools: installedTools,
 	}, nil
+}
+
+func loadPreinstalledTools(toolsDir string) (map[string]struct{}, error) {
+	tools := make(map[string]struct{})
+	entries, err := os.ReadDir(toolsDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			tools[entry.Name()] = struct{}{}
+		}
+	}
+	return tools, nil
 }
 
 func (r *toolRegistry) newTmpDir() (string, error) {

--- a/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry.go
+++ b/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry.go
@@ -154,6 +154,10 @@ func (r *toolRegistry) installTool(ctx context.Context, name, version, script st
 		return "", fmt.Errorf("failed to move the installed binary: %w, output: %s", err, string(out))
 	}
 
+	if err := os.RemoveAll(filepath.Dir(outPath)); err != nil {
+		return "", err
+	}
+
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return "", err
 	}

--- a/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry_test.go
+++ b/pkg/app/pipedv1/cmd/piped/grpcapi/tool_registry_test.go
@@ -81,6 +81,27 @@ func TestToolRegistry_InstallTool(t *testing.T) {
 	}
 }
 
+func TestToolRegistry_LoadPreinstalledTools(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	toolsDir, err := os.MkdirTemp(t.TempDir(), "tools")
+	require.NoError(t, err)
+
+	toolName := "tool-a"
+	toolVersion := "1.0.0"
+	toolPath := toolsDir + "/" + toolName + "-" + toolVersion
+	require.NoError(t, os.WriteFile(toolPath, []byte("binary"), 0o755))
+
+	registry, err := newToolRegistry(toolsDir)
+	require.NoError(t, err)
+
+	out, err := registry.InstallTool(ctx, toolName, toolVersion, "exit 1")
+	require.NoError(t, err)
+	assert.Equal(t, toolPath, out)
+}
+
 func TestToolRegistry_InstallTool_CacheHit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does**: Adds scanning of the tools directory on registry initialization in pipedv1, so already-installed tools are recognized without re-downloading.

Also cleans up the outDir after a successful tool install

**Why we need it**: Previously, newToolRegistry initialized installedTools as an empty map, causing piped to re-download and overwrite all tool binaries on every restart even if the binaries already existed on disk

**Which issue(s) this PR fixes**: 

Fixes #6709

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
