### PR TITLE
test: add basic input validation tests for plugin api structs

### DIFF
--- a/pkg/plugin/api/v1alpha1/common/common_test.go
+++ b/pkg/plugin/api/v1alpha1/common/common_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentSourceValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  *DeploymentSource
+		wantErr bool
+	}{
+		{
+			name:    "nil struct is valid",
+			source:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty struct is valid",
+			source:  &DeploymentSource{},
+			wantErr: false,
+		},
+		{
+			name: "full struct is valid",
+			source: &DeploymentSource{
+				ApplicationDirectory:      "app-dir",
+				CommitHash:                "commit-hash",
+				ApplicationConfig:         []byte("config"),
+				ApplicationConfigFilename: ".pipe.yaml",
+				SharedConfigDirectory:     "shared-dir",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.source.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/plugin/api/v1alpha1/deployment/api_test.go
+++ b/pkg/plugin/api/v1alpha1/deployment/api_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	model "github.com/pipe-cd/pipecd/pkg/model"
+)
+
+func newValidDeployment() *model.Deployment {
+	return &model.Deployment{
+		Id:              "dep-id",
+		ApplicationId:   "app-id",
+		ApplicationName: "app-name",
+		PipedId:         "piped-id",
+		ProjectId:       "project-id",
+		GitPath: &model.ApplicationGitPath{
+			Repo: &model.ApplicationGitRepository{
+				Id: "repo-id",
+			},
+			Path: "path",
+		},
+		Trigger: &model.DeploymentTrigger{
+			Commit: &model.Commit{
+				Hash:      "hash",
+				Message:   "msg",
+				Author:    "auth",
+				Branch:    "branch",
+				CreatedAt: 123456,
+			},
+			Commander: "commander",
+			Timestamp: 123456,
+		},
+	}
+}
+
+func newValidPipelineStage() *model.PipelineStage {
+	return &model.PipelineStage{
+		Id:        "stage-id",
+		Name:      "stage-name",
+		CreatedAt: 123456,
+		UpdatedAt: 123456,
+	}
+}
+
+func TestDetermineVersionsRequestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *DetermineVersionsRequest
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			req:         nil,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid: missing input",
+			req:         &DetermineVersionsRequest{},
+			expectedErr: "DetermineVersionsRequest.Input",
+		},
+		{
+			name: "valid: input provided",
+			req: &DetermineVersionsRequest{
+				Input: &PlanPluginInput{
+					Deployment: newValidDeployment(),
+				},
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestDetermineStrategyRequestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *DetermineStrategyRequest
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			req:         nil,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid: missing input",
+			req:         &DetermineStrategyRequest{},
+			expectedErr: "DetermineStrategyRequest.Input",
+		},
+		{
+			name: "valid: input provided",
+			req: &DetermineStrategyRequest{
+				Input: &PlanPluginInput{
+					Deployment: newValidDeployment(),
+				},
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestExecuteStageRequestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *ExecuteStageRequest
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			req:         nil,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid: missing input",
+			req:         &ExecuteStageRequest{},
+			expectedErr: "ExecuteStageRequest.Input",
+		},
+		{
+			name: "valid: input provided",
+			req: &ExecuteStageRequest{
+				Input: &ExecutePluginInput{
+					Deployment: newValidDeployment(),
+					Stage:      newValidPipelineStage(),
+				},
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestBuildPipelineSyncStagesRequestStageConfigValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *BuildPipelineSyncStagesRequest_StageConfig
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			config:      nil,
+			expectedErr: "",
+		},
+		{
+			name: "invalid: empty name",
+			config: &BuildPipelineSyncStagesRequest_StageConfig{
+				Name:  "",
+				Index: 0,
+			},
+			expectedErr: "BuildPipelineSyncStagesRequest_StageConfig.Name",
+		},
+		{
+			name: "invalid: negative index",
+			config: &BuildPipelineSyncStagesRequest_StageConfig{
+				Name:  "stage-1",
+				Index: -1,
+			},
+			expectedErr: "BuildPipelineSyncStagesRequest_StageConfig.Index",
+		},
+		{
+			name: "valid",
+			config: &BuildPipelineSyncStagesRequest_StageConfig{
+				Name:  "stage-1",
+				Index: 0,
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestPlanPluginInputValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       *PlanPluginInput
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			input:       nil,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid: missing deployment",
+			input:       &PlanPluginInput{},
+			expectedErr: "PlanPluginInput.Deployment",
+		},
+		{
+			name: "valid",
+			input: &PlanPluginInput{
+				Deployment: newValidDeployment(),
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestExecutePluginInputValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       *ExecutePluginInput
+		expectedErr string
+	}{
+		{
+			name:        "nil struct is valid",
+			input:       nil,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid: missing deployment and stage",
+			input:       &ExecutePluginInput{},
+			expectedErr: "ExecutePluginInput.Deployment",
+		},
+		{
+			name: "invalid: missing stage only",
+			input: &ExecutePluginInput{
+				Deployment: newValidDeployment(),
+			},
+			expectedErr: "ExecutePluginInput.Stage",
+		},
+		{
+			name: "valid",
+			input: &ExecutePluginInput{
+				Deployment: newValidDeployment(),
+				Stage:      newValidPipelineStage(),
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/plugin/api/v1alpha1/livestate/api_test.go
+++ b/pkg/plugin/api/v1alpha1/livestate/api_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livestate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLivestateRequestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *GetLivestateRequest
+		wantErr bool
+	}{
+		{
+			name:    "nil struct is valid",
+			req:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty struct is valid",
+			req:     &GetLivestateRequest{},
+			wantErr: false,
+		},
+		{
+			name: "full struct is valid",
+			req: &GetLivestateRequest{
+				PipedId:         "piped-id",
+				ApplicationId:   "app-id",
+				ApplicationName: "app-name",
+				DeployTargets:   []string{"target-1"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/plugin/api/v1alpha1/planpreview/api_test.go
+++ b/pkg/plugin/api/v1alpha1/planpreview/api_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPlanPreviewRequestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *GetPlanPreviewRequest
+		wantErr bool
+	}{
+		{
+			name:    "nil struct is valid",
+			req:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty struct is valid",
+			req:     &GetPlanPreviewRequest{},
+			wantErr: false,
+		},
+		{
+			name: "full struct is valid",
+			req: &GetPlanPreviewRequest{
+				ApplicationId:   "app-id",
+				ApplicationName: "app-name",
+				PipedId:         "piped-id",
+				DeployTargets:   []string{"target-1"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPlanPreviewResultValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		res     *PlanPreviewResult
+		wantErr bool
+	}{
+		{
+			name:    "nil struct is valid",
+			res:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty struct is valid",
+			res:     &PlanPreviewResult{},
+			wantErr: false,
+		},
+		{
+			name: "full struct is valid",
+			res: &PlanPreviewResult{
+				DeployTarget: "target-1",
+				Summary:      "summary-text",
+				NoChange:     false,
+				Details:      []byte("details"),
+				DiffLanguage: "diff",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.res.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What this PR does

Adds basic input validation unit tests for PipeCD Plugin API structs under:

```text
pkg/plugin/api/v1alpha1/...
```

The tests cover generated:

```text
protoc-gen-validate
```

validation behavior across:
- `common`
- `deployment`
- `livestate`
- `planpreview`

Specifically, this PR adds validation coverage for:
- Required fields
- Minimum string length checks
- Index boundary validation
- Nested model validation

---

# Why we need it

PipeCD’s plugin API depends on generated validation logic to enforce:
- Request correctness
- API schema integrity
- Plugin contract consistency

at the API boundary.

Adding explicit validation tests helps ensure:
- Invalid plugin API payloads are rejected early
- Required API contracts remain enforced
- Nested validation behavior continues working correctly
- Future proto/schema changes do not accidentally weaken validation guarantees

This improves:
- API reliability
- Contract stability
- Confidence when evolving plugin interfaces
- Long-term schema safety

---

# Which issue(s) this PR fixes

Fixes:

```text
#[issue-number]
```

---

# Does this PR introduce a user-facing change?

```text
No
```

---

# How are users affected by this change

There is no direct user-facing behavior change.

Developers and maintainers benefit from:
- Stronger Plugin API validation coverage
- Better regression protection
- Improved confidence in request validation behavior

This reduces the risk of validation regressions in plugin-related request handling.

---

# Is this a breaking change

```text
No
```

---

# How to migrate (if breaking change)

```text
N/A
```

---

# Verification

Verified locally using:

```bash
go test ./pkg/plugin/api/v1alpha1/...
go test ./pkg/plugin/api/v1alpha1/deployment -v
```

All Plugin API validation tests pass successfully, including:
- Required-field validation
- Nested validation
- Boundary validation cases
- Generated PGV constraint enforcement