### PR TITLE
docs: add contribution guides overview

### DIFF
--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/_index.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/_index.md
@@ -5,3 +5,14 @@ weight: 6
 description: >
   This guide is for anyone who wants to contribute to the PipeCD project. We are so excited to have you!
 ---
+
+PipeCD has several contribution guides. If you are new to the project, start by choosing the guide that matches the type of change you want to make.
+
+## Choose a contribution path
+
+- [Contribute to PipeCD](contributing-to-pipecd/) for general project contribution guidance, local development setup, pull request expectations, and community links.
+- [Contribute to PipeCD Documentation](contributing-documentation/) for documentation file locations, local preview steps, and the docs pull request process.
+- [Contribute to PipeCD plugins](contributing-plugins/) for plugin contribution guidance and plugin-specific development resources.
+- [Contribute to PipeCD Blogs](contributing-blogs/) for blog front matter, content guidance, and local preview steps.
+
+For a first contribution, keep the change small and focused. If your work relates to a tracked issue, mention it in the pull request description so reviewers have the right context.


### PR DESCRIPTION
This PR adds a short overview to the `docs-v1.0.x` contribution guidelines landing page so new contributors can quickly choose the right guide for general PipeCD contributions, documentation changes, plugin contributions, or blog contributions. The contribution guidelines section already has useful child pages, but the parent `Contribute` page only had front matter and did not guide readers to the right next step. This is a small docs-only improvement for docs discoverability.

Refs #6679