### PR TITLE
Skip kubernetes envtest when assets are missing

### DIFF
--- a/pkg/app/piped/executor/kubernetes/sync_test.go
+++ b/pkg/app/piped/executor/kubernetes/sync_test.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +46,49 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/config"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
+
+var requiredEnvtestBinaries = []string{
+	"etcd",
+	"kube-apiserver",
+}
+
+func envtestAssetsDir() string {
+	if dir := os.Getenv("KUBEBUILDER_ASSETS"); dir != "" {
+		return dir
+	}
+	return "/usr/local/kubebuilder/bin"
+}
+
+func missingEnvtestBinaries(dir string) []string {
+	missing := make([]string, 0, len(requiredEnvtestBinaries))
+	for _, binary := range requiredEnvtestBinaries {
+		if _, err := os.Stat(filepath.Join(dir, binary)); err != nil {
+			missing = append(missing, binary)
+		}
+	}
+	return missing
+}
+
+func requireEnvtestAssets(t *testing.T) {
+	t.Helper()
+
+	dir := envtestAssetsDir()
+	missing := missingEnvtestBinaries(dir)
+	if len(missing) == 0 {
+		return
+	}
+
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		for _, binary := range requiredEnvtestBinaries {
+			if _, err := exec.LookPath(binary); err != nil {
+				t.Skipf("skipping envtest-dependent test: missing envtest binaries in %q (%s); run `make test/go` or set KUBEBUILDER_ASSETS", dir, strings.Join(missing, ", "))
+			}
+		}
+		return
+	}
+
+	t.Skipf("skipping envtest-dependent test: KUBEBUILDER_ASSETS=%q is missing %s; run `make test/go` or reinstall envtest assets", dir, strings.Join(missing, ", "))
+}
 
 func TestEnsureSync(t *testing.T) {
 	t.Parallel()
@@ -184,6 +230,8 @@ func TestEnsureSync(t *testing.T) {
 }
 
 func TestExecutor_ensureSync(t *testing.T) {
+	requireEnvtestAssets(t)
+
 	ctrl := gomock.NewController(t)
 
 	// initialize tool registry
@@ -280,6 +328,16 @@ func TestExecutor_ensureSync(t *testing.T) {
 	assert.Equal(t, "apps/v1", deployment.GetAnnotations()["pipecd.dev/original-api-version"])
 	assert.Equal(t, "apps/v1:Deployment:default:simple", deployment.GetAnnotations()["pipecd.dev/resource-key"])
 	assert.Equal(t, "0123456789", deployment.GetAnnotations()["pipecd.dev/commit-hash"])
+}
+
+func TestMissingEnvtestBinaries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "etcd"), []byte("#!/bin/sh\n"), 0755)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"kube-apiserver"}, missingEnvtestBinaries(dir))
 }
 
 func kubeconfigFromRestConfig(restConfig *rest.Config) (string, error) {


### PR DESCRIPTION
**What this PR does**:

Adds an envtest asset preflight to `TestExecutor_ensureSync` so direct package tests skip with a clear message when `etcd` or `kube-apiserver` are unavailable, and adds focused unit coverage for the preflight helper.

**Why we need it**:

Direct `go test` on the Kubernetes executor package currently fails with an environment/setup error unless contributors use the Makefile wrapper that provisions envtest assets. This change makes that failure mode explicit and less misleading.

**Which issue(s) this PR fixes**:

Fixes #7013

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Not applicable; test-only change for contributors.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: Not applicable.

## Summary
- add a preflight check for required envtest binaries before starting `envtest.Environment`
- skip the envtest-dependent Kubernetes executor test with a clear message when assets are unavailable
- add focused coverage for envtest binary detection

## Linked Issue
Fixes #7013

## What Changed
- added `requireEnvtestAssets` and binary detection helpers in `pkg/app/piped/executor/kubernetes/sync_test.go`
- gated `TestExecutor_ensureSync` behind the preflight check
- added `TestMissingEnvtestBinaries`

## Verification
- `go test ./pkg/app/piped/executor/kubernetes -run 'TestMissingEnvtestBinaries|TestEnsureSync|TestExecutor_ensureSync' -count=1` — passed
- `KUBEBUILDER_ASSETS='' go test ./pkg/app/piped/executor/kubernetes -run TestExecutor_ensureSync -count=1 -v` — passed
- `make check` — not run successfully: failed in `build/web` because `yarn` is not installed in this environment
- `make test/go MODULES=.` — failed: upstream test suite currently fails in `pkg/app/piped/executor/kubernetes` and `pkg/app/piped/platformprovider/kubernetes` on this checkout
- `make check/dco` — failed: upstream commit `25ae69937e55e8330bff96c34346718f3e5e7148` is missing a `Signed-off-by` line, so the repository DCO check does not pass cleanly on top of `upstream/master`

## Scope
- only `pkg/app/piped/executor/kubernetes/sync_test.go` was changed; unrelated files were not modified
