### PR TITLE
Add plugin init scaffold to pipectl

### DIFF
--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/_index.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-plugins/_index.md
@@ -108,6 +108,34 @@ spec:
 5. **Add a README** documenting configuration and usage
 6. **Submit a PR** linking to the discussion issue
 
+### Scaffold a new plugin
+
+Use `pipectl` to generate a compile-ready plugin skeleton:
+
+```bash
+# Stage-only plugin (similar to the wait plugin)
+pipectl plugin init ./my-plugin --kind stage --stages MY_STAGE
+
+# Deployment-minimal plugin (similar to the ecs layout)
+pipectl plugin init ./my-plugin --kind deployment --stages MY_SYNC,MY_ROLLBACK
+
+# Community plugin module path (default uses piped-plugin-sdk-go only)
+pipectl plugin init ./my-plugin --kind stage --stages MY_STAGE \
+  --module github.com/my-org/piped-plugin-my-plugin
+```
+
+Then build the generated plugin:
+
+```bash
+cd ./my-plugin
+go mod tidy
+go build .
+```
+
+Generated `go.mod` files pin `github.com/pipe-cd/piped-plugin-sdk-go` to the version used by the scaffold (aligned with official plugins such as `wait`). When the SDK is upgraded in the main repository, update `DefaultSDKVersion` in `pkg/app/pipectl/pluginscaffold/scaffold.go` and regenerate golden testdata if needed.
+
+`--force` removes the entire output directory before writing. Verify the path before running it.
+
 ### Build and test
 
 ```bash

--- a/docs/content/en/docs-v1.0.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v1.0.x/user-guide/command-line-tool.md
@@ -357,6 +357,17 @@ You can encrypt it the same way you do [from the web](../managing-application/se
 
 > **Note:** The docs for pipectl available command may be outdated. We suggest users use the `help` command for the updated usage while using pipectl.
 
+### Scaffolding a Piped plugin
+
+Generate a compile-ready plugin skeleton (stage-only or deployment-minimal layout):
+
+```console
+pipectl plugin init ./my-plugin --kind stage --stages MY_STAGE
+pipectl plugin init ./my-plugin --kind deployment --stages MY_SYNC,MY_ROLLBACK
+```
+
+Use `--dry-run` to list files without writing, and `--force` to replace an existing output directory (this deletes the target path). See [Contributing plugins](../contribution-guidelines/contributing-plugins/#scaffold-a-new-plugin) for details.
+
 ### You want more?
 
 We always want to add more needed commands into pipectl. Please let us know what command you want to add by creating issues in the [pipe-cd/pipecd](https://github.com/pipe-cd/pipecd/issues) repository. We also welcome your pull request to add the command.

--- a/pkg/app/pipectl/cmd/plugin/init.go
+++ b/pkg/app/pipectl/cmd/plugin/init.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipectl/pluginscaffold"
+	"github.com/pipe-cd/pipecd/pkg/cli"
+)
+
+type initCmd struct {
+	root *command
+
+	outputDir  string
+	kind       string
+	stages     []string
+	modulePath string
+	pluginName string
+	dryRun     bool
+	force      bool
+}
+
+func newInitCommand(root *command) *cobra.Command {
+	c := &initCmd{root: root}
+	cmd := &cobra.Command{
+		Use:   "init [output-dir]",
+		Short: "Scaffold a new Piped v1 plugin.",
+		Long: `Generate a compile-ready plugin skeleton for stage-only or deployment-minimal plugins.
+
+With --force, an existing output directory is removed before writing. Double-check the path to avoid deleting unrelated data.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c.outputDir = args[0]
+			return cli.WithContext(c.run)(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&c.kind, "kind", string(pluginscaffold.KindStage), "Plugin kind: stage or deployment")
+	cmd.Flags().StringSliceVar(&c.stages, "stages", nil, "Comma-separated stage names in UPPER_SNAKE_CASE (required)")
+	cmd.Flags().StringVar(&c.modulePath, "module", "", "Go module path (default: github.com/example/piped-plugin-<name>)")
+	cmd.Flags().StringVar(&c.pluginName, "name", "", "Plugin name (default: basename of output-dir)")
+	cmd.Flags().BoolVar(&c.dryRun, "dry-run", false, "Print files without writing")
+	cmd.Flags().BoolVar(&c.force, "force", false, "Remove and recreate the output directory if it already exists")
+
+	_ = cmd.MarkFlagRequired("stages")
+
+	return cmd
+}
+
+func (c *initCmd) run(_ context.Context, input cli.Input) error {
+	outputDir, err := filepath.Abs(c.outputDir)
+	if err != nil {
+		return err
+	}
+
+	pluginName := c.pluginName
+	if pluginName == "" {
+		pluginName = filepath.Base(outputDir)
+	}
+
+	stages := normalizeStages(c.stages)
+	if len(stages) == 0 {
+		return fmt.Errorf("--stages is required")
+	}
+
+	kind := pluginscaffold.Kind(c.kind)
+	opts := pluginscaffold.Options{
+		OutputDir:  outputDir,
+		PluginName: pluginName,
+		ModulePath: c.modulePath,
+		Kind:       kind,
+		Stages:     stages,
+		DryRun:     c.dryRun,
+		Force:      c.force,
+	}
+
+	files, err := pluginscaffold.Generate(opts)
+	if err != nil {
+		return err
+	}
+
+	if c.dryRun {
+		for _, f := range files {
+			input.Logger.Info("would write file", zap.String("path", f.Path))
+		}
+		return nil
+	}
+
+	if err := pluginscaffold.Write(opts, files); err != nil {
+		return err
+	}
+
+	input.Logger.Info("plugin scaffold written", zap.String("dir", outputDir), zap.Int("files", len(files)))
+	return nil
+}
+
+func normalizeStages(in []string) []string {
+	var out []string
+	for _, s := range in {
+		for _, part := range strings.Split(s, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/app/pipectl/cmd/plugin/init_test.go
+++ b/pkg/app/pipectl/cmd/plugin/init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,22 +15,14 @@
 package plugin
 
 import (
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-type command struct{}
+func TestNormalizeStages(t *testing.T) {
+	t.Parallel()
 
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+	assert.Equal(t, []string{"A", "B"}, normalizeStages([]string{"A,B"}))
+	assert.Equal(t, []string{"A", "B"}, normalizeStages([]string{"A", "B"}))
 }

--- a/pkg/app/pipectl/pluginscaffold/embed.go
+++ b/pkg/app/pipectl/pluginscaffold/embed.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package pluginscaffold
 
-import (
-	"github.com/spf13/cobra"
-)
+import "embed"
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
-}
+//go:embed templates/**
+var templateFS embed.FS

--- a/pkg/app/pipectl/pluginscaffold/golden_test.go
+++ b/pkg/app/pipectl/pluginscaffold/golden_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginscaffold
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var goldenStageOpts = Options{
+	PluginName: "demo",
+	ModulePath: "github.com/example/piped-plugin-demo",
+	Kind:       KindStage,
+	Stages:     []string{"DEMO_WAIT"},
+}
+
+var goldenDeploymentOpts = Options{
+	PluginName: "demo",
+	ModulePath: "github.com/example/piped-plugin-demo",
+	Kind:       KindDeployment,
+	Stages:     []string{"DEMO_SYNC", "DEMO_ROLLBACK"},
+}
+
+func TestGenerate_golden(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		opts      Options
+		goldenDir string
+	}{
+		{
+			name:      "stage",
+			opts:      goldenStageOpts,
+			goldenDir: "testdata/golden/stage",
+		},
+		{
+			name:      "deployment",
+			opts:      goldenDeploymentOpts,
+			goldenDir: "testdata/golden/deployment",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			files, err := Generate(tc.opts)
+			require.NoError(t, err)
+
+			if os.Getenv("UPDATE_GOLDEN") != "" {
+				updateGolden(t, tc.goldenDir, files)
+			}
+
+			for _, f := range files {
+				goldenPath := filepath.Join(tc.goldenDir, filepath.FromSlash(f.Path))
+				want, err := os.ReadFile(goldenPath)
+				require.NoError(t, err, "missing golden file %s (run UPDATE_GOLDEN=1 go test ./pkg/app/pipectl/pluginscaffold -run Golden -count=1)", goldenPath)
+				require.Equal(t, string(want), string(f.Content), "file %s", f.Path)
+			}
+
+			var goldenCount int
+			err = filepath.WalkDir(tc.goldenDir, func(path string, d os.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if !d.IsDir() {
+					goldenCount++
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, len(files), goldenCount, "golden file count mismatch for %s", tc.goldenDir)
+		})
+	}
+}
+
+func updateGolden(t *testing.T, goldenDir string, files []File) {
+	t.Helper()
+
+	for _, f := range files {
+		path := filepath.Join(goldenDir, filepath.FromSlash(f.Path))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, f.Content, 0o644))
+	}
+}

--- a/pkg/app/pipectl/pluginscaffold/names.go
+++ b/pkg/app/pipectl/pluginscaffold/names.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginscaffold
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var stageNamePattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// ValidatePluginName checks the plugin name is a valid identifier segment.
+func ValidatePluginName(name string) error {
+	if name == "" {
+		return fmt.Errorf("plugin name must not be empty")
+	}
+	for i, r := range name {
+		if i == 0 {
+			if !unicode.IsLetter(r) {
+				return fmt.Errorf("plugin name must start with a letter")
+			}
+			continue
+		}
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+			continue
+		}
+		return fmt.Errorf("plugin name contains invalid character %q", r)
+	}
+	return nil
+}
+
+// ValidateStageNames checks stage names are UPPER_SNAKE_CASE.
+func ValidateStageNames(stages []string) error {
+	if len(stages) == 0 {
+		return fmt.Errorf("at least one stage is required")
+	}
+	seen := make(map[string]struct{}, len(stages))
+	for _, stage := range stages {
+		if stage == "" {
+			return fmt.Errorf("stage name must not be empty")
+		}
+		if !stageNamePattern.MatchString(stage) {
+			return fmt.Errorf("stage name %q must be UPPER_SNAKE_CASE (e.g. MY_SYNC)", stage)
+		}
+		if _, ok := seen[stage]; ok {
+			return fmt.Errorf("duplicate stage name %q", stage)
+		}
+		seen[stage] = struct{}{}
+	}
+	return nil
+}
+
+// TypePrefix converts a plugin name to an exported Go type prefix (e.g. my-plugin -> MyPlugin).
+func TypePrefix(pluginName string) string {
+	parts := strings.FieldsFunc(pluginName, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		if len(part) > 1 {
+			b.WriteString(strings.ToLower(part[1:]))
+		}
+	}
+	if b.Len() == 0 {
+		return "Plugin"
+	}
+	return b.String()
+}
+
+// StageFileBase returns a lowercase file-safe name for a stage.
+func StageFileBase(stage string) string {
+	return strings.ToLower(stage)
+}
+
+// StageConstSuffix returns a suffix for stage const identifiers (e.g. DEMO_SYNC -> DemoSync).
+func StageConstSuffix(stage string) string {
+	return strings.TrimPrefix(StageFuncName(stage), "execute")
+}
+
+// StageFuncName returns an exported handler name (e.g. DEMO_SYNC -> executeDemoSync).
+func StageFuncName(stage string) string {
+	parts := strings.Split(stage, "_")
+	var b strings.Builder
+	b.WriteString("execute")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		if len(part) > 1 {
+			b.WriteString(strings.ToLower(part[1:]))
+		}
+	}
+	return b.String()
+}
+
+// DefaultModulePath returns the default Go module path for a community plugin.
+func DefaultModulePath(pluginName string) string {
+	return fmt.Sprintf("github.com/example/piped-plugin-%s", pluginName)
+}
+
+// FindRollbackStage returns the first stage name containing "ROLLBACK", or empty if none.
+func FindRollbackStage(stages []string) string {
+	for _, stage := range stages {
+		if strings.Contains(stage, "ROLLBACK") {
+			return stage
+		}
+	}
+	return ""
+}

