### PR TITLE
Add unit tests for executeApplyStage, executePlanStage, and executeRo…

### DIFF
--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
@@ -1,0 +1,43 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+func TestPlugin_executeApplyStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executeApplyStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployment
 
 import (

--- a/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/apply_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+func TestPlugin_executeApplyStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executeApplyStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TODO: add test
 func (p *Plugin) executePlanStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
 	slp, err := input.Client.StageLogPersister()
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+func TestPlugin_executePlanStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executePlanStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployment
 
 import (

--- a/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/plan_test.go
@@ -1,0 +1,43 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+func TestPlugin_executePlanStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executePlanStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TODO: add test
 func (p *Plugin) executeRollbackStage(ctx context.Context, input *sdk.ExecuteStageInput[config.ApplicationConfigSpec], dts []*sdk.DeployTarget[config.DeployTargetConfig]) sdk.StageStatus {
 	slp, err := input.Client.StageLogPersister()
 	if err != nil {

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
@@ -1,0 +1,59 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry"
+)
+
+func TestPlugin_executeRollbackStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+		{
+			name: "failure when CommitHash is empty",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", logpersistertest.NewTestLogPersister(t), toolregistry.NewToolRegistry(nil)),
+				Logger: zap.NewNop(),
+				Request: sdk.ExecuteStageRequest[config.ApplicationConfigSpec]{
+					RunningDeploymentSource: sdk.DeploymentSource[config.ApplicationConfigSpec]{
+						CommitHash: "",
+					},
+				},
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executeRollbackStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/app/pipedv1/plugin/terraform/config"
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+	"github.com/pipe-cd/piped-plugin-sdk-go/logpersister/logpersistertest"
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry"
+)
+
+func TestPlugin_executeRollbackStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   *sdk.ExecuteStageInput[config.ApplicationConfigSpec]
+		dts     []*sdk.DeployTarget[config.DeployTargetConfig]
+		want    sdk.StageStatus
+	}{
+		{
+			name: "failure when StageLogPersister is unavailable",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", nil, nil),
+				Logger: zap.NewNop(),
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+		{
+			name: "failure when CommitHash is empty",
+			input: &sdk.ExecuteStageInput[config.ApplicationConfigSpec]{
+				Client: sdk.NewClient(nil, "terraform", "app1", "stage1", logpersistertest.NewTestLogPersister(t), toolregistry.NewToolRegistry(nil)),
+				Logger: zap.NewNop(),
+				Request: sdk.ExecuteStageRequest[config.ApplicationConfigSpec]{
+					RunningDeploymentSource: sdk.DeploymentSource[config.ApplicationConfigSpec]{
+						CommitHash: "",
+					},
+				},
+			},
+			dts:  []*sdk.DeployTarget[config.DeployTargetConfig]{{}},
+			want: sdk.StageStatusFailure,
+		},
+	}
+
+	p := &Plugin{}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.executeRollbackStage(context.Background(), tc.input, tc.dts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
+++ b/pkg/app/pipedv1/plugin/terraform/deployment/rollback_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployment
 
 import (


### PR DESCRIPTION
**What this PR does:** Adds unit tests for three stage-execution functions in the pipedv1 Terraform plugin: `executeApplyStage`, `executePlanStage`, and `executeRollbackStage`. It also removes the // TODO: add test comments from their respective source files.

The new test suites cover the most common pre-execution failure scenarios (such as an unavailable `StageLogPersister` across all stages, and an empty `CommitHash` during the first deployment rollback).

**Why we need it:** These functions are core to the Terraform plugin's deployment lifecycle but were entirely untested. Adding tests here improves confidence in the pipedv1 plugin architecture, resolves long-standing TODOs, and aligns with the project's existing testing patterns seen in `plugin_test.go`.

**Which issue(s) this PR fixes**:  Fixes #7108 

**Does this PR introduce a user-facing change?**:

- How are users affected by this change: No, this is an internal test addition only.
- Is this breaking change: No
- How to migrate (if breaking change): N/A