### PR TITLE
Cache plan preview repository routing

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -80,14 +80,15 @@ type commandOutputGetter interface {
 type API struct {
 	apiservice.UnimplementedAPIServiceServer
 
-	applicationStore     apiApplicationStore
-	deploymentStore      apiDeploymentStore
-	pipedStore           apiPipedStore
-	eventStore           apiEventStore
-	deploymentTraceStore apiDeploymentTraceStore
-	commandStore         commandstore.Store
-	stageLogStore        stagelogstore.Store
-	commandOutputGetter  commandOutputGetter
+	applicationStore           apiApplicationStore
+	deploymentStore            apiDeploymentStore
+	pipedStore                 apiPipedStore
+	eventStore                 apiEventStore
+	deploymentTraceStore       apiDeploymentTraceStore
+	commandStore               commandstore.Store
+	stageLogStore              stagelogstore.Store
+	commandOutputGetter        commandOutputGetter
+	planPreviewRepositoryCache *planPreviewRepositoryCache
 
 	encryptionKeyCache cache.Cache
 	pipedStatCache     cache.Cache
@@ -116,6 +117,10 @@ func NewAPI(
 		commandStore:         commandstore.NewStore(ds, sc, logger),
 		stageLogStore:        stagelogstore.NewStore(fs, sc, logger),
 		commandOutputGetter:  cog,
+		planPreviewRepositoryCache: newPlanPreviewRepositoryCache(
+			1024,
+			time.Minute,
+		),
 		// Public key is variable but likely to be accessed multiple times in a short period.
 		encryptionKeyCache: memorycache.NewTTLCache(ctx, 5*time.Minute, 5*time.Minute),
 		pipedStatCache:     psc,
@@ -864,34 +869,37 @@ func (a *API) RequestPlanPreview(ctx context.Context, req *apiservice.RequestPla
 		return nil, err
 	}
 
-	// TODO: We may need to cache the list of pipeds to reduce load on database.
-	// Adding the cache after understanding the real situation from our metrics data.
-	pipeds, err := a.pipedStore.List(ctx, datastore.ListOptions{
-		Filters: []datastore.ListFilter{
-			{
-				Field:    "ProjectId",
-				Operator: datastore.OperatorEqual,
-				Value:    key.ProjectId,
+	cacheKey := planPreviewRepositoryCacheKey(key.ProjectId, req.RepoRemoteUrl, req.BaseBranch)
+	repositories, ok := a.planPreviewRepositoryCache.Get(cacheKey)
+	if !ok {
+		pipeds, err := a.pipedStore.List(ctx, datastore.ListOptions{
+			Filters: []datastore.ListFilter{
+				{
+					Field:    "ProjectId",
+					Operator: datastore.OperatorEqual,
+					Value:    key.ProjectId,
+				},
+				{
+					Field:    "Disabled",
+					Operator: datastore.OperatorEqual,
+					Value:    false,
+				},
 			},
-			{
-				Field:    "Disabled",
-				Operator: datastore.OperatorEqual,
-				Value:    false,
-			},
-		},
-	})
-	if err != nil {
-		return nil, gRPCStoreError(err, "list pipeds")
-	}
+		})
+		if err != nil {
+			return nil, gRPCStoreError(err, "list pipeds")
+		}
 
-	repositories := make(map[string]string, len(pipeds))
-	for _, p := range pipeds {
-		for _, r := range p.Repositories {
-			if r.Remote == req.RepoRemoteUrl && r.Branch == req.BaseBranch {
-				repositories[p.Id] = r.Id
-				break
+		repositories = make(map[string]string, len(pipeds))
+		for _, p := range pipeds {
+			for _, r := range p.Repositories {
+				if r.Remote == req.RepoRemoteUrl && r.Branch == req.BaseBranch {
+					repositories[p.Id] = r.Id
+					break
+				}
 			}
 		}
+		a.planPreviewRepositoryCache.Put(cacheKey, repositories)
 	}
 	if len(repositories) == 0 {
 		return &apiservice.RequestPlanPreviewResponse{}, nil

--- a/pkg/app/server/grpcapi/api_test.go
+++ b/pkg/app/server/grpcapi/api_test.go
@@ -16,11 +16,16 @@ package grpcapi
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
+	"github.com/pipe-cd/pipecd/pkg/datastore"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
@@ -101,4 +106,232 @@ func TestRequireAPIKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequestPlanPreviewCachesRepositoryRoutes(t *testing.T) {
+	pipedStore := &requestPlanPreviewPipedStore{
+		pipeds: []*model.Piped{
+			{
+				Id:        "piped-1",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-1",
+						Remote: "https://github.com/pipe-cd/example.git",
+						Branch: "master",
+					},
+				},
+			},
+			{
+				Id:        "piped-2",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-2",
+						Remote: "https://github.com/pipe-cd/example.git",
+						Branch: "master",
+					},
+				},
+			},
+			{
+				Id:        "piped-3",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-3",
+						Remote: "https://github.com/pipe-cd/other.git",
+						Branch: "master",
+					},
+				},
+			},
+		},
+	}
+	commandStore := &requestPlanPreviewCommandStore{}
+	api := &API{
+		pipedStore:                 pipedStore,
+		commandStore:               commandStore,
+		planPreviewRepositoryCache: newPlanPreviewRepositoryCache(1024, time.Minute),
+		logger:                     zap.NewNop(),
+	}
+	ctx := rpcauth.ContextWithAPIKey(context.TODO(), &model.APIKey{
+		ProjectId: "project-1",
+		Role:      model.APIKey_READ_WRITE,
+	})
+	req := &apiservice.RequestPlanPreviewRequest{
+		RepoRemoteUrl: "https://github.com/pipe-cd/example.git",
+		BaseBranch:    "master",
+		HeadBranch:    "feature",
+		HeadCommit:    "abcdef",
+		Timeout:       60,
+	}
+
+	resp, err := api.RequestPlanPreview(ctx, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Commands, 2)
+
+	resp, err = api.RequestPlanPreview(ctx, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Commands, 2)
+	assert.Equal(t, 1, pipedStore.listCalls)
+	assert.Len(t, commandStore.commands, 4)
+}
+
+func TestRequestPlanPreviewCachesEmptyRepositoryRoutes(t *testing.T) {
+	pipedStore := &requestPlanPreviewPipedStore{
+		pipeds: []*model.Piped{
+			{
+				Id:        "piped-1",
+				ProjectId: "project-1",
+				Repositories: []*model.ApplicationGitRepository{
+					{
+						Id:     "repo-1",
+						Remote: "https://github.com/pipe-cd/other.git",
+						Branch: "master",
+					},
+				},
+			},
+		},
+	}
+	api := &API{
+		pipedStore:                 pipedStore,
+		commandStore:               &requestPlanPreviewCommandStore{},
+		planPreviewRepositoryCache: newPlanPreviewRepositoryCache(1024, time.Minute),
+		logger:                     zap.NewNop(),
+	}
+	ctx := rpcauth.ContextWithAPIKey(context.TODO(), &model.APIKey{
+		ProjectId: "project-1",
+		Role:      model.APIKey_READ_WRITE,
+	})
+	req := &apiservice.RequestPlanPreviewRequest{
+		RepoRemoteUrl: "https://github.com/pipe-cd/example.git",
+		BaseBranch:    "master",
+	}
+
+	resp, err := api.RequestPlanPreview(ctx, req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Commands)
+
+	resp, err = api.RequestPlanPreview(ctx, req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Commands)
+	assert.Equal(t, 1, pipedStore.listCalls)
+}
+
+func BenchmarkRequestPlanPreviewRepositoryRouting(b *testing.B) {
+	for _, pipedCount := range []int{1, 100, 10000} {
+		b.Run(fmt.Sprintf("pipeds-%d", pipedCount), func(b *testing.B) {
+			pipedStore := &requestPlanPreviewPipedStore{
+				pipeds: makeRequestPlanPreviewPipeds(pipedCount),
+			}
+			api := &API{
+				pipedStore:                 pipedStore,
+				commandStore:               &requestPlanPreviewCommandStore{discard: true},
+				planPreviewRepositoryCache: newPlanPreviewRepositoryCache(1024, time.Minute),
+				logger:                     zap.NewNop(),
+			}
+			ctx := rpcauth.ContextWithAPIKey(context.TODO(), &model.APIKey{
+				ProjectId: "project-1",
+				Role:      model.APIKey_READ_WRITE,
+			})
+			req := &apiservice.RequestPlanPreviewRequest{
+				RepoRemoteUrl: "https://github.com/pipe-cd/example.git",
+				BaseBranch:    "master",
+				HeadBranch:    "feature",
+				HeadCommit:    "abcdef",
+				Timeout:       60,
+			}
+			if _, err := api.RequestPlanPreview(ctx, req); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := api.RequestPlanPreview(ctx, req); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+
+			if pipedStore.listCalls != 1 {
+				b.Fatalf("expected one piped list call, got %d", pipedStore.listCalls)
+			}
+		})
+	}
+}
+
+func makeRequestPlanPreviewPipeds(n int) []*model.Piped {
+	pipeds := make([]*model.Piped, 0, n)
+	for i := 0; i < n; i++ {
+		repoRemoteURL := fmt.Sprintf("https://github.com/pipe-cd/other-%d.git", i)
+		if i == n-1 {
+			repoRemoteURL = "https://github.com/pipe-cd/example.git"
+		}
+		pipeds = append(pipeds, &model.Piped{
+			Id:        fmt.Sprintf("piped-%d", i),
+			ProjectId: "project-1",
+			Repositories: []*model.ApplicationGitRepository{
+				{
+					Id:     fmt.Sprintf("repo-%d", i),
+					Remote: repoRemoteURL,
+					Branch: "master",
+				},
+			},
+		})
+	}
+	return pipeds
+}
+
+type requestPlanPreviewPipedStore struct {
+	pipeds    []*model.Piped
+	listCalls int
+}
+
+func (s *requestPlanPreviewPipedStore) Get(context.Context, string) (*model.Piped, error) {
+	return nil, datastore.ErrNotFound
+}
+
+func (s *requestPlanPreviewPipedStore) List(context.Context, datastore.ListOptions) ([]*model.Piped, error) {
+	s.listCalls++
+	return s.pipeds, nil
+}
+
+func (s *requestPlanPreviewPipedStore) Add(context.Context, *model.Piped) error {
+	return nil
+}
+
+func (s *requestPlanPreviewPipedStore) UpdateInfo(context.Context, string, string, string) error {
+	return nil
+}
+
+func (s *requestPlanPreviewPipedStore) EnablePiped(context.Context, string) error {
+	return nil
+}
+
+func (s *requestPlanPreviewPipedStore) DisablePiped(context.Context, string) error {
+	return nil
+}
+
+type requestPlanPreviewCommandStore struct {
+	commands []*model.Command
+	discard  bool
+}
+
+func (s *requestPlanPreviewCommandStore) ListUnhandledCommands(context.Context, string) ([]*model.Command, error) {
+	return nil, nil
+}
+
+func (s *requestPlanPreviewCommandStore) AddCommand(_ context.Context, command *model.Command) error {
+	if s.discard {
+		return nil
+	}
+	s.commands = append(s.commands, command)
+	return nil
+}
+
+func (s *requestPlanPreviewCommandStore) GetCommand(context.Context, string) (*model.Command, error) {
+	return nil, datastore.ErrNotFound
+}
+
+func (s *requestPlanPreviewCommandStore) UpdateCommandHandled(context.Context, string, model.CommandStatus, map[string]string, int64) error {
+	return nil
 }

--- a/pkg/app/server/grpcapi/plan_preview_route_cache.go
+++ b/pkg/app/server/grpcapi/plan_preview_route_cache.go
@@ -1,0 +1,100 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcapi
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const planPreviewRepositoryCachePrefix = "plan-preview-repository"
+
+type planPreviewRepositoryCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	ttl        time.Duration
+	entries    map[string]planPreviewRepositoryCacheEntry
+	nowFunc    func() time.Time
+}
+
+type planPreviewRepositoryCacheEntry struct {
+	repositories map[string]string
+	expiresAt    time.Time
+}
+
+func newPlanPreviewRepositoryCache(maxEntries int, ttl time.Duration) *planPreviewRepositoryCache {
+	return &planPreviewRepositoryCache{
+		maxEntries: maxEntries,
+		ttl:        ttl,
+		entries:    make(map[string]planPreviewRepositoryCacheEntry, maxEntries),
+		nowFunc:    time.Now,
+	}
+}
+
+func planPreviewRepositoryCacheKey(projectID, remoteURL, baseBranch string) string {
+	return fmt.Sprintf("%s:%d:%s:%d:%s:%d:%s", planPreviewRepositoryCachePrefix, len(projectID), projectID, len(remoteURL), remoteURL, len(baseBranch), baseBranch)
+}
+
+func (c *planPreviewRepositoryCache) Get(key string) (map[string]string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if !entry.expiresAt.After(c.nowFunc()) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return cloneStringMap(entry.repositories), true
+}
+
+func (c *planPreviewRepositoryCache) Put(key string, repositories map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.nowFunc()
+	if len(c.entries) >= c.maxEntries {
+		c.evictExpired(now)
+	}
+	for len(c.entries) >= c.maxEntries {
+		for k := range c.entries {
+			delete(c.entries, k)
+			break
+		}
+	}
+	c.entries[key] = planPreviewRepositoryCacheEntry{
+		repositories: cloneStringMap(repositories),
+		expiresAt:    now.Add(c.ttl),
+	}
+}
+
+func (c *planPreviewRepositoryCache) evictExpired(now time.Time) {
+	for key, entry := range c.entries {
+		if !entry.expiresAt.After(now) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- cache plan preview repository-to-piped matches by project, repo remote, and base branch
- avoid repeated full active-piped scans for repeated requests on the same route
- add focused tests and a benchmark covering 1, 100, and 10000 pipeds

## Linked Issue
Fixes #7087

## What Changed
- added a bounded in-memory TTL cache for `RequestPlanPreview` routing matches
- reused cached repository matches before falling back to `pipedStore.List`
- added regression tests for cached matches and cached empty results
- added a benchmark verifying repeated requests stay off the datastore scan path

## Verification
- `go test ./pkg/app/server/grpcapi -run 'TestRequestPlanPreview|TestRequireAPIKey'` — passed
- `go test -bench BenchmarkRequestPlanPreviewRepositoryRouting -benchmem ./pkg/app/server/grpcapi` — passed
- `make build/go` — passed
- `make check/gen/code` — passed
- `make check` — not passed: `lint/go` uses a pinned `golangci-lint` image built with Go 1.25, but this repository targets Go 1.26.2, so lint fails before the rest of `make check` can complete
- `make check/dco` — not passed: fails on upstream commit `25ae69937e55e8330bff96c34346718f3e5e7148`, which is already contained in `upstream/master`

## Scope
- only the plan preview routing path and its focused tests were changed; unrelated files were not modified

**What this PR does**:

Caches repository routing for plan preview requests so repeated requests do not rescan every active piped in the project.

**Why we need it**:

Plan preview is an interactive path, and repeated requests for the same repository and branch should not require a full active-piped scan each time.

**Which issue(s) this PR fixes**:

Fixes #7087

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Plan preview routing avoids repeated full scans for the same repository and base branch, reducing control-plane work on repeated requests.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: Not applicable
