### PR TITLE
Add initial chapters for the PipeCD plugin development book

### DIFF
--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/chapter-00-prerequisites.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/chapter-00-prerequisites.md
@@ -1,0 +1,73 @@
+---
+title: "Prerequisites and Setup"
+linkTitle: "Prerequisites"
+weight: 2
+description: >
+  What you need and how to set up a local PipeCD development environment.
+---
+
+← Back to Book Index: ./_index.md
+
+# Prerequisites and Setup
+
+This chapter covers what you should know and the tools you need before starting to build a PipeCD plugin, plus quick steps to set up a local development environment.
+
+## 1 — What You Need to Know Before Starting
+
+- Go programming: be comfortable reading and writing Go structs, interfaces, and functions. If you need a refresher, see https://go.dev/tour
+- Kubernetes basics: understand core objects such as Deployments and Services and how manifests describe them
+- Basic understanding of what a CD (continuous delivery) platform does and the role of a control plane vs. agents/plugins
+- Familiarity with gRPC is helpful but not required — the PipeCD plugin SDK abstracts most of the gRPC boilerplate
+
+## 2 — Required Tools
+
+- Go 1.22 or later — download from https://go.dev/dl/
+- kubectl 1.32 or later — https://kubernetes.io/docs/tasks/tools/
+- Docker — for running a local PipeCD control plane when you want to test end-to-end
+- git — for source control and contributing
+- A text editor or IDE with Go support (VS Code with the Go extension is recommended)
+
+## 3 — Setting Up a Local PipeCD Environment (high level)
+
+- Clone the PipeCD repository:
+
+```bash
+git clone https://github.com/pipe-cd/pipecd.git
+cd pipecd
+```
+
+- The `pipedv1`-related binaries live under `cmd/` (for example `cmd/pipedv1/`)
+- Official plugins live under `pkg/app/pipedv1/plugin/`
+- To build a plugin locally, change to the plugin directory and run `go build`:
+
+```bash
+cd pkg/app/pipedv1/plugin/kubernetes
+go build ./...
+```
+
+- Refer to the piped configuration schema at https://github.com/pipe-cd/pipecd/blob/master/pkg/configv1/piped.go to understand how plugins are registered in `piped` config
+- For full installation and local runtime instructions, see the official docs: https://pipecd.dev/docs
+
+## 4 — Verifying Your Setup
+
+Checklist you can run through locally:
+
+- [ ] `go version` shows Go 1.22 or later
+- [ ] `kubectl version --client` shows kubectl 1.32 or later
+- [ ] You can clone the pipecd repository and `cd cmd/pipedv1/`
+- [ ] You can build the kubernetes plugin:
+
+```bash
+cd pkg/app/pipedv1/plugin/kubernetes && go build ./...
+```
+- [ ] You can open a proto file and recognize a gRPC service definition, for example: https://github.com/pipe-cd/pipecd/blob/master/pkg/plugin/api/v1alpha1/deployment/api.proto
+
+## 5 — A Note on the Plugin SDK
+
+- The plugin SDK is located in `pkg/plugin/sdk/` inside the pipecd repository and provides helpers for building a gRPC server and wiring your implementation into `piped`.
+- Plugins are standalone Go binaries that implement one or more interfaces (Deployment, Livestate, etc.). The SDK handles the gRPC server setup; you implement the business logic.
+- Key SDK types and entry points live in `pkg/plugin/sdk/plugin.go` — consult the file in the repository for API details.
+
+---
+
+Next Chapter → ./chapter-01-introduction.md

