### PR TITLE
[Multi_K8s-Plugin] Extract duplicated target-building pattern into shared helpers

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/baseline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/baseline.go
@@ -46,59 +46,11 @@ func (p *Plugin) executeK8sMultiBaselineRolloutStage(ctx context.Context, input 
 		}
 	}
 
-	type targetConfig struct {
-		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
-		multiTarget  *kubeconfig.KubernetesMultiTarget
-	}
-
-	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], 0)
-	targetConfigs := make([]targetConfig, 0, len(dts))
-
-	for _, target := range dts {
-		deployTargetMap[target.Name] = target
-	}
-
-	// If no multi-targets are specified, roll out baseline to all deploy targets.
-	if len(cfg.Spec.Input.MultiTargets) == 0 {
-		for _, dt := range dts {
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  nil,
-			})
-		}
-	} else {
-		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
-			dt, ok := deployTargetMap[multiTarget.Target.Name]
-			if !ok {
-				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
-				continue
-			}
-
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  &multiTarget,
-			})
-		}
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, tc := range targetConfigs {
-		eg.Go(func() error {
-			lp.Infof("Start baseline rollout for target %s", tc.deployTarget.Name)
-			status := p.baselineRollout(ctx, input, tc.deployTarget, tc.multiTarget, stageCfg)
-			if status == sdk.StageStatusFailure {
-				return fmt.Errorf("failed to baseline rollout for target %s", tc.deployTarget.Name)
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		lp.Errorf("Failed while rolling out baseline (%v)", err)
-		return sdk.StageStatusFailure
-	}
-
-	return sdk.StageStatusSuccess
+	targets := buildStageTargets(lp, dts, cfg.Spec.Input.MultiTargets)
+	return runOnTargets(ctx, lp, targets, func(ctx context.Context, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], mt *kubeconfig.KubernetesMultiTarget) sdk.StageStatus {
+		lp.Infof("Start baseline rollout for target %s", dt.Name)
+		return p.baselineRollout(ctx, input, dt, mt, stageCfg)
+	})
 }
 
 func (p *Plugin) baselineRollout(

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/canary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/canary.go
@@ -47,59 +47,11 @@ func (p *Plugin) executeK8sMultiCanaryRolloutStage(ctx context.Context, input *s
 		}
 	}
 
-	type targetConfig struct {
-		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
-		multiTarget  *kubeconfig.KubernetesMultiTarget
-	}
-
-	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], 0)
-	targetConfigs := make([]targetConfig, 0, len(dts))
-
-	for _, target := range dts {
-		deployTargetMap[target.Name] = target
-	}
-
-	// If no multi-targets are specified, roll out canary to all deploy targets.
-	if len(cfg.Spec.Input.MultiTargets) == 0 {
-		for _, dt := range dts {
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  nil,
-			})
-		}
-	} else {
-		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
-			dt, ok := deployTargetMap[multiTarget.Target.Name]
-			if !ok {
-				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
-				continue
-			}
-
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  &multiTarget,
-			})
-		}
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, tc := range targetConfigs {
-		eg.Go(func() error {
-			lp.Infof("Start canary rollout for target %s", tc.deployTarget.Name)
-			status := p.canaryRollout(ctx, input, tc.deployTarget, tc.multiTarget, stageCfg)
-			if status == sdk.StageStatusFailure {
-				return fmt.Errorf("failed to canary rollout for target %s", tc.deployTarget.Name)
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		lp.Errorf("Failed while rolling out canary (%v)", err)
-		return sdk.StageStatusFailure
-	}
-
-	return sdk.StageStatusSuccess
+	targets := buildStageTargets(lp, dts, cfg.Spec.Input.MultiTargets)
+	return runOnTargets(ctx, lp, targets, func(ctx context.Context, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], mt *kubeconfig.KubernetesMultiTarget) sdk.StageStatus {
+		lp.Infof("Start canary rollout for target %s", dt.Name)
+		return p.canaryRollout(ctx, input, dt, mt, stageCfg)
+	})
 }
 
 func (p *Plugin) canaryRollout(

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/primary.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/primary.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 
 	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
@@ -47,58 +45,11 @@ func (p *Plugin) executeK8sMultiPrimaryRolloutStage(ctx context.Context, input *
 		}
 	}
 
-	type targetConfig struct {
-		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
-		multiTarget  *kubeconfig.KubernetesMultiTarget
-	}
-
-	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig])
-	targetConfigs := make([]targetConfig, 0, len(dts))
-
-	for _, target := range dts {
-		deployTargetMap[target.Name] = target
-	}
-
-	// If no multi-targets are specified, roll out primary to all deploy targets.
-	if len(cfg.Spec.Input.MultiTargets) == 0 {
-		for _, dt := range dts {
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  nil,
-			})
-		}
-	} else {
-		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
-			dt, ok := deployTargetMap[multiTarget.Target.Name]
-			if !ok {
-				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
-				continue
-			}
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  &multiTarget,
-			})
-		}
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, tc := range targetConfigs {
-		eg.Go(func() error {
-			lp.Infof("Start primary rollout for target %s", tc.deployTarget.Name)
-			status := p.primaryRollout(ctx, input, tc.deployTarget, tc.multiTarget, stageCfg)
-			if status == sdk.StageStatusFailure {
-				return fmt.Errorf("failed to primary rollout for target %s", tc.deployTarget.Name)
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		lp.Errorf("Failed while rolling out primary (%v)", err)
-		return sdk.StageStatusFailure
-	}
-
-	return sdk.StageStatusSuccess
+	targets := buildStageTargets(lp, dts, cfg.Spec.Input.MultiTargets)
+	return runOnTargets(ctx, lp, targets, func(ctx context.Context, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], mt *kubeconfig.KubernetesMultiTarget) sdk.StageStatus {
+		lp.Infof("Start primary rollout for target %s", dt.Name)
+		return p.primaryRollout(ctx, input, dt, mt, stageCfg)
+	})
 }
 
 func (p *Plugin) primaryRollout(

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -18,10 +18,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 
@@ -39,62 +36,11 @@ func (p *Plugin) executeK8sMultiSyncStage(ctx context.Context, input *sdk.Execut
 		return sdk.StageStatusFailure
 	}
 
-	type targetConfig struct {
-		deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
-		multiTarget  *kubeconfig.KubernetesMultiTarget
-	}
-
-	deployTargetMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], 0)
-	targetConfigs := make([]targetConfig, 0, len(dts))
-
-	// prevent the deployment when its deployTarget is not found in the piped config
-	for _, target := range dts {
-		deployTargetMap[target.Name] = target
-	}
-
-	// If no multi-targets are specified, sync to all deploy targets.
-	if len(cfg.Spec.Input.MultiTargets) == 0 {
-		for _, dt := range dts {
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  nil,
-			})
-		}
-	} else {
-		// Sync to the specified multi-targets.
-		for _, multiTarget := range cfg.Spec.Input.MultiTargets {
-			dt, ok := deployTargetMap[multiTarget.Target.Name]
-			if !ok {
-				lp.Infof("Ignore multi target '%s': not matched any deployTarget", multiTarget.Target.Name)
-				continue
-			}
-
-			targetConfigs = append(targetConfigs, targetConfig{
-				deployTarget: dt,
-				multiTarget:  &multiTarget,
-			})
-		}
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, tc := range targetConfigs {
-		// Start syncing the deployment to the target.
-		eg.Go(func() error {
-			lp.Infof("Start syncing the deployment to the target %s", tc.deployTarget.Name)
-			status := p.sync(ctx, input, tc.deployTarget, tc.multiTarget)
-			if status == sdk.StageStatusFailure {
-				return fmt.Errorf("failed to sync the deployment to the target %s", tc.deployTarget.Name)
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		lp.Errorf("Failed while syncing the deployment (%v)", err)
-		return sdk.StageStatusFailure
-	}
-
-	return sdk.StageStatusSuccess
+	targets := buildStageTargets(lp, dts, cfg.Spec.Input.MultiTargets)
+	return runOnTargets(ctx, lp, targets, func(ctx context.Context, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], mt *kubeconfig.KubernetesMultiTarget) sdk.StageStatus {
+		lp.Infof("Start syncing the deployment to the target %s", dt.Name)
+		return p.sync(ctx, input, dt, mt)
+	})
 }
 
 func (p *Plugin) sync(

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/targets.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/targets.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	kubeconfig "github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes_multicluster/config"
+)
+
+// stageTarget pairs a deploy target with its optional per-target multiTarget config.
+type stageTarget struct {
+	deployTarget *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig]
+	multiTarget  *kubeconfig.KubernetesMultiTarget
+}
+
+// buildStageTargets resolves which deploy targets a stage should run on.
+// If multiTargets is empty, all dts are included. Otherwise only the named targets.
+func buildStageTargets(
+	lp sdk.StageLogPersister,
+	dts []*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig],
+	multiTargets []kubeconfig.KubernetesMultiTarget,
+) []stageTarget {
+	dtMap := make(map[string]*sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], len(dts))
+	for _, dt := range dts {
+		dtMap[dt.Name] = dt
+	}
+	if len(multiTargets) == 0 {
+		targets := make([]stageTarget, len(dts))
+		for i, dt := range dts {
+			targets[i] = stageTarget{deployTarget: dt}
+		}
+		return targets
+	}
+	targets := make([]stageTarget, 0, len(multiTargets))
+	for _, mt := range multiTargets {
+		dt, ok := dtMap[mt.Target.Name]
+		if !ok {
+			lp.Infof("Ignore multi target '%s': not matched any deployTarget", mt.Target.Name)
+			continue
+		}
+		mt := mt // capture loop var
+		targets = append(targets, stageTarget{deployTarget: dt, multiTarget: &mt})
+	}
+	return targets
+}
+
+// runOnTargets fans out fn across targets in parallel using errgroup.
+// fn receives each target's deploy target and multiTarget (may be nil).
+// Returns StageStatusSuccess if all succeed, StageStatusFailure if any fail.
+func runOnTargets(
+	ctx context.Context,
+	lp sdk.StageLogPersister,
+	targets []stageTarget,
+	fn func(ctx context.Context, dt *sdk.DeployTarget[kubeconfig.KubernetesDeployTargetConfig], mt *kubeconfig.KubernetesMultiTarget) sdk.StageStatus,
+) sdk.StageStatus {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, tc := range targets {
+		eg.Go(func() error {
+			if status := fn(ctx, tc.deployTarget, tc.multiTarget); status == sdk.StageStatusFailure {
+				return fmt.Errorf("stage failed for target %s", tc.deployTarget.Name)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		lp.Errorf("Stage failed on one or more targets: %v", err)
+		return sdk.StageStatusFailure
+	}
+	return sdk.StageStatusSuccess
+}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/targets.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does**:
Extracts the repeated ~45-line target-resolution and errgroup pattern from the four stage entry-point functions (`executeK8sMultiSyncStage`, `executeK8sMultiCanaryRolloutStage`, `executeK8sMultiBaselineRolloutStage`, `executeK8sMultiPrimaryRolloutStage`) into two package-level helpers in a new file `deployment/targets.go`:

- `buildStageTargets(lp, dts, multiTargets)` resolves which deploy targets a stage should run on (all targets if multiTargets is empty, or the named subset)
- `runOnTargets(ctx, lp, targets, fn)` fans out `fn` across targets in parallel via errgroup

**Why we need it**:
All four rollout/sync entry-point functions contained identical boilerplate: build a deploy-target map, resolve the target list, fan out with errgroup, handle errors. Any bug fix or behaviour change had to be applied in four places. The helpers eliminate the duplication while keeping behaviour identical.

**Which issue(s) this PR fixes**:

Fixes #6446

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No user-facing change. Just internal refactor identical behaviour.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A