### PR TITLE
refactor: improve skip stage detection, propagate context in downloader, and style log viewer

### DIFF
--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -414,7 +414,7 @@ func (l *launcher) launchNewPiped(ctx context.Context, version string, config []
 		binaryDir   = filepath.Join(workingDir, "bin")
 		downloadURL = makeDownloadURL(version)
 	)
-	pipedPath, err := lifecycle.DownloadBinary(downloadURL, binaryDir, pipedBinaryFileName, false, logger)
+	pipedPath, err := lifecycle.DownloadBinary(ctx, downloadURL, binaryDir, pipedBinaryFileName, false, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download Piped from %s to %s (%w)", downloadURL, binaryDir, err)
 	}

--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -706,7 +706,7 @@ func (p *piped) runPlugins(ctx context.Context, pluginsCfg []config.PipedPlugin,
 	plugins := make([]*lifecycle.Command, 0, len(pluginsCfg))
 	for _, pCfg := range pluginsCfg {
 		// Download plugin binary to piped's pluginsDir.
-		pPath, err := lifecycle.DownloadBinary(pCfg.URL, p.pluginsDir, pCfg.Name, p.forcePluginRedownload, logger)
+		pPath, err := lifecycle.DownloadBinary(ctx, pCfg.URL, p.pluginsDir, pCfg.Name, p.forcePluginRedownload, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download plugin %s: %w", pCfg.Name, err)
 		}

--- a/pkg/app/pipedv1/controller/scheduler.go
+++ b/pkg/app/pipedv1/controller/scheduler.go
@@ -512,7 +512,7 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 
 	defer func() {
 		// Ensure reporting the status even if the stage is cancelled.
-		if err := s.reportStageStatus(context.Background(), ps.Id, finalStatus, ps.Requires); err != nil {
+		if err := s.reportStageStatus(context.Background(), ps.Id, finalStatus, ps.Requires, ""); err != nil {
 			s.logger.Error("failed to report stage status", zap.Error(err))
 		}
 	}()
@@ -537,29 +537,9 @@ func (s *scheduler) executeStage(sig StopSignal, ps *model.PipelineStage) (final
 		return status
 	}
 
-	// Check whether to execute the script rollback stage or not.
-	// If the base stage is executed, the script rollback stage will be executed.
-
-	// TODO: move this logic into the script run plugin and remove this later.
-	// if ps.Rollback {
-	// 	baseStageID := ps.Metadata["baseStageID"]
-	// 	if baseStageID == "" {
-	// 		return
-	// 	}
-
-	// 	baseStageStatus, ok := s.stageStatuses[baseStageID]
-	// 	if !ok {
-	// 		return
-	// 	}
-
-	// 	if baseStageStatus == model.StageStatus_STAGE_NOT_STARTED_YET || baseStageStatus == model.StageStatus_STAGE_SKIPPED {
-	// 		return
-	// 	}
-	// }
-
 	// Update stage status to RUNNING if needed.
 	if model.CanUpdateStageStatus(ps.Status, model.StageStatus_STAGE_RUNNING) {
-		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_RUNNING, ps.Requires); err != nil {
+		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_RUNNING, ps.Requires, ""); err != nil {
 			if sig.Signal() == StopSignalCancel {
 				return model.StageStatus_STAGE_CANCELLED
 			}
@@ -674,31 +654,32 @@ func (s *scheduler) shouldSkipStage(ctx context.Context, ps *model.PipelineStage
 	skip, err := s.determineSkipStage(ctx, stage.SkipOn)
 	if err != nil {
 		s.logger.Error("failed to check whether to skip the stage", zap.Error(err))
-		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires); err != nil {
+		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_FAILURE, ps.Requires, err.Error()); err != nil {
 			s.logger.Error("failed to report stage status", zap.Error(err))
 		}
 		return true, model.StageStatus_STAGE_FAILURE
 	}
 	if skip {
-		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_SKIPPED, ps.Requires); err != nil {
+		msg := "The stage was successfully skipped due to the skip configuration of the stage."
+		if err := s.reportStageStatus(ctx, ps.Id, model.StageStatus_STAGE_SKIPPED, ps.Requires, msg); err != nil {
 			s.logger.Error("failed to report stage status", zap.Error(err))
 			return true, model.StageStatus_STAGE_FAILURE
 		}
-		// TODO: Send this log message to the control-plane. (e.g. Use the statusReason field and show it on UI)
-		s.logger.Info("The stage was successfully skipped due to the skip configuration of the stage.")
+		s.logger.Info(msg)
 		return true, model.StageStatus_STAGE_SKIPPED
 	}
 
 	return false, model.StageStatus_STAGE_RUNNING
 }
 
-func (s *scheduler) reportStageStatus(ctx context.Context, stageID string, status model.StageStatus, requires []string) error {
+func (s *scheduler) reportStageStatus(ctx context.Context, stageID string, status model.StageStatus, requires []string, statusReason string) error {
 	var (
 		now = s.nowFunc()
 		req = &pipedservice.ReportStageStatusChangedRequest{
 			DeploymentId: s.deployment.Id,
 			StageId:      stageID,
 			Status:       status,
+			StatusReason: statusReason,
 			Requires:     requires,
 			CompletedAt:  now.Unix(),
 		}

--- a/pkg/app/pipedv1/controller/skipstage.go
+++ b/pkg/app/pipedv1/controller/skipstage.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"io"
 	"strings"
 
 	config "github.com/pipe-cd/pipecd/pkg/configv1"
@@ -30,12 +31,13 @@ func (s *scheduler) determineSkipStage(ctx context.Context, skipOpts config.Skip
 		return false, nil
 	}
 
-	// TODO: Do not use clone here in order to avoid unnecessary cloning.
-	repoCfg := s.deployment.GetGitPath().Repo
-	repo, err := s.gitClient.Clone(ctx, repoCfg.Id, repoCfg.Remote, repoCfg.Branch, "")
+	tds, err := s.targetDSP.Get(ctx, io.Discard)
 	if err != nil {
 		return false, err
 	}
+
+	repoCfg := s.deployment.GetGitPath().Repo
+	repo := git.NewRepo(tds.RepoDir, "git", repoCfg.Remote, repoCfg.Branch, nil)
 
 	// Check by path pattern
 	skip, err = skipByPathPattern(ctx, skipOpts, repo, s.runningDSP.Revision(), s.targetDSP.Revision())

--- a/pkg/lifecycle/binary.go
+++ b/pkg/lifecycle/binary.go
@@ -109,7 +109,7 @@ func RunBinary(ctx context.Context, execPath string, args []string) (*Command, e
 // this also marks it executable and returns its full path.
 //
 // If forceRedownload is true, any existing cached binary is removed before downloading.
-func DownloadBinary(sourceURL, destDir, destFile string, forceRedownload bool, logger *zap.Logger) (string, error) {
+func DownloadBinary(ctx context.Context, sourceURL, destDir, destFile string, forceRedownload bool, logger *zap.Logger) (string, error) {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return "", fmt.Errorf("could not create directory %s (%w)", destDir, err)
 	}
@@ -148,11 +148,6 @@ func DownloadBinary(sourceURL, destDir, destFile string, forceRedownload bool, l
 
 	switch u.Scheme {
 	case "oci":
-		// TODO: add context.Context as a argument for DownloadBinary.
-		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-		defer cancel()
-
 		if err := oci.PullFileFromRegistry(
 			ctx,
 			destDir,
@@ -165,7 +160,7 @@ func DownloadBinary(sourceURL, destDir, destFile string, forceRedownload bool, l
 			return "", fmt.Errorf("could not pull file from OCI (%w)", err)
 		}
 	case "http", "https":
-		req, err := http.NewRequest("GET", sourceURL, nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", sourceURL, nil)
 		if err != nil {
 			return "", fmt.Errorf("could not create request (%w)", err)
 		}

--- a/pkg/lifecycle/binary_test.go
+++ b/pkg/lifecycle/binary_test.go
@@ -98,7 +98,7 @@ func TestDownloadBinary(t *testing.T) {
 		destDir := t.TempDir()
 		destFile := "test-binary"
 		url := server.URL + "/binary"
-		path, err := DownloadBinary(url, destDir, destFile, false, logger)
+		path, err := DownloadBinary(context.TODO(), url, destDir, destFile, false, logger)
 		require.NoError(t, err)
 		assert.FileExists(t, path)
 	})
@@ -107,12 +107,12 @@ func TestDownloadBinary(t *testing.T) {
 		destDir := t.TempDir()
 		destFile := "test-binary"
 		url := server.URL + "/binary"
-		path, err := DownloadBinary(url, destDir, destFile, false, logger)
+		path, err := DownloadBinary(context.TODO(), url, destDir, destFile, false, logger)
 		require.NoError(t, err)
 		assert.FileExists(t, path)
 
 		// Try downloading again, should not error and file should still exist
-		path, err = DownloadBinary(url, destDir, destFile, false, logger)
+		path, err = DownloadBinary(context.TODO(), url, destDir, destFile, false, logger)
 		require.NoError(t, err)
 		assert.FileExists(t, path)
 	})
@@ -128,7 +128,7 @@ func TestDownloadBinary(t *testing.T) {
 		destFile := "test-binary"
 		url := "file://" + sourcePath
 
-		path, err := DownloadBinary(url, destDir, destFile, false, logger)
+		path, err := DownloadBinary(context.TODO(), url, destDir, destFile, false, logger)
 		require.NoError(t, err)
 		assert.FileExists(t, path)
 		content, err := os.ReadFile(path)
@@ -141,7 +141,7 @@ func TestDownloadBinary(t *testing.T) {
 		destFile := "test-binary"
 		url := "ftp://invalid-url"
 
-		path, err := DownloadBinary(url, destDir, destFile, false, logger)
+		path, err := DownloadBinary(context.TODO(), url, destDir, destFile, false, logger)
 		require.Error(t, err)
 		assert.Empty(t, path)
 	})

--- a/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
+++ b/web/src/components/deployments-detail-page/log-viewer/log/index.tsx
@@ -3,6 +3,7 @@ import { CircularProgress, Box } from "@mui/material";
 import { LogLine } from "../log-line";
 import { DEFAULT_BACKGROUND_COLOR } from "~/constants/term-colors";
 import { LogBlock } from "~~/model/logblock_pb";
+import useAuth from "~/contexts/auth-context/use-auth";
 
 export interface LogProps {
   logs: LogBlock.AsObject[];
@@ -11,6 +12,8 @@ export interface LogProps {
 
 export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
   const bottomRef = useRef<null | HTMLDivElement>(null);
+  const { me } = useAuth();
+  const username = me?.subject || "user";
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -21,11 +24,129 @@ export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
       sx={(theme) => ({
         fontFamily: theme.typography.fontFamilyMono,
         backgroundColor: DEFAULT_BACKGROUND_COLOR,
-        paddingTop: theme.spacing(1),
-        paddingBottom: theme.spacing(1),
+        paddingTop: theme.spacing(2),
+        paddingBottom: theme.spacing(2),
         height: "100%",
       })}
     >
+      {/* Powerline style prompt */}
+      <Box sx={{ ml: "5rem", mb: 2, userSelect: "none", display: "flex" }}>
+        <Box
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            height: "28px",
+            fontSize: "0.8rem",
+            lineHeight: 1,
+            overflow: "hidden",
+            borderRadius: "14px",
+          }}
+        >
+          {/* Segment 1: Username */}
+          <Box
+            sx={{
+              backgroundColor: "#df5b18",
+              color: "#fff",
+              pl: "16px",
+              pr: "26px",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              fontWeight: "bold",
+              position: "relative",
+              zIndex: 6,
+              borderTopLeftRadius: "14px",
+              borderBottomLeftRadius: "14px",
+              clipPath: "polygon(0% 0%, calc(100% - 10px) 0%, 100% 50%, calc(100% - 10px) 100%, 0% 100%)",
+            }}
+          >
+            {username}
+          </Box>
+
+          {/* Segment 2: Directory (~) */}
+          <Box
+            sx={{
+              backgroundColor: "#dca018",
+              color: "#fff",
+              pl: "24px",
+              pr: "24px",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              fontWeight: "bold",
+              fontSize: "1.1rem",
+              position: "relative",
+              zIndex: 5,
+              marginLeft: "-10px",
+              clipPath: "polygon(0% 0%, 10px 50%, 0% 100%, calc(100% - 10px) 100%, 100% 50%, calc(100% - 10px) 0%)",
+            }}
+          >
+            ~
+          </Box>
+
+          {/* Segment 3: Accent Arrow 1 (Green) */}
+          <Box
+            sx={{
+              backgroundColor: "#50b577",
+              width: "22px",
+              height: "100%",
+              position: "relative",
+              zIndex: 4,
+              marginLeft: "-10px",
+              clipPath: "polygon(0% 0%, 10px 50%, 0% 100%, calc(100% - 10px) 100%, 100% 50%, calc(100% - 10px) 0%)",
+            }}
+          />
+
+          {/* Segment 4: Accent Arrow 2 (Teal) */}
+          <Box
+            sx={{
+              backgroundColor: "#3ea5a2",
+              width: "22px",
+              height: "100%",
+              position: "relative",
+              zIndex: 3,
+              marginLeft: "-10px",
+              clipPath: "polygon(0% 0%, 10px 50%, 0% 100%, calc(100% - 10px) 100%, 100% 50%, calc(100% - 10px) 0%)",
+            }}
+          />
+
+          {/* Segment 5: Accent Arrow 3 (Dark Forest Green) */}
+          <Box
+            sx={{
+              backgroundColor: "#1b594b",
+              width: "22px",
+              height: "100%",
+              position: "relative",
+              zIndex: 2,
+              marginLeft: "-10px",
+              clipPath: "polygon(0% 0%, 10px 50%, 0% 100%, calc(100% - 10px) 100%, 100% 50%, calc(100% - 10px) 0%)",
+            }}
+          />
+
+          {/* Segment 6: stage.log */}
+          <Box
+            sx={{
+              backgroundColor: "#141819",
+              color: "#ecf0f1",
+              pl: "24px",
+              pr: "16px",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              fontWeight: "bold",
+              position: "relative",
+              zIndex: 1,
+              marginLeft: "-10px",
+              borderTopRightRadius: "14px",
+              borderBottomRightRadius: "14px",
+              clipPath: "polygon(0% 0%, 10px 50%, 0% 100%, 100% 100%, 100% 0%)",
+            }}
+          >
+            stage.log
+          </Box>
+        </Box>
+      </Box>
+
       {logs.map((log, i) => (
         <LogLine
           key={`log-${log.index}`}
@@ -56,3 +177,7 @@ export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
     </Box>
   );
 });
+
+
+
+


### PR DESCRIPTION
## Description

This PR introduces performance optimizations, robustness improvements, and a UI enhancement to the log viewer:
1. **Context Propagation in Binary Downloader**: Updates `DownloadBinary` to accept a `context.Context` and use `http.NewRequestWithContext`, enabling proper timeouts and cancellation.
2. **Optimized Skip Stage Check**: Replaces cloning of the git repository with local directory lookup via `targetDSP` during stage skip checks, reducing network overhead and disk usage.
3. **Detailed Status Reason Reporting**: Adds `statusReason` support to `reportStageStatus` to report skip reasons and failure messages to the control plane.
4. **Powerline-Style Log Viewer Header**: Enhances the web log viewer component with a sleek, multi-segmented Powerline terminal prompt.

---

## Key Changes

### ⚙️ Piped & Launcher (Go)
* **`pkg/lifecycle/binary.go` / `pkg/lifecycle/binary_test.go`**:
  * Added `ctx context.Context` parameter to `DownloadBinary`.
  * Replaced `http.NewRequest` with `http.NewRequestWithContext` to inherit cancellation signals.
  * Updated callers in `launcher.go`, `piped.go`, and test assertions to propagate context.
* **`pkg/app/pipedv1/controller/scheduler.go`**:
  * Updated `reportStageStatus` signature to include `statusReason`.
  * Set the `StatusReason` field inside `ReportStageStatusChangedRequest`.
  * Cleaned up legacy commented-out script rollback stage logic.
* **`pkg/app/pipedv1/controller/skipstage.go`**:
  * Avoided calling `gitClient.Clone` inside `determineSkipStage`.
  * Retrieved local directory using `s.targetDSP.Get(ctx, io.Discard)` to instantiate the repository object directly, preventing redundant repository clones.

### 🎨 Web Frontend (TypeScript/React)
* **`web/src/components/deployments-detail-page/log-viewer/log/index.tsx`**:
  * Integrated `useAuth` hook to query the active user's identity.
  * Added a custom Powerline-themed terminal prompt (Username `me?.subject`, Directory `~`, and File `stage.log`) constructed with Material UI `Box` and CSS `clipPath` polygons.
  * Increased vertical padding on the log container for better readability.
