### PR TITLE
Skip status and kind filters when all given values are empty

### DIFF
--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -548,11 +548,15 @@ func (a *API) ListDeployments(ctx context.Context, req *apiservice.ListDeploymen
 			}
 		}
 
-		filters = append(filters, datastore.ListFilter{
-			Field:    "Status",
-			Operator: datastore.OperatorEqual,
-			Value:    statuses[0],
-		})
+		// Empty values are skipped above, so the request may contain no usable
+		// status at all. In that case no status filter should be added.
+		if len(statuses) > 0 {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Status",
+				Operator: datastore.OperatorEqual,
+				Value:    statuses[0],
+			})
+		}
 	}
 	if len(req.Kinds) > 0 {
 		kinds := []model.ApplicationKind{}
@@ -566,11 +570,15 @@ func (a *API) ListDeployments(ctx context.Context, req *apiservice.ListDeploymen
 			}
 		}
 
-		filters = append(filters, datastore.ListFilter{
-			Field:    "Kind",
-			Operator: datastore.OperatorEqual,
-			Value:    kinds[0],
-		})
+		// Empty values are skipped above, so the request may contain no usable
+		// kind at all. In that case no kind filter should be added.
+		if len(kinds) > 0 {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Kind",
+				Operator: datastore.OperatorEqual,
+				Value:    kinds[0],
+			})
+		}
 	}
 	if len(req.ApplicationIds) > 0 {
 		filters = append(filters, datastore.ListFilter{

--- a/pkg/app/server/grpcapi/api.go
+++ b/pkg/app/server/grpcapi/api.go
@@ -547,11 +547,15 @@ func (a *API) ListDeployments(ctx context.Context, req *apiservice.ListDeploymen
 			}
 		}
 
-		filters = append(filters, datastore.ListFilter{
-			Field:    "Status",
-			Operator: datastore.OperatorEqual,
-			Value:    statuses[0],
-		})
+		// Empty values are skipped above, so the request may contain no usable
+		// status at all. In that case no status filter should be added.
+		if len(statuses) > 0 {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Status",
+				Operator: datastore.OperatorEqual,
+				Value:    statuses[0],
+			})
+		}
 	}
 	if len(req.Kinds) > 0 {
 		kinds := []model.ApplicationKind{}
@@ -565,11 +569,15 @@ func (a *API) ListDeployments(ctx context.Context, req *apiservice.ListDeploymen
 			}
 		}
 
-		filters = append(filters, datastore.ListFilter{
-			Field:    "Kind",
-			Operator: datastore.OperatorEqual,
-			Value:    kinds[0],
-		})
+		// Empty values are skipped above, so the request may contain no usable
+		// kind at all. In that case no kind filter should be added.
+		if len(kinds) > 0 {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "Kind",
+				Operator: datastore.OperatorEqual,
+				Value:    kinds[0],
+			})
+		}
 	}
 	if len(req.ApplicationIds) > 0 {
 		filters = append(filters, datastore.ListFilter{

--- a/pkg/app/server/grpcapi/api_test.go
+++ b/pkg/app/server/grpcapi/api_test.go
@@ -166,3 +166,86 @@ func TestListApplicationsCursor(t *testing.T) {
 		})
 	}
 }
+
+func TestListDeploymentsFilters(t *testing.T) {
+	testcases := []struct {
+		name            string
+		req             *apiservice.ListDeploymentsRequest
+		expectedFilters []string
+		expectedErr     string
+	}{
+		{
+			name:            "ok: no optional filter is given",
+			req:             &apiservice.ListDeploymentsRequest{Limit: 10},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "ok: a valid status is used as a filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{model.DeploymentStatus_DEPLOYMENT_SUCCESS.String()},
+				Limit:    10,
+			},
+			expectedFilters: []string{"ProjectId", "Status"},
+		},
+		{
+			name: "ok: statuses holding only empty values adds no status filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{""},
+				Limit:    10,
+			},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "ok: kinds holding only empty values adds no kind filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Kinds: []string{"", ""},
+				Limit: 10,
+			},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "invalid: unknown deployment status",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{"NOT_A_STATUS"},
+				Limit:    10,
+			},
+			expectedErr: "rpc error: code = InvalidArgument desc = NOT_A_STATUS is invalid deployment status",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var gotFilters []string
+			store := datastoretest.NewMockDeploymentStore(ctrl)
+			store.EXPECT().
+				List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error) {
+					for _, f := range opts.Filters {
+						gotFilters = append(gotFilters, f.Field)
+					}
+					return nil, "", nil
+				}).
+				AnyTimes()
+
+			api := &API{
+				deploymentStore: store,
+				logger:          zap.NewNop(),
+			}
+			ctx := rpcauth.ContextWithAPIKey(context.TODO(), &model.APIKey{
+				ProjectId: "project-id",
+				Role:      model.APIKey_READ_ONLY,
+			})
+
+			_, err := api.ListDeployments(ctx, tc.req)
+			if tc.expectedErr != "" {
+				assert.EqualError(t, err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedFilters, gotFilters)
+		})
+	}
+}

