### PR TITLE
[Multi_K8s-Plugin] Fix livestate loadManifests to stamp tracking labels and honour kustomizeDir

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -320,14 +320,15 @@ type loader interface {
 	LoadManifests(ctx context.Context, input provider.LoaderInput) ([]provider.Manifest, error)
 }
 
-// TODO: share this implementation with the deployment plugin
 func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec], spec *kubeconfig.KubernetesApplicationSpec, loader loader, logger *zap.Logger, multiTarget *kubeconfig.KubernetesMultiTarget) ([]provider.Manifest, error) {
 	// override values if multiTarget has value.
 	manifestPathes := spec.Input.Manifests
+	kustomizeDir := ""
 	if multiTarget != nil {
 		if len(multiTarget.Manifests) > 0 {
 			manifestPathes = multiTarget.Manifests
 		}
+		kustomizeDir = multiTarget.KustomizeDir
 	}
 
 	manifests, err := loader.LoadManifests(ctx, provider.LoaderInput{
@@ -340,6 +341,7 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 		Manifests:        manifestPathes,
 		Namespace:        spec.Input.Namespace,
 		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeDir:     kustomizeDir,
 		KustomizeOptions: spec.Input.KustomizeOptions,
 		HelmVersion:      spec.Input.HelmVersion,
 		HelmChart:        spec.Input.HelmChart,
@@ -349,6 +351,24 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 
 	if err != nil {
 		return nil, err
+	}
+
+	// Add builtin labels and annotations for tracking application live state.
+	for i := range manifests {
+		manifests[i].AddLabels(map[string]string{
+			provider.LabelManagedBy:   provider.ManagedByPiped,
+			provider.LabelPiped:       input.Request.PipedID,
+			provider.LabelApplication: input.Request.ApplicationID,
+			provider.LabelCommitHash:  input.Request.DeploymentSource.CommitHash,
+		})
+		manifests[i].AddAnnotations(map[string]string{
+			provider.LabelManagedBy:          provider.ManagedByPiped,
+			provider.LabelPiped:              input.Request.PipedID,
+			provider.LabelApplication:        input.Request.ApplicationID,
+			provider.LabelOriginalAPIVersion: manifests[i].APIVersion(),
+			provider.LabelResourceKey:        manifests[i].Key().String(),
+			provider.LabelCommitHash:         input.Request.DeploymentSource.CommitHash,
+		})
 	}
 
 	return manifests, nil


### PR DESCRIPTION
**What this PR does**:
Fixes `loadManifests` in `livestate/plugin.go` to match what `deployment/plugin.go` already does:

1. Honours `kustomizeDir` from the per-target `multiTarget` config previously the field was ignored, so kustomize overlay directories set per-target had no effect in livestate.
2. Stamps the standard tracking labels and annotations (`LabelManagedBy`, `LabelPiped`, `LabelApplication`, `LabelCommitHash`, `LabelOriginalAPIVersion`, `LabelResourceKey`) on every loaded manifest previously these were missing, causing a divergence between the manifests the deployment plugin applies and the manifests livestate uses for drift detection.


**Why we need it**:
The deployment and livestate plugins use separate `loadManifests` implementations that had diverged. Missing labels in the livestate version meant drift detection compared against manifests that lacked the builtin PipeCD tracking labels, potentially causing false drift reports or missed drift. Missing `kustomizeDir` meant per-target kustomize overlays were silently ignored during livestate checks.

**Which issue(s) this PR fixes**:

Fixes #6446

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Livestate drift detection becomes more accurate, it now compares against manifests with the same labels and overlays that were actually applied.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A