### PR TITLE
Docs V1: Add v1 stage plugin pages - wait, wait-approval, script-run

### DIFF
--- a/docs/content/en/docs-v1.0.x/plugins/_index.md
+++ b/docs/content/en/docs-v1.0.x/plugins/_index.md
@@ -44,10 +44,10 @@ The PipeCD maintainers develop and maintain the following plugins. Each plugin i
 
 | Plugin | Stage | Description |
 |--------|-------|-------------|
-| Wait | `WAIT` | Waits for a specified duration before continuing the pipeline. |
-| Wait approval | `WAIT_APPROVAL` | Pauses the pipeline until a user approves the deployment. |
-| Analysis | `ANALYSIS` | Evaluates the deployment by querying metrics, logs, or HTTP endpoints. |
-| Script run | `SCRIPT_RUN` | Runs arbitrary commands as a pipeline stage. |
+| [Wait](wait/) | `WAIT` | Waits for a specified duration before continuing the pipeline. |
+| [Wait approval](wait-approval/) | `WAIT_APPROVAL` | Pauses the pipeline until a user approves the deployment. |
+| [Analysis](analysis/) | `ANALYSIS` | Evaluates the deployment by querying metrics, logs, or HTTP endpoints. |
+| [Script run](script-run/) | `SCRIPT_RUN` | Runs arbitrary commands as a pipeline stage. |
 
 ## Community plugins
 

--- a/docs/content/en/docs-v1.0.x/plugins/script-run.md
+++ b/docs/content/en/docs-v1.0.x/plugins/script-run.md
@@ -1,0 +1,55 @@
+---
+title: "Script run plugin"
+linkTitle: "Script run"
+weight: 70
+description: >
+  Run arbitrary commands as a pipeline stage.
+---
+
+The `scriptrun` plugin provides the `SCRIPT_RUN` stage, which runs arbitrary shell commands as a step in the pipeline. Because it is a stage plugin, `SCRIPT_RUN` can be added to any deployment pipeline. It is useful for tasks such as smoke tests, notifications, or custom checks between deployment stages.
+
+## Prerequisites
+
+Register the plugin in the piped configuration:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  # ...
+  plugins:
+    - name: scriptrun
+      port: 7006
+      url: file:///path/to/plugin/binary  # or an https:// release URL
+```
+
+## The SCRIPT_RUN stage
+
+Add a `SCRIPT_RUN` stage and set the command to run under `with.run`. You can pass environment variables with `env`, and provide an `onRollback` command that runs if the deployment is rolled back:
+
+```yaml
+pipeline:
+  stages:
+    - name: K8S_CANARY_ROLLOUT
+    - name: SCRIPT_RUN
+      with:
+        env:
+          APP_URL: https://example.com
+        run: |
+          curl -sSf "$APP_URL/healthz"
+        onRollback: |
+          echo "rolling back"
+    - name: K8S_PRIMARY_ROLLOUT
+```
+
+If `onRollback` is set, PipeCD runs it during rollback through an automatically inserted `SCRIPT_RUN_ROLLBACK` stage. You do not add `SCRIPT_RUN_ROLLBACK` to your pipeline.
+
+## Configuration reference
+
+### SCRIPT_RUN stage options
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| run | string | The command(s) to run. | Yes |
+| env | map[string]string | Environment variables to set when running the command. | No |
+| onRollback | string | The command(s) to run if the deployment is rolled back. | No |

--- a/docs/content/en/docs-v1.0.x/plugins/wait-approval.md
+++ b/docs/content/en/docs-v1.0.x/plugins/wait-approval.md
@@ -1,0 +1,52 @@
+---
+title: "Wait approval plugin"
+linkTitle: "Wait approval"
+weight: 50
+description: >
+  Pause the pipeline until a user approves.
+---
+
+The `waitapproval` plugin provides the `WAIT_APPROVAL` stage, which pauses the pipeline until the required number of users approve the deployment from the PipeCD console. Because it is a stage plugin, `WAIT_APPROVAL` can be added to any deployment pipeline.
+
+## Prerequisites
+
+Register the plugin in the piped configuration:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  # ...
+  plugins:
+    - name: waitapproval
+      port: 7005
+      url: file:///path/to/plugin/binary  # or an https:// release URL
+```
+
+## The WAIT_APPROVAL stage
+
+Add a `WAIT_APPROVAL` stage and set the approvers and the number of approvals required under `with`. For example, require one approval before applying an infrastructure change:
+
+```yaml
+pipeline:
+  stages:
+    - name: TERRAFORM_PLAN
+    - name: WAIT_APPROVAL
+      with:
+        approvers:
+          - user-a
+          - user-b
+        minApproverNum: 1
+    - name: TERRAFORM_APPLY
+```
+
+The stage waits until at least `minApproverNum` users have approved it from the console, then continues.
+
+## Configuration reference
+
+### WAIT_APPROVAL stage options
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| approvers | []string | Users designated as approvers of the deployment. | Yes |
+| minApproverNum | int | Number of approvals required before the pipeline continues. | No (default `1`) |

--- a/docs/content/en/docs-v1.0.x/plugins/wait.md
+++ b/docs/content/en/docs-v1.0.x/plugins/wait.md
@@ -1,0 +1,48 @@
+---
+title: "Wait plugin"
+linkTitle: "Wait"
+weight: 40
+description: >
+  Pause the pipeline for a fixed duration.
+---
+
+The `wait` plugin provides the `WAIT` stage, which pauses the pipeline for a fixed duration before continuing to the next stage. Because it is a stage plugin, `WAIT` can be added to any deployment pipeline.
+
+## Prerequisites
+
+Register the plugin in the piped configuration:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  # ...
+  plugins:
+    - name: wait
+      port: 7004
+      url: file:///path/to/plugin/binary  # or an https:// release URL
+```
+
+## The WAIT stage
+
+Add a `WAIT` stage and set how long to pause under `with.duration`. For example, wait 5 minutes between a canary rollout and the primary rollout:
+
+```yaml
+pipeline:
+  stages:
+    - name: K8S_CANARY_ROLLOUT
+      with:
+        replicas: 10%
+    - name: WAIT
+      with:
+        duration: 5m
+    - name: K8S_PRIMARY_ROLLOUT
+```
+
+## Configuration reference
+
+### WAIT stage options
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| duration | duration | How long to pause before continuing (e.g. `5m`). | Yes |


### PR DESCRIPTION
**What this PR does**:

Adds pages for these v1 stage plugins: wait, wait-approval, script-run. 

Note: the sidebar weight values across the plugins section are currently inconsistent (e.g. ecs is `2`, analysis is `30`).  
After all the plugin pages are completed, I'll open a follow-up PR to normalize them so the sidebar order matches the index tables.


**Why we need it**:

The v1 plugins section missed these pages.

**Which issue(s) this PR fixes**:

Part of #6679

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
