### PR TITLE
[Multi_K8s-Plugin] Remove stale TODO comment in sync.go

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/sync.go
@@ -182,7 +182,6 @@ func (p *Plugin) sync(
 	applier := provider.NewApplier(kubectl, cfg.Spec.Input, deployTargetConfig, input.Logger)
 
 	// Start applying all manifests to add or update running resources.
-	// TODO: use applyManifests instead of applyManifestsSDK
 	if err := applyManifests(ctx, applier, manifests, cfg.Spec.Input.Namespace, lp); err != nil {
 		lp.Errorf("Failed while applying manifests (%v)", err)
 		return sdk.StageStatusFailure


### PR DESCRIPTION
**What this PR does**:
Removes a stale TODO comment in `deployment/sync.go` that said \"use applyManifests instead of applyManifestsSDK\". The code already calls `applyManifests`, the comment was never updated when the function was renamed.

**Why we need it**:
The comment is incorrect and misleading, it implies there is outstanding work where there is none.

**Which issue(s) this PR fixes**:
Fixes #6446

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: No change in behaviour.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A