### PR TITLE
docs: update hugo version and add windows notes for local preview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,9 +29,15 @@ If you find any issues related to the docs, we're happy to accept your help.
 # How to run the website locally
 
 ## Prerequisite
-
-- [Hugo 0.92.1+extended](https://gohugo.io/)
+- [Hugo 0.148.2+extended](https://gohugo.io/)
 
 ## Commands
 
 Run `make run/site` at the root directory of the repository and then access http://localhost:1313
+
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```

--- a/docs/content/en/docs-dev/contribution-guidelines/contributing-blogs.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/contributing-blogs.md
@@ -84,6 +84,13 @@ Your content here...
    ```
    Then visit `http://localhost:1313/blog/` to see your post.
 
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
+
 6. **Commit and push** your changes:
    ```bash
    git add .

--- a/docs/content/en/docs-dev/contribution-guidelines/contributing-documentation.md
+++ b/docs/content/en/docs-dev/contribution-guidelines/contributing-documentation.md
@@ -22,12 +22,19 @@ The content files are written in Markdown and live inside `/docs/content/en/`. Y
 
 To preview your changes as you work, you must run the documentation website on your local machine.
 
-1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.92.1 or higher)](https://gohugo.io/getting-started/installing/) installed.
+1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.148.2 or higher)](https://gohugo.io/getting-started/installing/) installed.
 2.  **Run the Server:** From the root of the `pipecd` repository, run the following command:
     ```bash
     make run/site
     ```
 3.  **Preview:** Open your browser and go to `http://localhost:1313` to see the live-reloading site.
+
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
 
 ## How to submit your changes (The PR Process)
 

--- a/docs/content/en/docs-v0.56.x/contribution-guidelines/contributing-blogs.md
+++ b/docs/content/en/docs-v0.56.x/contribution-guidelines/contributing-blogs.md
@@ -84,6 +84,13 @@ Your content here...
    ```
    Then visit `http://localhost:1313/blog/` to see your post.
 
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
+
 6. **Commit and push** your changes:
    ```bash
    git add .

--- a/docs/content/en/docs-v0.56.x/contribution-guidelines/contributing-documentation.md
+++ b/docs/content/en/docs-v0.56.x/contribution-guidelines/contributing-documentation.md
@@ -22,12 +22,19 @@ The content files are written in Markdown and live inside `/docs/content/en/`. Y
 
 To preview your changes as you work, you must run the documentation website on your local machine.
 
-1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.92.1 or higher)](https://gohugo.io/getting-started/installing/) installed.
+1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.148.2 or higher)](https://gohugo.io/getting-started/installing/) installed.
 2.  **Run the Server:** From the root of the `pipecd` repository, run the following command:
     ```bash
     make run/site
     ```
 3.  **Preview:** Open your browser and go to `http://localhost:1313` to see the live-reloading site.
+
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
 
 ## How to submit your changes (The PR Process)
 

--- a/docs/content/en/docs-v0.57.x/contribution-guidelines/contributing-blogs.md
+++ b/docs/content/en/docs-v0.57.x/contribution-guidelines/contributing-blogs.md
@@ -84,6 +84,13 @@ Your content here...
    ```
    Then visit `http://localhost:1313/blog/` to see your post.
 
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
+
 6. **Commit and push** your changes:
    ```bash
    git add .

--- a/docs/content/en/docs-v0.57.x/contribution-guidelines/contributing-documentation.md
+++ b/docs/content/en/docs-v0.57.x/contribution-guidelines/contributing-documentation.md
@@ -22,12 +22,19 @@ The content files are written in Markdown and live inside `/docs/content/en/`. Y
 
 To preview your changes as you work, you must run the documentation website on your local machine.
 
-1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.92.1 or higher)](https://gohugo.io/getting-started/installing/) installed.
+1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.148.2 or higher)](https://gohugo.io/getting-started/installing/) installed.
 2.  **Run the Server:** From the root of the `pipecd` repository, run the following command:
     ```bash
     make run/site
     ```
 3.  **Preview:** Open your browser and go to `http://localhost:1313` to see the live-reloading site.
+
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
 
 ## How to submit your changes (The PR Process)
 

--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-blogs.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-blogs.md
@@ -84,6 +84,13 @@ Your content here...
    ```
    Then visit `http://localhost:1313/blog/` to see your post.
 
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
+
 6. **Commit and push** your changes:
    ```bash
    git add .

--- a/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-documentation.md
+++ b/docs/content/en/docs-v1.0.x/contribution-guidelines/contributing-documentation.md
@@ -22,12 +22,19 @@ The content files are written in Markdown and live inside `/docs/content/en/`. Y
 
 To preview your changes as you work, you must run the documentation website on your local machine.
 
-1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.92.1 or higher)](https://gohugo.io/getting-started/installing/) installed.
+1.  **Install Prerequisite:** You must have the **extended** version of [Hugo (v0.148.2 or higher)](https://gohugo.io/getting-started/installing/) installed.
 2.  **Run the Server:** From the root of the `pipecd` repository, run the following command:
     ```bash
     make run/site
     ```
 3.  **Preview:** Open your browser and go to `http://localhost:1313` to see the live-reloading site.
+
+> **Note for Windows users:**
+> The `make run/site` command uses `make` and `grep`, which are not natively available in Windows PowerShell. You can either use an environment like WSL or run the Hugo command manually in PowerShell:
+> ```powershell
+> $env:RELEASE = (Select-String -Path RELEASE -Pattern "^tag:").Line.Split(":")[1].Trim()
+> hugo server --source=docs
+> ```
 
 ## How to submit your changes (The PR Process)
 


### PR DESCRIPTION
Fixes #6741 by updating the minimum required Hugo version to v0.148.2 and adding Windows PowerShell workaround notes for the \make run/site\ command.

The note reads the release version dynamically from the \RELEASE\ file at the repo root so it never goes stale across releases.