### PR TITLE
fix: remove duplicate email icon from website footer

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -153,11 +153,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipecd/issu
 	url = "https://slack.cncf.io"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
-[[params.links.developer]]
-	name = "Developer mailing list"
-	url = "mailto:pipecd.dev@gmail.com"
-	icon = "fa fa-envelope"
-        desc = "Discuss development issues around the project"
 
 # Append the release versions here.
 [[params.versions]]


### PR DESCRIPTION
## What this PR does
Removes the duplicate email icon from the website footer.

## Which issue this fixes
Fixes #6763

## Changes
- Removed duplicate `Developer mailing list` email entry from 
  `docs/config.toml` as it was identical to the `User mailing list` 
  email entry, causing two email icons to appear in the footer.

## Does this PR introduce a user-facing change?
Yes — footer now displays only one email icon instead of two.