### PR TITLE
Reduce stage log Put allocation overhead

### DIFF
--- a/pkg/app/server/stagelogstore/filestore.go
+++ b/pkg/app/server/stagelogstore/filestore.go
@@ -70,14 +70,11 @@ func (f *stageLogFileStore) Get(ctx context.Context, deploymentID, stageID strin
 func (f *stageLogFileStore) Put(ctx context.Context, deploymentID, stageID string, retriedCount int32, lf *logFragment) error {
 	path := stageLogPath(deploymentID, stageID, retriedCount)
 	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
 	for _, lb := range lf.Blocks {
-		// TODO: Reduce the number of marshaling log blocks for improving performance
-		raw, err := json.Marshal(lb)
-		if err != nil {
+		if err := encoder.Encode(lb); err != nil {
 			return err
 		}
-		buf.Write(raw)
-		buf.WriteString("\n")
 	}
 
 	if lf.Completed {

--- a/pkg/app/server/stagelogstore/filestore_test.go
+++ b/pkg/app/server/stagelogstore/filestore_test.go
@@ -15,8 +15,11 @@
 package stagelogstore
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -25,6 +28,7 @@ import (
 
 	"github.com/pipe-cd/pipecd/pkg/filestore"
 	"github.com/pipe-cd/pipecd/pkg/filestore/filestoretest"
+	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
 func TestFileStoreGet(t *testing.T) {
@@ -120,4 +124,126 @@ EOL`,
 			assert.Equal(t, tc.expectedCompleted, lf.Completed)
 		})
 	}
+}
+
+func TestFileStorePut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := filestoretest.NewMockStore(ctrl)
+
+	fs := stageLogFileStore{
+		filestore: store,
+	}
+
+	lf := &logFragment{
+		Blocks: []*model.LogBlock{
+			{
+				Index:     1,
+				Log:       "Hello 1",
+				Severity:  model.LogSeverity_INFO,
+				CreatedAt: 1590499431,
+			},
+			{
+				Index:     2,
+				Log:       "Hello 2\nWorld",
+				Severity:  model.LogSeverity_ERROR,
+				CreatedAt: 1590499432,
+			},
+		},
+		Completed: true,
+	}
+
+	store.EXPECT().
+		Put(context.TODO(), "log/deployment-id/stage-id/0.txt", []byte("{\"index\":1,\"log\":\"Hello 1\",\"created_at\":1590499431}\n{\"index\":2,\"log\":\"Hello 2\\nWorld\",\"severity\":2,\"created_at\":1590499432}\nEOL")).
+		Return(nil)
+
+	assert.NoError(t, fs.Put(context.TODO(), "deployment-id", "stage-id", 0, lf))
+}
+
+func BenchmarkStageLogFileStorePut(b *testing.B) {
+	for _, blockCount := range []int{10, 100, 1000} {
+		lf := benchmarkLogFragment(blockCount, true)
+		b.Run("legacy/"+strconv.Itoa(blockCount), func(b *testing.B) {
+			store := stageLogFileStore{filestore: benchmarkFilestore{}}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := benchmarkLegacyPut(&store, ctx, "deployment-id", "stage-id", 0, lf); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("current/"+strconv.Itoa(blockCount), func(b *testing.B) {
+			store := stageLogFileStore{filestore: benchmarkFilestore{}}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := store.Put(ctx, "deployment-id", "stage-id", 0, lf); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func benchmarkLegacyPut(f *stageLogFileStore, ctx context.Context, deploymentID, stageID string, retriedCount int32, lf *logFragment) error {
+	path := stageLogPath(deploymentID, stageID, retriedCount)
+	var buf bytes.Buffer
+	for _, lb := range lf.Blocks {
+		raw, err := json.Marshal(lb)
+		if err != nil {
+			return err
+		}
+		buf.Write(raw)
+		buf.WriteString("\n")
+	}
+
+	if lf.Completed {
+		buf.Write(eol)
+	}
+	return f.filestore.Put(ctx, path, buf.Bytes())
+}
+
+func benchmarkLogFragment(blockCount int, completed bool) *logFragment {
+	blocks := make([]*model.LogBlock, 0, blockCount)
+	for i := 0; i < blockCount; i++ {
+		blocks = append(blocks, &model.LogBlock{
+			Index:     int64(i),
+			Log:       strings.Repeat("benchmark-stage-log-line-", 4) + strconv.Itoa(i),
+			Severity:  model.LogSeverity_INFO,
+			CreatedAt: 1590499431 + int64(i),
+		})
+	}
+	return &logFragment{
+		Blocks:    blocks,
+		Completed: completed,
+	}
+}
+
+type benchmarkFilestore struct{}
+
+func (benchmarkFilestore) Get(context.Context, string) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (benchmarkFilestore) GetReader(context.Context, string) (io.ReadCloser, error) {
+	panic("not implemented")
+}
+
+func (benchmarkFilestore) Put(context.Context, string, []byte) error {
+	return nil
+}
+
+func (benchmarkFilestore) List(context.Context, string) ([]filestore.ObjectAttrs, error) {
+	panic("not implemented")
+}
+
+func (benchmarkFilestore) Delete(context.Context, string) error {
+	panic("not implemented")
+}
+
+func (benchmarkFilestore) Close() error {
+	return nil
 }


### PR DESCRIPTION
## Summary
- reduce stage-log `Put` overhead by encoding log blocks directly into the final buffer instead of allocating a `[]byte` per block
- add a filestore compatibility test that locks the persisted line-delimited format and `EOL` marker
- add a benchmark that compares the legacy and current write paths for larger stage-log fragments

## Linked Issue
Fixes #7026

## What Changed
- replace per-block `json.Marshal` plus `buf.Write` with a single `json.Encoder` writing into the destination buffer
- add `TestFileStorePut` to verify persisted output remains backward compatible
- add `BenchmarkStageLogFileStorePut` to capture the allocation and latency improvement against the legacy implementation

## Verification
- `go test ./pkg/app/server/stagelogstore` — passed
- `go test -run '^$' -bench BenchmarkStageLogFileStorePut -benchmem ./pkg/app/server/stagelogstore` — passed
- `make build/go` — passed
- `make check/gen/code` — passed
- `make check` — failed: `yarn` is not installed in this environment, so `build/web` could not run
- `make lint/go` — failed: the pinned `golangci-lint` image is built with Go 1.25, but the repository targets Go 1.26.2
- `make test/go` — failed: unrelated pre-existing repository test failures in `pkg/app/piped/executor/kubernetes` and Darwin tool tests in `pkg/app/piped/platformprovider/kubernetes`
- `make check/dco` — failed: upstream history on this branch contains commit `25ae69937e55e8330bff96c34346718f3e5e7148` without `Signed-off-by`, and rewriting shared upstream history is not safe

## Scope
- only `pkg/app/server/stagelogstore` implementation and tests were changed; unrelated files were not modified

**What this PR does**:

Reduces allocation overhead in stage-log filestore persistence and adds regression coverage for the persisted format and benchmarked write path.

**Why we need it**:

The existing `Put` path rebuilt the full payload with per-block `json.Marshal` allocations on every write. This keeps the format the same while lowering per-write allocation cost.

**Which issue(s) this PR fixes**:

Fixes #7026

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Stage-log persistence is more efficient under larger or frequently updated logs
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: not applicable
