### PR TITLE
Support multi ssh-keys in git client

### DIFF
--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -179,12 +179,12 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	// Configure SSH config if needed.
 	if cfg.Git.ShouldConfigureSSHConfig() {
-		tempFile, err := git.AddSSHConfig(cfg.Git)
+		tempDir, err := git.AddSSHConfig(cfg.Git)
 		if err != nil {
 			input.Logger.Error("failed to configure ssh-config", zap.Error(err))
 			return err
 		}
-		defer os.Remove(tempFile)
+		defer os.RemoveAll(tempDir)
 		input.Logger.Info("successfully configured ssh-config")
 	}
 

--- a/pkg/configv1/piped.go
+++ b/pkg/configv1/piped.go
@@ -215,10 +215,35 @@ type PipedGit struct {
 	// Base64 encoded string of password.
 	// This will be used to clone the source repo with https basic auth.
 	Password string `json:"password,omitempty"`
+	// Additional SSH keys to be evaluated for specific hosts.
+	SSHKeys []PipedSSHKeyEntry `json:"sshKeys,omitempty"`
+}
+
+type PipedSSHKeyEntry struct {
+	// The host name. e.g. github.com, gitlab.com
+	Host string `json:"host"`
+	// The hostname or IP address of the remote git server.
+	// e.g. github.com, gitlab.com
+	// Default is the same value with Host.
+	HostName string `json:"hostName,omitempty"`
+	// The path to the private ssh key file.
+	SSHKeyFile string `json:"sshKeyFile,omitempty"`
+	// Base64 encoded string of ssh-key.
+	SSHKeyData string `json:"sshKeyData,omitempty"`
+}
+
+func (e PipedSSHKeyEntry) LoadSSHKey() ([]byte, error) {
+	if e.SSHKeyData != "" {
+		return base64.StdEncoding.DecodeString(e.SSHKeyData)
+	}
+	if e.SSHKeyFile != "" {
+		return os.ReadFile(e.SSHKeyFile)
+	}
+	return nil, errors.New("either sshKeyFile or sshKeyData must be set")
 }
 
 func (g PipedGit) ShouldConfigureSSHConfig() bool {
-	return g.SSHKeyData != "" || g.SSHKeyFile != ""
+	return g.SSHKeyData != "" || g.SSHKeyFile != "" || len(g.SSHKeys) > 0
 }
 
 func (g PipedGit) LoadSSHKey() ([]byte, error) {
@@ -243,6 +268,33 @@ func (g *PipedGit) Validate() error {
 	if isSSH && (g.SSHKeyData != "" && g.SSHKeyFile != "") {
 		return errors.New("only either sshKeyFile or sshKeyData can be set")
 	}
+
+	seenHosts := make(map[string]struct{})
+	legacyHost := "github.com"
+	if g.Host != "" {
+		legacyHost = g.Host
+	}
+
+	if g.SSHKeyData != "" || g.SSHKeyFile != "" {
+		seenHosts[legacyHost] = struct{}{}
+	}
+
+	for i, key := range g.SSHKeys {
+		if key.Host == "" {
+			return fmt.Errorf("sshKeys[%d].host must be set", i)
+		}
+		if key.SSHKeyData == "" && key.SSHKeyFile == "" {
+			return fmt.Errorf("either sshKeys[%d].sshKeyFile or sshKeys[%d].sshKeyData must be set", i, i)
+		}
+		if key.SSHKeyData != "" && key.SSHKeyFile != "" {
+			return fmt.Errorf("only either sshKeys[%d].sshKeyFile or sshKeys[%d].sshKeyData can be set", i, i)
+		}
+		if _, ok := seenHosts[key.Host]; ok {
+			return fmt.Errorf("duplicate host %q found in ssh keys configuration", key.Host)
+		}
+		seenHosts[key.Host] = struct{}{}
+	}
+
 	if isPassword && (g.Username == "" || g.Password == "") {
 		return errors.New("both username and password must be set")
 	}
@@ -258,6 +310,14 @@ func (g *PipedGit) Mask() {
 	}
 	if len(g.SSHKeyData) != 0 {
 		g.SSHKeyData = maskString
+	}
+	for i := range g.SSHKeys {
+		if len(g.SSHKeys[i].SSHKeyFile) != 0 {
+			g.SSHKeys[i].SSHKeyFile = maskString
+		}
+		if len(g.SSHKeys[i].SSHKeyData) != 0 {
+			g.SSHKeys[i].SSHKeyData = maskString
+		}
 	}
 	if len(g.Password) != 0 {
 		g.Password = maskString

--- a/pkg/configv1/piped_test.go
+++ b/pkg/configv1/piped_test.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1044,10 +1045,40 @@ func TestPipeGitValidate(t *testing.T) {
 			git:  PipedGit{},
 			err:  nil,
 		},
+		{
+			name: "Duplicate Host in SSHKeys",
+			git: PipedGit{
+				SSHKeys: []PipedSSHKeyEntry{
+					{Host: "github.com", SSHKeyFile: "/tmp/key1"},
+					{Host: "github.com", SSHKeyData: "data2"},
+				},
+			},
+			err: fmt.Errorf("duplicate host %q found in ssh keys configuration", "github.com"),
+		},
+		{
+			name: "Legacy Host colliding with a SSHKeys entry",
+			git: PipedGit{
+				Host:       "gitlab.com",
+				SSHKeyFile: "/tmp/legacy",
+				SSHKeys: []PipedSSHKeyEntry{
+					{Host: "gitlab.com", SSHKeyFile: "/tmp/key1"},
+				},
+			},
+			err: fmt.Errorf("duplicate host %q found in ssh keys configuration", "gitlab.com"),
+		},
+		{
+			name: "Both SSHKeyFile and SSHKeyData set on one entry",
+			git: PipedGit{
+				SSHKeys: []PipedSSHKeyEntry{
+					{Host: "github.com", SSHKeyFile: "/tmp/key1", SSHKeyData: "data1"},
+				},
+			},
+			err: fmt.Errorf("only either sshKeys[0].sshKeyFile or sshKeys[0].sshKeyData can be set"),
+		},
 	}
 	for _, tc := range testcases {
 		tc := tc
-		t.Run(tc.git.SSHKeyData, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := tc.git.Validate()
 			assert.Equal(t, tc.err, err)

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -63,31 +63,63 @@ func AddSSHConfig(cfg configv1.PipedGit) (string, error) {
 		return "", fmt.Errorf("failed to create a directory %s: %v", sshDir, err)
 	}
 
-	sshKey, err := cfg.LoadSSHKey()
-	if err != nil {
-		return "", err
-	}
-
-	sshKeyFile, err := os.CreateTemp(sshDir, "piped-ssh-key-*")
+	tempDir, err := os.MkdirTemp(sshDir, "piped-ssh-keys-*")
 	if err != nil {
 		return "", err
 	}
 	needCleanUp := false
 	defer func() {
 		if needCleanUp {
-			os.Remove(sshKeyFile.Name())
+			os.RemoveAll(tempDir)
 		}
 	}()
 
-	if _, err := sshKeyFile.Write(sshKey); err != nil {
-		needCleanUp = true
-		return "", err
+	var configsData []byte
+
+	if cfg.SSHKeyData != "" || cfg.SSHKeyFile != "" {
+		sshKey, err := cfg.LoadSSHKey()
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		keyPath, err := writeSSHKeyFile(tempDir, sshKey)
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		configData, err := generateSSHConfig(sshConfig{
+			Host:         cfg.Host,
+			HostName:     cfg.HostName,
+			IdentityFile: keyPath,
+		})
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		configsData = append(configsData, []byte(configData)...)
 	}
 
-	configData, err := generateSSHConfig(cfg, sshKeyFile.Name())
-	if err != nil {
-		needCleanUp = true
-		return "", err
+	for _, key := range cfg.SSHKeys {
+		sshKey, err := key.LoadSSHKey()
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		keyPath, err := writeSSHKeyFile(tempDir, sshKey)
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		configData, err := generateSSHConfig(sshConfig{
+			Host:         key.Host,
+			HostName:     key.HostName,
+			IdentityFile: keyPath,
+		})
+		if err != nil {
+			needCleanUp = true
+			return "", err
+		}
+		configsData = append(configsData, []byte(configData)...)
 	}
 
 	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -97,29 +129,21 @@ func AddSSHConfig(cfg configv1.PipedGit) (string, error) {
 	}
 	defer f.Close()
 
-	if _, err := f.Write([]byte(configData)); err != nil {
+	if _, err := f.Write(configsData); err != nil {
 		needCleanUp = true
 		return "", fmt.Errorf("failed to write sshConfig to %s: %v", cfgPath, err)
 	}
 
-	return sshKeyFile.Name(), nil
+	return tempDir, nil
 }
 
-func generateSSHConfig(cfg configv1.PipedGit, sshKeyFile string) (string, error) {
-	var (
-		buffer bytes.Buffer
-		data   = sshConfig{
-			Host:         defaultHost,
-			IdentityFile: sshKeyFile,
-		}
-	)
+func generateSSHConfig(data sshConfig) (string, error) {
+	var buffer bytes.Buffer
 
-	if cfg.Host != "" {
-		data.Host = cfg.Host
+	if data.Host == "" {
+		data.Host = defaultHost
 	}
-	if cfg.HostName != "" {
-		data.HostName = cfg.HostName
-	} else {
+	if data.HostName == "" {
 		data.HostName = data.Host
 	}
 
@@ -127,4 +151,21 @@ func generateSSHConfig(cfg configv1.PipedGit, sshKeyFile string) (string, error)
 		return "", err
 	}
 	return buffer.String(), nil
+}
+
+func writeSSHKeyFile(dir string, key []byte) (string, error) {
+	f, err := os.CreateTemp(dir, "piped-ssh-key-*")
+	if err != nil {
+		return "", err
+	}
+	if err := os.Chmod(f.Name(), 0600); err != nil {
+		f.Close()
+		return "", err
+	}
+	_, err = f.Write(key)
+	f.Close()
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
 }

--- a/pkg/git/ssh_config_test.go
+++ b/pkg/git/ssh_config_test.go
@@ -15,6 +15,8 @@
 package git
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,9 +84,51 @@ Host gitlab.com
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			sshKeyFile := "/etc/piped-secret/ssh-key"
-			got, err := generateSSHConfig(tc.cfg, sshKeyFile)
+			got, err := generateSSHConfig(sshConfig{
+				Host:         tc.cfg.Host,
+				HostName:     tc.cfg.HostName,
+				IdentityFile: sshKeyFile,
+			})
 			assert.Equal(t, tc.expected, got)
 			assert.Equal(t, tc.expectedErr, err)
 		})
 	}
+}
+
+func TestAddSSHConfig(t *testing.T) {
+	tempHome := t.TempDir()
+	cfg := configv1.PipedGit{
+		SSHConfigFilePath: tempHome + "/.ssh/config",
+		Host:              "gitlab.com",
+		SSHKeyData:        "bGVnYWN5",
+		SSHKeys: []configv1.PipedSSHKeyEntry{
+			{
+				Host:       "github.com",
+				SSHKeyData: "ZXh0cmE=",
+			},
+		},
+	}
+
+	tempDir, err := AddSSHConfig(cfg)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tempDir)
+
+	files, err := os.ReadDir(tempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 2)
+
+	for _, file := range files {
+		info, err := file.Info()
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "SSH identity file must have 0600 permissions")
+	}
+
+	cfgContent, err := os.ReadFile(tempHome + "/.ssh/config")
+	assert.NoError(t, err)
+	cfgStr := string(cfgContent)
+	gitlabIdx := strings.Index(cfgStr, "Host gitlab.com")
+	githubIdx := strings.Index(cfgStr, "Host github.com")
+	assert.True(t, gitlabIdx >= 0, "expected Host gitlab.com block in ssh config")
+	assert.True(t, githubIdx >= 0, "expected Host github.com block in ssh config")
+	assert.True(t, gitlabIdx < githubIdx, "legacy host (gitlab.com) must appear before extra host (github.com)")
 }


### PR DESCRIPTION
**What this PR does**:

This PR implements support for multiple SSH keys in the Piped Git configuration. It introduces a new `sshKeys` list field to [PipedGit](cci:2://file:///home/bibisha/Desktop/pipe/pipecd/pkg/configv1/piped.go:191:0-219:1) while maintaining full backward compatibility with the existing single-key setup.

Key changes:
- **Prioritized Config**: Refactored [AddSSHConfig](cci:1://file:///home/bibisha/Desktop/pipe/pipecd/pkg/git/ssh_config.go:50:0-137:1) to generate a composite `~/.ssh/config` file that writes the legacy host entry first followed by entries in the `sshKeys` list, preserving SSH's first-match-wins logic.
- **Secure File Handling**: Identity files are created in a temporary directory with strict `0600` permissions via a new [writeSSHKeyFile](cci:1://file:///home/bibisha/Desktop/pipe/pipecd/pkg/git/ssh_config.go:155:0-170:1) helper.
- **Improved Lifecycle**: The Git package now returns a temporary directory path to the Piped runtime, ensuring all generated identity files are removed in a single `os.RemoveAll` call.
- **Validation**: Added strict validation in `pkg/configv1` to prevent duplicate host mappings and ensure configuration integrity.

**Why we need it**:

Some repositories may require distinct SSH keys (e.g., repository-specific deployment keys or keys across different organizations/domains) that cannot be handled by a single global SSH key.

**Which issue(s) this PR fixes**:

Fixes #4311

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Users can now optionally define multiple SSH keys in their Piped configuration. Existing configurations continue to work without modification.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A.