--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/chapter-01-introduction.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/chapter-01-introduction.md
@@ -1,0 +1,50 @@
+---
+title: "Introduction"
+linkTitle: "Introduction"
+weight: 3
+description: >
+  An introduction to the PipeCD Plugin Development Book: goals, audience, and what you'll build.
+---
+
+← Back to Book Index: ./_index.md
+
+# Introduction
+
+## 1 — What This Book Is About
+
+This book walks you through building a real PipeCD plugin from scratch. It uses a learn-by-doing approach: every concept is introduced alongside working code and minimal runnable examples. By the end of the book you will have a working DeploymentPlugin that `piped` can load and execute.
+
+## 2 — What Is PipeCD
+
+PipeCD is a CNCF open source GitOps continuous delivery platform that focuses on safe, auditable, and automated delivery flows. It decouples control-plane responsibilities from platform-specific deployment logic by using plugins.
+
+In the `pipedv1` architecture, each deployment platform (for example Kubernetes, ECS, or Terraform) can be implemented as a separate plugin process. Plugins run as independent gRPC servers and communicate with `piped` over localhost. This design makes PipeCD extensible: anyone can write a plugin to support a new platform or deployment strategy.
+
+## 3 — Who This Book Is For
+
+- Go developers who want to contribute to PipeCD
+- Platform engineers who want to extend PipeCD for a custom deployment target
+- Anyone curious about plugin architectures, gRPC-based integrations, and building small, testable Go programs
+
+## 4 — What We Will Build
+
+- A working `DeploymentPlugin` implementation that `piped` can load and execute
+- The plugin will implement required SDK interfaces and provide simple stage implementations you can run locally
+- Later chapters cover wiring the plugin into `piped`, running it against a local control plane, and testing behavior
+
+## 5 — A Note on Versions
+
+This English translation and expansion is based on the PipeCD codebase as of May 19, 2026. The original Japanese book was written in June 2025 by Warashi. This edition updates examples to match the current plugin SDK and adds material aimed at English-speaking contributors. Always check the official PipeCD documentation for the latest information: https://pipecd.dev/docs
+
+Credit and thanks to Warashi for the original work: https://zenn.dev/warashi/books/try-and-learn-pipecd-plugin
+
+## 6 — How to Use This Book
+
+- Read chapters in order — each chapter builds on the previous one
+- Every chapter includes working code you can copy and run locally
+- The final plugin examples are available in the PipeCD examples repository: https://github.com/pipe-cd/pipe-cd-examples
+- If you get stuck, ask for help in the #pipecd channel on the Cloud Native Slack or open an issue in the PipeCD repository
+
+---
+
+Next Chapter → ./chapter-02-what-we-will-build.md

