### PR TITLE
ci: add concurrency groups to build workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ on:
       - 'release-v*'
       - 'feat/*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GO_VERSION: 1.26.2
   NODE_VERSION: 20.19.0

--- a/.github/workflows/build_tool.yaml
+++ b/.github/workflows/build_tool.yaml
@@ -8,6 +8,10 @@ on:
     paths:
       - tool/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   code:
     runs-on: ubuntu-24.04

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'RELEASE'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gh-release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**What this PR does**:

Adds workflow-level concurrency groups to these GitHub Actions workflows:

- `.github/workflows/build.yaml`
- `.github/workflows/build_tool.yaml`
- `.github/workflows/gen.yaml`
- `.github/workflows/prerelease.yaml`

This makes older runs for the same pull request stop when a newer commit starts running.

**Why we need it**:

When several commits are pushed to the same pull request quickly, GitHub Actions can keep running checks for older commits.

Those older checks are no longer useful because the pull request now points to a newer commit. Cancelling them saves CI minutes and runner capacity.

**Which issue(s) this PR fixes**:

Fixes #6905

**Does this PR introduce a user-facing change?**:

No.

- **How are users affected by this change**:
  Users are not affected. This only changes GitHub Actions workflow behavior for pull requests.
- **Is this breaking change**:
  No.
- **How to migrate (if breaking change)**:
  No migration is needed.
