### PR TITLE
docs: move plugin-architecture piped usage guide to official documentation

### DIFF
--- a/docs/content/en/docs-v1.0.x/installation/install-piped/plugin-architecture.md
+++ b/docs/content/en/docs-v1.0.x/installation/install-piped/plugin-architecture.md
@@ -1,0 +1,165 @@
+---
+title: "Plugin Architecture (Alpha)"
+linkTitle: "Plugin Architecture"
+weight: 10
+description: >
+  How to run piped and plugins with the plugin-based architecture (alpha).
+---
+
+{{< alert title="Note" color="warning" >}}
+This page is still in preparation. The content will be changed and might not work well yet.
+{{< /alert >}}
+
+This page shows how to run piped and plugins of alpha status.
+
+See [cmd/pipedv1/README.md](https://github.com/pipe-cd/pipecd/blob/master/cmd/pipedv1/README.md) if you want to develop or debug piped.
+
+## Prerequisites
+
+- kubectl and a k8s cluster (not required if you won't use the kubernetes plugin)
+
+## 1. Setup Control Plane
+
+1. Run a Control Plane that your piped will connect to. If you want to run a Control Plane locally, see [How to run Control Plane locally](https://github.com/pipe-cd/pipecd/blob/master/cmd/pipecd/README.md#how-to-run-control-plane-locally).
+    - The Control Plane version must be v0.52.0 or later.
+
+2. Generate a new piped key/ID:
+    1. Access the Control Plane console.
+    2. Go to the piped list page at `https://{console-address}/settings/piped`.
+    3. Add a new piped via the `+ADD` button.
+    4. Copy the generated piped ID and base64 encoded key.
+
+## 2. Run Plugin-Arched Piped
+
+1. Download the piped binary:
+
+```sh
+# OS="darwin" or "linux" CPU_ARCH="arm64" or "amd64"
+curl -Lo ./piped_kubecon_jp_2025 https://github.com/pipe-cd/pipecd/releases/download/kubecon-jp-2025/piped_kubecon_jp_2025_{OS}_{CPU_ARCH}
+
+chmod +x ./piped_kubecon_jp_2025
+```
+
+2. Create a piped config file:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  apiAddress: {CONTROL_PLANE_API_ADDRESS} # like "localhost:8080"
+  projectID: {PROJECT_ID}
+  pipedID: {PIPED_ID}
+  pipedKeyData: {BASE64_ENCODED_PIPED_KEY} # or use pipedKeyFile
+  repositories:
+    - repoID: repo1
+      remote: https://github.com/your-account/your-repo
+      branch: xxx
+  plugins:
+    - name: kubernetes
+      port: 7001
+      url: https://github.com/pipe-cd/pipecd/releases/download/kubecon-jp-2025/plugin_kubernetes_kubecon_jp_2025_darwin_arm64
+      deployTargets:
+        - name: cluster1
+          config:
+            masterURL: https://127.0.0.1:61337
+            kubeConfigPath: /path/to/kubeconfig
+            kubectlVersion: 1.33.0
+    - name: wait
+      port: 7002
+      url: https://github.com/pipe-cd/pipecd/releases/download/kubecon-jp-2025/plugin_wait_kubecon_jp_2025_darwin_arm64
+    - name: example-stage
+      port: 7003
+      url: https://github.com/pipe-cd/community-plugins/releases/download/kubecon-jp-2025/plugin_example-stage_kubecon_jp_2025_darwin_arm64
+      config:
+        - commonMessage: "[common message]"
+```
+
+3. Run piped:
+
+```sh
+./piped_kubecon_jp_2025 piped --config-file=/path/to/piped-config.yaml --tools-dir=/tmp/piped-bin
+```
+
+{{< alert title="Note" color="info" >}}
+If your Control Plane runs locally, add `--insecure=true` to skip TLS certificate checks.
+{{< /alert >}}
+
+## 3. Deploy an Application
+
+1. Create an `app.pipecd.yaml`:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: canary
+  labels:
+    env: example
+    team: product
+  pipeline:
+    stages:
+      - name: K8S_CANARY_ROLLOUT
+        with:
+          replicas: 10%
+      - name: WAIT
+        with:
+          duration: 10s
+      - name: K8S_PRIMARY_ROLLOUT
+      - name: K8S_CANARY_CLEAN
+```
+
+2. Create resources in the same directory as `app.pipecd.yaml`:
+
+`deployment.yaml`:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary
+  labels:
+    app: canary
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: canary
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: canary
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+      - name: helloworld
+        image: ghcr.io/pipe-cd/helloworld:v0.32.0
+        args:
+          - server
+        ports:
+        - containerPort: 9085
+```
+
+`service.yaml`:
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary
+spec:
+  selector:
+    app: canary
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085
+```
+
+3. Push `app.pipecd.yaml` and resources to your remote repository.
+4. On the Control Plane console, register the application via the `PIPED V1 ADD FROM SUGGESTIONS` tab.
+
+## See Also
+
+- [Kubernetes plugin README](/pkg/app/pipedv1/plugin/kubernetes/README.md)
+- [Wait stage plugin README](/pkg/app/pipedv1/plugin/wait/README.md)
+- [Example-stage plugin README](https://github.com/pipe-cd/community-plugins/blob/main/plugins/example-stage/README.md)


### PR DESCRIPTION
## What this PR does
Moves the plugin-architecture Piped usage guide from 
`cmd/pipedv1/README-usage-alpha.md` to the official documentation at
`docs/content/en/docs-v1.0.x/installation/install-piped/plugin-architecture.md`

## Which issue this fixes
Fixes #6742

## Changes
- Added new documentation page for plugin-architecture piped usage
- Replaced alpha notice with Hugo alert block
- Updated internal links to align with documentation pages
- Content includes: Prerequisites, Setup Control Plane, Run Piped, Deploy an Application

## Does this PR introduce a user-facing change?
Yes - users can now find the plugin-architecture piped usage guide 
in the official docs instead of having to look inside cmd/ directory.