### PR TITLE
Update CODEOWNERS paths for plugins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,5 +10,5 @@ CONTRIBUTING.md @pipe-cd/pipecd-approvers-docs @pipe-cd/pipecd-approvers
 README.md @pipe-cd/pipecd-approvers-docs @pipe-cd/pipecd-approvers
 
 # Piped plugins
-/pkg/plugin @pipe-cd/pipecd-approvers-plugins @pipe-cd/pipecd-approvers
-/pkg/app/pipedv1 @pipe-cd/pipecd-approvers-plugins @pipe-cd/pipecd-approvers
+/pkg/plugin/ @pipe-cd/pipecd-approvers-plugins @pipe-cd/pipecd-approvers
+/pkg/app/pipedv1/ @pipe-cd/pipecd-approvers-plugins @pipe-cd/pipecd-approvers


### PR DESCRIPTION
**What this PR does**:

As @mohammedfirdouss noticed me that he didn't have the permission to merge changes in plugins dir even with the plugin team members config, I think it maybe caused by this missing `/` in the CODEOWNER.

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
