### PR TITLE
fix(kubernetes_multicluster): honor per-target kustomize overrides in livestate

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin.go
@@ -324,9 +324,17 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 	// override values if multiTarget has value.
 	manifestPathes := spec.Input.Manifests
 	kustomizeDir := ""
+	kustomizeVersion := spec.Input.KustomizeVersion
+	kustomizeOptions := spec.Input.KustomizeOptions
 	if multiTarget != nil {
 		if len(multiTarget.Manifests) > 0 {
 			manifestPathes = multiTarget.Manifests
+		}
+		if multiTarget.KustomizeVersion != "" {
+			kustomizeVersion = multiTarget.KustomizeVersion
+		}
+		if len(multiTarget.KustomizeOptions) > 0 {
+			kustomizeOptions = multiTarget.KustomizeOptions
 		}
 		kustomizeDir = multiTarget.KustomizeDir
 	}
@@ -340,9 +348,9 @@ func (p Plugin) loadManifests(ctx context.Context, input *sdk.GetLivestateInput[
 		ConfigFilename:   input.Request.DeploymentSource.ApplicationConfigFilename,
 		Manifests:        manifestPathes,
 		Namespace:        spec.Input.Namespace,
-		KustomizeVersion: spec.Input.KustomizeVersion,
+		KustomizeVersion: kustomizeVersion,
 		KustomizeDir:     kustomizeDir,
-		KustomizeOptions: spec.Input.KustomizeOptions,
+		KustomizeOptions: kustomizeOptions,
 		HelmVersion:      spec.Input.HelmVersion,
 		HelmChart:        spec.Input.HelmChart,
 		HelmOptions:      spec.Input.HelmOptions,

--- a/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes_multicluster/livestate/plugin_test.go
@@ -15,10 +15,12 @@
 package livestate
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
@@ -657,6 +659,129 @@ func Test_calculateSyncStatus(t *testing.T) {
 			t.Parallel()
 			got := calculateSyncStatus(tt.args.states)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type capturingLoader struct {
+	capturedInput provider.LoaderInput
+}
+
+func (c *capturingLoader) LoadManifests(_ context.Context, input provider.LoaderInput) ([]provider.Manifest, error) {
+	c.capturedInput = input
+	return nil, nil
+}
+
+func TestLoadManifests_KustomizeOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		specInput   kubeconfig.KubernetesDeploymentInput
+		multiTarget *kubeconfig.KubernetesMultiTarget
+		wantVersion string
+		wantOptions map[string]string
+	}{
+		{
+			name: "top-level values are used when multiTarget is nil",
+			specInput: kubeconfig.KubernetesDeploymentInput{
+				KustomizeVersion: "5.3.0",
+				KustomizeOptions: map[string]string{
+					"flag": "value",
+				},
+			},
+			multiTarget: nil,
+			wantVersion: "5.3.0",
+			wantOptions: map[string]string{
+				"flag": "value",
+			},
+		},
+		{
+			name: "multiTarget kustomizeVersion overrides top-level",
+			specInput: kubeconfig.KubernetesDeploymentInput{
+				KustomizeVersion: "5.3.0",
+			},
+			multiTarget: &kubeconfig.KubernetesMultiTarget{
+				KustomizeVersion: "5.4.3",
+			},
+			wantVersion: "5.4.3",
+			wantOptions: nil,
+		},
+		{
+			name: "multiTarget kustomizeOptions override top-level",
+			specInput: kubeconfig.KubernetesDeploymentInput{
+				KustomizeOptions: map[string]string{
+					"original": "value",
+				},
+			},
+			multiTarget: &kubeconfig.KubernetesMultiTarget{
+				KustomizeOptions: map[string]string{
+					"enable-helm": "",
+				},
+			},
+			wantVersion: "",
+			wantOptions: map[string]string{
+				"enable-helm": "",
+			},
+		},
+		{
+			name: "multiTarget overrides both version and options",
+			specInput: kubeconfig.KubernetesDeploymentInput{
+				KustomizeVersion: "5.3.0",
+				KustomizeOptions: map[string]string{
+					"original": "value",
+				},
+			},
+			multiTarget: &kubeconfig.KubernetesMultiTarget{
+				KustomizeVersion: "5.4.3",
+				KustomizeOptions: map[string]string{
+					"enable-helm": "",
+				},
+			},
+			wantVersion: "5.4.3",
+			wantOptions: map[string]string{
+				"enable-helm": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cl := &capturingLoader{}
+			p := &Plugin{}
+
+			spec := &kubeconfig.KubernetesApplicationSpec{
+				Input: tt.specInput,
+			}
+
+			input := &sdk.GetLivestateInput[kubeconfig.KubernetesApplicationSpec]{
+				Request: sdk.GetLivestateRequest[kubeconfig.KubernetesApplicationSpec]{
+					PipedID:         "piped-id",
+					ApplicationID:   "app-id",
+					ApplicationName: "app-name",
+					DeploymentSource: sdk.DeploymentSource[kubeconfig.KubernetesApplicationSpec]{
+						CommitHash:                "commit-hash",
+						ApplicationDirectory:      "testdata",
+						ApplicationConfigFilename: "app.pipecd.yaml",
+					},
+				},
+			}
+
+			_, err := p.loadManifests(
+				context.Background(),
+				input,
+				spec,
+				cl,
+				zaptest.NewLogger(t),
+				tt.multiTarget,
+			)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantVersion, cl.capturedInput.KustomizeVersion)
+			assert.Equal(t, tt.wantOptions, cl.capturedInput.KustomizeOptions)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

This PR fixes the multicluster `livestate` plugin to honor per-target `KustomizeVersion` and `KustomizeOptions` overrides when loading manifests.

Previously, `loadManifests()` always used the top-level kustomize settings from the application spec, ignoring any overrides defined in `KubernetesMultiTarget`. This could cause `livestate` to render manifests differently from the deployment plugin.

This change applies the same override precedence already used by the deployment plugin and adds regression tests to cover the behavior.

**Why we need it**:

The deployment plugin already respects per-target kustomize overrides, but the `livestate` plugin did not. This inconsistency could result in incorrect manifest rendering and inaccurate drift detection for applications using per-target kustomize settings.

**Which issue(s) this PR fixes**:

Fixes #7106 

**Does this PR introduce a user-facing change?**:

No.

- **How are users affected by this change**:
  Users who configure per-target `KustomizeVersion` or `KustomizeOptions` will now have `livestate` render manifests consistently with the deployment plugin, resulting in more accurate drift detection.

- **Is this breaking change**:
  No.

- **How to migrate (if breaking change)**:
  N/A.