--- a/pkg/app/server/grpcapi/api_test.go
+++ b/pkg/app/server/grpcapi/api_test.go
@@ -19,8 +19,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+	"github.com/pipe-cd/pipecd/pkg/datastore/datastoretest"
 	"github.com/pipe-cd/pipecd/pkg/model"
 	"github.com/pipe-cd/pipecd/pkg/rpc/rpcauth"
 )
@@ -99,6 +103,89 @@ func TestRequireAPIKey(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.expectedErr, "")
 			}
+		})
+	}
+}
+
+func TestListDeploymentsFilters(t *testing.T) {
+	testcases := []struct {
+		name            string
+		req             *apiservice.ListDeploymentsRequest
+		expectedFilters []string
+		expectedErr     string
+	}{
+		{
+			name:            "ok: no optional filter is given",
+			req:             &apiservice.ListDeploymentsRequest{Limit: 10},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "ok: a valid status is used as a filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{model.DeploymentStatus_DEPLOYMENT_SUCCESS.String()},
+				Limit:    10,
+			},
+			expectedFilters: []string{"ProjectId", "Status"},
+		},
+		{
+			name: "ok: statuses holding only empty values adds no status filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{""},
+				Limit:    10,
+			},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "ok: kinds holding only empty values adds no kind filter",
+			req: &apiservice.ListDeploymentsRequest{
+				Kinds: []string{"", ""},
+				Limit: 10,
+			},
+			expectedFilters: []string{"ProjectId"},
+		},
+		{
+			name: "invalid: unknown deployment status",
+			req: &apiservice.ListDeploymentsRequest{
+				Statuses: []string{"NOT_A_STATUS"},
+				Limit:    10,
+			},
+			expectedErr: "rpc error: code = InvalidArgument desc = NOT_A_STATUS is invalid deployment status",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var gotFilters []string
+			store := datastoretest.NewMockDeploymentStore(ctrl)
+			store.EXPECT().
+				List(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, opts datastore.ListOptions) ([]*model.Deployment, string, error) {
+					for _, f := range opts.Filters {
+						gotFilters = append(gotFilters, f.Field)
+					}
+					return nil, "", nil
+				}).
+				AnyTimes()
+
+			api := &API{
+				deploymentStore: store,
+				logger:          zap.NewNop(),
+			}
+			ctx := rpcauth.ContextWithAPIKey(context.TODO(), &model.APIKey{
+				ProjectId: "project-id",
+				Role:      model.APIKey_READ_ONLY,
+			})
+
+			_, err := api.ListDeployments(ctx, tc.req)
+			if tc.expectedErr != "" {
+				assert.EqualError(t, err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedFilters, gotFilters)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

In `APIService.ListDeployments`, the status and kind filters are added only when at least one usable value was collected, instead of reading `statuses[0]` / `kinds[0]` on a slice that can be empty.

```go
+		// Empty values are skipped above, so the request may contain no usable
+		// status at all. In that case no status filter should be added.
+		if len(statuses) > 0 {
 			filters = append(filters, datastore.ListFilter{
 				Field:    "Status",
 				Operator: datastore.OperatorEqual,
 				Value:    statuses[0],
 			})
+		}
```

Same guard for `kinds`. Behaviour is unchanged when a valid value is given.

**Why we need it**:

The loop right above already skips empty values, so a request like `statuses: [""]` leaves the slice empty and the index access panics with `index out of range [0] with length 0`. The API server has no recovery interceptor, so the panic stops the whole control plane process, not just that request. It is reachable with `pipectl deployment list --status=,`. Full details and how I checked it are in #7098.

I only added the two guards. I did not change how empty values are treated, since both the handler and pipectl already skip them on purpose.

**How I tested it**

Added `TestListDeploymentsFilters`, which checks which filters actually reach the datastore.

Without the fix it reproduces the panic at the old line:

```
--- FAIL: TestListDeploymentsFilters/ok:_statuses_holding_only_empty_values_adds_no_status_filter
panic: runtime error: index out of range [0] with length 0
    .../pkg/app/server/grpcapi/api.go:553
```

With the fix:

```
--- PASS: TestListDeploymentsFilters
    --- PASS: .../ok:_no_optional_filter_is_given
    --- PASS: .../ok:_a_valid_status_is_used_as_a_filter
    --- PASS: .../ok:_statuses_holding_only_empty_values_adds_no_status_filter
    --- PASS: .../ok:_kinds_holding_only_empty_values_adds_no_kind_filter
    --- PASS: .../invalid:_unknown_deployment_status
ok  	github.com/pipe-cd/pipecd/pkg/app/server/grpcapi
```

`go test ./pkg/app/server/grpcapi/...` passes, and `go build ./cmd/pipecd ./cmd/pipectl` is fine.

`go vet` on that package still prints two `copies lock value` warnings for `RegisterEvent`. Those are already on master without my change, so I left them alone.

**Which issue(s) this PR fixes**:

Fixes #7098

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: A request whose status or kind values are all empty is handled like no filter was given, instead of crashing the control plane.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: Not applicable
