### PR TITLE
docs: document --use-base64-encoding flag for pipectl encrypt

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -354,6 +354,18 @@ You can encrypt it the same way you do [from the web](../managing-application/se
       --piped-id={PIPED_ID} \
       --input-file={PATH_TO_SECRET_FILE}
   ```
+  - With Base64 encoding (for Kubernetes Secrets):
+
+    pipectl encrypt \
+        --address={CONTROL_PLANE_API_ADDRESS} \
+        --api-key={API_KEY} \
+        --piped-id={PIPED_ID} \
+        --use-base64-encoding \
+        --input-file={PATH_TO_SECRET_FILE}
+
+  Note: Use `--use-base64-encoding` when encrypting secrets for Kubernetes.
+  Kubernetes Secret `data` field requires values to be base64-encoded.
+  This flag base64-encodes the value before encrypting it.
 
 Note: The docs for pipectl available command is maybe outdated, we suggest users use the `help` command for the updated usage while using pipectl.
 


### PR DESCRIPTION
## What this PR does
Adds documentation for the `--use-base64-encoding` flag in the `pipectl encrypt` command section.

## Which issue this fixes
Fixes #6509

## Changes
- Added usage example with `--use-base64-encoding` flag
- Added a note explaining when and why to use this flag (Kubernetes Secret `data` field requires base64-encoded values)

## Does this PR introduce a user-facing change?
Yes — improves discoverability of an undocumented flag for users encrypting secrets for Kubernetes.