### PR TITLE
Docs v1: add plugins overview page

### DIFF
--- a/docs/content/en/docs-v1.0.x/plugins/_index.md
+++ b/docs/content/en/docs-v1.0.x/plugins/_index.md
@@ -3,8 +3,46 @@ title: "Plugins"
 linkTitle: "Plugins"
 weight: 2
 description: >
-  Learn more about Plugins in PipeCD v1.
+  This section describes the plugins available for PipeCD v1 and how to use them.
 ---
 
-> **Note:**
-> The Plugins section is a work in progress. Check back soon. Happy PipeCDing!
+In PipeCD v1, plugins handle deployments. `piped` runs each configured plugin as a separate process and communicates with it over gRPC, so which platforms your `piped` can deploy to depends on which plugins you configure. See more about [plugins](../concepts/#plugins).
+
+There are two types of plugins:
+
+- **Deployment plugins**: handle the deployment for a specific platform such as Kubernetes or Terraform.
+- **Stage plugins**: provide pipeline stages that can be used with any deployment plugin, such as `WAIT` or `ANALYSIS`.
+
+## Official plugins
+
+The PipeCD maintainers develop and maintain the following plugins. Each plugin is versioned and released independently. You can download the plugin binaries from the [releases page](https://github.com/pipe-cd/pipecd/releases).
+
+### Deployment plugins
+
+| Plugin | Description |
+|--------|-------------|
+| Kubernetes | Deploys applications to a Kubernetes cluster. Supports quick sync and pipeline sync with canary, baseline, and blue-green strategies. |
+| Kubernetes multi-cluster | Deploys a single application to multiple Kubernetes clusters with one pipeline. |
+| Terraform | Applies infrastructure changes by running `terraform plan` and `terraform apply` in a pipeline. |
+| Amazon ECS | Deploys applications to Amazon ECS. |
+
+### Stage plugins
+
+| Plugin | Stage | Description |
+|--------|-------|-------------|
+| Wait | `WAIT` | Waits for a specified duration before continuing the pipeline. |
+| Wait approval | `WAIT_APPROVAL` | Pauses the pipeline until a user approves the deployment. |
+| Analysis | `ANALYSIS` | Evaluates the deployment by querying metrics, logs, or HTTP endpoints. |
+| Script run | `SCRIPT_RUN` | Runs arbitrary commands as a pipeline stage. |
+
+## Community plugins
+
+The PipeCD community maintains additional plugins in the [community-plugins repository](https://github.com/pipe-cd/community-plugins). Visit the repository for a list of available plugins and their documentation.
+
+## Using a plugin
+
+To add a plugin to your `piped` and register deploy targets, see [Configuring a plugin](../user-guide/managing-piped/configuring-a-plugin/).
+
+## Writing your own plugin
+
+Anyone can develop a plugin for PipeCD. See the [plugin development guide](../contribution-guidelines/contributing-plugins/) to get started.


### PR DESCRIPTION
**What this PR does**:
Fills in the plugins overview page

**Why we need it**:
The plugins section is the entry point for plugin docs in v1 and has been empty. 
Plugin pages for each are coming in through #6698, #6712 and #6878 - once those merge, the plugin names in the tables can link to their pages.

**Which issue(s) this PR fixes**:

Part of #5615

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
