### PR TITLE
Support transfer specific applications by using labels flag for transfer command

### DIFF
--- a/pkg/app/pipectl/cmd/transfer/backup.go
+++ b/pkg/app/pipectl/cmd/transfer/backup.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ type backup struct {
 	root *command
 
 	outputFile string
+	labels     []string
 }
 
 func newBackupCommand(root *command) *cobra.Command {
@@ -51,6 +53,8 @@ Note: deployment history is not included because the API does not expose a write
 	}
 
 	cmd.Flags().StringVar(&c.outputFile, "output-file", c.outputFile, "The path of the output JSON file to save the backup data.")
+	cmd.Flags().StringSliceVar(&c.labels, "labels", c.labels, "Filter applications by labels. Expect input as comma-separated KEY:VALUE pairs (e.g., --labels=env:prod,team:backend).")
+
 	cmd.MarkFlagRequired("output-file")
 
 	return cmd
@@ -59,6 +63,14 @@ Note: deployment history is not included because the API does not expose a write
 func (c *backup) run(ctx context.Context, input cli.Input) error {
 	input.Logger.Info("Starting control plane backup...")
 
+	labels := map[string]string{}
+	for _, label := range c.labels {
+		sp := strings.SplitN(label, ":", 2)
+		if len(sp) == 2 {
+			labels[sp[0]] = sp[1]
+		}
+	}
+
 	cli, err := c.root.clientOptions.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize client: %w", err)
@@ -66,7 +78,7 @@ func (c *backup) run(ctx context.Context, input cli.Input) error {
 	defer cli.Close()
 
 	// Collect all applications via paginated ListApplications calls.
-	applications, err := listAllApplications(ctx, cli, input.Logger)
+	applications, err := listAllApplications(ctx, cli, labels, input.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to list applications: %w", err)
 	}
@@ -97,12 +109,12 @@ func (c *backup) run(ctx context.Context, input cli.Input) error {
 // listAllApplications fetches all applications (both enabled and disabled) from the control plane
 // using cursor-based pagination. The ListApplications API filters by the disabled field as a strict
 // equality match, so two separate paginated sweeps are required.
-func listAllApplications(ctx context.Context, cli apiservice.Client, logger *zap.Logger) ([]*model.Application, error) {
-	enabled, err := listApplicationsByDisabledStatus(ctx, cli, false, logger)
+func listAllApplications(ctx context.Context, cli apiservice.Client, labels map[string]string, logger *zap.Logger) ([]*model.Application, error) {
+	enabled, err := listApplicationsByDisabledStatus(ctx, cli, false, labels, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list enabled applications: %w", err)
 	}
-	disabled, err := listApplicationsByDisabledStatus(ctx, cli, true, logger)
+	disabled, err := listApplicationsByDisabledStatus(ctx, cli, true, labels, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disabled applications: %w", err)
 	}
@@ -111,17 +123,21 @@ func listAllApplications(ctx context.Context, cli apiservice.Client, logger *zap
 }
 
 // listApplicationsByDisabledStatus paginates through ListApplications for a given disabled status.
-func listApplicationsByDisabledStatus(ctx context.Context, cli apiservice.Client, disabled bool, logger *zap.Logger) ([]*model.Application, error) {
+func listApplicationsByDisabledStatus(ctx context.Context, cli apiservice.Client, disabled bool, labels map[string]string, logger *zap.Logger) ([]*model.Application, error) {
 	var (
 		all    []*model.Application
 		cursor string
 	)
 	for {
-		resp, err := cli.ListApplications(ctx, &apiservice.ListApplicationsRequest{
+		req := &apiservice.ListApplicationsRequest{
 			Disabled: disabled,
 			Cursor:   cursor,
 			Limit:    500,
-		})
+		}
+		if len(labels) > 0 {
+			req.Labels = labels
+		}
+		resp, err := cli.ListApplications(ctx, req)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/app/pipectl/cmd/transfer/restore_application.go
+++ b/pkg/app/pipectl/cmd/transfer/restore_application.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -33,6 +34,7 @@ type restoreApplication struct {
 
 	inputFile        string
 	pipedMappingFile string
+	labels           []string
 }
 
 func newRestoreApplicationCommand(root *command) *cobra.Command {
@@ -56,6 +58,8 @@ to preserve their original status.`,
 
 	cmd.Flags().StringVar(&c.inputFile, "input-file", c.inputFile, "The path of the backup JSON file produced by 'pipectl transfer backup'.")
 	cmd.Flags().StringVar(&c.pipedMappingFile, "piped-id-mapping-file", c.pipedMappingFile, "Path to the piped ID mapping JSON produced by 'pipectl transfer restore piped'.")
+	cmd.Flags().StringSliceVar(&c.labels, "labels", c.labels, "Filter applications to restore by labels. Expect input as comma-separated KEY:VALUE pairs (e.g., --labels=env:prod,team:backend).")
+
 	cmd.MarkFlagRequired("input-file")
 	cmd.MarkFlagRequired("piped-id-mapping-file")
 
@@ -68,11 +72,25 @@ func (c *restoreApplication) run(ctx context.Context, input cli.Input) error {
 		zap.String("piped-id-mapping-file", c.pipedMappingFile),
 	)
 
+	labels := map[string]string{}
+	for _, label := range c.labels {
+		sp := strings.SplitN(label, ":", 2)
+		if len(sp) == 2 {
+			labels[sp[0]] = sp[1]
+		}
+	}
+
 	data, err := readBackupFile(c.inputFile)
 	if err != nil {
 		return fmt.Errorf("failed to read backup file: %w", err)
 	}
 	input.Logger.Info(fmt.Sprintf("Found %d application(s) in backup (created at %s)", len(data.Applications), data.CreatedAt))
+
+	// Filter applications by labels if specified.
+	applications := filterApplicationsByLabels(data.Applications, labels)
+	if len(labels) > 0 {
+		input.Logger.Info(fmt.Sprintf("Filtered to %d application(s) matching labels", len(applications)))
+	}
 
 	_, pipedIDMap, err := loadPipedMapping(c.pipedMappingFile)
 	if err != nil {
@@ -86,7 +104,7 @@ func (c *restoreApplication) run(ctx context.Context, input cli.Input) error {
 	}
 	defer cli.Close()
 
-	restored, failed := restoreApplications(ctx, cli, data.Applications, pipedIDMap, input.Logger)
+	restored, failed := restoreApplications(ctx, cli, applications, pipedIDMap, input.Logger)
 
 	input.Logger.Info("Application restore completed",
 		zap.Int("restored", restored),
@@ -178,4 +196,29 @@ func restoreApplications(ctx context.Context, cli apiservice.Client, application
 		restored++
 	}
 	return restored, failed
+}
+
+// filterApplicationsByLabels returns applications that match all specified labels.
+// If labels is empty, all applications are returned.
+func filterApplicationsByLabels(applications []*model.Application, labels map[string]string) []*model.Application {
+	if len(labels) == 0 {
+		return applications
+	}
+	filtered := make([]*model.Application, 0, len(applications))
+	for _, app := range applications {
+		if matchLabels(app.Labels, labels) {
+			filtered = append(filtered, app)
+		}
+	}
+	return filtered
+}
+
+// matchLabels returns true if appLabels contains all key-value pairs in filterLabels.
+func matchLabels(appLabels, filterLabels map[string]string) bool {
+	for k, v := range filterLabels {
+		if appLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
**What this PR does**:

as title

The command will be like

```
  pipectl transfer backup/restore application \
    --labels=env:prod,team:backend
```

**Why we need it**:

In case users want to use the transfer command to backup/restore not all applications from the project but only some specific applications, they can use labels to filter/fetch the required applications instead of doing all at once.

**Which issue(s) this PR fixes**:

Follow #6692 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
