### PR TITLE
docs: add contributing-plugins guide to docs-dev

### DIFF
--- a/docs/content/en/docs-dev/contribution-guidelines/contributing-plugins/_index.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/contributing-plugins/_index.md
@@ -1,0 +1,140 @@
+---
+title: "Contribute to PipeCD plugins"
+linkTitle: "Contribute to PipeCD plugins"
+weight: 4
+description: >
+  Learn how to create PipeCD plugins.
+---
+
+PipeCD's plugin architecture allows anyone to extend `piped`'s capabilities by creating custom plugins. This guide explains how to develop and contribute plugins.
+
+For more links and local development notes, see [Plugin development resources](./plugin-development-resources/).
+
+## Understanding the plugin architecture
+
+In PipeCD v1, plugins are the actors that execute deployments on behalf of `piped`. Instead of `piped` directly deploying to platforms, plugins handle platform-specific logic while `piped`'s core controls deployment flows.
+
+**Key concepts:**
+
+- **Plugins** run as gRPC servers, launched and managed by `piped`
+- **Deploy targets** define where a plugin deploys (e.g., a Kubernetes cluster)
+- Plugins can be **official** (maintained by PipeCD team) or **community-contributed**
+
+For a detailed overview, see the [Plugin Architecture blog post](https://pipecd.dev/blog/2024/11/28/overview-of-the-plan-for-pluginnable-pipecd/).
+
+## Plugin types
+
+Plugins can implement one or more of these interfaces:
+
+| Interface | Purpose |
+|-----------|---------|
+| **Deployment** | Plan and execute deployment stages |
+| **LiveState** | Fetch and build the state of live resources |
+| **Drift** | Calculate drift between live and git-source manifests |
+
+For example:
+- A Kubernetes plugin implements all three interfaces
+- A Wait stage plugin only implements the Deployment interface
+
+## Where plugins live
+
+- **Official plugins**: Located in `/pkg/app/pipedv1/plugin/` in the [pipecd repository](https://github.com/pipe-cd/pipecd)
+- **Community plugins**: Located in the [pipe-cd/community-plugins](https://github.com/pipe-cd/community-plugins) repository
+
+## Getting started
+
+### Prerequisites
+
+- [Go 1.24 or later](https://go.dev/)
+- Understanding of gRPC
+- Familiarity with the platform you're building a plugin for
+
+### Study existing plugins
+
+Before creating a new plugin, study the existing ones:
+
+| Plugin | Complexity | Good for learning |
+|--------|------------|-------------------|
+| [wait](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/wait) | Simple | Basic plugin structure |
+| [waitapproval](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/waitapproval) | Simple | Stage-only plugin |
+| [kubernetes](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/kubernetes) | Complex | Full-featured plugin |
+| [terraform](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/terraform) | Complex | Infrastructure as Code plugin |
+
+Community plugins:
+
+| Plugin | Description |
+|--------|-------------|
+| [opentofu](https://github.com/pipe-cd/community-plugins/tree/main/plugins/opentofu) | OpenTofu deployment plugin |
+
+### Plugin structure
+
+A minimal plugin needs:
+
+```
+your-plugin/
+├── go.mod
+├── go.sum
+├── main.go           # Entry point, starts gRPC server
+├── plugin.go         # Implements plugin interfaces
+├── config/           # Plugin-specific configuration
+│   └── application.go
+└── README.md         # Documentation
+```
+
+### Plugin configuration
+
+Plugins are configured in the `piped` config. See the [`piped` installation guide](/docs-dev/installation/install-piped/) for configuration examples:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  plugins:
+    - name: your-plugin
+      port: 7001              # Any unused port
+      url: <PLUGIN_URL>
+      deployTargets:          # Optional, depends on plugin
+        - name: target1
+          config:
+            # Plugin-specific config
+```
+
+## Contributing to official plugins
+
+1. **Open an issue** first to discuss your plugin idea with maintainers
+2. **Fork and clone** the [pipecd repository](https://github.com/pipe-cd/pipecd)
+3. **Create your plugin** under `/pkg/app/pipedv1/plugin/your-plugin/`
+4. **Write tests**: see existing plugins for patterns
+5. **Add a README** documenting configuration and usage
+6. **Submit a PR** linking to the discussion issue
+
+### Build and test
+
+```bash
+# Build all plugins
+make build/plugin
+
+# Run tests
+make test/go
+
+# Run piped locally with your plugin
+make run/piped CONFIG_FILE=piped-config.yaml EXPERIMENTAL=true INSECURE=true
+```
+
+## Contributing to community plugins
+
+The [community-plugins repository](https://github.com/pipe-cd/community-plugins) welcomes plugins that may not fit in the official repo.
+
+1. **Fork** the community-plugins repository
+2. **Create your plugin** following the structure above
+3. **Submit a PR** with documentation
+
+## Resources
+
+- [Plugin development resources](./plugin-development-resources/)
+- [Plugin Architecture RFC](https://github.com/pipe-cd/pipecd/blob/master/docs/rfcs/0015-pipecd-plugin-arch-meta.md)
+- [Installing piped](/docs-dev/installation/install-piped/)
+- [Plugin Alpha Release blog](https://pipecd.dev/blog/2025/06/16/plugin-architecture-piped-alpha-version-has-been-released/)
+- [#pipecd Slack channel](https://cloud-native.slack.com/) for questions
+
+Thank you for contributing to PipeCD plugins!

--- a/docs/content/en/docs-dev/contribution-guidelines/contributing-plugins/plugin-development-resources.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/contributing-plugins/plugin-development-resources.md
@@ -1,0 +1,90 @@
+---
+title: "Plugin development resources"
+linkTitle: "Plugin development resources"
+weight: 5
+description: >
+  Links and short notes for developing PipeCD plugins.
+---
+
+> **Note:**
+> This section is still a work in progress. A full tutorial and an in-docs translation of the Zenn book are planned over time.
+>
+> For a hands-on walkthrough, read [**Build and learn PipeCD plugins**](https://zenn.dev/warashi/books/try-and-learn-pipecd-plugin) (Zenn; Japanese title *作って学ぶ PipeCD プラグイン*). The same book is linked again in [Links](#links), together with other references. Use your browser's translate feature to read this in English. Verify commands and field names against this documentation and the [`pipecd`](https://github.com/pipe-cd/pipecd) repository.
+
+Use this page together with [Contribute to PipeCD plugins](../), which covers layout, `make` targets, and how to open a pull request.
+
+## How the pieces fit together
+
+- **Control plane**: registers projects and `piped` agents; the web UI shows deployment status.
+- **`piped`**: runs your plugins as separate binaries and talks to them over gRPC.
+- **Plugins**: carry out deployments (and optionally live state and drift) for a platform or tool.
+
+If you are new to PipeCD v1, read [Migrating from v0 to v1](/docs-dev/migrating-from-v0-to-v1/).
+
+### Terms
+
+| Term | Meaning |
+|------|---------|
+| **Application** | Git content for one deployable unit: manifests plus a `*.pipecd.yaml` file. |
+| **Deployment** | One run of the deployment pipeline for an app (from Git, a trigger, or the UI). |
+| **Deploy target** | Where the plugin deploys, set under `spec.plugins` in the `piped` config. |
+| **Pipeline** | Ordered **stages** (for example sync, canary, wait) from the application config. |
+| **Stage** | One step in the pipeline; your plugin implements the stages it supports. |
+
+For plugin interfaces (**Deployment**, **LiveState**, **Drift**), see [Plugin types](../#plugin-types). A first plugin usually implements **Deployment** only.
+
+## Local development
+
+Use a `piped` v1 build that matches your work. From the repo you can run `make run/piped` as in the [contributing guide](../#build-and-test). To install a release binary, see [Installing on a single machine](/docs-dev/installation/install-piped/installing-on-single-machine/).
+
+Example when running the v1 `piped` CLI:
+
+```console
+./piped run --config-file=PATH_TO_PIPED_CONFIG --insecure=true
+```
+
+Use `--insecure=true` only when it matches your control plane (for example plain HTTP or your dev TLS settings).
+
+The install guide linked above uses the same `run` subcommand. If another page or tutorial shows different syntax, run `./piped --help` on your binary to match your build.
+
+Older blog posts or books may target an older `piped`. Prefer this documentation and the default branch of [`pipecd`](https://github.com/pipe-cd/pipecd).
+
+## `piped` config and application config
+
+You need both:
+
+1. **`piped` configuration**: control plane address, Git `repositories`, and `spec.plugins` (URL, port, `deployTargets`, plugin-specific fields). See [Piped configuration reference](/docs-dev/user-guide/managing-piped/configuration-reference/).
+2. **Application configuration**: the `*.pipecd.yaml` in Git (plugin, pipeline, deploy options). See [Adding an application](/docs-dev/user-guide/managing-application/adding-an-application/).
+
+Code in your plugin reads the application config via its own types (often under `config/`). `deployTargets` come from the `piped` config.
+
+## Example plugins
+
+| Plugin | Notes |
+|--------|-------|
+| [kubernetes](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/kubernetes) | Full official plugin |
+| [wait](https://github.com/pipe-cd/pipecd/tree/master/pkg/app/pipedv1/plugin/wait) | Small official example |
+| [example-stage](https://github.com/pipe-cd/community-plugins/tree/main/plugins/example-stage) | Community sample (see [Installing on a single machine](/docs-dev/installation/install-piped/installing-on-single-machine/)) |
+
+## Cache under ~/.piped
+
+After rebuilding a plugin, `piped` may still use files under **`~/.piped`** (including **`~/.piped/plugins`**). If your changes do not show up, remove those directories or clear the cache your team uses, then restart `piped`.
+
+## Debugging
+
+- **Web UI**: deployment and stage status.
+- **Stdout**: logs from `piped` and the plugin (verbose but quick for local work).
+- **Stage logs**: through the SDK; see [`StageLogPersister`](https://github.com/pipe-cd/pipecd/blob/master/pkg/plugin/sdk/logpersister/persister.go) in the repo.
+
+## Links
+
+| Resource | Notes |
+|----------|-------|
+| [**Build and learn PipeCD plugins** (Zenn)](https://zenn.dev/warashi/books/try-and-learn-pipecd-plugin) | Japanese tutorial book (*作って学ぶ PipeCD プラグイン*) |
+| [DeepWiki (pipecd)](https://deepwiki.com/pipe-cd/pipecd) | Unofficial wiki-style overview of the repository. |
+| [Plugin Architecture RFC](https://github.com/pipe-cd/pipecd/blob/master/docs/rfcs/0015-pipecd-plugin-arch-meta.md) | Design (RFC) |
+| [Plugin Architecture overview (blog)](https://pipecd.dev/blog/2024/11/28/overview-of-the-plan-for-pluginnable-pipecd/) | Architecture overview |
+| [Plugin alpha release (blog)](https://pipecd.dev/blog/2025/06/16/plugin-architecture-piped-alpha-version-has-been-released/) | Piped plugin alpha |
+| [#pipecd (CNCF Slack)](https://cloud-native.slack.com/) | Community chat |
+
+See also [Contributing to PipeCD](/docs-dev/contribution-guidelines/contributing/) for local control plane setup and pull requests.


### PR DESCRIPTION
**What this PR does**:
Adds the `contributing-plugins/` section to `docs-dev`, which was missing entirely. Ported from `docs-v1.0.x/contribution-guidelines/contributing-plugins/` with internal links updated to point to `docs-dev` where those pages exist.

Also fixes a broken link introduced in #6758, where `contributing.md` in `docs-dev` links to `../contributing-plugins/` — that path had no target until now.

**Why we need it**:
`docs-dev` is the source for the next release. Plugin contributors reading the dev docs had no guide on how to build or contribute plugins.

**Which issue(s) this PR fixes**:

Refs #6679

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Plugin contributors using `docs-dev` can now access the full plugin contribution guide.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A