### PR TITLE
fix: improve footer icons layout on mobile devices

### DIFF
--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -8,13 +8,13 @@
 <div class="{{ $bg_color }} row d-print-none">
   <div class="container-fluid py-3 mx-sm-5">
     <div class="row">
-      <div class="col-8 py-3 order-sm-2 {{ $text_color }}">
+      <div class="col-12 col-sm-8 py-3 order-sm-2 {{ $text_color }}"></div>
         <a href="https://www.cncf.io/projects/pipecd/" target="_blank">
           <img src="{{ $cncf_logo }}" alt="cncf logo" width="250">
           <div class="py-2 {{ $text_color }}">PipeCD is a Cloud Native Computing Foundation sandbox project.</div>
         </a>
       </div>
-      <div class="col-4 order-sm-3 d-flex align-items-center justify-content-center">
+      <div class="col-12 col-sm-4 order-sm-3 d-flex flex-wrap align-items-center justify-content-center"></div>
         {{ with $links }}
         {{ with index . "developer"}}
         <ul class="list-inline mb-0">

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -8,13 +8,13 @@
 <div class="{{ $bg_color }} row d-print-none">
   <div class="container-fluid py-3 mx-sm-5">
     <div class="row">
-      <div class="col-12 col-sm-8 py-3 order-sm-2 {{ $text_color }}"></div>
+      <div class="col-12 col-sm-8 py-3 order-sm-2 {{ $text_color }}">
         <a href="https://www.cncf.io/projects/pipecd/" target="_blank">
           <img src="{{ $cncf_logo }}" alt="cncf logo" width="250">
           <div class="py-2 {{ $text_color }}">PipeCD is a Cloud Native Computing Foundation sandbox project.</div>
         </a>
       </div>
-      <div class="col-12 col-sm-4 order-sm-3 d-flex flex-wrap align-items-center justify-content-center"></div>
+      <div class="col-12 col-sm-4 order-sm-3 d-flex flex-wrap align-items-center justify-content-center">
         {{ with $links }}
         {{ with index . "developer"}}
         <ul class="list-inline mb-0">


### PR DESCRIPTION
## What this PR does
Fixes the footer icons layout that breaks on small screens / mobile devices.

## Which issue this fixes
Fixes #6510

## Changes
- Changed `col-4` to `col-12 col-sm-4` so footer icons take full width on mobile
- Changed `col-8` to `col-12 col-sm-8` so CNCF logo section also wraps correctly on mobile
- Added `flex-wrap` to prevent icons from overflowing on small screens

## Does this PR introduce a user-facing change?
Yes — footer now displays correctly on mobile devices.
