### PR TITLE
Fix data race in MetadataStoreRegistry stores map

### DIFF
--- a/pkg/app/pipedv1/cmd/piped/piped.go
+++ b/pkg/app/pipedv1/cmd/piped/piped.go
@@ -414,7 +414,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			commandReporter,
 			notifier,
 			decrypter,
-			*metadataStoreRegistry,
+			metadataStoreRegistry,
 			p.gracePeriod,
 			input.Logger,
 			tracerProvider,

--- a/pkg/app/pipedv1/controller/controller.go
+++ b/pkg/app/pipedv1/controller/controller.go
@@ -96,7 +96,7 @@ type controller struct {
 	commandReporter       commandstore.Reporter
 	notifier              notifier
 	secretDecrypter       secretDecrypter
-	metadataStoreRegistry metadatastore.MetadataStoreRegistry
+	metadataStoreRegistry *metadatastore.MetadataStoreRegistry
 
 	// The registry of all plugins.
 	pluginRegistry plugin.PluginRegistry
@@ -138,7 +138,7 @@ func NewController(
 	commandReporter commandstore.Reporter,
 	notifier notifier,
 	secretDecrypter secretDecrypter,
-	metadataStoreRegistry metadatastore.MetadataStoreRegistry,
+	metadataStoreRegistry *metadatastore.MetadataStoreRegistry,
 	gracePeriod time.Duration,
 	logger *zap.Logger,
 	tracerProvider trace.TracerProvider,

--- a/pkg/app/pipedv1/metadatastore/registry.go
+++ b/pkg/app/pipedv1/metadatastore/registry.go
@@ -17,6 +17,7 @@ package metadatastore
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/pipe-cd/pipecd/pkg/model"
 	service "github.com/pipe-cd/pipecd/pkg/plugin/pipedservice"
@@ -26,6 +27,9 @@ import (
 type MetadataStoreRegistry struct {
 	apiClient apiClient
 
+	// storesMu protects stores against concurrent access from the
+	// Register/Delete lifecycle calls and the gRPC handler methods below.
+	storesMu sync.RWMutex
 	// stores is a map of metadata store for each deployment.
 	// The key is the deployment ID.
 	stores map[string]*metadataStore
@@ -41,19 +45,34 @@ func NewMetadataStoreRegistry(apiClient apiClient) *MetadataStoreRegistry {
 // If the metadata store already exists, the new one will replace the existing one.
 func (r *MetadataStoreRegistry) Register(d *model.Deployment) MetadataStore {
 	store := newMetadataStore(r.apiClient, d)
+
+	r.storesMu.Lock()
 	r.stores[d.Id] = store
+	r.storesMu.Unlock()
+
 	return store
 }
 
 // Delete deletes the metadata store for the given deployment in order to release the resources.
 // If the metadata store is not found, it is a no-op.
 func (r *MetadataStoreRegistry) Delete(deploymentID string) {
+	r.storesMu.Lock()
 	delete(r.stores, deploymentID)
+	r.storesMu.Unlock()
+}
+
+// get returns the metadata store registered for the given deployment ID, if any.
+func (r *MetadataStoreRegistry) get(deploymentID string) (*metadataStore, bool) {
+	r.storesMu.RLock()
+	defer r.storesMu.RUnlock()
+
+	mds, ok := r.stores[deploymentID]
+	return mds, ok
 }
 
 // GetStageMetadata implements the backend of PluginService.GetStageMetadata().
 func (r *MetadataStoreRegistry) GetStageMetadata(ctx context.Context, req *service.GetStageMetadataRequest) (*service.GetStageMetadataResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.GetStageMetadataResponse{Found: false}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -67,7 +86,7 @@ func (r *MetadataStoreRegistry) GetStageMetadata(ctx context.Context, req *servi
 
 // PutStageMetadata implements the backend of PluginService.PutStageMetadata().
 func (r *MetadataStoreRegistry) PutStageMetadata(ctx context.Context, req *service.PutStageMetadataRequest) (*service.PutStageMetadataResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.PutStageMetadataResponse{}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -82,7 +101,7 @@ func (r *MetadataStoreRegistry) PutStageMetadata(ctx context.Context, req *servi
 
 // PutStageMetadataMulti implements the backend of PluginService.PutStageMetadataMulti().
 func (r *MetadataStoreRegistry) PutStageMetadataMulti(ctx context.Context, req *service.PutStageMetadataMultiRequest) (*service.PutStageMetadataMultiResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.PutStageMetadataMultiResponse{}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -97,7 +116,7 @@ func (r *MetadataStoreRegistry) PutStageMetadataMulti(ctx context.Context, req *
 
 // GetDeploymentMetadata implements the backend of PluginService.GetDeploymentMetadata().
 func (r *MetadataStoreRegistry) GetDeploymentPluginMetadata(ctx context.Context, req *service.GetDeploymentPluginMetadataRequest) (*service.GetDeploymentPluginMetadataResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.GetDeploymentPluginMetadataResponse{Found: false}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -111,7 +130,7 @@ func (r *MetadataStoreRegistry) GetDeploymentPluginMetadata(ctx context.Context,
 
 // PutDeploymentMetadata implements the backend of PluginService.PutDeploymentMetadata().
 func (r *MetadataStoreRegistry) PutDeploymentPluginMetadata(ctx context.Context, req *service.PutDeploymentPluginMetadataRequest) (*service.PutDeploymentPluginMetadataResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.PutDeploymentPluginMetadataResponse{}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -126,7 +145,7 @@ func (r *MetadataStoreRegistry) PutDeploymentPluginMetadata(ctx context.Context,
 
 // PutDeploymentMetadataMulti implements the backend of PluginService.PutDeploymentMetadataMulti().
 func (r *MetadataStoreRegistry) PutDeploymentPluginMetadataMulti(ctx context.Context, req *service.PutDeploymentPluginMetadataMultiRequest) (*service.PutDeploymentPluginMetadataMultiResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.PutDeploymentPluginMetadataMultiResponse{}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}
@@ -141,7 +160,7 @@ func (r *MetadataStoreRegistry) PutDeploymentPluginMetadataMulti(ctx context.Con
 
 // GetDeploymentSharedMetadata implements the backend of PluginService.GetDeploymentSharedMetadata().
 func (r *MetadataStoreRegistry) GetDeploymentSharedMetadata(ctx context.Context, req *service.GetDeploymentSharedMetadataRequest) (*service.GetDeploymentSharedMetadataResponse, error) {
-	mds, ok := r.stores[req.DeploymentId]
+	mds, ok := r.get(req.DeploymentId)
 	if !ok {
 		return &service.GetDeploymentSharedMetadataResponse{Found: false}, fmt.Errorf("metadata store not found for deployment %s", req.DeploymentId)
 	}

--- a/pkg/app/pipedv1/metadatastore/registry_test.go
+++ b/pkg/app/pipedv1/metadatastore/registry_test.go
@@ -16,6 +16,8 @@ package metadatastore
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -290,4 +292,54 @@ func TestRegistry(t *testing.T) {
 			assert.Error(t, err)
 		}
 	}
+}
+
+// TestRegistryConcurrentAccess ensures that the stores map of MetadataStoreRegistry
+// can be safely accessed by concurrent Register/Delete calls (writers, driven by the
+// deployment lifecycle) and gRPC handler calls (readers), without data races.
+// Run with `go test -race` to verify.
+func TestRegistryConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	ac := &fakeAPIClient{
+		shared:  make(map[string]string, 0),
+		plugins: make(map[string]metadata, 0),
+		stages:  make(map[string]metadata, 0),
+	}
+	r := NewMetadataStoreRegistry(ac)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	const deployments = 20
+	const opsPerDeployment = 8
+
+	for i := 0; i < deployments; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			id := fmt.Sprintf("deploy-%d", idx)
+			d := &model.Deployment{
+				Id: id,
+				MetadataV2: &model.DeploymentMetadata{
+					Shared:  &model.DeploymentMetadata_KeyValues{KeyValues: map[string]string{}},
+					Plugins: map[string]*model.DeploymentMetadata_KeyValues{},
+				},
+				Stages: []*model.PipelineStage{{Id: "stage-1"}},
+			}
+			r.Register(d)
+			r.Delete(id)
+		}(i)
+
+		for j := 0; j < opsPerDeployment; j++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				id := fmt.Sprintf("deploy-%d", idx)
+				_, _ = r.PutStageMetadata(ctx, &service.PutStageMetadataRequest{
+					DeploymentId: id, StageId: "stage-1", Key: "k", Value: "v",
+				})
+			}(i)
+		}
+	}
+	wg.Wait()
 }

--- a/pkg/app/pipedv1/metadatastore/store_test.go
+++ b/pkg/app/pipedv1/metadatastore/store_test.go
@@ -16,6 +16,7 @@ package metadatastore
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,13 +26,21 @@ import (
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
 
+// fakeAPIClient is a fake apiClient used in tests. Its maps are guarded by mu
+// since it may be shared by metadataStore instances of multiple deployments
+// exercised concurrently, e.g. in TestRegistryConcurrentAccess.
 type fakeAPIClient struct {
+	mu sync.Mutex
+
 	shared  metadata
 	plugins map[string]metadata
 	stages  map[string]metadata
 }
 
 func (c *fakeAPIClient) SaveDeploymentSharedMetadata(ctx context.Context, req *pipedservice.SaveDeploymentSharedMetadataRequest, opts ...grpc.CallOption) (*pipedservice.SaveDeploymentSharedMetadataResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	md := make(map[string]string, len(c.shared)+len(req.Metadata))
 	for k, v := range c.shared {
 		md[k] = v
@@ -44,6 +53,9 @@ func (c *fakeAPIClient) SaveDeploymentSharedMetadata(ctx context.Context, req *p
 }
 
 func (c *fakeAPIClient) SaveDeploymentPluginMetadata(ctx context.Context, req *pipedservice.SaveDeploymentPluginMetadataRequest, opts ...grpc.CallOption) (*pipedservice.SaveDeploymentPluginMetadataResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	ori := c.plugins[req.PluginName]
 	md := make(map[string]string, len(ori)+len(req.Metadata))
 	for k, v := range ori {
@@ -57,6 +69,9 @@ func (c *fakeAPIClient) SaveDeploymentPluginMetadata(ctx context.Context, req *p
 }
 
 func (c *fakeAPIClient) SaveStageMetadata(ctx context.Context, req *pipedservice.SaveStageMetadataRequest, opts ...grpc.CallOption) (*pipedservice.SaveStageMetadataResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	ori := c.stages[req.StageId]
 	md := make(map[string]string, len(ori)+len(req.Metadata))
 	for k, v := range ori {


### PR DESCRIPTION
Motivation:
MetadataStoreRegistry.stores was read by the 7 gRPC plugin-service
handler methods (GetStageMetadata, PutStageMetadata, etc.) and written
by Register/Delete, called from the deployment controller's
planner/scheduler goroutines, with no synchronization between them.
Under concurrent deployments, a handler reading the map for one
deployment could race with Register/Delete for another, triggering
Go's `fatal error: concurrent map read and map write`. This is a
runtime fatal error, not a recoverable panic, so it aborts the whole
piped process, killing every deployment running on that agent.

Approach:
Add a sync.RWMutex (storesMu) to MetadataStoreRegistry, matching the
per-field RWMutex pattern already used one level down in
metadataStore (store.go). Register/Delete take the write lock around
the map mutation; all 7 read call sites go through a new private get()
helper that takes the read lock, snapshots the *metadataStore pointer,
and releases the lock before delegating to the inner store (which has
its own locking), so the registry lock is never held across a call
into inner-store or gRPC logic.

While wiring this up, found that MetadataStoreRegistry was passed by
value from cmd/piped/piped.go into controller.NewController
(dereferencing the pointer), while grpcapi.NewPluginAPI kept the
original pointer. Since sync.RWMutex is a value type, that by-value
copy would have given the controller (writer side) and the gRPC
handlers (reader side) two independent mutex instances guarding the
same underlying map, defeating the fix for the real call graph even
though the isolated package test passed. Changed the controller struct
field and NewController parameter to *metadatastore.MetadataStoreRegistry
so both sides share the single instance created in piped.go.

Validation:
- Reproduced the exact race from the issue: added a concurrency test
  driving 20 concurrent Register+Delete deployment lifecycles against
  8 concurrent PutStageMetadata calls each, and ran it before the fix
  with `go test -race ./pkg/app/pipedv1/metadatastore/...` — it failed
  with a DATA RACE between registry.go's Register (write) and
  PutStageMetadata (read), matching the issue's reported failure mode.
- Kept this as TestRegistryConcurrentAccess in registry_test.go. Also
  added a mutex to the fakeAPIClient test double (store_test.go),
  which had its own, separate unsynchronized maps that a second
  concurrent metadataStore instance would race on independently of the
  registry fix.
- After the fix, `go test -race -count=1 ./pkg/app/pipedv1/metadatastore/...`
  passes, including TestRegistryConcurrentAccess.
- `go build ./pkg/app/pipedv1/...` and
  `go test -race -count=1 ./pkg/app/pipedv1/controller/... ./pkg/app/pipedv1/cmd/piped/...`
  pass, confirming the pointer-sharing fix compiles and the wider
  call graph is unaffected.
- `go vet ./pkg/app/pipedv1/...` shows no copylocks warnings related to
  MetadataStoreRegistry (pre-existing, unrelated copylocks warnings in
  the planpreview package are unchanged before/after this diff).

Fixes #7096

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.