### PR TITLE
[Multi_K8s-Plugin] Surface partial deletion errors in deleteResources

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/misc.go
@@ -252,20 +252,48 @@ func deleteVariantResources(ctx context.Context, lp sdk.StageLogPersister, kubec
 		clusterScoped = append(clusterScoped, r.Key())
 	}
 
-	var deletedCount int
-	deletedCount += deleteResources(ctx, lp, applier, services)
-	deletedCount += deleteResources(ctx, lp, applier, workloads)
-	deletedCount += deleteResources(ctx, lp, applier, others)
-	deletedCount += deleteResources(ctx, lp, applier, clusterScoped)
+	var (
+		deletedCount int
+		errs         []error
+	)
+
+	count, err := deleteResources(ctx, lp, applier, services)
+	deletedCount += count
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	count, err = deleteResources(ctx, lp, applier, workloads)
+	deletedCount += count
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	count, err = deleteResources(ctx, lp, applier, others)
+	deletedCount += count
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	count, err = deleteResources(ctx, lp, applier, clusterScoped)
+	deletedCount += count
+	if err != nil {
+		errs = append(errs, err)
+	}
+
 	lp.Successf("Successfully deleted %d resources", deletedCount)
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // deleteResources deletes the given resources.
-// It returns the number of deleted resources.
-func deleteResources(ctx context.Context, lp sdk.StageLogPersister, applier *provider.Applier, keys []provider.ResourceKey) int {
-	var deletedCount int
+// It returns the number of successfully deleted resources and any errors encountered.
+// It continues deleting remaining resources even if one fails (best-effort cleanup).
+func deleteResources(ctx context.Context, lp sdk.StageLogPersister, applier *provider.Applier, keys []provider.ResourceKey) (int, error) {
+	var (
+		deletedCount int
+		errs         []error
+	)
 
 	for _, k := range keys {
 		if err := applier.Delete(ctx, k); err != nil {
@@ -274,11 +302,12 @@ func deleteResources(ctx context.Context, lp sdk.StageLogPersister, applier *pro
 				continue
 			}
 			lp.Errorf("Failed while deleting resource %s (%v)", k.ReadableString(), err)
-			continue // continue to delete other resources
+			errs = append(errs, fmt.Errorf("failed to delete resource %s: %w", k.ReadableString(), err))
+			continue
 		}
 		deletedCount++
 		lp.Successf("- deleted resource: %s", k.ReadableString())
 	}
 
-	return deletedCount
+	return deletedCount, errors.Join(errs...)
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/primary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/primary.go
@@ -215,7 +215,11 @@ func (p *Plugin) primaryRollout(
 	}
 
 	lp.Infof("Start pruning %d resources", len(removeKeys))
-	deletedCount := deleteResources(ctx, lp, applier, removeKeys)
+	deletedCount, err := deleteResources(ctx, lp, applier, removeKeys)
+	if err != nil {
+		lp.Errorf("Failed to delete some resources, %d/%d resources were deleted (%v)", deletedCount, len(removeKeys), err)
+		return sdk.StageStatusFailure
+	}
 	lp.Successf("Successfully deleted %d resources", deletedCount)
 
 	return sdk.StageStatusSuccess

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -226,7 +226,11 @@ func (p *Plugin) sync(
 	}
 
 	lp.Infof("Start pruning %d resources", len(removeKeys))
-	deletedCount := deleteResources(ctx, lp, applier, removeKeys)
+	deletedCount, err := deleteResources(ctx, lp, applier, removeKeys)
+	if err != nil {
+		lp.Errorf("Failed to delete some resources, %d/%d resources were deleted (%v)", deletedCount, len(removeKeys), err)
+		return sdk.StageStatusFailure
+	}
 	lp.Successf("Successfully deleted %d resources", deletedCount)
 
 	return sdk.StageStatusSuccess


### PR DESCRIPTION
**What this PR does**:
Changes `deleteResources` in `deployment/misc.go` to return `(int, error)` instead of just `int`. All deletion errors are now collected via `errors.Join` and returned to callers. `deleteVariantResources` propagates combined errors. Stage functions (`sync`, `primaryRollout`) now fail the stage if any resource deletion fails rather than silently succeeding with a partial count.

**Why we need it**:
Previously, when deleting multiple resources (during prune or variant cleanup), any non-`ErrNotFound` error was logged but swallowed callers received only the success count and logged "Successfully deleted X resources" with no signal that some resources failed. A partially-failed cleanup appeared as a success.

**Which issue(s) this PR fixes**:

Fixes #6446

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: A deployment stage that previously reported success despite partial resource deletion failures will now correctly report failure, allowing the pipeline to retry or alert.
- **Is this breaking change**: No, this is a correctness fix. The deletion behaviour (best-effort, continues after individual failures) is unchanged.
- **How to migrate (if breaking change)**: N/A