### PR TITLE
fix(pipedv1): use FindSlackGroups for group mentions in trigger-failed notification

### DIFF
--- a/pkg/app/pipedv1/trigger/trigger.go
+++ b/pkg/app/pipedv1/trigger/trigger.go
@@ -493,7 +493,7 @@ func (t *Trigger) notifyDeploymentTriggerFailed(app *model.Application, appCfg *
 	var groups []string
 	if n := appCfg.DeploymentNotification; n != nil {
 		users = n.FindSlackUsers(model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED)
-		groups = n.FindSlackUsers(model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED)
+		groups = n.FindSlackGroups(model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED)
 	}
 
 	t.notifier.Notify(model.NotificationEvent{


### PR DESCRIPTION
**What this PR does**:

The failed-trigger notification in pipedv1 fills the group mentions by calling FindSlackUsers, so configured Slack groups are never mentioned when a trigger fails. Looks like a copy-paste from the line above. The v0 piped has it right. This switches it to FindSlackGroups.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Slack group mentions now work for trigger-failed notifications in pipedv1.
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: n/a
