### PR TITLE
Add pipedv1 Kubernetes multicluster simple example

### DIFF
--- a/examples/kubernetes_multicluster/simple/.piped/config-example.yaml
+++ b/examples/kubernetes_multicluster/simple/.piped/config-example.yaml
@@ -1,0 +1,34 @@
+# This file is an example only.
+# Replace the placeholder values before using it in a real Piped configuration.
+projectID: example-project # PipeCD project ID.
+pipedID: example-piped-id # Piped ID generated in the control plane.
+pipedKeyData: REPLACE_WITH_BASE64_ENCODED_PIPED_KEY # Base64-encoded piped key placeholder.
+apiAddress: localhost:8080 # Control-plane API address.
+plugins:
+  - name: kubernetes-multicluster # Plugin name registered in piped config.
+    url: file:///opt/pipecd/plugins/kubernetes-multicluster # Plugin binary location.
+    port: 7003 # gRPC port exposed by the plugin process.
+    config: {} # Plugin-wide config. Kept empty for this example.
+    deployTargets:
+      - name: cluster-a # Deploy target name referenced from app.pipecd.yaml.
+        labels:
+          region: us-east1 # Cluster selector label for this target.
+        config:
+          masterURL: https://cluster-a.example.com # Kubernetes API server URL placeholder.
+          kubeConfigPath: /path/to/cluster-a.kubeconfig # kubeconfig path placeholder.
+          kubectlVersion: 1.32.2 # kubectl version used for this target.
+          appStateInformer:
+            namespace: default # Namespace watched for application state.
+            includeResources: [] # Optional resources to include in the informer.
+            excludeResources: [] # Optional resources to exclude from the informer.
+      - name: cluster-b # Deploy target name referenced from app.pipecd.yaml.
+        labels:
+          region: us-west1 # Cluster selector label for this target.
+        config:
+          masterURL: https://cluster-b.example.com # Kubernetes API server URL placeholder.
+          kubeConfigPath: /path/to/cluster-b.kubeconfig # kubeconfig path placeholder.
+          kubectlVersion: 1.32.2 # kubectl version used for this target.
+          appStateInformer:
+            namespace: default # Namespace watched for application state.
+            includeResources: [] # Optional resources to include in the informer.
+            excludeResources: [] # Optional resources to exclude from the informer.

--- a/examples/kubernetes_multicluster/simple/README.md
+++ b/examples/kubernetes_multicluster/simple/README.md
@@ -1,0 +1,15 @@
+# Kubernetes Multi-Cluster Simple Example
+
+This example shows the first pipedv1 Kubernetes multicluster app in PipeCD. It deploys the same nginx manifests to two clusters through the kubernetes-multicluster plugin, using `cluster-a` and `cluster-b` as deploy targets.
+
+`K8S_MULTI_SYNC` performs a quick sync across every selected cluster at the same time. It applies the manifests in this directory to each target and, with `prune: true`, removes resources that are no longer tracked in Git.
+
+## Prerequisites
+
+- A pipedv1 setup with the `kubernetes-multicluster` plugin configured.
+- Matching deploy targets named `cluster-a` and `cluster-b`.
+- See [.piped/config-example.yaml](.piped/config-example.yaml) for the expected plugin config shape.
+
+## What's different from v0 examples
+
+v1 runs the kubernetes-multicluster plugin as a separate gRPC process registered in Piped config, instead of embedding the logic in the main binary like the older examples.

--- a/examples/kubernetes_multicluster/simple/app.pipecd.yaml
+++ b/examples/kubernetes_multicluster/simple/app.pipecd.yaml
@@ -1,0 +1,32 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: multicluster-simple
+  labels:
+    env: example
+    team: product
+  description: |
+    This example is the first pipedv1 Kubernetes multicluster example in PipeCD.
+    It shows the K8S_MULTI_SYNC stage, which applies the same manifests to all
+    selected clusters in one quick sync and deploys to cluster-a and cluster-b
+    simultaneously.
+  plugins:
+    kubernetes_multicluster:
+      quickSync:
+        prune: true
+      variantLabel:
+        key: pipecd.dev/variant
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2
+        multiTargets:
+          - target:
+              name: cluster-a
+              labels:
+                region: us-east1
+          - target:
+              name: cluster-b
+              labels:
+                region: us-west1

--- a/examples/kubernetes_multicluster/simple/deployment.yaml
+++ b/examples/kubernetes_multicluster/simple/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multicluster-simple
+  namespace: default
+  labels:
+    app: multicluster-simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: multicluster-simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: multicluster-simple
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/examples/kubernetes_multicluster/simple/service.yaml
+++ b/examples/kubernetes_multicluster/simple/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multicluster-simple
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: multicluster-simple
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary

This PR adds the first `pipedv1` example for the `kubernetes-multicluster` plugin under `examples/kubernetes_multicluster/simple`.

Part of #6266 

It includes:

- `app.pipecd.yaml` for a quick-sync multicluster application targeting `cluster-a` and `cluster-b`
- `deployment.yaml` and `service.yaml` for a simple NGINX workload
- `README.md` documenting what the example demonstrates and how it differs from v0 examples
- `.piped/config-example.yaml` showing the expected flat Piped configuration structure for the multicluster plugin

## Validation

- Parsed all new YAML files successfully
- Kept the example focused on the `pipedv1` multicluster quick-sync workflow

## Does this PR introduce a user-facing change?

Yes

## How are users affected by this change?

Users now have a concrete `pipedv1` example for the `kubernetes-multicluster` plugin, along with a companion Piped configuration sample that they can adapt for local setups or other examples.

## Is this a breaking change?

No

## How to migrate (if breaking change)

N/A