### PR TITLE
Docs V1: Expand the Terraform plugin

### DIFF
--- a/docs/content/en/docs-v1.0.x/plugins/terraform.md
+++ b/docs/content/en/docs-v1.0.x/plugins/terraform.md
@@ -1,28 +1,148 @@
 ---
-title: "Terraform Plugin"
+title: "Terraform plugin"
 linkTitle: "Terraform"
 weight: 20
 description: >
-  How to configure the Terraform plugin.
+  Apply infrastructure changes with Terraform.
 ---
 
-The Terraform plugin enables Piped to run Terraform-based deployments.
-A deploy target represents a Terraform execution environment (e.g., dev/prod workspace, shared variables, drift detection settings).
+The `terraform` plugin runs Terraform-based deployments. It reads the Terraform files in the application directory and applies them through a pipeline, running `terraform plan` and `terraform apply` as pipeline stages. A deploy target represents a Terraform execution environment: its variables and drift-detection setting.
+
+## Prerequisites
+
+1. **Register the plugin in the piped configuration.** Add a `terraform` plugin block with one or more `deployTargets`:
+
+   ```yaml
+   apiVersion: pipecd.dev/v1beta1
+   kind: Piped
+   spec:
+     # ...
+     plugins:
+       - name: terraform
+         port: 7002
+         url: file:///path/to/plugin/binary  # or an https:// release URL
+         deployTargets:
+           - name: dev
+             config:
+               vars:
+                 - "project=pipecd"
+               driftDetectionEnabled: true
+   ```
+
+2. **The plugin downloads `terraform` automatically.** `piped` fetches the `terraform` binary via the tool registry, so it does not need to be pre-installed on the `piped` host. The version defaults to `0.13.0`; pin a different one with `terraformVersion` in the application configuration.
+
+3. Put the application's Terraform files (`*.tf`) in the application directory alongside `app.pipecd.yaml`.
+
+## Quick sync
+
+With no `pipeline` defined, the plugin performs a **quick sync** (`TERRAFORM_APPLY`): it applies any detected changes to reach the state described by the Terraform files. This minimal `app.pipecd.yaml` deploys the Terraform files in the application directory:
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
-kind: Piped
+kind: TerraformApp
 spec:
-  ...
+  name: my-infra
   plugins:
