### PR TITLE
Update extract cookie logic to allow cookie contains equal sign

### DIFF
--- a/pkg/rpc/rpcauth/auth.go
+++ b/pkg/rpc/rpcauth/auth.go
@@ -136,10 +136,7 @@ func extractCookie(ctx context.Context) (map[string]string, error) {
 	cs := strings.Split(rawCookie[0], ";")
 	cookie := make(map[string]string, len(cs))
 	for _, c := range cs {
-		subs := strings.Split(strings.TrimSpace(c), "=")
-		if len(subs) != 2 {
-			return nil, status.Error(codes.Unauthenticated, "cookie is malformed")
-		}
+		subs := strings.SplitN(strings.TrimSpace(c), "=", 2)
 		cookie[subs[0]] = subs[1]
 	}
 	return cookie, nil

--- a/pkg/rpc/rpcauth/auth_test.go
+++ b/pkg/rpc/rpcauth/auth_test.go
@@ -216,12 +216,12 @@ func TestExtractCookie(t *testing.T) {
 			failed:         true,
 		},
 		{
-			name: "malformed cookie: wrong format",
+			name: "allow cookie with equal sign",
 			ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{
 				"cookie": []string{"token=xxx; another=yyy=zzz"},
 			}),
-			expectedCookie: nil,
-			failed:         true,
+			expectedCookie: map[string]string{"token": "xxx", "another": "yyy=zzz"},
+			failed:         false,
 		},
 		{
 			name: "ok",


### PR DESCRIPTION
**What this PR does**:

Update the extract cookie logic to allow cookie contains equal sign `=`

**Why we need it**:

Some cookies introduced by 3rd providers contain the `=` sign in their body. The body of the pipecd signed cookie remains, as it does not contain the equal sign (spec from jwt/v5), but currently, the pipecd auth logic checks all the cookie bodies that include cookies from 3rd providers and treats them as pipecd signed cookies.

Also, there was already a logic that verifies the token content, which will yield an error if the token string body contains an equal sign `=`, so no need to overdo it here.

ref: https://github.com/pipe-cd/pipecd/blob/master/pkg/jwt/verifier.go#L44

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**: Yes

- **How are users affected by this change**: Be able to use cookie from 3rd auth providers that contains equal sign `=`
- **Is this breaking change**: No
- **How to migrate (if breaking change)**:
