### PR TITLE
Limit filtered ListEvents responses

### DIFF
--- a/pkg/app/server/grpcapi/web_api.go
+++ b/pkg/app/server/grpcapi/web_api.go
@@ -16,6 +16,8 @@ package grpcapi
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -1889,10 +1891,12 @@ func (a *WebAPI) ListEvents(ctx context.Context, req *webservice.ListEventsReque
 	// NOTE: Filtering by labels is done by the application-side because we need to create composite indexes for every combination in the filter.
 	// We don't want to depend on any other search engine, that's why it filters here.
 	filtered := make([]*model.Event, 0, len(events))
-	for _, e := range events {
-		if e.ContainLabels(labels) {
-			filtered = append(filtered, e)
-		}
+	filtered, eventCursor, ok := appendLabelMatchedEvents(filtered, events, labels, pageSize)
+	if ok {
+		return &webservice.ListEventsResponse{
+			Events: filtered,
+			Cursor: eventCursor,
+		}, nil
 	}
 	// Stop running additional queries for more data, and return filtered events immediately with
 	// current cursor if the size before filtering is already less than the page size.
@@ -1914,21 +1918,43 @@ func (a *WebAPI) ListEvents(ctx context.Context, req *webservice.ListEventsReque
 		if len(events) == 0 {
 			break
 		}
-		for _, e := range events {
-			if e.ContainLabels(labels) {
-				filtered = append(filtered, e)
-			}
+		filtered, eventCursor, ok = appendLabelMatchedEvents(filtered, events, labels, pageSize)
+		if ok {
+			return &webservice.ListEventsResponse{
+				Events: filtered,
+				Cursor: eventCursor,
+			}, nil
 		}
 		// We've already specified UpdatedAt >= req.PageMinUpdatedAt, so we need to check just equality.
 		if events[len(events)-1].UpdatedAt == req.PageMinUpdatedAt {
 			break
 		}
 	}
-	// TODO: Think about possibility that the response of ListEvents exceeds the page size
 	return &webservice.ListEventsResponse{
 		Events: filtered,
 		Cursor: cursor,
 	}, nil
+}
+
+func appendLabelMatchedEvents(filtered []*model.Event, events []*model.Event, labels map[string]string, pageSize int) ([]*model.Event, string, bool) {
+	for _, e := range events {
+		if !e.ContainLabels(labels) {
+			continue
+		}
+		filtered = append(filtered, e)
+		if pageSize > 0 && len(filtered) == pageSize {
+			return filtered, makeEventCursor(e), true
+		}
+	}
+	return filtered, "", false
+}
+
+func makeEventCursor(e *model.Event) string {
+	b, _ := json.Marshal(map[string]interface{}{
+		"UpdatedAt": e.UpdatedAt,
+		"Id":        e.Id,
+	})
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 func (a *WebAPI) ListReleasedVersions(ctx context.Context, req *webservice.ListReleasedVersionsRequest) (*webservice.ListReleasedVersionsResponse, error) {

--- a/pkg/app/server/grpcapi/web_api_test.go
+++ b/pkg/app/server/grpcapi/web_api_test.go
@@ -16,6 +16,8 @@ package grpcapi
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -28,6 +30,98 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/datastore/datastoretest"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
+
+func TestAppendLabelMatchedEvents(t *testing.T) {
+	labels := map[string]string{"env": "prod"}
+
+	tests := []struct {
+		name       string
+		filtered   []*model.Event
+		events     []*model.Event
+		pageSize   int
+		wantIDs    []string
+		wantFull   bool
+		wantCursor map[string]interface{}
+	}{
+		{
+			name:     "dense matches stop at page size",
+			pageSize: 2,
+			events: []*model.Event{
+				eventWithLabels("event-1", 300, labels),
+				eventWithLabels("event-2", 200, labels),
+				eventWithLabels("event-3", 100, labels),
+			},
+			wantIDs:  []string{"event-1", "event-2"},
+			wantFull: true,
+			wantCursor: map[string]interface{}{
+				"Id":        "event-2",
+				"UpdatedAt": float64(200),
+			},
+		},
+		{
+			name:     "sparse matches append until page size",
+			pageSize: 2,
+			filtered: []*model.Event{
+				eventWithLabels("event-1", 400, labels),
+			},
+			events: []*model.Event{
+				eventWithLabels("event-2", 300, map[string]string{"env": "dev"}),
+				eventWithLabels("event-3", 200, labels),
+				eventWithLabels("event-4", 100, labels),
+			},
+			wantIDs:  []string{"event-1", "event-3"},
+			wantFull: true,
+			wantCursor: map[string]interface{}{
+				"Id":        "event-3",
+				"UpdatedAt": float64(200),
+			},
+		},
+		{
+			name:     "zero matches does not fill page",
+			pageSize: 2,
+			events: []*model.Event{
+				eventWithLabels("event-1", 300, map[string]string{"env": "dev"}),
+				eventWithLabels("event-2", 200, map[string]string{"env": "staging"}),
+			},
+			wantIDs:  []string{},
+			wantFull: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, cursor, full := appendLabelMatchedEvents(tt.filtered, tt.events, labels, tt.pageSize)
+			assert.Equal(t, tt.wantIDs, eventIDs(got))
+			assert.Equal(t, tt.wantFull, full)
+			if tt.wantCursor == nil {
+				assert.Empty(t, cursor)
+				return
+			}
+
+			data, err := base64.StdEncoding.DecodeString(cursor)
+			assert.NoError(t, err)
+			gotCursor := make(map[string]interface{})
+			assert.NoError(t, json.Unmarshal(data, &gotCursor))
+			assert.Equal(t, tt.wantCursor, gotCursor)
+		})
+	}
+}
+
+func eventWithLabels(id string, updatedAt int64, labels map[string]string) *model.Event {
+	return &model.Event{
+		Id:        id,
+		UpdatedAt: updatedAt,
+		Labels:    labels,
+	}
+}
+
+func eventIDs(events []*model.Event) []string {
+	ids := make([]string, 0, len(events))
+	for _, e := range events {
+		ids = append(ids, e.Id)
+	}
+	return ids
+}
 
 func TestValidateAppBelongsToProject(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Summary
- Limit label-filtered `ListEvents` responses to the requested logical page size.
- Return a cursor based on the last event actually included when filtering reaches `PageSize` inside a datastore page.

## Linked Issue
Fixes #7085

## What Changed
- Added a helper for appending label-matched events up to `PageSize`.
- Added regression coverage for dense matches, sparse matches, and zero-match filtering.

## Verification
- `go test ./pkg/app/server/grpcapi` — passed
- `go test -race ./pkg/app/server/grpcapi` — passed
- `docker run --rm -e GOCACHE=/repo/.cache/go-build -e GOLANGCI_LINT_CACHE=/repo/.cache/golangci-lint -v ${PWD}:/repo -w /repo golangci/golangci-lint:latest golangci-lint run -v --config /repo/.golangci.yml --fix=false ./pkg/app/server/grpcapi` — passed
- `make check` — failed: repository-pinned `make lint/go` image uses golangci-lint built with Go 1.25, while this repo targets Go 1.26.2
- `make test/go MODULES=.` — failed: `pkg/oci` could not dial `/var/run/docker.sock` in this environment
- `DOCKER_HOST=unix:///Users/rootp1/.colima/default/docker.sock go test -race ./pkg/oci` — passed
- `DOCKER_HOST=unix:///Users/rootp1/.colima/default/docker.sock make test/go MODULES=.` — failed: `pkg/oci` local registry tests returned EOF in the full suite; rerunning `pkg/oci` alone passed
- `make test/web` — passed
- `make lint/web` — passed
- `make lint/helm` — passed
- `make check/gen/code` — no-op because the Makefile target is named `check/gen`
- `make check/gen` — failed: target uses `docker run -it`, which cannot attach stdin in this non-interactive environment
- `docker run --rm -v ${PWD}:/repo --entrypoint ./tool/codegen/codegen.sh ghcr.io/pipe-cd/codegen@sha256:8b17498a7cfb58fbaf403ec7cab01a740238aaee43d030e65a40abb710f9e68a /repo && git diff --exit-code --quiet HEAD -- <generated paths>` — passed
- `make check/dco` — failed: script compares against stale `origin/master` and flagged upstream commit `25ae69937e55e8330bff96c34346718f3e5e7148`; `upstream/master..HEAD` contains only this signed-off commit

## Scope
- Only `pkg/app/server/grpcapi/web_api.go` and `pkg/app/server/grpcapi/web_api_test.go` were changed.

**What this PR does**:

Caps filtered `ListEvents` responses at `PageSize` and returns a continuation cursor from the last returned event when filtering fills a page.

**Why we need it**:

Without this, `ListEvents` can append every matching event from the final scanned datastore page and return more events than requested.

**Which issue(s) this PR fixes**:

Fixes #7085

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
