### PR TITLE
Update codegen image

### DIFF
--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Generate code
       # NOTE: Keep this container image as same as defined in Makefile
-      uses: docker://ghcr.io/pipe-cd/codegen@sha256:0a2f9805e50f5c6efb7771171ddf291251bf349c2e8627fbf59c3535eacbbee0 # v0.53.0-10-g64742f7
+      uses: docker://ghcr.io/pipe-cd/codegen@sha256:8b17498a7cfb58fbaf403ec7cab01a740238aaee43d030e65a40abb710f9e68a # v0.56.0-30-g0d71fd0
       with:
         entrypoint: ./tool/codegen/codegen.sh
         args: /github/workspace

--- a/Makefile
+++ b/Makefile
@@ -262,9 +262,10 @@ update/copyright:
 # Generate commands
 
 .PHONY: gen/code
+gen/code: CODEGEN_IMAGE ?= ghcr.io/pipe-cd/codegen@sha256:8b17498a7cfb58fbaf403ec7cab01a740238aaee43d030e65a40abb710f9e68a # v0.56.0-30-g0d71fd0
 gen/code:
 	# NOTE: Keep this container image as same as defined in .github/workflows/gen.yml
-	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh ghcr.io/pipe-cd/codegen@sha256:0a2f9805e50f5c6efb7771171ddf291251bf349c2e8627fbf59c3535eacbbee0 /repo # v0.53.0-10-g64742f7
+	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh $(CODEGEN_IMAGE) /repo
 
 .PHONY: gen/test-tls
 gen/test-tls:

--- a/Makefile
+++ b/Makefile
@@ -262,9 +262,9 @@ update/copyright:
 # Generate commands
 
 .PHONY: gen/code
+# NOTE: Keep this container image as same as defined in .github/workflows/gen.yml
 gen/code: CODEGEN_IMAGE ?= ghcr.io/pipe-cd/codegen@sha256:8b17498a7cfb58fbaf403ec7cab01a740238aaee43d030e65a40abb710f9e68a # v0.56.0-30-g0d71fd0
 gen/code:
-	# NOTE: Keep this container image as same as defined in .github/workflows/gen.yml
 	docker run --rm -v ${PWD}:/repo -it --entrypoint ./tool/codegen/codegen.sh $(CODEGEN_IMAGE) /repo
 
 .PHONY: gen/test-tls


### PR DESCRIPTION
**What this PR does**:

Update codegen container image to use the image with go version v1.26.2

**Why we need it**:

**Which issue(s) this PR fixes**:

Follow PR #6711 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
