### PR TITLE
fix(deploymentstore): return oldest uncompleted deployment as head

### DIFF
--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -123,14 +123,18 @@ func (s *store) sync(ctx context.Context) error {
 	}
 
 	headDeployments := make(map[string]*model.Deployment)
-	for _, d := range pendings {
+	for _, d := range runnings {
 		headDeployments[d.ApplicationId] = d
 	}
 	for _, d := range planneds {
-		headDeployments[d.ApplicationId] = d
+		if _, exists := headDeployments[d.ApplicationId]; !exists {
+			headDeployments[d.ApplicationId] = d
+		}
 	}
-	for _, d := range runnings {
-		headDeployments[d.ApplicationId] = d
+	for _, d := range pendings {
+		if _, exists := headDeployments[d.ApplicationId]; !exists {
+			headDeployments[d.ApplicationId] = d
+		}
 	}
 
 	s.plannedDeployments.Store(planneds)

--- a/pkg/app/pipedv1/apistore/deploymentstore/store.go
+++ b/pkg/app/pipedv1/apistore/deploymentstore/store.go
@@ -123,14 +123,18 @@ func (s *store) sync(ctx context.Context) error {
 	}
 
 	headDeployments := make(map[string]*model.Deployment)
-	for _, d := range pendings {
+	for _, d := range runnings {
 		headDeployments[d.ApplicationId] = d
 	}
 	for _, d := range planneds {
-		headDeployments[d.ApplicationId] = d
+		if _, exists := headDeployments[d.ApplicationId]; !exists {
+			headDeployments[d.ApplicationId] = d
+		}
 	}
-	for _, d := range runnings {
-		headDeployments[d.ApplicationId] = d
+	for _, d := range pendings {
+		if _, exists := headDeployments[d.ApplicationId]; !exists {
+			headDeployments[d.ApplicationId] = d
+		}
 	}
 
 	s.plannedDeployments.Store(planneds)


### PR DESCRIPTION
The head deployment selection in ListAppHeadDeployments was returning the newest instead of the oldest uncompleted deployment.

The previous loop order (pendings -> planneds -> runnings) caused newer statuses to overwrite older ones. For an app with both a pending and a running deployment, the running one won -- the opposite of what the Lister interface docstring promises.

Fix: iterate runnings first (oldest status), then planneds and pendings only if no entry already exists for that application ID.

Both piped and pipedv1 stores are fixed. Fixes #6780