-    - name: terraform
-      port: 7002
-      url: https://github.com/.../terraform_v0.3.0_linux_amd64
-      deployTargets:
-        - name: tf-dev
-          config:
-            vars:
-              - "project=pipecd"
+    terraform:
+      workspace: dev
+      vars:
+        - "project=pipecd"
 ```
 
-See [Configuration Reference for Terraform plugin](../user-guide/managing-piped/configuration-reference/#terraformplugin) for complete configuration details.
+## Sync with the specified pipeline
+
+Define a `pipeline` to run `terraform plan` before applying. A common pattern is to plan, pause for a manual approval, then apply:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: TerraformApp
+spec:
+  name: my-infra
+  pipeline:
+    stages:
+      - name: TERRAFORM_PLAN
+      - name: WAIT_APPROVAL
+        with:
+          approvers:
+            - user-a
+      - name: TERRAFORM_APPLY
+  plugins:
+    terraform:
+      workspace: dev
+```
+
+See [Pipeline stages](#pipeline-stages) for every available stage and its options.
+
+## Pipeline stages
+
+Stages are listed under `spec.pipeline.stages`, with options under `with`.
+
+### TERRAFORM_PLAN
+
+Runs `terraform plan` and shows the changes the deployment would apply. Use it before `TERRAFORM_APPLY` to review the plan (optionally behind a `WAIT_APPROVAL` stage).
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| exitOnNoChanges | bool | Exit the pipeline with a success status when the plan detects no changes. | false |
+
+### TERRAFORM_APPLY
+
+Runs `terraform apply` to apply the changes described by the Terraform files. This is also the stage that runs during a quick sync when no `pipeline` block is defined. It takes no options.
+
+### TERRAFORM_ROLLBACK
+
+Restores the infrastructure to the previous commit's Terraform files by running `terraform apply` against them. This stage is triggered automatically when a deployment fails or is cancelled with rollback. You do not add it to your pipeline; PipeCD inserts it automatically.
+
+## Livestate and drift detection
+
+The plugin detects drift by running `terraform plan` and comparing the actual infrastructure against the Terraform files in Git. If the plan reports changes, the application is marked `OUT_OF_SYNC`; otherwise it is `SYNCED`. Drift detection is controlled per deploy target by `driftDetectionEnabled`, which is enabled by default. It is an evolving feature and its behaviour may change in future releases.
+
+## Plan preview
+
+Before a pipeline runs, plan preview runs `terraform plan` and shows the changes the deployment would apply, so you can review them on the pull request.
+
+## Configuration reference
+
+### TerraformApplicationSpec
+
+The `spec` of a `TerraformApp` shares the [common application fields](../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.terraform`:
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| workspace | string | The Terraform workspace name. Empty means the `default` workspace. | No |
+| terraformVersion | string | Version of `terraform` to use. Empty means the default version (`0.13.0`). | No |
+| vars | []string | Variables passed to `terraform` commands with `-var`. Each entry is `key=value` (e.g. `image_id=ami-abc123`). | No |
+| varFiles | []string | Variable files passed to `terraform` commands with `-var-file`. | No |
+| commandFlags | [TerraformCommandFlags](#terraformcommandflags) | Additional flags passed to `terraform` commands. | No |
+| commandEnvs | [TerraformCommandEnvs](#terraformcommandenvs) | Additional environment variables set while running `terraform` commands. | No |
+
+### TerraformCommandFlags
+
+Extra flags appended to the underlying `terraform` commands.
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| shared | []string | Flags applied to every `terraform` command. | No |
+| init | []string | Flags applied to `terraform init`. | No |
+| plan | []string | Flags applied to `terraform plan`. | No |
+| apply | []string | Flags applied to `terraform apply`. | No |
+
+### TerraformCommandEnvs
+
+Extra environment variables set when running the underlying `terraform` commands.
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| shared | []string | Environment variables applied to every `terraform` command. | No |
+| init | []string | Environment variables applied to `terraform init`. | No |
+| plan | []string | Environment variables applied to `terraform plan`. | No |
+| apply | []string | Environment variables applied to `terraform apply`. | No |
+
+### DeployTargetConfig
+
+Configured under `plugins[].deployTargets[].config` in the **piped** configuration, one per Terraform execution environment.
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| vars | []string | Variables passed to `terraform` commands with `-var` for this target. Each entry is `key=value` (e.g. `image_id=ami-abc123`). | No |
+| driftDetectionEnabled | bool | Enable drift detection for this target. Default is `true`. | No |

--- a/docs/content/en/docs-v1.0.x/plugins/terraform.md
+++ b/docs/content/en/docs-v1.0.x/plugins/terraform.md
@@ -39,7 +39,7 @@ With no `pipeline` defined, the plugin performs a **quick sync** (`TERRAFORM_APP
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
-kind: TerraformApp
+kind: Application
 spec:
   name: my-infra
   plugins:
@@ -55,7 +55,7 @@ Define a `pipeline` to run `terraform plan` before applying. A common pattern is
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
-kind: TerraformApp
+kind: Application
 spec:
   name: my-infra
   pipeline:
@@ -105,7 +105,7 @@ Before a pipeline runs, plan preview runs `terraform plan` and shows the changes
 
 ### TerraformApplicationSpec
 
-The `spec` of a `TerraformApp` shares the [common application fields](../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.terraform`:
+The `spec` of a Terraform `Application` shares the [common application fields](../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.terraform`:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|


### PR DESCRIPTION
**What this PR does**:
Expands the v1 Terraform plugin page from a brief guide into a full one.
Every stage, field, and default here is taken from the plugin source under pkg/app/pipedv1/plugin/terraform/

**Why we need it**:
Terraform is a core deployment plugin, it needs to be complete. 

**Which issue(s) this PR fixes**:

Part of #6679

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
