### PR TITLE
Fix typos and heading level in piped configuration docs

### DIFF
--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -201,7 +201,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | type | string | Which management method should be used. Default is `KEY_PAIR`. | Yes |
-| config | [SecretManagementConfig](#secretmanagementconfig) | Configration for using secret management method. | Yes |
+| config | [SecretManagementConfig](#secretmanagementconfig) | Configuration for using secret management method. | Yes |
 
 ## SecretManagementConfig
 
@@ -248,7 +248,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The name of the receiver. | Yes |
-| slack | [NotificationReciverSlack](#notificationreceiverslack) | Configuration for slack receiver. | No |
+| slack | [NotificationReceiverSlack](#notificationreceiverslack) | Configuration for slack receiver. | No |
 | webhook | [NotificationReceiverWebhook](#notificationreceiverwebhook) | Configuration for webhook receiver. | No |
 
 #### NotificationReceiverSlack
@@ -258,10 +258,10 @@ Must be one of the following structs:
 | hookURL | string | The hookURL of a slack channel. | Yes |
 | oauthToken | string | [The token for Slack API use.](https://api.slack.com/authentication/basics) (deprecated)| No |
 | oauthTokenData | string | Base64 encoded string of [The token for Slack API use.](https://api.slack.com/authentication/basics) | No |
-| oauthTokenFile | string | The path to the oautoken file | No |
+| oauthTokenFile | string | The path to the oauthToken file | No |
 | channelID | string | The channel id which slack api send to. | No |
-| mentionedAccounts | []string | The accounts to which slack api referes. This field supports both `@username` and `username` writing styles.| No |
-| mentionedGroups | []string | The groups to which slack api referes. This field supports both `<!subteam^groupname>` and `groupname` writing styles.| No |
+| mentionedAccounts | []string | The accounts to which slack api refers. This field supports both `@username` and `username` writing styles.| No |
+| mentionedGroups | []string | The groups to which slack api refers. This field supports both `<!subteam^groupname>` and `groupname` writing styles.| No |
 
 #### NotificationReceiverWebhook
 

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuration-reference.md
@@ -206,7 +206,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | type | string | Which management method should be used. Default is `KEY_PAIR`. | Yes |
-| config | [SecretManagementConfig](#secretmanagementconfig) | Configration for using secret management method. | Yes |
+| config | [SecretManagementConfig](#secretmanagementconfig) | Configuration for using secret management method. | Yes |
 
 ## SecretManagementConfig
 
@@ -253,7 +253,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The name of the receiver. | Yes |
-| slack | [NotificationReciverSlack](#notificationreceiverslack) | Configuration for slack receiver. | No |
+| slack | [NotificationReceiverSlack](#notificationreceiverslack) | Configuration for slack receiver. | No |
 | webhook | [NotificationReceiverWebhook](#notificationreceiverwebhook) | Configuration for webhook receiver. | No |
 
 #### NotificationReceiverSlack
@@ -263,10 +263,10 @@ Must be one of the following structs:
 | hookURL | string | The hookURL of a slack channel. | Yes |
 | oauthToken | string | [The token for Slack API use.](https://api.slack.com/authentication/basics) (deprecated)| No |
 | oauthTokenData | string | Base64 encoded string of [The token for Slack API use.](https://api.slack.com/authentication/basics) | No |
-| oauthTokenFile | string | The path to the oautoken file | No |
+| oauthTokenFile | string | The path to the oauthToken file | No |
 | channelID | string | The channel id which slack api send to. | No |
-| mentionedAccounts | []string | The accounts to which slack api referes. This field supports both `@username` and `username` writing styles.| No |
-| mentionedGroups | []string | The groups to which slack api referes. This field supports both `<!subteam^groupname>` and `groupname` writing styles.| No |
+| mentionedAccounts | []string | The accounts to which slack api refers. This field supports both `@username` and `username` writing styles.| No |
+| mentionedGroups | []string | The groups to which slack api refers. This field supports both `<!subteam^groupname>` and `groupname` writing styles.| No |
 
 #### NotificationReceiverWebhook
 

--- a/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuring-a-plugin.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/managing-piped/configuring-a-plugin.md
@@ -74,7 +74,7 @@ spec:
 
 See [Configuration Reference for Kubernetes plugin](../configuration-reference/#kubernetesplugin) for complete configuration details.
 
-### Configuring Terraform plugin
+## Configuring Terraform plugin
 
 The Terraform plugin enables Piped to run Terraform-based deployments.
 A deploy target represents a Terraform execution environment (e.g., dev/prod workspace, shared variables, drift detection settings).


### PR DESCRIPTION
**What this PR does**:
Fixes multiple typos and a heading level inconsistency in the piped configuration documentation, across both docs-v1.0.x and docs-dev.

**Why we need it**:

**Which issue(s) this PR fixes**:
Addresses #6124

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Improved documentation readability and correctness. The broken link text NotificationReciverSlack is now consistent with the actual heading anchor NotificationReceiverSlack.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:  N/A
