### PR TITLE
Remove leftover Hugo front matter from CI overview doc

### DIFF
--- a/.github/ci.md
+++ b/.github/ci.md
@@ -1,11 +1,7 @@
----
-title: "CI Overview"
-linkTitle: "CI Overview"
-weight: 30
-description: >
-  An overview of PipeCD’s GitHub Actions CI workflows, what each workflow does,
-  and when it runs.
----
+# CI Overview
+
+An overview of PipeCD’s GitHub Actions CI workflows, what each workflow does,
+and when it runs.
 
 ## Who Is This Document For?
 


### PR DESCRIPTION
**What this PR does**:

Replaces the Hugo front matter in `.github/ci.md` with a regular Markdown heading, keeping the description as an intro paragraph.

**Why we need it**:

This file was moved out of the Hugo docs site into `.github/` in #6649, so its front matter is no longer processed. GitHub renders the leftover YAML block as a literal table at the top of the page, and the document had no visible title.

<img width="788" height="343" alt="image" src="https://github.com/user-attachments/assets/b0c89f59-32ea-4755-9d14-043b8be9038a" />


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No, documentation-only change.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: n/a
