### PR TITLE
[Multi_K8s-Plugin] Implement health status for DaemonSet, ReplicaSet and Pod

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/health_status.go
@@ -16,8 +16,10 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
@@ -36,8 +38,25 @@ func (m Manifest) calculateHealthStatus() (sdk.ResourceHealthStatus, string) {
 			return sdk.ResourceHealthStateUnknown, ""
 		}
 		return statefulSetHealthStatus(obj)
+	case m.IsReplicaSet():
+		obj := &appsv1.ReplicaSet{}
+		if err := m.ConvertToStructuredObject(obj); err != nil {
+			return sdk.ResourceHealthStateUnknown, ""
+		}
+		return replicaSetHealthStatus(obj)
+	case m.IsDaemonSet():
+		obj := &appsv1.DaemonSet{}
+		if err := m.ConvertToStructuredObject(obj); err != nil {
+			return sdk.ResourceHealthStateUnknown, ""
+		}
+		return daemonSetHealthStatus(obj)
+	case m.IsPod():
+		obj := &corev1.Pod{}
+		if err := m.ConvertToStructuredObject(obj); err != nil {
+			return sdk.ResourceHealthStateUnknown, ""
+		}
+		return podHealthStatus(obj)
 	default:
-		// TODO: Implement health status calculation for other resource types.
 		return sdk.ResourceHealthStateUnknown, fmt.Sprintf("Unimplemented or unknown resource: %s", m.body.GroupVersionKind())
 	}
 }
@@ -103,4 +122,82 @@ func statefulSetHealthStatus(obj *appsv1.StatefulSet) (sdk.ResourceHealthStatus,
 	}
 
 	return sdk.ResourceHealthStateHealthy, ""
+}
+
+func replicaSetHealthStatus(obj *appsv1.ReplicaSet) (sdk.ResourceHealthStatus, string) {
+	if obj.Status.ObservedGeneration == 0 || obj.Generation > obj.Status.ObservedGeneration {
+		return sdk.ResourceHealthStateUnhealthy, "Waiting for rollout to finish because observed replica set generation less than desired generation"
+	}
+
+	var cond *appsv1.ReplicaSetCondition
+	for i := range obj.Status.Conditions {
+		c := obj.Status.Conditions[i]
+		if c.Type == appsv1.ReplicaSetReplicaFailure {
+			cond = &c
+			break
+		}
+	}
+	if cond != nil && cond.Status == corev1.ConditionTrue {
+		return sdk.ResourceHealthStateUnhealthy, cond.Message
+	}
+
+	if obj.Spec.Replicas == nil {
+		return sdk.ResourceHealthStateUnhealthy, "The number of desired replicas is unspecified"
+	}
+
+	if obj.Status.AvailableReplicas < *obj.Spec.Replicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for remaining %d/%d replicas to be available", obj.Status.Replicas-obj.Status.AvailableReplicas, obj.Status.Replicas)
+	}
+
+	if *obj.Spec.Replicas != obj.Status.ReadyReplicas {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("The number of ready replicas (%d) is different from the desired number (%d)", obj.Status.ReadyReplicas, *obj.Spec.Replicas)
+	}
+
+	return sdk.ResourceHealthStateHealthy, ""
+}
+
+func daemonSetHealthStatus(obj *appsv1.DaemonSet) (sdk.ResourceHealthStatus, string) {
+	if obj.Status.ObservedGeneration == 0 || obj.Generation > obj.Status.ObservedGeneration {
+		return sdk.ResourceHealthStateUnhealthy, "Waiting for rollout to finish because observed daemon set generation less than desired generation"
+	}
+
+	if obj.Status.UpdatedNumberScheduled < obj.Status.DesiredNumberScheduled {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for daemon set %q rollout to finish because %d out of %d new pods have been updated", obj.GetName(), obj.Status.UpdatedNumberScheduled, obj.Status.DesiredNumberScheduled)
+	}
+	if obj.Status.NumberAvailable < obj.Status.DesiredNumberScheduled {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("Waiting for daemon set %q rollout to finish because %d of %d updated pods are available", obj.GetName(), obj.Status.NumberAvailable, obj.Status.DesiredNumberScheduled)
+	}
+
+	if obj.Status.NumberMisscheduled > 0 {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("%d nodes that are running the daemon pod, but are not supposed to run the daemon pod", obj.Status.NumberMisscheduled)
+	}
+	if obj.Status.NumberUnavailable > 0 {
+		return sdk.ResourceHealthStateUnhealthy, fmt.Sprintf("%d nodes that should be running the daemon pod and have none of the daemon pod running and available", obj.Status.NumberUnavailable)
+	}
+
+	return sdk.ResourceHealthStateHealthy, ""
+}
+
+func podHealthStatus(obj *corev1.Pod) (sdk.ResourceHealthStatus, string) {
+	if obj.Spec.RestartPolicy == corev1.RestartPolicyAlways {
+		var messages []string
+		for _, s := range obj.Status.ContainerStatuses {
+			waiting := s.State.Waiting
+			if waiting == nil {
+				continue
+			}
+			if strings.HasPrefix(waiting.Reason, "Err") || strings.HasSuffix(waiting.Reason, "Error") || strings.HasSuffix(waiting.Reason, "BackOff") {
+				messages = append(messages, waiting.Message)
+			}
+		}
+		if len(messages) > 0 {
+			return sdk.ResourceHealthStateUnhealthy, strings.Join(messages, ", ")
+		}
+	}
+
+	if obj.Status.Phase == corev1.PodRunning || obj.Status.Phase == corev1.PodSucceeded {
+		return sdk.ResourceHealthStateHealthy, obj.Status.Message
+	}
+
+	return sdk.ResourceHealthStateUnhealthy, obj.Status.Message
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/provider/manifest.go
@@ -161,6 +161,18 @@ func (m Manifest) IsDaemonSet() bool {
 	return isBuiltinAPIGroup(m.body.GroupVersionKind().Group) && m.body.GetKind() == KindDaemonSet
 }
 
+// IsReplicaSet returns true if the manifest is a ReplicaSet.
+// It checks the API group and the kind of the manifest.
+func (m Manifest) IsReplicaSet() bool {
+	return m.body.GroupVersionKind().Group == "apps" && m.body.GetKind() == KindReplicaSet
+}
+
+// IsPod returns true if the manifest is a Pod.
+// It checks the API group and the kind of the manifest.
+func (m Manifest) IsPod() bool {
+	return m.body.GroupVersionKind().Group == "" && m.body.GetKind() == KindPod
+}
+
 // IsSecret returns true if the manifest is a Secret.
 // It checks the API group and the kind of the manifest.
 func (m Manifest) IsSecret() bool {


### PR DESCRIPTION
**What this PR does**:
Implements health status calculation for DaemonSet, ReplicaSet, and Pod resource types in the kubernetes_multicluster plugin. Previously these three types all returned `ResourceHealthStateUnknown`. Adds `IsPod()` and `IsReplicaSet()` helper methods to `Manifest` to support the new cases.

**Why we need it**:
The single-cluster kubernetes plugin already handles DaemonSet, ReplicaSet, and Pod. This brings the multicluster plugin to parity.

**Which issue(s) this PR fixes**:
Fixes #6446

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: Health status in the UI will now correctly show Healthy/Unhealthy for DaemonSet, ReplicaSet, and Pod resources instead of always showing Unknown.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A