### PR TITLE
Fix broken link to CI overview in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ All pull requests undergo checks by the continuous integration system, GitHub Ac
 
 When you submit a pull request to PipeCD, multiple CI workflows are triggered to validate your changes. These checks help ensure code quality, correctness, and consistency across the project.
 
-To better understand which CI workflows run and what they are responsible for, please refer to the [CI overview documentation](docs/content/en/docs-v1.0.x/development/ci.md).
+To better understand which CI workflows run and what they are responsible for, please refer to the [CI overview documentation](.github/ci.md).
 
 ### Branch Organization
 


### PR DESCRIPTION
**What this PR does**:

Updates the CI overview documentation link in `CONTRIBUTING.md` to point to `.github/ci.md`.

**Why we need it**:

The CI overview doc was moved from `docs/content/en/docs-v1.0.x/development/ci.md` to `.github/ci.md` in #6649, but the link in `CONTRIBUTING.md` was not updated, so it currently leads to a 404.

<img width="959" height="509" alt="image" src="https://github.com/user-attachments/assets/60e909c9-542a-45da-bc39-93fa3f06e119" />

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No, documentation-only change.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: n/a
