### PR TITLE
fix(ci): define GO_VERSION and pin checkout action 

### DIFF
--- a/.github/workflows/plugin_release.yaml
+++ b/.github/workflows/plugin_release.yaml
@@ -14,11 +14,14 @@ on:
 permissions:
   contents: write
 
+env:
+  GO_VERSION: 1.26.2
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: pipe-cd/pipecd
           fetch-depth: 0


### PR DESCRIPTION
setup-go referenced ${{ env.GO_VERSION }} but the workflow never declared it, so it silently used an arbitrary Go version instead of 1.26.2. Also pin actions/checkout to the same SHA (v4.2.2) used by every other workflow in this repo.

**What this PR does**:

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
