### PR TITLE
Fetch all pages in piped ListApplications

### DIFF
--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -238,10 +238,17 @@ func (a *PipedAPI) ListApplications(ctx context.Context, req *pipedservice.ListA
 			},
 		},
 	}
-	// TODO: Support pagination in ListApplications
-	apps, _, err := a.applicationStore.List(ctx, opts)
-	if err != nil {
-		return nil, gRPCStoreError(err, "fetch applications")
+	var apps []*model.Application
+	for {
+		page, cursor, err := a.applicationStore.List(ctx, opts)
+		if err != nil {
+			return nil, gRPCStoreError(err, "fetch applications")
+		}
+		apps = append(apps, page...)
+		if cursor == "" {
+			break
+		}
+		opts.Cursor = cursor
 	}
 
 	return &pipedservice.ListApplicationsResponse{

--- a/pkg/app/server/grpcapi/piped_api_test.go
+++ b/pkg/app/server/grpcapi/piped_api_test.go
@@ -17,17 +17,33 @@ package grpcapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
 
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
 	"github.com/pipe-cd/pipecd/pkg/cache"
 	"github.com/pipe-cd/pipecd/pkg/cache/cachetest"
 	"github.com/pipe-cd/pipecd/pkg/datastore"
 	"github.com/pipe-cd/pipecd/pkg/datastore/datastoretest"
 	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
+
+type testPipedTokenVerifier struct {
+	pipedKey string
+}
+
+func (v testPipedTokenVerifier) Verify(_ context.Context, _, _, pipedKey string) error {
+	if pipedKey != v.pipedKey {
+		return fmt.Errorf("invalid piped key, want: %s, got: %s", v.pipedKey, pipedKey)
+	}
+	return nil
+}
 
 func TestValidateAppBelongsToPiped(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -119,6 +135,67 @@ func TestValidateAppBelongsToPiped(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
+}
+
+func TestPipedAPIListApplicationsFetchesAllPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := datastoretest.NewMockApplicationStore(ctrl)
+	firstPage := make([]*model.Application, 0, 1)
+	firstPage = append(firstPage, &model.Application{Id: "app-1"})
+	secondPage := make([]*model.Application, 0, 1)
+	secondPage = append(secondPage, &model.Application{Id: "app-2"})
+
+	firstOpts := datastore.ListOptions{
+		Filters: []datastore.ListFilter{
+			{
+				Field:    "ProjectId",
+				Operator: datastore.OperatorEqual,
+				Value:    "test-project-id",
+			},
+			{
+				Field:    "PipedId",
+				Operator: datastore.OperatorEqual,
+				Value:    "test-piped-id",
+			},
+			{
+				Field:    "Disabled",
+				Operator: datastore.OperatorEqual,
+				Value:    false,
+			},
+		},
+	}
+	secondOpts := firstOpts
+	secondOpts.Cursor = "next-page"
+
+	store.EXPECT().
+		List(gomock.Any(), firstOpts).
+		Return(firstPage, "next-page", nil)
+	store.EXPECT().
+		List(gomock.Any(), secondOpts).
+		Return(secondPage, "", nil)
+
+	api := &PipedAPI{
+		applicationStore: store,
+	}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD{
+		"authorization": []string{"PIPED-TOKEN " + rpcauth.MakePipedToken("test-project-id", "test-piped-id", "test-piped-key")},
+	})
+
+	got, err := rpcauth.PipedTokenUnaryServerInterceptor(testPipedTokenVerifier{pipedKey: "test-piped-key"}, zap.NewNop())(
+		ctx,
+		nil,
+		nil,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return api.ListApplications(ctx, nil)
+		},
+	)
+
+	assert.NoError(t, err)
+	resp, ok := got.(*pipedservice.ListApplicationsResponse)
+	assert.True(t, ok)
+	assert.Equal(t, append(firstPage, secondPage...), resp.Applications)
 }
 
 func TestValidateDeploymentBelongsToPiped(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

## Summary
- paginate `PipedAPI.ListApplications` internally until the datastore cursor is exhausted
- add a regression test that verifies multi-page application results are fully returned to piped clients

**Why we need it**:

`PipedAPI.ListApplications` currently returns only the first datastore page and silently drops additional applications when a piped manages more than one page of apps.

**Which issue(s) this PR fixes**:

Fixes #7051

## What Changed
- replaced the single `applicationStore.List` call in `pkg/app/server/grpcapi/piped_api.go` with an internal loop over datastore cursors
- added `TestPipedAPIListApplicationsFetchesAllPages` in `pkg/app/server/grpcapi/piped_api_test.go`

## Verification
- `go test ./pkg/app/server/grpcapi -run TestPipedAPIListApplicationsFetchesAllPages` — passed
- `go test ./pkg/app/server/grpcapi` — passed
- `$(go env GOPATH)/bin/golangci-lint run --config .golangci.yml ./pkg/app/server/grpcapi/...` — passed
- `make check/gen/code` — passed
- `make check` — failed: repository lint step uses `golangci-lint` v2.4.0 built with Go 1.25, but this repository targets Go 1.26.2, so lint aborts before the test phase
- `./hack/ensure-dco.sh` — failed: reports pre-existing commit `25ae69937e55e8330bff96c34346718f3e5e7148` missing `Signed-off-by`; new commit `5430db3949cb1ef3a5bdb90608629f90e44e24eb` is signed off

## Scope
- unrelated files were not changed; only the piped ListApplications handler and its focused test were updated

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: piped clients now receive all registered applications even when the datastore returns multiple pages
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: not applicable

