### PR TITLE
Prevent rollback stage builder panics on empty stage lists

### DIFF
--- a/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin.go
@@ -16,6 +16,7 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"slices"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
@@ -24,6 +25,8 @@ import (
 )
 
 type Plugin struct{}
+
+var errRollbackRequiresStages = errors.New("rollback requires at least one stage")
 
 const (
 	// StageCloudRunSync does quick sync by rolling out the new version
@@ -43,8 +46,12 @@ func (p *Plugin) FetchDefinedStages() []string {
 }
 
 func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages, err := buildPipelineStages(input.Request.Stages, input.Request.Rollback)
+	if err != nil {
+		return nil, err
+	}
 	return &sdk.BuildPipelineSyncStagesResponse{
-		Stages: buildPipelineStages(input.Request.Stages, input.Request.Rollback),
+		Stages: stages,
 	}, nil
 }
 
@@ -90,7 +97,7 @@ func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
 	return out
 }
 
-func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.PipelineStage {
+func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) ([]sdk.PipelineStage, error) {
 	out := make([]sdk.PipelineStage, 0, len(stages)+1)
 	for _, stage := range stages {
 		out = append(out, sdk.PipelineStage{
@@ -102,6 +109,9 @@ func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.Pipe
 		})
 	}
 	if autoRollback {
+		if len(stages) == 0 {
+			return nil, errRollbackRequiresStages
+		}
 		out = append(out, sdk.PipelineStage{
 			Name: StageRollback,
 			Index: slices.MinFunc(stages, func(a, b sdk.StageConfig) int {
@@ -112,5 +122,5 @@ func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.Pipe
 			AvailableOperation: sdk.ManualOperationNone,
 		})
 	}
-	return out
+	return out, nil
 }

--- a/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/cloudrun/deployment/plugin_test.go
@@ -82,6 +82,7 @@ func Test_buildPipelineStages(t *testing.T) {
 		stages       []sdk.StageConfig
 		autoRollback bool
 		expected     []sdk.PipelineStage
+		expectedErr  bool
 	}{
 		{
 			name: "without auto rollback",
@@ -150,13 +151,23 @@ func Test_buildPipelineStages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "with auto rollback and no stages",
+			autoRollback: true,
+			expectedErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := buildPipelineStages(tt.stages, tt.autoRollback)
+			actual, err := buildPipelineStages(tt.stages, tt.autoRollback)
+			if tt.expectedErr {
+				assert.ErrorIs(t, err, errRollbackRequiresStages)
+				return
+			}
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline.go
@@ -16,6 +16,7 @@ package deployment
 
 import (
 	"encoding/json"
+	"errors"
 	"slices"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
@@ -68,6 +69,8 @@ const (
 	StageDescriptionK8sRollback = "Rollback the deployment"
 )
 
+var errRollbackRequiresStages = errors.New("rollback requires at least one stage")
+
 func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
 	out := make([]sdk.QuickSyncStage, 0, 2)
 
@@ -116,6 +119,9 @@ func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) ([]sdk.Pipelin
 	}
 
 	if autoRollback {
+		if len(stages) == 0 {
+			return nil, errRollbackRequiresStages
+		}
 		// we set the index of the rollback stage to the minimum index of all stages.
 		minIndex := slices.MinFunc(stages, func(a, b sdk.StageConfig) int {
 			return a.Index - b.Index

--- a/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/deployment/pipeline_test.go
@@ -79,11 +79,12 @@ func Test_buildPipelineStages(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		stages       []sdk.StageConfig
-		autoRollback bool
-		expected     []sdk.PipelineStage
-		expectedErr  bool
+		name          string
+		stages        []sdk.StageConfig
+		autoRollback  bool
+		expected      []sdk.PipelineStage
+		expectedErr   bool
+		expectedErrIs error
 	}{
 		{
 			name: "without auto rollback",
@@ -151,6 +152,12 @@ func Test_buildPipelineStages(t *testing.T) {
 					AvailableOperation: sdk.ManualOperationNone,
 				},
 			},
+		},
+		{
+			name:          "with auto rollback and no stages",
+			autoRollback:  true,
+			expectedErr:   true,
+			expectedErrIs: errRollbackRequiresStages,
 		},
 		{
 			name: "with traffic routing stage with all primary",
@@ -275,7 +282,11 @@ func Test_buildPipelineStages(t *testing.T) {
 				Logger: zaptest.NewLogger(t),
 			})
 			if tt.expectedErr {
-				assert.Error(t, err)
+				if tt.expectedErrIs != nil {
+					assert.ErrorIs(t, err, tt.expectedErrIs)
+				} else {
+					assert.Error(t, err)
+				}
 				return
 			} else {
 				assert.NoError(t, err)

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline.go
@@ -15,6 +15,7 @@
 package deployment
 
 import (
+	"errors"
 	"slices"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
@@ -70,6 +71,8 @@ const (
 	StageDescriptionK8sMultiTrafficRouting = "Update traffic routing percentages for all targets"
 )
 
+var errRollbackRequiresStages = errors.New("rollback requires at least one stage")
+
 func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
 	out := make([]sdk.QuickSyncStage, 0, 2)
 
@@ -96,7 +99,7 @@ func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
 }
 
 // buildPipelineStages builds the pipeline stages with the given SDK stages.
-func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.PipelineStage {
+func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) ([]sdk.PipelineStage, error) {
 	out := make([]sdk.PipelineStage, 0, len(stages)+1)
 
 	for _, s := range stages {
@@ -110,6 +113,9 @@ func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.Pipe
 	}
 
 	if autoRollback {
+		if len(stages) == 0 {
+			return nil, errRollbackRequiresStages
+		}
 		// we set the index of the rollback stage to the minimum index of all stages.
 		minIndex := slices.MinFunc(stages, func(a, b sdk.StageConfig) int {
 			return a.Index - b.Index
@@ -124,5 +130,5 @@ func buildPipelineStages(stages []sdk.StageConfig, autoRollback bool) []sdk.Pipe
 		})
 	}
 
-	return out
+	return out, nil
 }

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/pipeline_test.go
@@ -83,6 +83,7 @@ func Test_buildPipelineStages(t *testing.T) {
 		stages       []sdk.StageConfig
 		autoRollback bool
 		expected     []sdk.PipelineStage
+		expectedErr  bool
 	}{
 		{
 			name: "without auto rollback",
@@ -151,13 +152,23 @@ func Test_buildPipelineStages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "with auto rollback and no stages",
+			autoRollback: true,
+			expectedErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := buildPipelineStages(tt.stages, tt.autoRollback)
+			actual, err := buildPipelineStages(tt.stages, tt.autoRollback)
+			if tt.expectedErr {
+				assert.ErrorIs(t, err, errRollbackRequiresStages)
+				return
+			}
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/deployment/plugin.go
@@ -51,8 +51,12 @@ func (p *Plugin) FetchDefinedStages() []string {
 
 // BuildPipelineSyncStages returns the stages for the pipeline sync strategy.
 func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *kubeconfig.KubernetesPluginConfig, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages, err := buildPipelineStages(input.Request.Stages, input.Request.Rollback)
+	if err != nil {
+		return nil, err
+	}
 	return &sdk.BuildPipelineSyncStagesResponse{
-		Stages: buildPipelineStages(input.Request.Stages, input.Request.Rollback),
+		Stages: stages,
 	}, nil
 }
 

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin.go
@@ -41,6 +41,8 @@ type Plugin struct{}
 
 var _ sdk.DeploymentPlugin[sdk.ConfigNone, config.DeployTargetConfig, config.ApplicationConfigSpec] = (*Plugin)(nil)
 
+var errRollbackRequiresStages = errors.New("rollback requires at least one stage")
+
 // BuildPipelineSyncStages implements sdk.DeploymentPlugin.
 func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone, input *sdk.BuildPipelineSyncStagesInput) (*sdk.BuildPipelineSyncStagesResponse, error) {
 	reqStages := input.Request.Stages
@@ -56,6 +58,9 @@ func (p *Plugin) BuildPipelineSyncStages(ctx context.Context, _ *sdk.ConfigNone,
 		})
 	}
 	if input.Request.Rollback {
+		if len(reqStages) == 0 {
+			return nil, errRollbackRequiresStages
+		}
 		minIndex := slices.MinFunc(reqStages, func(a, b sdk.StageConfig) int { return a.Index - b.Index }).Index
 		out = append(out, sdk.PipelineStage{
 			Name:               stageRollback,

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plugin_test.go
@@ -48,6 +48,7 @@ func TestPlugin_BuildPipelineSyncStages(t *testing.T) {
 		name  string
 		input *sdk.BuildPipelineSyncStagesInput
 		want  *sdk.BuildPipelineSyncStagesResponse
+		err   error
 	}{
 		{
 			name: "single stage without rollback",
@@ -153,6 +154,15 @@ func TestPlugin_BuildPipelineSyncStages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "rollback without stages",
+			input: &sdk.BuildPipelineSyncStagesInput{
+				Request: sdk.BuildPipelineSyncStagesRequest{
+					Rollback: true,
+				},
+			},
+			err: errRollbackRequiresStages,
+		},
 	}
 
 	p := &Plugin{}
@@ -162,7 +172,7 @@ func TestPlugin_BuildPipelineSyncStages(t *testing.T) {
 			t.Parallel()
 
 			got, err := p.BuildPipelineSyncStages(t.Context(), nil, tt.input)
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, tt.err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
**What this PR does**:

Prevents rollback-enabled pipeline stage builders from panicking on empty stage lists in the Terraform, Kubernetes, Kubernetes multicluster, and Cloud Run piped v1 plugins.

**Why we need it**:

These builders currently call `slices.MinFunc` on an empty slice when rollback is enabled without configured stages, which crashes the builder instead of returning a controlled validation error.

**Which issue(s) this PR fixes**:

Fixes #7001

## Summary
- guard rollback stage synthesis when no stages are configured
- return a stable validation error instead of panicking
- add regression coverage for the empty-stage rollback case in each affected plugin

## Linked Issue
Fixes #7001

## What Changed
- added empty-stage validation before computing rollback indices in the affected builders
- updated multicluster and Cloud Run callers to propagate builder errors
- extended existing table-driven tests to cover rollback-enabled empty stage lists

## Verification
- `go -C pkg/app/pipedv1/plugin/terraform test ./deployment -run 'TestPlugin_BuildPipelineSyncStages' && go -C pkg/app/pipedv1/plugin/kubernetes test ./deployment -run 'Test_buildPipelineStages' && go -C pkg/app/pipedv1/plugin/kubernetes_multicluster test ./deployment -run 'Test_buildPipelineStages' && go -C pkg/app/pipedv1/plugin/cloudrun test ./deployment -run 'Test_buildPipelineStages'` — passed
- `make build/go` — passed
- `make check/gen/code` — passed
- `make check` — failed: `yarn` is not installed locally, so the repository-wide web build step in `build/web` could not run
- `make test/integration` — failed: Docker is unavailable (`/var/run/docker.sock` missing) for the Firestore and MySQL integration suites
- `make check/dco` — failed before the new commit because upstream `master` HEAD commit `25ae69937e55e8330bff96c34346718f3e5e7148` is missing a `Signed-off-by` line; this PR commit itself is signed off
- `make test/go MODULES=pkg/app/pipedv1/plugin/terraform,pkg/app/pipedv1/plugin/kubernetes,pkg/app/pipedv1/plugin/kubernetes_multicluster,pkg/app/pipedv1/plugin/cloudrun` — not completed locally: the broader module-wide run did not finish in a reasonable time after entering the heavier Kubernetes suites, so the focused regression command above was used as the closest confirmed local alternative

## Scope
- Only the affected piped v1 rollback stage builders and their focused regression tests were changed.

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: rollback-enabled empty pipeline requests now return a validation error instead of crashing the builder path
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: Not applicable
