### PR TITLE
docs: audit and fix missing language tags in markdown code blocks

### DIFF
--- a/docs/content/en/blog/control-plane-on-ecs.md
+++ b/docs/content/en/blog/control-plane-on-ecs.md
@@ -13,6 +13,7 @@ This blog is a part of PipeCD best practice series, a guideline for you to opera
 Currently, you can deploy and operate the PipeCD control plane on a Kubernetes cluster easily, but some developers that would like to introduce PipeCD can not prepare Kubernetes environments. If you have the same problem, this blog is for you. We will show you how to deploy the PipeCD control plane on Amazon ECS.
 
 ### Architecture
+
 > Note: Please refer to [architecture-overview](/docs/user-guide/managing-controlplane/architecture-overview/) docs for definitions of PipeCD components such as server, ops, cache, datastore and filestore.
 
 ![](/images/control-plane-on-ecs.png)
@@ -20,9 +21,11 @@ Currently, you can deploy and operate the PipeCD control plane on a Kubernetes c
 Following the above graph for PipeCD control plane runs on Amazon ECS, we have to prepare these next components
 
 ### Secrets Manager
+
 You should put config files (control-plane-config.yaml, envoy-config.yaml) on Secrets Manager because config files contain some credentials such as database passwords.
 The examples of config files for ECS are [here](https://github.com/pipe-cd/control-plane-aws-ecs-terraform-demo/tree/main/config). Please edit these files according to your environment.
-```
+
+```bash
 aws secretsmanager create-secret --name control-plane-config \
 --description "Configuration of control plane" \
 --secret-string `base64 control-plane-config.yaml`
@@ -30,31 +33,37 @@ aws secretsmanager create-secret --name envoy-config \
 --description "Configuration of control plane" \
 --secret-string `base64 envoy-config.yaml`
 ```
+
 You should also put encryption key
-```
+
+```bash
 aws secretsmanager create-secret --name encryption-key \
 --description "Encryption key for control plane" \
 --secret-string `openssl rand 64 | base64`
 ```
 
 ### RDS(datastore)
+
 It is possible to use RDS as a datastore. Edit your configuration file for the control plane according to your RDS setting.
+
 ```yaml
-  datastore:
-    type: MYSQL
-    config: 
-        url: root:password@tcp(endpoint_of_rds:3306) 
-        database: quickstart
+datastore:
+  type: MYSQL
+  config:
+    url: root:password@tcp(endpoint_of_rds:3306)
+    database: quickstart
 ```
 
 ### Redis(cache)
+
 It is possible to use Redis as a cache. Note the endpoint of Redis for the task definition.
 
-
 ### S3(filestore)
+
 It is possible to use S3 as a filestore. The filestore contains state files that describe your secure infrastructure, so make sure to make the bucket private. Only allow pipecd-server(ECS) to access this bucket.
 
 ### ECS
+
 You need to create two different services for pipecd-server and a pipecd-ops because they have the same ports and different permissions. The pipecd-server can be accessed by external clients such as piped or web clients, so this service includes the pipe-cd gateway and this service must be connected to the application loadbalancer. The pipecd-ops can only be accessed by admin users, so this service must only be accessed via SSM session manager.
 ECS agent sets config files as environment variables in container from secrets manager. Create configuration files from environment variables in the container as below.
 
@@ -65,14 +74,15 @@ echo $ENVOY_CONFIG; echo $ENVOY_CONFIG | base64 -d >> envoy-config.yaml
 > Note: Attach IAM policy to get secrets from Secrets Manager to task execution role.
 
 > Note: If you manage both of RDS and ECS by terraform, you can rewite datastore endpoint in the configuration file.
-`sed -i -e s/pipecd-mysql/${var.db_instance_address}/ control-plane-config.yaml;`
+> `sed -i -e s/pipecd-mysql/${var.db_instance_address}/ control-plane-config.yaml;`
 
 > Note: Attach IAM policy to access filestore to task role.
 
-
 #### task definitions examples (using terraform variables)
+
 1. gateway and server
-```
+
+```hcl
 {
 name  = "pipecd-gateway"
 image = var.gateway_image_url
@@ -124,7 +134,8 @@ secrets = [
 ```
 
 2. ops
-```
+
+```hcl
 {
 name  = "pipecd-ops"
 image = var.ops_image_url
@@ -163,20 +174,24 @@ secrets = [
 ```
 
 ### ALB
+
 You must prepare two target groups for both HTTP and gRPC. Make two hosts and listner rules as below. Listner protocol should be HTTPS becuase it uses gRPC.
 
 ![](/images/control-plane-alb.png)
 
 ### Terraform example
+
 PipeCD gives [control-plane-aws-ecs-terraform-demo](https://github.com/pipe-cd/control-plane-aws-ecs-terraform-demo), which we use Terraform to prepare PipeCD controlplane components and install it on air.
 
 #### Prepare
+
 1. Prepare SSL certificate
-Prepare your domain and SSL certificate from AWS certificate manager.
+   Prepare your domain and SSL certificate from AWS certificate manager.
 
 2. Create a s3 bucket for terraform backend
-Write bucket name to `00-main.tf`
-```
+   Write bucket name to `00-main.tf`
+
+```terraform
 terraform {
   backend "s3" {
     bucket  = "example-pipecd-control-plane-tfstate" #your bucket name for terraform backend
@@ -193,13 +208,14 @@ terraform {
 ```
 
 3. Edit `variables.tf` for your project
-```
+
+```terraform
 //export
 locals {
   alb = {
     certificate_arn = ""
   }
-  
+
   redis = {
     node_type = "cache.t2.micro"
   }
@@ -216,7 +232,8 @@ locals {
 ```
 
 4. Create a S3 bucket for filestore and write the bucket name for it to `control-plane-config.yaml` and `variables.tf`
-```
+
+```yaml
 apiVersion: "pipecd.dev/v1beta1"
 kind: ControlPlane
 spec:
@@ -228,7 +245,7 @@ spec:
   filestore:
     type: S3
     config: # edit here
-        bucket: example-pipecd-control-plane-filestore 
+        bucket: example-pipecd-control-plane-filestore
         region: ap-northeast-1
   projects:
     - id: quickstart
@@ -236,7 +253,8 @@ spec:
           username: hello-pipecd
           passwordHash: "$2a$10$ye96mUqUqTnjUqgwQJbJzel/LJibRhUnmzyypACkvrTSnQpVFZ7qK" # bcrypt value of "hello-pipecd"
 ```
-```
+
+```terraform
 //export
 locals {
   s3 = { # These must be unique in the world.
@@ -244,9 +262,11 @@ locals {
   }
 }
 ```
+
 5. Write config of RDS for datastore to `control-plane-config.yaml`
-Note: Do not edit hostname (pipecd-mysql) because it will be edited autimaticaly by terraform.
-```
+   Note: Do not edit hostname (pipecd-mysql) because it will be edited autimaticaly by terraform.
+
+```yaml
 apiVersion: "pipecd.dev/v1beta1"
 kind: ControlPlane
 spec:
@@ -257,8 +277,8 @@ spec:
       database: quickstart
   filestore:
     type: S3
-    config: 
-      bucket: example-pipecd-control-plane-filestore 
+    config:
+      bucket: example-pipecd-control-plane-filestore
       region: ap-northeast-1
   projects:
     - id: quickstart
@@ -268,7 +288,8 @@ spec:
 ```
 
 6. Put an encryption key and config file in Secrets Manager and write the path to `variables.tf`
-```
+
+```terraform
 locals {
   sm = {
     control_plane_config_secret = ""
@@ -279,13 +300,16 @@ locals {
 ```
 
 #### Deploy
-```
+
+```bash
 terraform apply
 ```
 
 #### login admin console
+
 You can login pipecd-ops via ECS exec.
-```
+
+```bash
 aws ssm start-session --target ecs:${CLUSTER}_${TASK_ID}_${CONTAINER_ID} --document-name AWS-StartPortForwardingSession --parameters '{"portNumber":["9082"],"localPortNumber":["19082"]}'
 ```
 

--- a/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
+++ b/docs/content/en/blog/pipecd-at-kubecon-eu-2024.md
@@ -25,7 +25,7 @@ PipeCD team also be around the project booth, let's come and discuss.
 
 Booth information
 
-```
+```text
 Project: PipeCD
 Kiosk #: PP16-A
 Kiosk Shift: Part-time - AM (Fri)

--- a/docs/content/en/blog/pipecd-at-kubecon-hongkong-2024.md
+++ b/docs/content/en/blog/pipecd-at-kubecon-hongkong-2024.md
@@ -27,8 +27,9 @@ We will also be around the project booth. Let's come and discuss!
 Booth information:
 
  <!-- TODO: Input the booth info -->
-```
-Project: PipeCDi
+
+```text
+Project: PipeCD
 Kiosk #: TBA
 Kiosk Shift: TBA
 Location: TBA

--- a/docs/content/en/docs-dev/contribution-guidelines/contributing.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/contributing.md
@@ -28,14 +28,14 @@ There are many ways to contribute, and many don't involve writing code:
 
 PipeCD consists of several components:
 
-| Component | Description |
-|-----------|-------------|
-| [cmd/pipecd](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipecd) | Control Plane — manages deployment data and provides gRPC API |
-| [cmd/piped](https://github.com/pipe-cd/pipecd/tree/master/cmd/piped) | Piped agent — runs in your cluster |
-| [cmd/pipectl](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipectl) | Command-line tool |
-| [cmd/launcher](https://github.com/pipe-cd/pipecd/tree/master/cmd/launcher) | Command executor for remote upgrade |
-| [web](https://github.com/pipe-cd/pipecd/tree/master/web) | Web UI |
-| [docs](https://github.com/pipe-cd/pipecd/tree/master/docs) | Documentation |
+| Component                                                                  | Description                                                   |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [cmd/pipecd](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipecd)     | Control Plane — manages deployment data and provides gRPC API |
+| [cmd/piped](https://github.com/pipe-cd/pipecd/tree/master/cmd/piped)       | Piped agent — runs in your cluster                            |
+| [cmd/pipectl](https://github.com/pipe-cd/pipecd/tree/master/cmd/pipectl)   | Command-line tool                                             |
+| [cmd/launcher](https://github.com/pipe-cd/pipecd/tree/master/cmd/launcher) | Command executor for remote upgrade                           |
+| [web](https://github.com/pipe-cd/pipecd/tree/master/web)                   | Web UI                                                        |
+| [docs](https://github.com/pipe-cd/pipecd/tree/master/docs)                 | Documentation                                                 |
 
 ### Prerequisites
 
@@ -95,6 +95,7 @@ kubectl port-forward -n pipecd svc/pipecd 8080
 Open [http://localhost:8080?project=quickstart](http://localhost:8080?project=quickstart)
 
 Login credentials:
+
 - **Username:** `hello-pipecd`
 - **Password:** `hello-pipecd`
 
@@ -162,7 +163,7 @@ make build/go       # Build Go binaries
 
 2. **Use descriptive titles** — Follow commit message style: present tense, capitalize first letter
 
-   ```
+   ```text
    Add imports to Terraform plan result
    ```
 
@@ -186,6 +187,7 @@ If your change affects users, update the PR description:
 
 ```md
 **Does this PR introduce a user-facing change?**:
+
 - **How are users affected by this change**:
 - **Is this breaking change**:
 - **How to migrate (if breaking change)**:

--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -17,102 +17,109 @@ The Pipectl command-line tool can be installed using one of the following method
 
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipecd/releases).
 
-    We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Run the following script:
+   We recommend using the latest version of pipectl to avoid unforeseen issues.
+   Run the following script:
 
-    ``` console
-    # OS="darwin" or "linux"
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipecd/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_{OS}_amd64
-    ```
+   ```console
+   # OS="darwin" or "linux"
+   curl -Lo ./pipectl https://github.com/pipe-cd/pipecd/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_{OS}_amd64
+   ```
 
 2. Make the pipectl binary executable.
 
-    ``` console
-    chmod +x ./pipectl
-    ```
+   ```console
+   chmod +x ./pipectl
+   ```
 
 3. Move the binary to your PATH.
 
-    ``` console
-    sudo mv ./pipectl /usr/local/bin/pipectl
-    ```
+   ```console
+   sudo mv ./pipectl /usr/local/bin/pipectl
+   ```
 
 4. Test to ensure the version you installed is up-to-date.
 
-    ``` console
-    pipectl version
-    ```
+   ```console
+   pipectl version
+   ```
 
 ### Using Asdf
 
 About [Asdf](https://asdf-vm.com/)
 
 1. Add pipectl plugin to asdf. (If you have not yet `asdf add plugin add pipectl`.)
-    ```console
-    asdf plugin add pipectl
-    ```
+
+   ```console
+   asdf plugin add pipectl
+   ```
 
 2. Install pipectl. Available versions are [here](https://github.com/pipe-cd/pipecd/releases).
-    ```console
-    asdf install pipectl {VERSION}
-    ```
+
+   ```console
+   asdf install pipectl {VERSION}
+   ```
 
 3. Set a version.
-    ```console
-    asdf global pipectl {VERSION}
-    ```
+
+   ```console
+   asdf global pipectl {VERSION}
+   ```
 
 4. Test to ensure the version you installed is up-to-date.
 
-    ``` console
-    pipectl version
-    ```
+   ```console
+   pipectl version
+   ```
 
 ### Using Aqua
 
 About [Aqua](https://aquaproj.github.io/)
 
 1. Add pipectl to `aqua.yaml`. (If you want to select a version, use `aqua g -i -s pipe-cd/pipecd/pipectl`)
-    ```console
-    aqua g -i pipe-cd/pipecd/pipectl
-    ```
+
+   ```console
+   aqua g -i pipe-cd/pipecd/pipectl
+   ```
 
 2. Install pipectl.
-    ```console
-    aqua i
-    ```
+
+   ```console
+   aqua i
+   ```
 
 3. Test to ensure the version you installed is up-to-date.
-    ```console
-    pipectl version
-    ```
+   ```console
+   pipectl version
+   ```
 
 ### Using Homebrew
 
 About [Homebrew](https://brew.sh/)
 
 1. Add the `pipe-cd/tap` and fetch new formulae from GitHub.
-    ```console
-    brew tap pipe-cd/tap
-    brew update
-    ```
+
+   ```console
+   brew tap pipe-cd/tap
+   brew update
+   ```
 
 2. Install pipectl.
-    ```console
-    brew install pipectl
-    ```
+
+   ```console
+   brew install pipectl
+   ```
 
 3. Test to ensure the version you installed is up-to-date.
-    ```console
-    pipectl version
-    ```
+   ```console
+   pipectl version
+   ```
 
 ### Run in Docker container
 
 We are storing every version of docker image for pipectl on GitHub Container Registry.
 Available versions are [here](https://github.com/pipe-cd/pipecd/releases).
 
-```
+```console
 docker run --rm ghcr.io/pipe-cd/pipectl:{VERSION} -h
 ```
 
@@ -122,6 +129,7 @@ In order for pipectl to authenticate with PipeCD's Control Plane, it needs an AP
 There are two kinds of key role: `READ_ONLY` and `READ_WRITE`. Depending on the command, it might require an appropriate role to execute.
 
 ![](/images/settings-api-key.png)
+
 <p style="text-align: center;">
 Adding a new API key from Settings tab
 </p>
@@ -134,7 +142,7 @@ When executing a command of pipectl you have to specify either a string of API k
 
 Run `help` to know the available commands:
 
-``` console
+```console
 $ pipectl --help
 
 The command line tool for PipeCD.
@@ -169,7 +177,7 @@ Use "pipectl [command] --help" for more information about a command.
 
 Add a new application into the project:
 
-``` console
+```console
 pipectl application add \
     --address=CONTROL_PLANE_API_ADDRESS \
     --api-key=API_KEY \
@@ -183,7 +191,7 @@ pipectl application add \
 
 Run `help` to know what command flags should be specified:
 
-``` console
+```console
 $ pipectl application add --help
 
 Add a new application.
@@ -220,7 +228,7 @@ Global Flags:
 
 - Send a request to sync an application and exit immediately when the deployment is triggered:
 
-  ``` console
+  ```console
   pipectl application sync \
       --address={CONTROL_PLANE_API_ADDRESS} \
       --api-key={API_KEY} \
@@ -229,7 +237,7 @@ Global Flags:
 
 - Send a request to sync an application and wait until the triggered deployment reaches one of the specified statuses:
 
-  ``` console
+  ```console
   pipectl application sync \
       --address={CONTROL_PLANE_API_ADDRESS} \
       --api-key={API_KEY} \
@@ -241,7 +249,7 @@ Global Flags:
 
 Display the information of a given application in JSON format:
 
-``` console
+```console
 pipectl application get \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -252,7 +260,7 @@ pipectl application get \
 
 Find and display the information of matching applications in JSON format:
 
-``` console
+```console
 pipectl application list \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -264,7 +272,7 @@ pipectl application list \
 
 Disable an application with given id:
 
-``` console
+```console
 pipectl application disable \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -275,7 +283,7 @@ pipectl application disable \
 
 Delete an application with given id:
 
-``` console
+```console
 pipectl application delete \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -297,7 +305,7 @@ pipectl deployment list \
 
 Wait until a given deployment reaches one of the specified statuses:
 
-``` console
+```console
 pipectl deployment wait-status \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -320,7 +328,7 @@ pipectl deployment logs \
 
 Register an event that can be used by EventWatcher:
 
-``` console
+```console
 pipectl event register \
     --address={CONTROL_PLANE_API_ADDRESS} \
     --api-key={API_KEY} \
@@ -338,7 +346,7 @@ You can encrypt it the same way you do [from the web](../managing-application/se
 
 - From stdin:
 
-  ``` console
+  ```console
   pipectl encrypt \
       --address={CONTROL_PLANE_API_ADDRESS} \
       --api-key={API_KEY} \
@@ -347,7 +355,7 @@ You can encrypt it the same way you do [from the web](../managing-application/se
 
 - From the `--input-file` flag:
 
-  ``` console
+  ```console
   pipectl encrypt \
       --address={CONTROL_PLANE_API_ADDRESS} \
       --api-key={API_KEY} \
@@ -359,10 +367,9 @@ Note: The docs for pipectl available command is maybe outdated, we suggest users
 
 ### Generating an application config (app.pipecd.yaml)
 
-
 Generate an app.pipecd.yaml interactively:
 
-``` console
+```console
 $ pipectl init
 Which platform? Enter the number [0]Kubernetes [1]ECS: 1
 Name of the application: myApp

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/script-run.md
@@ -3,7 +3,7 @@ title: "Script Run stage"
 linkTitle: "Script Run stage"
 weight: 4
 description: >
-   Specific guide for configuring Script Run stage
+  Specific guide for configuring Script Run stage
 ---
 
 `SCRIPT_RUN` stage is one stage in the pipeline and you can execute any commands.
@@ -12,7 +12,7 @@ description: >
 
 ## How to configure SCRIPT_RUN stage
 
-Add a `SCRIPT_RUN` to your pipeline and write commands. 
+Add a `SCRIPT_RUN` to your pipeline and write commands.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
@@ -60,7 +60,7 @@ The commands run in the directory where this application configuration file exis
 If your script is so long, you can separate the script as a file.
 You can put the file with the app.pipecd.yaml in the same dir and then you can execute the script like this.
 
-```
+```yaml
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -73,7 +73,7 @@ spec:
             sh script.sh
 ```
 
-```
+```text
 .
 ├── app.pipecd.yaml
 └── script.sh
@@ -84,6 +84,7 @@ spec:
 Currently, you can use the commands which are installed in the environment for the piped.
 
 For example, If you are using the container platform and the offcial piped container image, you can use the command below.
+
 - git
 - ssh
 - jq
@@ -91,9 +92,10 @@ For example, If you are using the container platform and the offcial piped conta
 - commands installed by piped in $PIPED_TOOL_DIR (check at runtime)
 - built-in commands installed in the base image
 
-The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX commands available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)). 
+The public piped image available in PipeCD main repo (ref: [Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/cmd/piped/Dockerfile)) is based on [alpine](https://hub.docker.com/_/alpine/) and only has a few UNIX commands available (ref: [piped-base Dockerfile](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/Dockerfile)).
 
 If you want to use your commands, you can realize it with either step below.
+
 - Prepare your own environment container image then add [piped binary](https://github.com/pipe-cd/pipecd/releases) to it.
 - Build your own container image based on `ghcr.io/pipe-cd/piped` image.
 
@@ -101,33 +103,33 @@ If you want to use your commands, you can realize it with either step below.
 
 You can use the envrionment values related to the deployment.
 
-| Name | Description | Example |
-|-|-|-|
-|SR_DEPLOYMENT_ID| The deployment id | 877625fc-196a-40f9-b6a9-99decd5494a0 |
-|SR_APPLICATION_ID| The application id | 8d7609e0-9ff6-4dc7-a5ac-39660768606a |
-|SR_APPLICATION_NAME| The application name | example |
-|SR_TRIGGERED_AT| The timestamp when the deployment is triggered  | 1719571113 |
-|SR_TRIGGERED_COMMIT_HASH| The commit hash that triggered the deployment | 2bf969a3dad043aaf8ae6419943255e49377da0d |
-|SR_TRIGGERED_COMMANDER| The ID of user who triggered the deployment via UI. This is APIKey's ID if it was triggered via `pipectl sync`. This is empty if it was triggered by your piped. | userid |
-|SR_REPOSITORY_URL| The repository url configured in the piped config  | git@github.com:org/repo.git, https://github.com/org/repo |
-|SR_SUMMARY| The summary of the deployment | Sync with the specified pipeline because piped received a command from user via web console or pipectl|
-|SR_CONTEXT_RAW| The json encoded string of above values | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
-|SR_LABELS_XXX| The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABELS_ENV` and `SR_LABELS_TEAM` are registered.  | prd, server |
-|SR_IS_ROLLBACK| This is `true` if the deployment is rollbacking. Otherwise, this is `false`. | false |
+| Name                     | Description                                                                                                                                                                                                 | Example                                                                                                                                                                                                                                                                                                                        |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| SR_DEPLOYMENT_ID         | The deployment id                                                                                                                                                                                           | 877625fc-196a-40f9-b6a9-99decd5494a0                                                                                                                                                                                                                                                                                           |
+| SR_APPLICATION_ID        | The application id                                                                                                                                                                                          | 8d7609e0-9ff6-4dc7-a5ac-39660768606a                                                                                                                                                                                                                                                                                           |
+| SR_APPLICATION_NAME      | The application name                                                                                                                                                                                        | example                                                                                                                                                                                                                                                                                                                        |
+| SR_TRIGGERED_AT          | The timestamp when the deployment is triggered                                                                                                                                                              | 1719571113                                                                                                                                                                                                                                                                                                                     |
+| SR_TRIGGERED_COMMIT_HASH | The commit hash that triggered the deployment                                                                                                                                                               | 2bf969a3dad043aaf8ae6419943255e49377da0d                                                                                                                                                                                                                                                                                       |
+| SR_TRIGGERED_COMMANDER   | The ID of user who triggered the deployment via UI. This is APIKey's ID if it was triggered via `pipectl sync`. This is empty if it was triggered by your piped.                                            | userid                                                                                                                                                                                                                                                                                                                         |
+| SR_REPOSITORY_URL        | The repository url configured in the piped config                                                                                                                                                           | git@github.com:org/repo.git, https://github.com/org/repo                                                                                                                                                                                                                                                                       |
+| SR_SUMMARY               | The summary of the deployment                                                                                                                                                                               | Sync with the specified pipeline because piped received a command from user via web console or pipectl                                                                                                                                                                                                                         |
+| SR_CONTEXT_RAW           | The json encoded string of above values                                                                                                                                                                     | {"deploymentID":"877625fc-196a-40f9-b6a9-99decd5494a0","applicationID":"8d7609e0-9ff6-4dc7-a5ac-39660768606a","applicationName":"example","triggeredAt":1719571113,"triggeredCommitHash":"2bf969a3dad043aaf8ae6419943255e49377da0d","repositoryURL":"git@github.com:org/repo.git","labels":{"env":"example","team":"product"}} |
+| SR_LABELS_XXX            | The label attached to the deployment. The env name depends on the label name. For example, if a deployment has the labels `env:prd` and `team:server`, `SR_LABELS_ENV` and `SR_LABELS_TEAM` are registered. | prd, server                                                                                                                                                                                                                                                                                                                    |
+| SR_IS_ROLLBACK           | This is `true` if the deployment is rollbacking. Otherwise, this is `false`.                                                                                                                                | false                                                                                                                                                                                                                                                                                                                          |
 
 ### Use `SR_CONTEXT_RAW` with jq
 
 You can use jq command to refer to the values from `SR_CONTEXT_RAW`.
 
-```
-      - name: SCRIPT_RUN
-        with:
-          run: |
-            echo "Get deploymentID from SR_CONTEXT_RAW"
-            echo $SR_CONTEXT_RAW | jq -r '.deploymentID'
-            sleep 10
-          onRollback: |
-            echo "rollback script-run"
+```yaml
+- name: SCRIPT_RUN
+  with:
+    run: |
+      echo "Get deploymentID from SR_CONTEXT_RAW"
+      echo $SR_CONTEXT_RAW | jq -r '.deploymentID'
+      sleep 10
+    onRollback: |
+      echo "rollback script-run"
 ```
 
 ## Rollback
@@ -176,7 +178,8 @@ When there are multiple SCRIPT_RUN stages, they are executed in the same order a
 Also, only for the executed SCRIPT_RUNs are rollbacked.
 
 For example, consider when deployment proceeds in the following order from 1 to 7.
-```
+
+```text
 1. K8S_CANARY_ROLLOUT
 2. WAIT
 3. SCRIPT_RUN
@@ -187,6 +190,7 @@ For example, consider when deployment proceeds in the following order from 1 to 
 ```
 
 Then
+
 - If 3 is canceled or fails while running, only SCRIPT_RUN of 3 will be rollbacked.
 - If 4 is canceled or fails while running, only SCRIPT_RUN of 3 will be rollbacked.
 - If 6 is canceled or fails while running, only SCRIPT_RUNs 3 and 5 will be rollbacked. The order of executing is 3 -> 5.

--- a/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
+++ b/docs/content/en/docs-dev/user-guide/managing-controlplane/auth.md
@@ -47,7 +47,6 @@ Requirements and Troubleshooting:
 - Roles claim value must use the same values as pre-configured project RBAC Roles.
 - Claims can be retrieved from the IdToken or UserInfo endpoint. The UserInfo endpoint will be used if the issuer supports it.
 - You can use set a custom claim key name for roles and username in the OIDC provider. Using `usernameClaimKey` and `rolesClaimKey` in the configuration. If not set, the default value will be chosen in the following order:
-
   - Supported Claims Key for Username (in order of priority): `username`, `preferred_username`,`name`, `cognito:username`
   - Supported Claims Key for Role (in order of priority): `groups`, `roles`, `cognito:groups`, `custom:roles`, `custom:groups`
 
@@ -238,13 +237,13 @@ The below table represents PipeCD's resources with actions on those resources.
 
 Each role is defined as a combination of multiple policies under this format.
 
-```
+```text
 resources=RESOURCE_NAMES;actions=ACTION_NAMES
 ```
 
 The `*` represents all resources and all actions for a resource.
 
-```
+```text
 resources=*;actions=ACTION_NAMES
 resources=RESOURCE_NAMES;actions=*
 resources=*;actions=*

--- a/docs/content/en/docs-dev/user-guide/managing-piped/runtime-options.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/runtime-options.md
@@ -10,14 +10,14 @@ You can configure some options when running Piped and launcher.
 
 ## Options for Piped
 
-```
+```console
 Usage:
   piped piped [flags]
 
 Flags:
       --add-login-user-to-passwd                   Whether to add login user to $HOME/passwd. This is typically for applications running as a random user ID.
       --admin-port int                             The port number used to run a HTTP server for admin tasks such as metrics, healthz. (default 9085)
-      --app-manifest-cache-count int               The number of app manifests to cache. The cache-key contains the commit hash. The default is 150. (default 150)     
+      --app-manifest-cache-count int               The number of app manifests to cache. The cache-key contains the commit hash. The default is 150. (default 150)
       --cert-file string                           The path to the TLS certificate file.
       --config-aws-secret string                   The ARN of secret that contains Piped config and be stored in AWS Secrets Manager.
       --config-aws-ssm-parameter string            The name of parameter of Piped config stored in AWS Systems Manager Parameter Store. SecureString is also supported.
@@ -42,7 +42,7 @@ Global Flags:
 
 ## Options for launcher
 
-```
+```console
 Usage:
   launcher launcher [flags]
 

--- a/docs/content/en/docs-dev/user-guide/metrics.md
+++ b/docs/content/en/docs-dev/user-guide/metrics.md
@@ -12,6 +12,7 @@ This page walks you through how to set up and use them.
 ## Monitoring overview
 
 ![](/images/metrics-architecture.png)
+
 <p style="text-align: center;">
 Monitoring Architecture
 </p>
@@ -23,44 +24,53 @@ The piped agent collects its metrics and periodically sends them to the Control 
 Developers managing the piped agent can also get metrics directly from the piped agent and monitor them with their custom monitoring service.
 
 ## Enable monitoring system
+
 To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
 
-```
+```bash
 --set monitoring.enabled=true
 ```
 
 ## Dashboards
+
 If you've already enabled monitoring system in the previous section, you can access Grafana using port forwarding:
 
-```
+```bash
 kubectl port-forward -n {NAMESPACE} svc/{PIPECD_RELEASE_NAME}-grafana 3000:80
 ```
 
 #### Control Plane dashboards
+
 There are three dashboards related to Control Plane:
+
 - Overview - usage stats of PipeCD
 - Incoming Requests - gRPC and HTTP requests stats to check for any negative impact on users
 - Go - processes stats of PipeCD components
 
 #### Piped dashboards
+
 Visualize the metrics of Piped registered in the Control plane.
+
 - Overview - usage stats of piped agents
 - Process - resource usage of piped agent
 - Go - processes stats of piped agents.
 
 #### Cluster dashboards
+
 Because cluster dashboards tracks cluster-wide metrics, defaults to disable. You can enable it with:
 
-```
+```bash
 --monitoring.clusterStats=true
 ```
 
 There are three dashboards that track metrics for:
+
 - Node - nodes stats within the Kubernetes cluster where PipeCD runs on
 - Pod - stats for pods that make PipeCD up
 - Prometheus - stats for Prometheus itself
 
 ## Alert notifications
+
 If you want to send alert notifications to external services like Slack, you need to set an alertmanager configuration file.
 
 For example, let's say you use Slack as a receiver. Create `values.yaml` and put the following configuration to there.
@@ -70,18 +80,18 @@ prometheus:
   alertmanagerFiles:
     alertmanager.yml:
       global:
-        slack_api_url: {YOUR_WEBHOOK_URL}
+        slack_api_url: { YOUR_WEBHOOK_URL }
       route:
         receiver: slack-notifications
       receivers:
         - name: slack-notifications
           slack_configs:
-            - channel: '#your-channel'
+            - channel: "#your-channel"
 ```
 
 And give it to the `helm install` command when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
 
-```
+```bash
 --values=values.yaml
 ```
 
@@ -89,36 +99,38 @@ See [here](https://prometheus.io/docs/alerting/latest/configuration/) for more d
 
 ## Piped agent metrics
 
-| Metric | Type | Description |
-| --- | --- | --- |
-| `cloudprovider_kubernetes_tool_calls_total` | counter | Number of calls made to run the tool like kubectl, kustomize. |
-| `deployment_status` | gauge | The current status of deployment. 1 for current status, 0 for others. |
-| `livestatestore_kubernetes_api_requests_total` | counter | Number of requests sent to kubernetes api server. |
-| `livestatestore_kubernetes_resource_events_total` | counter | Number of resource events received from kubernetes server. |
-| `plan_preview_command_handled_total` | counter | Total number of plan-preview commands handled at piped. |
-| `plan_preview_command_handling_seconds` | histogram | Histogram of handling seconds of plan-preview commands. |
-| `plan_preview_command_received_total` | counter | Total number of plan-preview commands received at piped. |
+| Metric                                            | Type      | Description                                                           |
+| ------------------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `cloudprovider_kubernetes_tool_calls_total`       | counter   | Number of calls made to run the tool like kubectl, kustomize.         |
+| `deployment_status`                               | gauge     | The current status of deployment. 1 for current status, 0 for others. |
+| `livestatestore_kubernetes_api_requests_total`    | counter   | Number of requests sent to kubernetes api server.                     |
+| `livestatestore_kubernetes_resource_events_total` | counter   | Number of resource events received from kubernetes server.            |
+| `plan_preview_command_handled_total`              | counter   | Total number of plan-preview commands handled at piped.               |
+| `plan_preview_command_handling_seconds`           | histogram | Histogram of handling seconds of plan-preview commands.               |
+| `plan_preview_command_received_total`             | counter   | Total number of plan-preview commands received at piped.              |
 
 ## Control plane metrics
 
 All Piped's metrics are sent to the control plane so that they are also available on the control plane's metrics server.
 
-| Metric | Type | Description |
-| --- | --- | --- |
-| `cache_get_operation_total` | counter | Number of cache get operation while processing. |
-| `grpcapi_create_deployment_total` | counter | Number of successful CreateDeployment RPC with project label. |
-| `http_request_duration_milliseconds` | histogram | Histogram of request latencies in milliseconds. |
-| `http_requests_total` | counter | Total number of HTTP requests. |
-| `insight_application_total` | gauge | Number of applications currently controlled by control plane. |
+| Metric                               | Type      | Description                                                   |
+| ------------------------------------ | --------- | ------------------------------------------------------------- |
+| `cache_get_operation_total`          | counter   | Number of cache get operation while processing.               |
+| `grpcapi_create_deployment_total`    | counter   | Number of successful CreateDeployment RPC with project label. |
+| `http_request_duration_milliseconds` | histogram | Histogram of request latencies in milliseconds.               |
+| `http_requests_total`                | counter   | Total number of HTTP requests.                                |
+| `insight_application_total`          | gauge     | Number of applications currently controlled by control plane. |
 
 ## Health Checking
 
 The below components expose their endpoint for health checking.
+
 - server
 - ops
 - piped
 - launcher (only when you run with designating the `launcher-admin-port` option.)
 
 The spec of the health check endpoint is as below.
+
 - Path: `/healthz`
 - Port: the same as admin server's port. 9085 by default.


### PR DESCRIPTION
**What this PR does**:
Audits all active (non-versioned) documentation markdown files under `docs/content/en/` and adds the appropriate language syntax highlighting tags (`bash`, `yaml`, `hcl`, `terraform`, `console`, `text`) to all code blocks that previously used plain untagged backticks (```).

Specifically, this PR fixes **28 code blocks** across **9 active documentation files**:
- **control-plane-on-ecs.md** (HCL/Terraform, YAML configs, bash commands)
- **pipecd-at-kubecon-eu-2024.md** / **pipecd-at-kubecon-hongkong-2024.md** (Plain text schedule metadata)
- **metrics.md** (Port forwarding and Helm CLI commands)
- **command-line-tool.md** (`pipectl` CLI examples)
- **script-run.md** (YAML snippets and folder structure text)
- **auth.md** (Access policies text)
- **runtime-options.md** (CLI help console output)
- **contributing.md** (Commit message examples)


**Why we need it**:
Without specifying language tags, code blocks render as unstyled plain text on the generated documentation site. Adding appropriate syntax tags enhances readability, visually structures the commands, and provides a polished developer experience for users reading the documentation.

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: The code blocks in the documentation on the PipeCD website will now render with proper syntax highlighting.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