--- a/pkg/app/pipectl/pluginscaffold/names_test.go
+++ b/pkg/app/pipectl/pluginscaffold/names_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginscaffold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateStageNames(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, ValidateStageNames([]string{"DEMO_SYNC"}))
+	assert.Error(t, ValidateStageNames([]string{"demo_sync"}))
+	assert.Error(t, ValidateStageNames(nil))
+}
+
+func TestTypePrefix(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "MyPlugin", TypePrefix("my-plugin"))
+	assert.Equal(t, "Demo", TypePrefix("demo"))
+}
+
+func TestStageFuncName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "executeDemoSync", StageFuncName("DEMO_SYNC"))
+}
+
+func TestStageConstSuffix(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "DemoSync", StageConstSuffix("DEMO_SYNC"))
+}
+
+func TestFindRollbackStage(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "DEMO_ROLLBACK", FindRollbackStage([]string{"DEMO_SYNC", "DEMO_ROLLBACK"}))
+	assert.Empty(t, FindRollbackStage([]string{"DEMO_SYNC"}))
+}

--- a/pkg/app/pipectl/pluginscaffold/scaffold.go
+++ b/pkg/app/pipectl/pluginscaffold/scaffold.go
@@ -1,0 +1,219 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginscaffold
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+// DefaultSDKVersion is the piped-plugin-sdk-go version written to generated go.mod files.
+// Bump it when official plugins (for example wait) upgrade their SDK dependency.
+const DefaultSDKVersion = "v0.3.0"
+
+// Kind is the scaffold template set to use.
+type Kind string
+
+const (
+	KindStage      Kind = "stage"
+	KindDeployment Kind = "deployment"
+)
+
+// Options configures plugin scaffolding.
+type Options struct {
+	OutputDir  string
+	PluginName string
+	ModulePath string
+	Kind       Kind
+	Stages     []string
+	DryRun     bool
+	Force      bool
+}
+
+// File describes a generated file.
+type File struct {
+	Path    string
+	Content []byte
+}
+
+// Generate renders plugin scaffold files without writing to disk.
+func Generate(opts Options) ([]File, error) {
+	if err := ValidatePluginName(opts.PluginName); err != nil {
+		return nil, err
+	}
+	if err := ValidateStageNames(opts.Stages); err != nil {
+		return nil, err
+	}
+	if opts.ModulePath == "" {
+		opts.ModulePath = DefaultModulePath(opts.PluginName)
+	}
+	switch opts.Kind {
+	case KindStage, KindDeployment:
+	default:
+		return nil, fmt.Errorf("kind must be %q or %q", KindStage, KindDeployment)
+	}
+
+	data := templateData{
+		PluginName: opts.PluginName,
+		TypePrefix: TypePrefix(opts.PluginName),
+		ModulePath: opts.ModulePath,
+		SDKVersion: DefaultSDKVersion,
+		Stages:     append([]string(nil), opts.Stages...),
+	}
+	if rollback := FindRollbackStage(opts.Stages); rollback != "" {
+		data.RollbackStage = stageEntry{
+			Name:        rollback,
+			FileBase:    StageFileBase(rollback),
+			FuncName:    StageFuncName(rollback),
+			ConstSuffix: StageConstSuffix(rollback),
+		}
+	}
+	for _, stage := range opts.Stages {
+		data.StageEntries = append(data.StageEntries, stageEntry{
+			Name:        stage,
+			FileBase:    StageFileBase(stage),
+			FuncName:    StageFuncName(stage),
+			ConstSuffix: StageConstSuffix(stage),
+		})
+	}
+
+	templateSet := string(opts.Kind)
+	templateRoot := filepath.Join("templates", templateSet)
+
+	var files []File
+	err := fs.WalkDir(templateFS, templateRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".tmpl") {
+			return nil
+		}
+		if filepath.Base(path) == "stage.go.tmpl" {
+			return nil
+		}
+		rel, err := filepath.Rel(templateRoot, path)
+		if err != nil {
+			return err
+		}
+		outName := strings.TrimSuffix(rel, ".tmpl")
+		content, err := renderTemplate(path, data)
+		if err != nil {
+			return err
+		}
+		files = append(files, File{Path: outName, Content: content})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk templates: %w", err)
+	}
+
+	if opts.Kind == KindDeployment {
+		stageTmpl, err := templateFS.ReadFile(filepath.Join(templateRoot, "stage.go.tmpl"))
+		if err != nil {
+			return nil, fmt.Errorf("read stage template: %w", err)
+		}
+		tmpl, err := template.New("stage").Parse(string(stageTmpl))
+		if err != nil {
+			return nil, fmt.Errorf("parse stage template: %w", err)
+		}
+		for _, stage := range data.StageEntries {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, data.withStage(stage)); err != nil {
+				return nil, fmt.Errorf("execute stage template for %s: %w", stage.Name, err)
+			}
+			files = append(files, File{
+				Path:    filepath.Join("deployment", stage.FileBase+".go"),
+				Content: buf.Bytes(),
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files, nil
+}
+
+// Write writes generated files to opts.OutputDir.
+func Write(opts Options, files []File) error {
+	if _, err := os.Stat(opts.OutputDir); err == nil {
+		if !opts.Force {
+			return fmt.Errorf("output directory %q already exists (use --force to overwrite)", opts.OutputDir)
+		}
+		if err := os.RemoveAll(opts.OutputDir); err != nil {
+			return fmt.Errorf("remove existing output directory: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat output directory: %w", err)
+	}
+	if err := os.MkdirAll(opts.OutputDir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	for _, f := range files {
+		path := filepath.Join(opts.OutputDir, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, f.Content, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", f.Path, err)
+		}
+	}
+	return nil
+}
+
+type templateData struct {
+	PluginName    string
+	TypePrefix    string
+	ModulePath    string
+	SDKVersion    string
+	Stages        []string
+	StageEntries  []stageEntry
+	RollbackStage stageEntry
+	CurrentStage  stageEntry
+}
+
+type stageEntry struct {
+	Name        string
+	FileBase    string
+	FuncName    string
+	ConstSuffix string
+}
+
+func (d templateData) withStage(s stageEntry) templateData {
+	d.CurrentStage = s
+	return d
+}
+
+func renderTemplate(path string, data templateData) ([]byte, error) {
+	raw, err := templateFS.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New(filepath.Base(path)).Parse(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse template %s: %w", path, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute template %s: %w", path, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/app/pipectl/pluginscaffold/scaffold_test.go
+++ b/pkg/app/pipectl/pluginscaffold/scaffold_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginscaffold
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_stage(t *testing.T) {
+	t.Parallel()
+
+	files, err := Generate(Options{
+		PluginName: "demo",
+		ModulePath: "github.com/example/piped-plugin-demo",
+		Kind:       KindStage,
+		Stages:     []string{"DEMO_WAIT"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, filePaths(files), "main.go")
+	assert.Contains(t, filePaths(files), "plugin.go")
+}
+
+func TestGenerate_deployment(t *testing.T) {
+	t.Parallel()
+
+	files, err := Generate(Options{
+		PluginName: "demo",
+		ModulePath: "github.com/example/piped-plugin-demo",
+		Kind:       KindDeployment,
+		Stages:     []string{"DEMO_SYNC", "DEMO_ROLLBACK"},
+	})
+	require.NoError(t, err)
+	paths := filePaths(files)
+	assert.Contains(t, paths, filepath.Join("deployment", "plugin.go"))
+	assert.Contains(t, paths, filepath.Join("deployment", "demo_sync.go"))
+	assert.Contains(t, paths, filepath.Join("deployment", "demo_rollback.go"))
+}
+
+func TestWrite_and_build_stage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration build in short mode")
+	}
+	t.Parallel()
+
+	testWriteAndBuild(t, goldenStageOpts)
+}
+
+func TestWrite_and_build_deployment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration build in short mode")
+	}
+	t.Parallel()
+
+	testWriteAndBuild(t, goldenDeploymentOpts)
+}
+
+func testWriteAndBuild(t *testing.T, opts Options) {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "plugin")
+	opts.OutputDir = dir
+
+	files, err := Generate(opts)
+	require.NoError(t, err)
+	require.NoError(t, Write(opts, files))
+
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cmd = exec.Command("go", "build", "-o", filepath.Join(dir, "plugin"), ".")
+	cmd.Dir = dir
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	_, err = os.Stat(filepath.Join(dir, "plugin"))
+	require.NoError(t, err)
+}
+
+func filePaths(files []File) []string {
+	out := make([]string, len(files))
+	for i, f := range files {
+		out[i] = f.Path
+	}
+	return out
+}

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/README.md.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{ .PluginName }} PipeCD plugin (deployment)
+
+Scaffolded with `pipectl plugin init --kind deployment`.
+
+## Stages
+
+{{- range .Stages }}
+- `{{ . }}`
+{{- end }}
+
+## Build
+
+```bash
+go build .
+```
+
+## Next steps
+
+Implement stage logic under `deployment/` and configure deploy targets in `config/`.

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/config/application.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/config/application.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// {{ .TypePrefix }}ApplicationSpec is the application configuration in app.pipecd.yaml.
+type {{ .TypePrefix }}ApplicationSpec struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/config/deploy_target.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/config/deploy_target.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// {{ .TypePrefix }}DeployTargetConfig holds per deploy target configuration.
+type {{ .TypePrefix }}DeployTargetConfig struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/config/plugin.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/config/plugin.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// {{ .TypePrefix }}PluginConfig holds plugin-level configuration from piped spec.plugins[].config.
+type {{ .TypePrefix }}PluginConfig struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/deployment/pipeline.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/deployment/pipeline.go.tmpl
@@ -1,0 +1,83 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+const (
+{{- range .StageEntries }}
+	Stage{{ .ConstSuffix }} = "{{ .Name }}"
+{{- end }}
+)
+
+var allStages = []string{
+{{- range .StageEntries }}
+	Stage{{ .ConstSuffix }},
+{{- end }}
+}
+
+func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.PipelineStage {
+	stages := input.Request.Stages
+	out := make([]sdk.PipelineStage, 0, len(stages)+1)
+	for _, rs := range stages {
+		out = append(out, sdk.PipelineStage{
+			Index:              rs.Index,
+			Name:               rs.Name,
+			Rollback:           false,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+{{- if .RollbackStage.Name }}
+	if input.Request.Rollback {
+		out = append(out, sdk.PipelineStage{
+			Name:               Stage{{ .RollbackStage.ConstSuffix }},
+			Index:              len(stages) + 1,
+			Rollback:           true,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+{{- end }}
+	return out
+}
+
+func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
+	out := make([]sdk.QuickSyncStage, 0, len(allStages))
+	for _, name := range allStages {
+{{- if .RollbackStage.Name }}
+		if name == Stage{{ .RollbackStage.ConstSuffix }} {
+			continue
+		}
+{{- end }}
+		out = append(out, sdk.QuickSyncStage{
+			Name:        name,
+			Description: name,
+			Rollback:    false,
+		})
+	}
+{{- if .RollbackStage.Name }}
+	if autoRollback {
+		out = append(out, sdk.QuickSyncStage{
+			Name:        Stage{{ .RollbackStage.ConstSuffix }},
+			Description: "rollback",
+			Rollback:    true,
+		})
+	}
+{{- end }}
+	return out
+}

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/deployment/plugin.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/deployment/plugin.go.tmpl
@@ -1,0 +1,95 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"errors"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"{{ .ModulePath }}/config"
+)
+
+var ErrUnsupportedStage = errors.New("unsupported stage")
+
+var _ sdk.DeploymentPlugin[config.{{ .TypePrefix }}PluginConfig, config.{{ .TypePrefix }}DeployTargetConfig, config.{{ .TypePrefix }}ApplicationSpec] = (*{{ .TypePrefix }}Plugin)(nil)
+
+type {{ .TypePrefix }}Plugin struct{}
+
+func (p *{{ .TypePrefix }}Plugin) FetchDefinedStages() []string {
+	return allStages
+}
+
+func (p *{{ .TypePrefix }}Plugin) BuildQuickSyncStages(
+	_ context.Context,
+	_ *config.{{ .TypePrefix }}PluginConfig,
+	input *sdk.BuildQuickSyncStagesInput,
+) (*sdk.BuildQuickSyncStagesResponse, error) {
+	return &sdk.BuildQuickSyncStagesResponse{
+		Stages: buildQuickSyncPipeline(input.Request.Rollback),
+	}, nil
+}
+
+func (p *{{ .TypePrefix }}Plugin) BuildPipelineSyncStages(
+	_ context.Context,
+	_ *config.{{ .TypePrefix }}PluginConfig,
+	input *sdk.BuildPipelineSyncStagesInput,
+) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	return &sdk.BuildPipelineSyncStagesResponse{
+		Stages: buildPipelineStages(input),
+	}, nil
+}
+
+func (p *{{ .TypePrefix }}Plugin) ExecuteStage(
+	ctx context.Context,
+	cfg *config.{{ .TypePrefix }}PluginConfig,
+	deployTargets []*sdk.DeployTarget[config.{{ .TypePrefix }}DeployTargetConfig],
+	input *sdk.ExecuteStageInput[config.{{ .TypePrefix }}ApplicationSpec],
+) (*sdk.ExecuteStageResponse, error) {
+	if len(deployTargets) == 0 {
+		input.Logger.Error("no deploy targets")
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+	switch input.Request.StageName {
+{{- range .StageEntries }}
+	case Stage{{ .ConstSuffix }}:
+		return &sdk.ExecuteStageResponse{
+			Status: p.{{ .FuncName }}(ctx, cfg, deployTargets[0], input),
+		}, nil
+{{- end }}
+	default:
+		return nil, ErrUnsupportedStage
+	}
+}
+
+func (p *{{ .TypePrefix }}Plugin) DetermineVersions(
+	_ context.Context,
+	_ *config.{{ .TypePrefix }}PluginConfig,
+	_ *sdk.DetermineVersionsInput[config.{{ .TypePrefix }}ApplicationSpec],
+) (*sdk.DetermineVersionsResponse, error) {
+	return &sdk.DetermineVersionsResponse{Versions: []sdk.ArtifactVersion{}}, nil
+}
+
+func (p *{{ .TypePrefix }}Plugin) DetermineStrategy(
+	_ context.Context,
+	_ *config.{{ .TypePrefix }}PluginConfig,
+	_ *sdk.DetermineStrategyInput[config.{{ .TypePrefix }}ApplicationSpec],
+) (*sdk.DetermineStrategyResponse, error) {
+	return &sdk.DetermineStrategyResponse{
+		Strategy: sdk.SyncStrategyPipelineSync,
+		Summary:  "pipeline sync",
+	}, nil
+}

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/go.mod.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/go.mod.tmpl
@@ -1,0 +1,5 @@
+module {{ .ModulePath }}
+
+go 1.25.0
+
+require github.com/pipe-cd/piped-plugin-sdk-go {{ .SDKVersion }}

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/main.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/main.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package main
 
 import (
-	"github.com/spf13/cobra"
+	"log"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"{{ .ModulePath }}/deployment"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
+func main() {
+	plugin, err := sdk.NewPlugin(
+		"0.0.1",
+		sdk.WithDeploymentPlugin(&deployment.{{ .TypePrefix }}Plugin{}),
+	)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+	if err := plugin.Run(); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/deployment/stage.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/deployment/stage.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package deployment
 
 import (
-	"github.com/spf13/cobra"
+	"context"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"{{ .ModulePath }}/config"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+func (p *{{ .TypePrefix }}Plugin) {{ .CurrentStage.FuncName }}(
+	_ context.Context,
+	_ *config.{{ .TypePrefix }}PluginConfig,
+	_ *sdk.DeployTarget[config.{{ .TypePrefix }}DeployTargetConfig],
+	input *sdk.ExecuteStageInput[config.{{ .TypePrefix }}ApplicationSpec],
+) sdk.StageStatus {
+	lp := input.Client.LogPersister()
+	lp.Info("TODO: implement {{ .CurrentStage.Name }} stage logic")
+	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/stage/README.md.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/stage/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{ .PluginName }} PipeCD plugin (stage-only)
+
+Scaffolded with `pipectl plugin init`.
+
+## Stages
+
+{{- range .Stages }}
+- `{{ . }}`
+{{- end }}
+
+## Build
+
+```bash
+go build .
+```
+
+## Configure piped
+
+Register this plugin in your Piped config. See [contributing plugins](https://pipecd.dev/docs/contribution-guidelines/contributing-plugins/).

--- a/pkg/app/pipectl/pluginscaffold/templates/stage/go.mod.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/stage/go.mod.tmpl
@@ -1,0 +1,5 @@
+module {{ .ModulePath }}
+
+go 1.25.0
+
+require github.com/pipe-cd/piped-plugin-sdk-go {{ .SDKVersion }}

--- a/pkg/app/pipectl/pluginscaffold/templates/stage/main.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/stage/main.go.tmpl
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package main
 
 import (
-	"github.com/spf13/cobra"
+	"log"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
+func main() {
+	plugin, err := sdk.NewPlugin("0.0.1", sdk.WithStagePlugin(&plugin{}))
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+	if err := plugin.Run(); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/pkg/app/pipectl/pluginscaffold/templates/stage/plugin.go.tmpl
+++ b/pkg/app/pipectl/pluginscaffold/templates/stage/plugin.go.tmpl
@@ -1,0 +1,75 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+type plugin struct{}
+
+// FetchDefinedStages implements sdk.StagePlugin.
+func (p *plugin) FetchDefinedStages() []string {
+	return []string{
+{{- range .Stages }}
+		"{{ . }}",
+{{- end }}
+	}
+}
+
+// BuildPipelineSyncStages implements sdk.StagePlugin.
+func (p *plugin) BuildPipelineSyncStages(_ context.Context, _ sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages := make([]sdk.PipelineStage, 0, len(input.Request.Stages))
+	for _, rs := range input.Request.Stages {
+		stages = append(stages, sdk.PipelineStage{
+			Index:              rs.Index,
+			Name:               rs.Name,
+			Rollback:           false,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+	return &sdk.BuildPipelineSyncStagesResponse{Stages: stages}, nil
+}
+
+// ExecuteStage implements sdk.StagePlugin.
+func (p *plugin) ExecuteStage(ctx context.Context, _ sdk.ConfigNone, _ sdk.DeployTargetsNone, input *sdk.ExecuteStageInput[struct{}]) (*sdk.ExecuteStageResponse, error) {
+	switch input.Request.StageName {
+{{- range .StageEntries }}
+	case "{{ .Name }}":
+		return &sdk.ExecuteStageResponse{Status: p.{{ .FuncName }}(ctx, input)}, nil
+{{- end }}
+	default:
+		input.Logger.Error("unsupported stage", zap.String("stage", input.Request.StageName))
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+}
+
+{{- range .StageEntries }}
+func (p *plugin) {{ .FuncName }}(_ context.Context, input *sdk.ExecuteStageInput[struct{}]) sdk.StageStatus {
+	lp, err := input.Client.StageLogPersister()
+	if err != nil {
+		input.Logger.Error("no stage log persister", zap.Error(err))
+		return sdk.StageStatusFailure
+	}
+	lp.Info("TODO: implement {{ .Name }} stage logic")
+	return sdk.StageStatusFailure
+}
+
+{{- end }}

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/README.md
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/README.md
@@ -1,0 +1,17 @@
+# demo PipeCD plugin (deployment)
+
+Scaffolded with `pipectl plugin init --kind deployment`.
+
+## Stages
+- `DEMO_SYNC`
+- `DEMO_ROLLBACK`
+
+## Build
+
+```bash
+go build .
+```
+
+## Next steps
+
+Implement stage logic under `deployment/` and configure deploy targets in `config/`.

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/application.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/application.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// DemoApplicationSpec is the application configuration in app.pipecd.yaml.
+type DemoApplicationSpec struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/deploy_target.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/deploy_target.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// DemoDeployTargetConfig holds per deploy target configuration.
+type DemoDeployTargetConfig struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/plugin.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/config/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package config
 
-import (
-	"github.com/spf13/cobra"
-)
-
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+// DemoPluginConfig holds plugin-level configuration from piped spec.plugins[].config.
+type DemoPluginConfig struct {
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/demo_rollback.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/demo_rollback.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package deployment
 
 import (
-	"github.com/spf13/cobra"
+	"context"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"github.com/example/piped-plugin-demo/config"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+func (p *DemoPlugin) executeDemoRollback(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	_ *sdk.DeployTarget[config.DemoDeployTargetConfig],
+	input *sdk.ExecuteStageInput[config.DemoApplicationSpec],
+) sdk.StageStatus {
+	lp := input.Client.LogPersister()
+	lp.Info("TODO: implement DEMO_ROLLBACK stage logic")
+	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/demo_sync.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/demo_sync.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package deployment
 
 import (
-	"github.com/spf13/cobra"
+	"context"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"github.com/example/piped-plugin-demo/config"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
-	}
-
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+func (p *DemoPlugin) executeDemoSync(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	_ *sdk.DeployTarget[config.DemoDeployTargetConfig],
+	input *sdk.ExecuteStageInput[config.DemoApplicationSpec],
+) sdk.StageStatus {
+	lp := input.Client.LogPersister()
+	lp.Info("TODO: implement DEMO_SYNC stage logic")
+	return sdk.StageStatusFailure
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/pipeline.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/pipeline.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+const (
+	StageDemoSync = "DEMO_SYNC"
+	StageDemoRollback = "DEMO_ROLLBACK"
+)
+
+var allStages = []string{
+	StageDemoSync,
+	StageDemoRollback,
+}
+
+func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.PipelineStage {
+	stages := input.Request.Stages
+	out := make([]sdk.PipelineStage, 0, len(stages)+1)
+	for _, rs := range stages {
+		out = append(out, sdk.PipelineStage{
+			Index:              rs.Index,
+			Name:               rs.Name,
+			Rollback:           false,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+	if input.Request.Rollback {
+		out = append(out, sdk.PipelineStage{
+			Name:               StageDemoRollback,
+			Index:              len(stages) + 1,
+			Rollback:           true,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+	return out
+}
+
+func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
+	out := make([]sdk.QuickSyncStage, 0, len(allStages))
+	for _, name := range allStages {
+		if name == StageDemoRollback {
+			continue
+		}
+		out = append(out, sdk.QuickSyncStage{
+			Name:        name,
+			Description: name,
+			Rollback:    false,
+		})
+	}
+	if autoRollback {
+		out = append(out, sdk.QuickSyncStage{
+			Name:        StageDemoRollback,
+			Description: "rollback",
+			Rollback:    true,
+		})
+	}
+	return out
+}

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/plugin.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/deployment/plugin.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"errors"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"github.com/example/piped-plugin-demo/config"
+)
+
+var ErrUnsupportedStage = errors.New("unsupported stage")
+
+var _ sdk.DeploymentPlugin[config.DemoPluginConfig, config.DemoDeployTargetConfig, config.DemoApplicationSpec] = (*DemoPlugin)(nil)
+
+type DemoPlugin struct{}
+
+func (p *DemoPlugin) FetchDefinedStages() []string {
+	return allStages
+}
+
+func (p *DemoPlugin) BuildQuickSyncStages(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	input *sdk.BuildQuickSyncStagesInput,
+) (*sdk.BuildQuickSyncStagesResponse, error) {
+	return &sdk.BuildQuickSyncStagesResponse{
+		Stages: buildQuickSyncPipeline(input.Request.Rollback),
+	}, nil
+}
+
+func (p *DemoPlugin) BuildPipelineSyncStages(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	input *sdk.BuildPipelineSyncStagesInput,
+) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	return &sdk.BuildPipelineSyncStagesResponse{
+		Stages: buildPipelineStages(input),
+	}, nil
+}
+
+func (p *DemoPlugin) ExecuteStage(
+	ctx context.Context,
+	cfg *config.DemoPluginConfig,
+	deployTargets []*sdk.DeployTarget[config.DemoDeployTargetConfig],
+	input *sdk.ExecuteStageInput[config.DemoApplicationSpec],
+) (*sdk.ExecuteStageResponse, error) {
+	if len(deployTargets) == 0 {
+		input.Logger.Error("no deploy targets")
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+	switch input.Request.StageName {
+	case StageDemoSync:
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeDemoSync(ctx, cfg, deployTargets[0], input),
+		}, nil
+	case StageDemoRollback:
+		return &sdk.ExecuteStageResponse{
+			Status: p.executeDemoRollback(ctx, cfg, deployTargets[0], input),
+		}, nil
+	default:
+		return nil, ErrUnsupportedStage
+	}
+}
+
+func (p *DemoPlugin) DetermineVersions(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	_ *sdk.DetermineVersionsInput[config.DemoApplicationSpec],
+) (*sdk.DetermineVersionsResponse, error) {
+	return &sdk.DetermineVersionsResponse{Versions: []sdk.ArtifactVersion{}}, nil
+}
+
+func (p *DemoPlugin) DetermineStrategy(
+	_ context.Context,
+	_ *config.DemoPluginConfig,
+	_ *sdk.DetermineStrategyInput[config.DemoApplicationSpec],
+) (*sdk.DetermineStrategyResponse, error) {
+	return &sdk.DetermineStrategyResponse{
+		Strategy: sdk.SyncStrategyPipelineSync,
+		Summary:  "pipeline sync",
+	}, nil
+}

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/go.mod
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/piped-plugin-demo
+
+go 1.25.0
+
+require github.com/pipe-cd/piped-plugin-sdk-go v0.3.0

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/main.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/deployment/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package main
 
 import (
-	"github.com/spf13/cobra"
+	"log"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+
+	"github.com/example/piped-plugin-demo/deployment"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
+func main() {
+	plugin, err := sdk.NewPlugin(
+		"0.0.1",
+		sdk.WithDeploymentPlugin(&deployment.DemoPlugin{}),
+	)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+	if err := plugin.Run(); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/README.md
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/README.md
@@ -1,0 +1,16 @@
+# demo PipeCD plugin (stage-only)
+
+Scaffolded with `pipectl plugin init`.
+
+## Stages
+- `DEMO_WAIT`
+
+## Build
+
+```bash
+go build .
+```
+
+## Configure piped
+
+Register this plugin in your Piped config. See [contributing plugins](https://pipecd.dev/docs/contribution-guidelines/contributing-plugins/).

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/go.mod
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/piped-plugin-demo
+
+go 1.25.0
+
+require github.com/pipe-cd/piped-plugin-sdk-go v0.3.0

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/main.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plugin
+package main
 
 import (
-	"github.com/spf13/cobra"
+	"log"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
 
-type command struct{}
-
-func NewCommand() *cobra.Command {
-	c := &command{}
-	cmd := &cobra.Command{
-		Use:   "plugin",
-		Short: "Do plugin tasks.",
+func main() {
+	plugin, err := sdk.NewPlugin("0.0.1", sdk.WithStagePlugin(&plugin{}))
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	cmd.AddCommand(
-		newInitCommand(c),
-		newPushCommand(c),
-	)
-
-	return cmd
+	if err := plugin.Run(); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/plugin.go
+++ b/pkg/app/pipectl/pluginscaffold/testdata/golden/stage/plugin.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+type plugin struct{}
+
+// FetchDefinedStages implements sdk.StagePlugin.
+func (p *plugin) FetchDefinedStages() []string {
+	return []string{
+		"DEMO_WAIT",
+	}
+}
+
+// BuildPipelineSyncStages implements sdk.StagePlugin.
+func (p *plugin) BuildPipelineSyncStages(_ context.Context, _ sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages := make([]sdk.PipelineStage, 0, len(input.Request.Stages))
+	for _, rs := range input.Request.Stages {
+		stages = append(stages, sdk.PipelineStage{
+			Index:              rs.Index,
+			Name:               rs.Name,
+			Rollback:           false,
+			Metadata:           map[string]string{},
+			AvailableOperation: sdk.ManualOperationNone,
+		})
+	}
+	return &sdk.BuildPipelineSyncStagesResponse{Stages: stages}, nil
+}
+
+// ExecuteStage implements sdk.StagePlugin.
+func (p *plugin) ExecuteStage(ctx context.Context, _ sdk.ConfigNone, _ sdk.DeployTargetsNone, input *sdk.ExecuteStageInput[struct{}]) (*sdk.ExecuteStageResponse, error) {
+	switch input.Request.StageName {
+	case "DEMO_WAIT":
+		return &sdk.ExecuteStageResponse{Status: p.executeDemoWait(ctx, input)}, nil
+	default:
+		input.Logger.Error("unsupported stage", zap.String("stage", input.Request.StageName))
+		return &sdk.ExecuteStageResponse{Status: sdk.StageStatusFailure}, nil
+	}
+}
+func (p *plugin) executeDemoWait(_ context.Context, input *sdk.ExecuteStageInput[struct{}]) sdk.StageStatus {
+	lp, err := input.Client.StageLogPersister()
+	if err != nil {
+		input.Logger.Error("no stage log persister", zap.Error(err))
+		return sdk.StageStatusFailure
+	}
+	lp.Info("TODO: implement DEMO_WAIT stage logic")
+	return sdk.StageStatusFailure
+}


### PR DESCRIPTION
**What this PR does**:

Adds `pipectl plugin init` and the `pluginscaffold` package to generate compile-ready Piped v1 plugin skeletons from embedded templates:

- **Stage-only** layout (based on the `wait` plugin)
- **Deployment-minimal** layout (based on a slim `ecs`-style layout)

The command supports `--kind`, `--stages`, `--module`, `--name`, `--dry-run`, and `--force`. Tests include golden output, name validation, and integration checks that run `go mod tidy` and `go build` for both kinds.

**Why we need it**:

Plugin authors currently copy and rename files from existing plugins (`wait`, `ecs`), which is slow and easy to get wrong. This addresses the MVP in #6694 and part of the scaffold epic in #6693.

**Which issue(s) this PR fixes**:

Fixes #6694

Related to #6693 (does not implement the full epic; see scope below).

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Plugin authors can run `pipectl plugin init` to create a new plugin directory with a valid layout and stub implementations. Documentation is added under [Contributing plugins](https://pipecd.dev/docs/contribution-guidelines/contributing-plugins/#scaffold-a-new-plugin) and [Command-line tool](https://pipecd.dev/docs/user-guide/command-line-tool/#scaffolding-a-piped-plugin).
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A

---

### Scope

| In scope | Out of scope (follow-up) |
|----------|---------------------------|
| `pipectl plugin init` | `pipectl plugin add-stage` (#6705) |
| Stage + deployment-minimal templates | `--livestate`, `--planpreview`, `--initialize` (#6693) |
| Community module path default | In-tree `pkg/app/pipedv1/plugin/...` helper |

This change is additive: `piped` runtime and existing plugins are not modified. `pipectl plugin push` is unchanged.

The diff is larger than the ~300-line guideline in CONTRIBUTING because of embedded templates and golden `testdata`; it is limited to one feature (the init scaffold).

---

### Test plan

- [x] `make check`
- [x] `go test -race ./pkg/app/pipectl/pluginscaffold/... ./pkg/app/pipectl/cmd/plugin/...`

```bash
make build/go MOD=pipectl

./.artifacts/pipectl plugin init /tmp/demo-stage \
  --kind stage --stages DEMO_WAIT
(cd /tmp/demo-stage && go mod tidy && go build .)

./.artifacts/pipectl plugin init /tmp/demo-deployment \
  --kind deployment --stages DEMO_SYNC,DEMO_ROLLBACK
(cd /tmp/demo-deployment && go mod tidy && go build .)

./.artifacts/pipectl plugin init /tmp/demo-dry-run \
  --kind stage --stages DEMO_WAIT --dry-run
```