### PR TITLE
Use password-stdin in Kubernetes Helm provider

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm.go
@@ -55,13 +55,13 @@ func (h *Helm) LoginToOCIRegistry(ctx context.Context, address, username, passwo
 		"login",
 		"-u",
 		username,
-		"-p",
-		password,
+		"--password-stdin",
 		address,
 	}
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, h.execPath, args...)
+	cmd.Stdin = strings.NewReader(password)
 	cmd.Stderr = &stderr
 
 	h.logger.Info("login to oci registry", zap.String("address", address))
@@ -138,10 +138,16 @@ func (h *Helm) AddRepository(ctx context.Context, repo config.HelmChartRepositor
 	if repo.Insecure {
 		args = append(args, "--insecure-skip-tls-verify")
 	}
-	if repo.Username != "" || repo.Password != "" {
-		args = append(args, "--username", repo.Username, "--password", repo.Password)
+	if repo.Username != "" {
+		args = append(args, "--username", repo.Username)
+	}
+	if repo.Password != "" {
+		args = append(args, "--password-stdin")
 	}
 	cmd := exec.CommandContext(ctx, h.execPath, args...)
+	if repo.Password != "" {
+		cmd.Stdin = strings.NewReader(repo.Password)
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		h.logger.Error("failed to add chart repository", zap.String("name", repo.Name), zap.Error(err))

--- a/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/provider/helm_test.go
@@ -16,6 +16,8 @@ package provider
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,6 +27,7 @@ import (
 
 	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
 
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/config"
 	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/kubernetes/toolregistry"
 )
 
@@ -82,6 +85,43 @@ func TestTemplateLocalChart_WithNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, namespace, metadata["namespace"])
 	}
+}
+
+func TestLoginToOCIRegistry_PasswordUsesStdin(t *testing.T) {
+	t.Parallel()
+
+	execPath, argsPath, stdinPath := newFakeHelm(t)
+	helm := NewHelm(execPath, zaptest.NewLogger(t))
+
+	err := helm.LoginToOCIRegistry(t.Context(), "ghcr.io", "test-user", "super-secret")
+	require.NoError(t, err)
+
+	args := readFakeHelmOutput(t, argsPath)
+	assert.NotContains(t, args, "super-secret")
+	assert.Contains(t, args, "--password-stdin")
+	assert.Equal(t, "super-secret", strings.TrimSpace(readFakeHelmOutput(t, stdinPath)))
+}
+
+func TestAddRepository_PasswordUsesStdin(t *testing.T) {
+	t.Parallel()
+
+	execPath, argsPath, stdinPath := newFakeHelm(t)
+	helm := NewHelm(execPath, zaptest.NewLogger(t))
+
+	err := helm.AddRepository(t.Context(), config.HelmChartRepository{
+		Name:     "test-repo",
+		Address:  "https://example.com/charts",
+		Username: "test-user",
+		Password: "super-secret",
+	})
+	require.NoError(t, err)
+
+	args := readFakeHelmOutput(t, argsPath)
+	assert.NotContains(t, args, "super-secret")
+	assert.Contains(t, args, "--username")
+	assert.Contains(t, args, "test-user")
+	assert.Contains(t, args, "--password-stdin")
+	assert.Equal(t, "super-secret", strings.TrimSpace(readFakeHelmOutput(t, stdinPath)))
 }
 
 func TestVerifyHelmValueFilePath(t *testing.T) {
@@ -209,4 +249,30 @@ func TestTemplateRemoteChart(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "testapp-helloworld", name)
 	}
+}
+
+func newFakeHelm(t *testing.T) (execPath, argsPath, stdinPath string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	argsPath = filepath.Join(dir, "args.txt")
+	stdinPath = filepath.Join(dir, "stdin.txt")
+	execPath = filepath.Join(dir, "helm")
+
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"printf '%s\\n' \"$@\" > \"" + argsPath + "\"",
+		"cat > \"" + stdinPath + "\"",
+	}, "\n")
+
+	require.NoError(t, os.WriteFile(execPath, []byte(script), 0o755))
+	return execPath, argsPath, stdinPath
+}
+
+func readFakeHelmOutput(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
 }


### PR DESCRIPTION
## Summary
- stop passing Helm registry and repository passwords via argv in the single-cluster Kubernetes provider
- align the single-cluster provider with the existing multicluster --password-stdin pattern
- add regression tests that fail if secrets appear in recorded command arguments

## Linked Issue
Fixes #6993

## What Changed
- LoginToOCIRegistry now uses --password-stdin and writes the password to stdin
- AddRepository now uses --password-stdin when a repository password is configured
- added fake-Helm regression tests covering both code paths

## Verification
- go -C pkg/app/pipedv1/plugin/kubernetes test ./provider -run Test(LoginToOCIRegistry_PasswordUsesStdin|AddRepository_PasswordUsesStdin|TemplateLocalChart|TemplateRemoteChart|VerifyHelmValueFilePath) — passed
- make build/go — passed
- make check/dco — passed
- make check — not run to completion: local environment is missing yarn, so build/web failed before later checks
- KUBEBUILDER_ASSETS=/Users/rootp1/Documents/repos/n/new/pipecd/.dev/bin/k8s/1.36.2-darwin-arm64 go -C pkg/app/pipedv1/plugin/kubernetes test ./... — not completed locally: broader module run did not finish within the session window after envtest setup
- make lint/go MODULES=pkg/app/pipedv1/plugin/kubernetes — not run: local environment is missing docker, which the repository lint target requires
- make lint/helm — not run: local environment is missing helm

## Scope
- Only the single-cluster Kubernetes Helm provider and its focused regression tests were changed.

**What this PR does**:

Stops the single-cluster Kubernetes Helm provider from exposing Helm passwords in process arguments by switching to stdin-based credential passing.

**Why we need it**:

It removes avoidable credential exposure in argv and aligns this provider with the safer multicluster implementation that already exists in the repository.

**Which issue(s) this PR fixes**:

Fixes #6993

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Helm credentials are no longer exposed in local process arguments when the single-cluster Kubernetes provider logs in to OCI registries or adds authenticated chart repositories.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: Not applicable
