### PR TITLE
[Multi_K8s-Plugin] Pin Is* methods to exact Kubernetes API groups

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/config/application.go
@@ -109,8 +109,6 @@ type KubernetesDeploymentInput struct {
 	// Default is false.
 	AutoCreateNamespace bool `json:"autoCreateNamespace,omitempty"`
 
-	// TODO: Define fields for KubernetesDeploymentInput.
-
 	MultiTargets []KubernetesMultiTarget `json:"multiTargets,omitempty"`
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/diff_test.go
@@ -38,12 +38,12 @@ func TestDiff(t *testing.T) {
 	}{
 		{
 			name: "Secret no diff 1",
-			manifests: `apiVersion: apps/v1
+			manifests: `apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -53,7 +53,7 @@ metadata:
 		},
 		{
 			name: "Secret no diff 2",
-			manifests: `apiVersion: apps/v1
+			manifests: `apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -62,7 +62,7 @@ data:
 stringData:
   foo: bar
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -76,7 +76,7 @@ stringData:
 		},
 		{
 			name: "Secret no diff with merge",
-			manifests: `apiVersion: apps/v1
+			manifests: `apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -84,7 +84,7 @@ data:
   password: hoge
   foo: YmFy
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -98,7 +98,7 @@ stringData:
 		},
 		{
 			name: "Secret no diff override false-positive",
-			manifests: `apiVersion: apps/v1
+			manifests: `apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -106,7 +106,7 @@ data:
   password: hoge
   foo: YmFy
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
@@ -122,14 +122,14 @@ stringData:
 		},
 		{
 			name: "Secret has diff",
-			manifests: `apiVersion: apps/v1
+			manifests: `apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management
 data:
   foo: YmFy
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: secret-management

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
@@ -25,34 +25,6 @@ import (
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
-var builtinAPIGroups = map[string]struct{}{
-	"admissionregistration.k8s.io": {},
-	"apiextensions.k8s.io":         {},
-	"apiregistration.k8s.io":       {},
-	"apps":                         {},
-	"authentication.k8s.io":        {},
-	"authorization.k8s.io":         {},
-	"autoscaling":                  {},
-	"batch":                        {},
-	"certificates.k8s.io":          {},
-	"coordination.k8s.io":          {},
-	"extensions":                   {},
-	"internal.autoscaling.k8s.io":  {},
-	"metrics.k8s.io":               {},
-	"networking.k8s.io":            {},
-	"node.k8s.io":                  {},
-	"policy":                       {},
-	"rbac.authorization.k8s.io":    {},
-	"scheduling.k8s.io":            {},
-	"storage.k8s.io":               {},
-	"":                             {},
-}
-
-func isBuiltinAPIGroup(apiGroup string) bool {
-	_, ok := builtinAPIGroups[apiGroup]
-	return ok
-}
-
 // Manifest represents a Kubernetes resource manifest.
 type Manifest struct {
 	body *unstructured.Unstructured
@@ -121,13 +93,12 @@ func (m Manifest) Name() string {
 // IsWorkload returns true if the manifest is a Deployment, StatefulSet, DaemonSet, ReplicaSet, or Pod.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsWorkload() bool {
-	// TODO: check the API group more strictly.
-	if !isBuiltinAPIGroup(m.body.GroupVersionKind().Group) {
-		return false
-	}
+	group := m.body.GroupVersionKind().Group
 	switch m.body.GetKind() {
-	case KindDeployment, KindStatefulSet, KindDaemonSet, KindReplicaSet, KindPod:
-		return true
+	case KindDeployment, KindStatefulSet, KindDaemonSet, KindReplicaSet:
+		return group == "apps"
+	case KindPod:
+		return group == ""
 	default:
 		return false
 	}
@@ -136,43 +107,37 @@ func (m Manifest) IsWorkload() bool {
 // IsService returns true if the manifest is a Service.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsService() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindService
+	return m.body.GroupVersionKind().Group == "" && m.body.GetKind() == KindService
 }
 
 // IsDeployment returns true if the manifest is a Deployment.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsDeployment() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindDeployment
+	return m.body.GroupVersionKind().Group == "apps" && m.body.GetKind() == KindDeployment
 }
 
 // IsStatefulSet returns true if the manifest is a StatefulSet.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsStatefulSet() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindStatefulSet
+	return m.body.GroupVersionKind().Group == "apps" && m.body.GetKind() == KindStatefulSet
 }
 
 // IsDaemonSet returns true if the manifest is a DaemonSet.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsDaemonSet() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindDaemonSet
+	return m.body.GroupVersionKind().Group == "apps" && m.body.GetKind() == KindDaemonSet
 }
 
 // IsSecret returns true if the manifest is a Secret.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsSecret() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindSecret
+	return m.body.GroupVersionKind().Group == "" && m.body.GetKind() == KindSecret
 }
 
 // IsConfigMap returns true if the manifest is a ConfigMap.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsConfigMap() bool {
-	// TODO: check the API group more strictly.
-	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindConfigMap
+	return m.body.GroupVersionKind().Group == "" && m.body.GetKind() == KindConfigMap
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.


### PR DESCRIPTION
**What this PR does**:
Tightens the API group checks in `provider/manifest.go`. The `Is*` methods previously used `isBuiltinAPIGroup()` which accepted any of ~20 builtin Kubernetes API groups, a Deployment-like CRD from a non-`apps` group would pass `IsDeployment()`. Each method is now pinned to its exact API group:

- `IsDeployment`, `IsStatefulSet`, `IsDaemonSet`, `IsReplicaSet` → group must be `"apps"`
- `IsService`, `IsSecret`, `IsConfigMap`, `IsPod` → group must be `""` (core)
- `IsWorkload` → applies the per-Kind group rule above

`isBuiltinAPIGroup` and the `builtinAPIGroups` map are now unused and have been removed.


**Why we need it**:
The loose check could misidentify a custom resource with the same Kind string but a different API group as a known Kubernetes workload or service, causing incorrect variant label injection or cleanup behaviour.

**Which issue(s) this PR fixes**:

Fixes #6446

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No change for standard Kubernetes resources. Users with CRDs that share a Kind name with a builtin resource (e.g. a CRD named `Deployment` in a non-`apps` group) will no longer have that resource treated as a workload which is the correct behaviour.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A