### PR TITLE
docs: unify Control Plane terminology capitalization

### DIFF
--- a/docs/content/en/blog/ci-cd-gap-fulfill-with-pipecd.md
+++ b/docs/content/en/blog/ci-cd-gap-fulfill-with-pipecd.md
@@ -73,7 +73,7 @@ spec:
               yamlField: $.spec.template.spec.containers[0].image
 ```
 
-Then, in the last step of your CI pipeline, you need to use pipectl to send an event to PipeCD controlplane like this
+Then, in the last step of your CI pipeline, you need to use pipectl to send an event to PipeCD Control Plane like this
 
 ```bash
 $ pipectl event register --name=event-test --data=ghcr.io/pipecd/helloworld:v0.49.0

--- a/docs/content/en/blog/control-plane-on-ecs.md
+++ b/docs/content/en/blog/control-plane-on-ecs.md
@@ -289,4 +289,4 @@ You can login pipecd-ops via ECS exec.
 aws ssm start-session --target ecs:${CLUSTER}_${TASK_ID}_${CONTAINER_ID} --document-name AWS-StartPortForwardingSession --parameters '{"portNumber":["9082"],"localPortNumber":["19082"]}'
 ```
 
-That's all! Now you have your own PipeCD controlplane and it's ready to go!!
+That's all! Now you have your own PipeCD Control Plane and it's ready to go!!

--- a/docs/content/en/docs-dev/faq/_index.md
+++ b/docs/content/en/docs-dev/faq/_index.md
@@ -51,7 +51,7 @@ You can create a new Piped key. Go to the `Piped` tab at `Settings` page, and cl
 ### 7. What is the strong point if PipeCD is used only for Kubernetes?
 
 - Simple interface, easy to understand no extra CRD required
-- Easy to install, upgrade, and manage (both the ControlPlane and the agent Piped)
+- Easy to install, upgrade, and manage (both the Control Plane and the agent Piped)
 - Not strict depend on any Kubernetes API, not being part of issues for your Kubernetes cluster versioning upgrade
 - Easy to interact with any CI; Plan preview feature gives you an early look at what will be changed in your cluster even before manifests update
 - Insights show metrics like lead time, deployment frequency, MTTR, and change failure rate to measure delivery performance

--- a/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-dev/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -74,7 +74,7 @@ helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/l
 
 Currently, besides `Firestore` PipeCD supports other databases as its datastore such as `MySQL`. Also as for filestore, PipeCD supports `AWS S3` and `MINIO` either.
 
-For example, in case of using `MySQL` as datastore and `MINIO` as filestore, the ControlPlane configuration will be as follow:
+For example, in case of using `MySQL` as datastore and `MINIO` as filestore, the Control Plane configuration will be as follow:
 
 ```yaml
 apiVersion: "pipecd.dev/v1beta1"

--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -47,7 +47,7 @@ And you will access the main page of PipeCD Control Plane console, which looks l
 
 ![](/images/pipecd-control-plane-mainpage.png)
 
-For more about PipeCD control plane management, please check [Managing ControlPlane](/docs/user-guide/managing-controlplane/).
+For more about PipeCD control plane management, please check [Managing Control Plane](/docs/user-guide/managing-controlplane/).
 
 #### 1.2. Installing Piped
 

--- a/docs/content/en/docs-v0.56.x/faq/_index.md
+++ b/docs/content/en/docs-v0.56.x/faq/_index.md
@@ -51,7 +51,7 @@ You can create a new Piped key. Go to the `Piped` tab at `Settings` page, and cl
 ### 7. What is the strong point if PipeCD is used only for Kubernetes?
 
 - Simple interface, easy to understand no extra CRD required
-- Easy to install, upgrade, and manage (both the ControlPlane and the agent Piped)
+- Easy to install, upgrade, and manage (both the Control Plane and the agent Piped)
 - Not strict depend on any Kubernetes API, not being part of issues for your Kubernetes cluster versioning upgrade
 - Easy to interact with any CI; Plan preview feature gives you an early look at what will be changed in your cluster even before manifests update
 - Insights show metrics like lead time, deployment frequency, MTTR, and change failure rate to measure delivery performance

--- a/docs/content/en/docs-v0.56.x/installation/install-control-plane/installing-controlplane-on-k8s.md
+++ b/docs/content/en/docs-v0.56.x/installation/install-control-plane/installing-controlplane-on-k8s.md
@@ -74,7 +74,7 @@ helm upgrade -i pipecd oci://ghcr.io/pipe-cd/chart/pipecd --version {{< blocks/l
 
 Currently, besides `Firestore` PipeCD supports other databases as its datastore such as `MySQL`. Also as for filestore, PipeCD supports `AWS S3` and `MINIO` either.
 
-For example, in case of using `MySQL` as datastore and `MINIO` as filestore, the ControlPlane configuration will be as follow:
+For example, in case of using `MySQL` as datastore and `MINIO` as filestore, the Control Plane configuration will be as follow:
 
 ```yaml
 apiVersion: "pipecd.dev/v1beta1"

--- a/docs/content/en/docs-v0.56.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.56.x/quickstart/_index.md
@@ -47,7 +47,7 @@ And you will access the main page of PipeCD Control Plane console, which looks l
 
 ![](/images/pipecd-control-plane-mainpage.png)
 
-For more about PipeCD control plane management, please check [Managing ControlPlane](/docs/user-guide/managing-controlplane/).
+For more about PipeCD control plane management, please check [Managing Control Plane](/docs/user-guide/managing-controlplane/).
 
 #### 1.2. Installing Piped
 


### PR DESCRIPTION
# What this PR does

Normalizes unspaced terminology inconsistencies for the core PipeCD architectural component:

```text
Control Plane
```

across English documentation.

This PR specifically fixes occurrences such as:
- `controlplane`
- `ControlPlane`

by standardizing them to:

```text
Control Plane
```

within:
- English prose
- Markdown link text
- Documentation references

The change is intentionally:
- Semantic-only
- Minimal in scope
- Non-structural

No formatting, layout, or documentation restructuring changes are included.

---

# Why we need it

Consistent terminology is important for:
- Documentation clarity
- Contributor familiarity with PipeCD architecture
- Searchability
- Readability across documentation

Previously, multiple spacing and casing variants of:

```text
Control Plane
```

existed throughout the documentation, creating inconsistency in architectural terminology.

This PR standardizes those references while intentionally avoiding unrelated formatting churn.

---

# Which issue(s) this PR fixes

Fixes:

```text
#[issue-number]
```

---

# Does this PR introduce a user-facing change?

```text
No
```

---

# How are users affected by this change

Documentation readers and contributors will now see consistent architectural terminology across:
- PipeCD documentation
- Developer guides
- Blog content

This improves:
- Readability
- Terminology consistency
- Documentation professionalism

without changing:
- Functionality
- Documentation structure
- Runtime behavior

---

# Is this a breaking change

```text
No
```

---

# How to migrate (if breaking change)

```text
N/A
```