--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/index.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/index.md
@@ -1,0 +1,44 @@
+---
+title: "PipeCD Plugin Development Book"
+linkTitle: "Plugin Development Book"
+weight: 1
+description: >
+
+ A practical, chapter-by-chapter guide to building PipeCD plugins from scratch using the `pipedv1` plugin SDK.
+---
+
+PipeCD Plugin Development Book — English translation and expansion of the original Japanese tutorial by Warashi.
+
+This book is an English translation and expansion of the original Japanese book by Warashi (https://zenn.dev/warashi/books/try-and-learn-pipecd-plugin). It has been updated to reflect the current `pipedv1` plugin SDK and expanded with new content for English-speaking contributors.
+
+Credit: Warashi — https://zenn.dev/warashi/books/try-and-learn-pipecd-plugin
+
+Code examples in this book are verified against the current PipeCD codebase where possible; when uncertain, placeholders marked `[TODO: verify against current SDK]` are used.
+
+Chapters:
+
+1. 00. Prerequisites and Setup
+2. 01. Introduction
+3. 02. What We Will Build
+4. 03. Technology Choices
+5. 04. Project Initialization
+6. 05. Adding Dependencies
+7. 06. Understanding Plugin Types
+8. 07. First Steps in Plugin Implementation
+9. 08. Satisfying the DeploymentPlugin Interface
+10. 09. Defining Configuration Types
+11. 10. Stub Implementation
+12. 11. Implementing FetchDefinedStages
+13. 12. Implementing DetermineVersions
+14. 13. Implementing DetermineStrategy
+15. 14. Implementing BuildPipelineSyncStages
+16. 15. Implementing BuildQuickSyncStages
+17. 16. Implementing ExecuteStage
+18. 17. ExecuteStage: The DIFF Stage
+19. 18. ExecuteStage: The SYNC Stage
+20. 19. ExecuteStage: The ROLLBACK Stage
+21. 20. Updating the Main Function
+22. 21. Running Your Plugin with Piped
+23. 22. Conclusion and Next Steps
+
+For more implementation resources see [Plugin development resources](./plugin-development-resources/).

--- a/examples/kubernetes_multicluster/simple/.piped/config-example.yaml
+++ b/examples/kubernetes_multicluster/simple/.piped/config-example.yaml
@@ -1,0 +1,34 @@
+# This file is an example only.
+# Replace the placeholder values before using it in a real Piped configuration.
+projectID: example-project # PipeCD project ID.
+pipedID: example-piped-id # Piped ID generated in the control plane.
+pipedKeyData: REPLACE_WITH_BASE64_ENCODED_PIPED_KEY # Base64-encoded piped key placeholder.
+apiAddress: localhost:8080 # Control-plane API address.
+plugins:
+  - name: kubernetes-multicluster # Plugin name registered in piped config.
+    url: file:///opt/pipecd/plugins/kubernetes-multicluster # Plugin binary location.
+    port: 7003 # gRPC port exposed by the plugin process.
+    config: {} # Plugin-wide config. Kept empty for this example.
+    deployTargets:
+      - name: cluster-a # Deploy target name referenced from app.pipecd.yaml.
+        labels:
+          region: us-east1 # Cluster selector label for this target.
+        config:
+          masterURL: https://cluster-a.example.com # Kubernetes API server URL placeholder.
+          kubeConfigPath: /path/to/cluster-a.kubeconfig # kubeconfig path placeholder.
+          kubectlVersion: 1.32.2 # kubectl version used for this target.
+          appStateInformer:
+            namespace: default # Namespace watched for application state.
+            includeResources: [] # Optional resources to include in the informer.
+            excludeResources: [] # Optional resources to exclude from the informer.
+      - name: cluster-b # Deploy target name referenced from app.pipecd.yaml.
+        labels:
+          region: us-west1 # Cluster selector label for this target.
+        config:
+          masterURL: https://cluster-b.example.com # Kubernetes API server URL placeholder.
+          kubeConfigPath: /path/to/cluster-b.kubeconfig # kubeconfig path placeholder.
+          kubectlVersion: 1.32.2 # kubectl version used for this target.
+          appStateInformer:
+            namespace: default # Namespace watched for application state.
+            includeResources: [] # Optional resources to include in the informer.
+            excludeResources: [] # Optional resources to exclude from the informer.

--- a/examples/kubernetes_multicluster/simple/README.md
+++ b/examples/kubernetes_multicluster/simple/README.md
@@ -1,0 +1,15 @@
+# Kubernetes Multi-Cluster Simple Example
+
+This example shows the first pipedv1 Kubernetes multicluster app in PipeCD. It deploys the same nginx manifests to two clusters through the kubernetes-multicluster plugin, using `cluster-a` and `cluster-b` as deploy targets.
+
+`K8S_MULTI_SYNC` performs a quick sync across every selected cluster at the same time. It applies the manifests in this directory to each target and, with `prune: true`, removes resources that are no longer tracked in Git.
+
+## Prerequisites
+
+- A pipedv1 setup with the `kubernetes-multicluster` plugin configured.
+- Matching deploy targets named `cluster-a` and `cluster-b`.
+- See [.piped/config-example.yaml](.piped/config-example.yaml) for the expected plugin config shape.
+
+## What's different from v0 examples
+
+v1 runs the kubernetes-multicluster plugin as a separate gRPC process registered in Piped config, instead of embedding the logic in the main binary like the older examples.

--- a/examples/kubernetes_multicluster/simple/app.pipecd.yaml
+++ b/examples/kubernetes_multicluster/simple/app.pipecd.yaml
@@ -1,0 +1,32 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: multicluster-simple
+  labels:
+    env: example
+    team: product
+  description: |
+    This example is the first pipedv1 Kubernetes multicluster example in PipeCD.
+    It shows the K8S_MULTI_SYNC stage, which applies the same manifests to all
+    selected clusters in one quick sync and deploys to cluster-a and cluster-b
+    simultaneously.
+  plugins:
+    kubernetes_multicluster:
+      quickSync:
+        prune: true
+      variantLabel:
+        key: pipecd.dev/variant
+      input:
+        manifests:
+          - deployment.yaml
+          - service.yaml
+        kubectlVersion: 1.32.2
+        multiTargets:
+          - target:
+              name: cluster-a
+              labels:
+                region: us-east1
+          - target:
+              name: cluster-b
+              labels:
+                region: us-west1

--- a/examples/kubernetes_multicluster/simple/deployment.yaml
+++ b/examples/kubernetes_multicluster/simple/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multicluster-simple
+  namespace: default
+  labels:
+    app: multicluster-simple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: multicluster-simple
+      pipecd.dev/variant: primary
+  template:
+    metadata:
+      labels:
+        app: multicluster-simple
+        pipecd.dev/variant: primary
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/examples/kubernetes_multicluster/simple/service.yaml
+++ b/examples/kubernetes_multicluster/simple/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multicluster-simple
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: multicluster-simple
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
This PR adds the opening chapters of the PipeCD plugin development book in English. It introduces the book, covers prerequisites and local setup, and updates the book index to include the new chapters.

The scope is limited to documentation and the initial plugin SDK onboarding material.

Testing: not run, documentation-only change.

Part of #6679 