### PR TITLE
Limit filtered deployment pages to request size

### DIFF
--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -16,6 +16,8 @@ package grpcapi
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -49,6 +51,13 @@ import (
 var (
 	breakingChangesRegex = regexp.MustCompile(`(?s)### Breaking Changes(.*?)(### |$)`)
 )
+
+const listDeploymentsCursorPrefix = "filtered:"
+
+type listDeploymentsCursor struct {
+	DatastoreCursor string `json:"datastoreCursor,omitempty"`
+	Skip            int    `json:"skip,omitempty"`
+}
 
 type encrypter interface {
 	Encrypt(text string) (string, error)
@@ -882,69 +891,117 @@ func (a *WebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploy
 	}
 
 	pageSize := int(req.PageSize)
+	cursor := req.Cursor
+	skip := 0
+	if len(labels) > 0 {
+		parsedCursor, ok, err := decodeListDeploymentsCursor(req.Cursor)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid cursor")
+		}
+		if ok {
+			cursor = parsedCursor.DatastoreCursor
+			skip = parsedCursor.Skip
+		}
+	}
 	options := datastore.ListOptions{
 		Filters: filters,
 		Orders:  orders,
 		Limit:   pageSize,
-		Cursor:  req.Cursor,
+		Cursor:  cursor,
 	}
-	deployments, cursor, err := a.deploymentStore.List(ctx, options)
-	if err != nil {
-		a.logger.Error("failed to get deployments", zap.Error(err))
-		return nil, gRPCStoreError(err, "get deployments")
-	}
-	if len(labels) == 0 || len(deployments) == 0 {
+
+	if len(labels) == 0 {
+		deployments, nextCursor, err := a.deploymentStore.List(ctx, options)
+		if err != nil {
+			a.logger.Error("failed to get deployments", zap.Error(err))
+			return nil, gRPCStoreError(err, "get deployments")
+		}
 		return &webservice.ListDeploymentsResponse{
 			Deployments: deployments,
-			Cursor:      cursor,
+			Cursor:      nextCursor,
 		}, nil
 	}
 
-	// Start filtering them by labels.
-	//
-	// NOTE: Filtering by labels is done by the application-side because we need to create composite indexes for every combination in the filter.
-	// We don't want to depend on any other search engine, that's why it filters here.
-	filtered := make([]*model.Deployment, 0, len(deployments))
-	for _, d := range deployments {
-		if d.ContainLabels(labels) {
-			filtered = append(filtered, d)
-		}
-	}
-	// Stop running additional queries for more data, and return filtered deployments immediately with
-	// current cursor if the size before filtering is already less than the page size.
-	if len(deployments) < pageSize {
-		return &webservice.ListDeploymentsResponse{
-			Deployments: filtered,
-			Cursor:      cursor,
-		}, nil
-	}
-	// Repeat the query until the number of filtered deployments reaches the page size,
-	// or until it finishes scanning to page_min_updated_at.
-	for len(filtered) < pageSize {
-		options.Cursor = cursor
-		deployments, cursor, err = a.deploymentStore.List(ctx, options)
+	// NOTE: Filtering by labels is done by the application side because adding datastore indexes
+	// for every label combination is not practical.
+	filtered := make([]*model.Deployment, 0, pageSize)
+	for {
+		pageCursor := options.Cursor
+		deployments, nextCursor, err := a.deploymentStore.List(ctx, options)
 		if err != nil {
 			a.logger.Error("failed to get deployments", zap.Error(err))
 			return nil, gRPCStoreError(err, "get deployments")
 		}
 		if len(deployments) == 0 {
-			break
+			return &webservice.ListDeploymentsResponse{
+				Deployments: filtered,
+				Cursor:      nextCursor,
+			}, nil
 		}
-		for _, d := range deployments {
-			if d.ContainLabels(labels) {
-				filtered = append(filtered, d)
+		if skip > len(deployments) {
+			return nil, status.Error(codes.InvalidArgument, "invalid cursor")
+		}
+		for i := skip; i < len(deployments); i++ {
+			d := deployments[i]
+			if !d.ContainLabels(labels) {
+				continue
+			}
+			filtered = append(filtered, d)
+			if len(filtered) == pageSize {
+				if i+1 < len(deployments) {
+					cursor, err := encodeListDeploymentsCursor(listDeploymentsCursor{
+						DatastoreCursor: pageCursor,
+						Skip:            i + 1,
+					})
+					if err != nil {
+						return nil, status.Error(codes.Internal, "failed to encode cursor")
+					}
+					return &webservice.ListDeploymentsResponse{
+						Deployments: filtered,
+						Cursor:      cursor,
+					}, nil
+				}
+				return &webservice.ListDeploymentsResponse{
+					Deployments: filtered,
+					Cursor:      nextCursor,
+				}, nil
 			}
 		}
-		// We've already specified UpdatedAt >= req.PageMinUpdatedAt, so we need to check just equality.
-		if deployments[len(deployments)-1].UpdatedAt == req.PageMinUpdatedAt {
-			break
+		if len(deployments) < pageSize || deployments[len(deployments)-1].UpdatedAt == req.PageMinUpdatedAt {
+			return &webservice.ListDeploymentsResponse{
+				Deployments: filtered,
+				Cursor:      nextCursor,
+			}, nil
 		}
+		skip = 0
+		options.Cursor = nextCursor
 	}
-	// TODO: Think about possibility that the response of ListDeployments exceeds the page size
-	return &webservice.ListDeploymentsResponse{
-		Deployments: filtered,
-		Cursor:      cursor,
-	}, nil
+}
+
+func encodeListDeploymentsCursor(cursor listDeploymentsCursor) (string, error) {
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	return listDeploymentsCursorPrefix + base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeListDeploymentsCursor(raw string) (listDeploymentsCursor, bool, error) {
+	if !strings.HasPrefix(raw, listDeploymentsCursorPrefix) {
+		return listDeploymentsCursor{}, false, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(raw, listDeploymentsCursorPrefix))
+	if err != nil {
+		return listDeploymentsCursor{}, false, err
+	}
+	var cursor listDeploymentsCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return listDeploymentsCursor{}, false, err
+	}
+	if cursor.Skip < 0 {
+		return listDeploymentsCursor{}, false, fmt.Errorf("negative skip")
+	}
+	return cursor, true, nil
 }
 
 func (a *WebAPI) ListDeploymentTraces(ctx context.Context, req *webservice.ListDeploymentTracesRequest) (*webservice.ListDeploymentTracesResponse, error) {

--- a/pkg/app/server/grpcapi/web_api_test.go
+++ b/pkg/app/server/grpcapi/web_api_test.go
@@ -18,15 +18,22 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/webservice"
 	"github.com/pipe-cd/pipecd/pkg/cache"
 	"github.com/pipe-cd/pipecd/pkg/cache/cachetest"
 	"github.com/pipe-cd/pipecd/pkg/datastore"
 	"github.com/pipe-cd/pipecd/pkg/datastore/datastoretest"
+	"github.com/pipe-cd/pipecd/pkg/jwt"
 	"github.com/pipe-cd/pipecd/pkg/model"
+	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
 
 func TestValidateAppBelongsToProject(t *testing.T) {
@@ -389,4 +396,207 @@ func TestValidateApprover(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
+}
+
+func TestListDeploymentsWithLabelsReturnsStableFilteredPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	firstOpts := datastore.ListOptions{
+		Filters: []datastore.ListFilter{
+			{
+				Field:    "ProjectId",
+				Operator: datastore.OperatorEqual,
+				Value:    "project-id",
+			},
+			{
+				Field:    "UpdatedAt",
+				Operator: datastore.OperatorGreaterThanOrEqual,
+				Value:    int64(0),
+			},
+		},
+		Orders: []datastore.Order{
+			{
+				Field:     "UpdatedAt",
+				Direction: datastore.Desc,
+			},
+			{
+				Field:     "Id",
+				Direction: datastore.Asc,
+			},
+		},
+		Limit:  2,
+		Cursor: "",
+	}
+	secondOpts := firstOpts
+	secondOpts.Cursor = "page-2"
+	thirdOpts := firstOpts
+	thirdOpts.Cursor = "page-3"
+
+	store := datastoretest.NewMockDeploymentStore(ctrl)
+	store.EXPECT().
+		List(gomock.Any(), firstOpts).
+		Return([]*model.Deployment{
+			testDeployment("dep-1", 300, map[string]string{"team": "backend"}),
+			testDeployment("dep-2", 299, map[string]string{"team": "frontend"}),
+		}, "page-2", nil)
+	store.EXPECT().
+		List(gomock.Any(), secondOpts).
+		Return([]*model.Deployment{
+			testDeployment("dep-3", 298, map[string]string{"team": "backend"}),
+			testDeployment("dep-4", 297, map[string]string{"team": "backend"}),
+		}, "page-3", nil)
+	store.EXPECT().
+		List(gomock.Any(), secondOpts).
+		Return([]*model.Deployment{
+			testDeployment("dep-3", 298, map[string]string{"team": "backend"}),
+			testDeployment("dep-4", 297, map[string]string{"team": "backend"}),
+		}, "page-3", nil)
+	store.EXPECT().
+		List(gomock.Any(), thirdOpts).
+		Return([]*model.Deployment{}, "", nil)
+
+	api := &WebAPI{
+		deploymentStore: store,
+		logger:          zap.NewNop(),
+	}
+
+	firstResp, err := listDeploymentsWithClaims(t, api, &webservice.ListDeploymentsRequest{
+		PageSize: 2,
+		Options: &webservice.ListDeploymentsRequest_Options{
+			Labels: map[string]string{"team": "backend"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"dep-1", "dep-3"}, deploymentIDs(firstResp.Deployments))
+
+	cursor, ok, err := decodeListDeploymentsCursor(firstResp.Cursor)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, listDeploymentsCursor{
+		DatastoreCursor: "page-2",
+		Skip:            1,
+	}, cursor)
+
+	secondResp, err := listDeploymentsWithClaims(t, api, &webservice.ListDeploymentsRequest{
+		PageSize: 2,
+		Cursor:   firstResp.Cursor,
+		Options: &webservice.ListDeploymentsRequest_Options{
+			Labels: map[string]string{"team": "backend"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"dep-4"}, deploymentIDs(secondResp.Deployments))
+	assert.Equal(t, "", secondResp.Cursor)
+}
+
+func TestListDeploymentsWithLabelsKeepsDatastoreCursorAtPageBoundary(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := datastore.ListOptions{
+		Filters: []datastore.ListFilter{
+			{
+				Field:    "ProjectId",
+				Operator: datastore.OperatorEqual,
+				Value:    "project-id",
+			},
+			{
+				Field:    "UpdatedAt",
+				Operator: datastore.OperatorGreaterThanOrEqual,
+				Value:    int64(0),
+			},
+		},
+		Orders: []datastore.Order{
+			{
+				Field:     "UpdatedAt",
+				Direction: datastore.Desc,
+			},
+			{
+				Field:     "Id",
+				Direction: datastore.Asc,
+			},
+		},
+		Limit:  2,
+		Cursor: "",
+	}
+
+	store := datastoretest.NewMockDeploymentStore(ctrl)
+	store.EXPECT().
+		List(gomock.Any(), opts).
+		Return([]*model.Deployment{
+			testDeployment("dep-1", 300, map[string]string{"team": "backend"}),
+			testDeployment("dep-2", 299, map[string]string{"team": "backend"}),
+		}, "page-2", nil)
+
+	api := &WebAPI{
+		deploymentStore: store,
+		logger:          zap.NewNop(),
+	}
+
+	resp, err := listDeploymentsWithClaims(t, api, &webservice.ListDeploymentsRequest{
+		PageSize: 2,
+		Options: &webservice.ListDeploymentsRequest_Options{
+			Labels: map[string]string{"team": "backend"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"dep-1", "dep-2"}, deploymentIDs(resp.Deployments))
+	assert.Equal(t, "page-2", resp.Cursor)
+}
+
+func listDeploymentsWithClaims(t *testing.T, api *WebAPI, req *webservice.ListDeploymentsRequest) (*webservice.ListDeploymentsResponse, error) {
+	t.Helper()
+
+	interceptor := rpcauth.JWTUnaryServerInterceptor(
+		staticJWTVerifier{
+			claims: jwt.NewClaims("user-id", "", time.Minute, model.Role{ProjectId: "project-id"}),
+		},
+		allowAllAuthorizer{},
+		zap.NewNop(),
+	)
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("cookie", "token=test-token"))
+	resp, err := interceptor(
+		ctx,
+		req,
+		&grpc.UnaryServerInfo{FullMethod: "/webservice.WebService/ListDeployments"},
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return api.ListDeployments(ctx, req.(*webservice.ListDeploymentsRequest))
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*webservice.ListDeploymentsResponse), nil
+}
+
+func deploymentIDs(deployments []*model.Deployment) []string {
+	ids := make([]string, 0, len(deployments))
+	for _, d := range deployments {
+		ids = append(ids, d.Id)
+	}
+	return ids
+}
+
+func testDeployment(id string, updatedAt int64, labels map[string]string) *model.Deployment {
+	return &model.Deployment{
+		Id:        id,
+		UpdatedAt: updatedAt,
+		Labels:    labels,
+	}
+}
+
+type staticJWTVerifier struct {
+	claims *jwt.Claims
+}
+
+func (v staticJWTVerifier) Verify(string) (*jwt.Claims, error) {
+	return v.claims, nil
+}
+
+type allowAllAuthorizer struct{}
+
+func (allowAllAuthorizer) Authorize(context.Context, string, model.Role) bool {
+	return true
 }


### PR DESCRIPTION
**What this PR does**:

- limits `ListDeployments` responses to the requested filtered page size when label filters are applied
- returns a resume cursor that can continue from the middle of a datastore page without skipping matching deployments
- adds regression tests for mid-page resume and exact datastore page-boundary behavior

**Why we need it**:

- the current handler can return more than one logical page of filtered deployments in a single response
- the returned datastore cursor alone is not a stable resume point when the filtered page ends in the middle of a fetched datastore page

**Which issue(s) this PR fixes**:

Fixes #7074

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: filtered deployment pagination now respects the requested page size and follow-up requests continue without duplicates or gaps
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: not applicable

## Summary
- enforce the requested logical page size after label filtering in `WebAPI.ListDeployments`
- encode an internal resume cursor only when a filtered page ends mid-datastore-page
- cover the new cursor behavior with focused `grpcapi` regression tests

## Linked Issue
Fixes #7074

## What Changed
- added a private cursor format for `ListDeployments` filtered pagination resumes
- stopped appending matches once the filtered page reaches `PageSize`
- added tests for stable filtered pagination across multiple datastore pages

## Verification
- `go test ./pkg/app/server/grpcapi -run 'TestListDeploymentsWithLabels'` — passed
- `cd pkg/app/server/grpcapi && /Users/rootp1/go/bin/golangci-lint run -v --config /Users/rootp1/Documents/repos/n/new/pipecd-issue2/.golangci.yml ./...` — passed
- `make update/web-deps` — passed
- `make check` — failed: repository-pinned `golangci-lint` image is built with Go 1.25.0 while this repo targets Go 1.26.2, so lint aborts before analysis
- `/Users/rootp1/go/bin/golangci-lint run -v --config .golangci.yml` across repo modules — failed: unrelated existing `goheader` issue in `web/node_modules/flatted/golang/pkg/flatted/flatted.go` after installing web dependencies
- `make check/gen/code` — passed
- `make check/dco` — failed: existing upstream commit `25ae69937e55e8330bff96c34346718f3e5e7148` is missing a `Signed-off-by` line
- `make test` — not completed: root `go test -failfast -race ./pkg/... ./cmd/...` remained running without further output for several minutes on this machine and was stopped after targeted checks had already passed

## Scope
- only `pkg/app/server/grpcapi/web_api.go` and `pkg/app/server/grpcapi/web_api_test.go` were changed for this fix
