### PR TITLE
Docs v0: fix broken links in feature-status, metrics and config reference

### DIFF
--- a/docs/content/en/docs-dev/feature-status/_index.md
+++ b/docs/content/en/docs-dev/feature-status/_index.md
@@ -135,7 +135,7 @@ Note: These are statuses for Cloud Run service. Cloud Run job has not been suppo
 | Support [Minio](https://github.com/minio/minio) as file store | Beta |
 | [Insights](../user-guide/insights/) - Show the delivery performance of a team or an application | Beta |
 | [Deployment Chain](../user-guide/managing-application/deployment-chain/) - Allow rolling out to multiple clusters gradually or promoting across environments | Alpha |
-| [Metrics](../user-guide/managing-controlplane/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |
+| [Metrics](../user-guide/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |
 
 ## Pipectl
 

--- a/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/managing-piped/configuration-reference.md
@@ -97,7 +97,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | masterURL | string | The master URL of the kubernetes cluster. Empty means in-cluster. | No |
-| kubectlVersion | string | Version of kubectl which will be used to connect to your cluster. Empty means the version set on [piped config](../user-guide/managing-piped/configuration-reference/#platformproviderkubernetesconfig) or [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kubectl.sh#L24) will be used. | No |
+| kubectlVersion | string | Version of kubectl which will be used to connect to your cluster. Empty means the [default version](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/toolregistry/install.go#L29) will be used. | No |
 | kubeConfigPath | string | The path to the kubeconfig file. Empty means in-cluster. | No |
 | appStateInformer | [KubernetesAppStateInformer](#kubernetesappstateinformer) | Configuration for application resource informer. | No |
 

--- a/docs/content/en/docs-dev/user-guide/metrics.md
+++ b/docs/content/en/docs-dev/user-guide/metrics.md
@@ -23,7 +23,7 @@ The piped agent collects its metrics and periodically sends them to the Control 
 Developers managing the piped agent can also get metrics directly from the piped agent and monitor them with their custom monitoring service.
 
 ## Enable monitoring system
-To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../installation/install-control-plane/installing-controlplane-on-k8s/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --set monitoring.enabled=true
@@ -79,7 +79,7 @@ prometheus:
             - channel: '#your-channel'
 ```
 
-And give it to the `helm install` command when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+And give it to the `helm install` command when [installing](../../installation/install-control-plane/installing-controlplane-on-k8s/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --values=values.yaml

--- a/docs/content/en/docs-v0.57.x/feature-status/_index.md
+++ b/docs/content/en/docs-v0.57.x/feature-status/_index.md
@@ -135,7 +135,7 @@ Note: These are statuses for Cloud Run service. Cloud Run job has not been suppo
 | Support [Minio](https://github.com/minio/minio) as file store | Beta |
 | [Insights](../user-guide/insights/) - Show the delivery performance of a team or an application | Beta |
 | [Deployment Chain](../user-guide/managing-application/deployment-chain/) - Allow rolling out to multiple clusters gradually or promoting across environments | Alpha |
-| [Metrics](../user-guide/managing-controlplane/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |
+| [Metrics](../user-guide/metrics/) - Dashboards for PipeCD and Piped metrics | Beta |
 
 ## Pipectl
 

--- a/docs/content/en/docs-v0.57.x/user-guide/managing-piped/configuration-reference.md
+++ b/docs/content/en/docs-v0.57.x/user-guide/managing-piped/configuration-reference.md
@@ -97,7 +97,7 @@ Must be one of the following structs:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | masterURL | string | The master URL of the kubernetes cluster. Empty means in-cluster. | No |
-| kubectlVersion | string | Version of kubectl which will be used to connect to your cluster. Empty means the version set on [piped config](../user-guide/managing-piped/configuration-reference/#platformproviderkubernetesconfig) or [default version](https://github.com/pipe-cd/pipecd/blob/master/tool/piped-base/install-kubectl.sh#L24) will be used. | No |
+| kubectlVersion | string | Version of kubectl which will be used to connect to your cluster. Empty means the [default version](https://github.com/pipe-cd/pipecd/blob/master/pkg/app/piped/toolregistry/install.go#L29) will be used. | No |
 | kubeConfigPath | string | The path to the kubeconfig file. Empty means in-cluster. | No |
 | appStateInformer | [KubernetesAppStateInformer](#kubernetesappstateinformer) | Configuration for application resource informer. | No |
 

--- a/docs/content/en/docs-v0.57.x/user-guide/metrics.md
+++ b/docs/content/en/docs-v0.57.x/user-guide/metrics.md
@@ -23,7 +23,7 @@ The piped agent collects its metrics and periodically sends them to the Control 
 Developers managing the piped agent can also get metrics directly from the piped agent and monitor them with their custom monitoring service.
 
 ## Enable monitoring system
-To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+To enable monitoring system for PipeCD, you first need to set the following value to `helm install` when [installing](../../installation/install-control-plane/installing-controlplane-on-k8s/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --set monitoring.enabled=true
@@ -79,7 +79,7 @@ prometheus:
             - channel: '#your-channel'
 ```
 
-And give it to the `helm install` command when [installing](../../../installation/install-controlplane/#2-preparing-control-plane-configuration-file-and-installing).
+And give it to the `helm install` command when [installing](../../installation/install-control-plane/installing-controlplane-on-k8s/#2-preparing-control-plane-configuration-file-and-installing).
 
 ```
 --values=values.yaml


### PR DESCRIPTION
**What this PR does**:
Fixes three broken links in v0 docs (404 on live site)

**Why we need it**:
Links 404 for users. Fixed in both docs-v0.57.x and docs-dev.

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:  docs links resolve correctly
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
