### PR TITLE
fix: propagate json.Unmarshal error in mysql rowDataConverter

### DIFF
--- a/pkg/datastore/mysql/iterator.go
+++ b/pkg/datastore/mysql/iterator.go
@@ -24,7 +24,7 @@ import (
 )
 
 type dataConverter interface {
-	Data() map[string]interface{}
+	Data() (map[string]interface{}, error)
 }
 
 // Iterator for MySQL result set
@@ -59,7 +59,10 @@ func (it *Iterator) Cursor() (string, error) {
 		return "", datastore.ErrInvalidCursor
 	}
 
-	lastObjData := it.last.Data()
+	lastObjData, err := it.last.Data()
+	if err != nil {
+		return "", err
+	}
 
 	cursor := make(map[string]interface{}, len(it.orders))
 	for _, o := range it.orders {
@@ -80,11 +83,13 @@ type rowDataConverter struct {
 }
 
 // Data make JSON object with key in CamelCase format.
-func (r *rowDataConverter) Data() map[string]interface{} {
+func (r *rowDataConverter) Data() (map[string]interface{}, error) {
 	jsonRaw := convertKeys(json.RawMessage(r.val), convertSnakeToCamel)
 	obj := make(map[string]interface{})
-	json.Unmarshal(jsonRaw, &obj)
-	return obj
+	if err := json.Unmarshal(jsonRaw, &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
 }
 
 // convertKeys convert all keys of json object with convert function.

--- a/pkg/datastore/mysql/iterator_test.go
+++ b/pkg/datastore/mysql/iterator_test.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"encoding/base64"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,10 +26,11 @@ import (
 
 type dummyDoc struct {
 	val map[string]interface{}
+	err error
 }
 
-func (d *dummyDoc) Data() map[string]interface{} {
-	return d.val
+func (d *dummyDoc) Data() (map[string]interface{}, error) {
+	return d.val, d.err
 }
 
 func TestCursor(t *testing.T) {
@@ -41,6 +43,15 @@ func TestCursor(t *testing.T) {
 		{
 			name:      "invalid cursor error returns on last is nil",
 			iter:      Iterator{},
+			expectErr: true,
+		},
+		{
+			name: "error on last data conversion",
+			iter: Iterator{
+				last: &dummyDoc{
+					err: errors.New("data conversion error"),
+				},
+			},
 			expectErr: true,
 		},
 		{
@@ -108,6 +119,7 @@ func TestData(t *testing.T) {
 		name         string
 		rowData      string
 		expectedData map[string]interface{}
+		expectErr    bool
 	}{
 		{
 			name:    "valid data",
@@ -118,6 +130,7 @@ func TestData(t *testing.T) {
 				"UpdatedAt": float64(100),
 				"CreatedAt": float64(100),
 			},
+			expectErr: false,
 		},
 		{
 			name:    "valid nested data",
@@ -130,14 +143,25 @@ func TestData(t *testing.T) {
 				"UpdatedAt": float64(100),
 				"CreatedAt": float64(100),
 			},
+			expectErr: false,
+		},
+		{
+			name:         "invalid json data",
+			rowData:      `{"id": "object-id", "name": "app-1", "updated_at": 100, "created_at": 100`, // missing closing brace
+			expectedData: nil,
+			expectErr:    true,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			converter := &rowDataConverter{val: tc.rowData}
-			data := converter.Data()
+			data, err := converter.Data()
 			assert.Equal(t, tc.expectedData, data)
+			assert.Equal(t, tc.expectErr, err != nil)
+			if err != nil {
+				t.Logf("Expected error caught: %v", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Resolves #6699

The rowDataConverter in the MySQL datastore now returns an error that bubbles up through Iterator.Next() to handle silent json.Unmarshal failures.