### PR TITLE
Add unit tests for applierGroup.Get

### DIFF
--- a/pkg/app/piped/executor/kubernetes/applier_group_test.go
+++ b/pkg/app/piped/executor/kubernetes/applier_group_test.go
@@ -15,9 +15,15 @@
 package kubernetes
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	provider "github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/kubernetes"
+	"github.com/pipe-cd/pipecd/pkg/app/piped/platformprovider/kubernetes/kubernetestest"
+	"github.com/pipe-cd/pipecd/pkg/config"
 )
 
 func TestMakeKeyFromProviderLabels(t *testing.T) {
@@ -59,6 +65,210 @@ func TestMakeKeyFromProviderLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := makeKeyFromProviderLabels(tc.labels)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestApplierGroupGet(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	defaultApplier := kubernetestest.NewMockApplier(ctrl)
+	applierA := kubernetestest.NewMockApplier(ctrl)
+	applierB := kubernetestest.NewMockApplier(ctrl)
+
+	testcases := []struct {
+		name           string
+		resourceRoutes []config.KubernetesResourceRoute
+		appliers       map[string]provider.Applier
+		labeledCps     map[string][]string
+		resourceKey    provider.ResourceKey
+		wantApplier    provider.Applier
+		wantErr        error
+	}{
+		{
+			name:           "empty routes, fallback to default",
+			resourceRoutes: nil,
+			appliers:       map[string]provider.Applier{"default": defaultApplier},
+			resourceKey:    provider.ResourceKey{Kind: "Deployment", Name: "app"},
+			wantApplier:    defaultApplier,
+			wantErr:        nil,
+		},
+		{
+			name: "matched route by provider name",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Deployment",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Name: "provider-a",
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+			},
+			resourceKey: provider.ResourceKey{Kind: "Deployment", Name: "app"},
+			wantApplier: applierA,
+			wantErr:     nil,
+		},
+		{
+			name: "matched route by name but provider applier not found",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Deployment",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Name: "provider-a",
+					},
+				},
+			},
+			appliers:    map[string]provider.Applier{},
+			resourceKey: provider.ResourceKey{Kind: "Deployment", Name: "app"},
+			wantApplier: nil,
+			wantErr:     fmt.Errorf("provider provider-a specified in resourceRoutes was not found"),
+		},
+		{
+			name: "matched route by provider labels",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Service",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Labels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+				"provider-b": applierB,
+			},
+			labeledCps: map[string][]string{
+				"env:prod": {"provider-a", "provider-b"},
+			},
+			resourceKey: provider.ResourceKey{Kind: "Service", Name: "srv"},
+			wantApplier: provider.NewMultiApplier(applierA, applierB),
+			wantErr:     nil,
+		},
+		{
+			name: "matched route by labels but no matching labeled providers",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Service",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Labels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+			appliers:    map[string]provider.Applier{},
+			labeledCps:  map[string][]string{},
+			resourceKey: provider.ResourceKey{Kind: "Service", Name: "srv"},
+			wantApplier: nil,
+			wantErr:     fmt.Errorf("there are no provider that matches the specified labels (map[env:prod])"),
+		},
+		{
+			name: "matched route by labels but applier for matched provider not found",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Service",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Labels: map[string]string{"env": "prod"},
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+			},
+			labeledCps: map[string][]string{
+				"env:prod": {"provider-a", "provider-b"},
+			},
+			resourceKey: provider.ResourceKey{Kind: "Service", Name: "srv"},
+			wantApplier: nil,
+			wantErr:     fmt.Errorf("provider provider-b specified in resourceRoutes was not found"),
+		},
+		{
+			name: "route matcher kind mismatch, fallback to default",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Kind: "Deployment",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Name: "provider-a",
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+			},
+			resourceKey: provider.ResourceKey{Kind: "Service", Name: "srv"},
+			wantApplier: defaultApplier,
+			wantErr:     nil,
+		},
+		{
+			name: "route matcher name mismatch, fallback to default",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: &config.KubernetesResourceRouteMatcher{
+						Name: "app-prod",
+					},
+					Provider: config.KubernetesProviderMatcher{
+						Name: "provider-a",
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+			},
+			resourceKey: provider.ResourceKey{Kind: "Deployment", Name: "app-dev"},
+			wantApplier: defaultApplier,
+			wantErr:     nil,
+		},
+		{
+			name: "route matcher nil matches any resource",
+			resourceRoutes: []config.KubernetesResourceRoute{
+				{
+					Match: nil,
+					Provider: config.KubernetesProviderMatcher{
+						Name: "provider-a",
+					},
+				},
+			},
+			appliers: map[string]provider.Applier{
+				"provider-a": applierA,
+			},
+			resourceKey: provider.ResourceKey{Kind: "ConfigMap", Name: "cfg"},
+			wantApplier: applierA,
+			wantErr:     nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := &applierGroup{
+				resourceRoutes:   tc.resourceRoutes,
+				appliers:         tc.appliers,
+				labeledProviders: tc.labeledCps,
+				defaultApplier:   defaultApplier,
+			}
+
+			got, err := ag.Get(tc.resourceKey)
+			if tc.wantErr != nil {
+				assert.EqualError(t, err, tc.wantErr.Error())
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantApplier, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves the `TODO: Add test for this applierGroup function` comment in `pkg/app/piped/executor/kubernetes/applier_group.go`.

It introduces a table-driven test suite `TestApplierGroupGet` in `applier_group_test.go` to cover the various matching and error-handling conditions of the Kubernetes resource applier routing logic.

**Which issue(s) this PR fixes**:
Fixes #7003 

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A