### PR TITLE
[PipeCD-Web]: Fix livestate UI for non-k8s plugins

### DIFF
--- a/web/src/components/application-detail-page/application-state-view/live-state-view/graph-view/resource-node/index.tsx
+++ b/web/src/components/application-detail-page/application-state-view/live-state-view/graph-view/resource-node/index.tsx
@@ -26,7 +26,8 @@ export const ResourceNode: FC<Props> = memo(function ResourceNode({
       onClick={() => onClick(resource)}
     >
       <Typography variant="caption">
-        {findMetadataByKey(resource.resourceMetadataMap, "Kind")}
+        {findMetadataByKey(resource.resourceMetadataMap, "Kind") ??
+          resource.resourceType}
       </Typography>
       <Box sx={{ display: "flex" }}>
         <HealthStatusIcon health={resource.healthStatus} />

--- a/web/src/components/application-detail-page/application-state-view/live-state-view/resource-detail/index.tsx
+++ b/web/src/components/application-detail-page/application-state-view/live-state-view/resource-detail/index.tsx
@@ -1,7 +1,6 @@
 import { Box } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { FC } from "react";
-import { findMetadataByKey } from "~/utils/find-metadata-by-key";
 import { ResourceState } from "~~/model/application_live_state_pb";
 import {
   CloseButton,
@@ -33,43 +32,32 @@ export const ResourceDetail: FC<ResourceDetailProps> = ({
           alignItems: "center",
         }}
       >
-        <InfoRowTitle>Kind</InfoRowTitle>
-        <InfoRowValue>
-          {findMetadataByKey(resource.resourceMetadataMap, "Kind")}
-        </InfoRowValue>
+        <InfoRowTitle>Resource Type</InfoRowTitle>
+        <InfoRowValue>{resource.resourceType}</InfoRowValue>
       </Box>
-      <Box
-        sx={{
-          pt: 1,
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <InfoRowTitle>Namespace</InfoRowTitle>
-        <InfoRowValue>
-          {findMetadataByKey(resource.resourceMetadataMap, "Namespace")}
-        </InfoRowValue>
-      </Box>
-      <Box
-        sx={{
-          pt: 1,
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <InfoRowTitle>Api Version</InfoRowTitle>
-        <InfoRowValue>
-          {findMetadataByKey(resource.resourceMetadataMap, "API Version")}
-        </InfoRowValue>
-      </Box>
-      <Box
-        sx={{
-          pt: 1,
-        }}
-      >
-        <InfoRowTitle>Health Description</InfoRowTitle>
-        <InfoRowValue>{resource.healthDescription || "Empty"}</InfoRowValue>
-      </Box>
+      {resource.resourceMetadataMap.map(([key, value]) => (
+        <Box
+          key={key}
+          sx={{
+            pt: 1,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <InfoRowTitle>{key}</InfoRowTitle>
+          <InfoRowValue>{value || "Empty"}</InfoRowValue>
+        </Box>
+      ))}
+      {resource.healthDescription && (
+        <Box
+          sx={{
+            pt: 1,
+          }}
+        >
+          <InfoRowTitle>Health Description</InfoRowTitle>
+          <InfoRowValue>{resource.healthDescription}</InfoRowValue>
+        </Box>
+      )}
     </PanelWrap>
   );
 };


### PR DESCRIPTION
**What this PR does**: 
- Render resource metadata in the livestate detail panel instead of hardcode k8s-specific fields (`Kind`, `Namespace`, `API Version`)
- Show `resourceType` as fallback label on resource node cards when `Kind` metadata is not present

**Why we need it**: currently, the livestate UI was built with only for k8s plugin, causing non-k8s plugins to display empty or meaningless fields in the resource detail panel and missing type labels on resource cards.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
