### PR TITLE
Adding devcontainer for development ease

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "PipeCD",
+  "image": "mcr.microsoft.com/devcontainers/go:1.26-trixie",
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "24.10.0" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": { "moby": false }
+  },
+  "onCreateCommand": {
+    "tools": "ARCH=$(dpkg --print-architecture) && curl -fsSLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-${ARCH} && curl -fsSLo /tmp/kubectl https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && sudo install -m 755 /tmp/kind /tmp/kubectl /usr/local/bin/ && rm /tmp/kind /tmp/kubectl && curl -fsSL https://get.helm.sh/helm-v3.17.3-linux-${ARCH}.tar.gz | sudo tar -xz --strip-components=1 -C /usr/local/bin linux-${ARCH}/helm",
+    // setup-envtest is required by `make test/go`.
+    "go-deps": "go mod download && make setup-envtest",
+    "web-deps": "make update/web-deps"
+  },
+
+  // 8080: Control Plane via `kubectl port-forward -n pipecd svc/pipecd 8080`
+  // 9090: web dev server via `make run/web`
+  "forwardPorts": [8080, 9090],
+
+  "hostRequirements": { "cpus": 4 },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+
+  "remoteUser": "vscode"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,9 +304,20 @@ where the `CONFIG_FILE` is the path to your piped configuration file and the `IN
 
 Replace `path/to/piped-config.yaml` with the actual path to your configuration file.
 
-### Online one-click setup for contributing
+### Using the Dev Container
 
-We are preparing Gitpod and Codespace to facilitate the setup process for contributing.
+A [Dev Container](.devcontainer/devcontainer.json) is available if you prefer not to
+install the toolchain yourself. It provides Go, Node.js, Docker, kubectl, Helm and kind,
+pinned to the versions used by CI.
+
+- **GitHub Codespaces**: click `Code` > `Codespaces` > `Create codespace` on GitHub.
+- **VS Code**: run `Dev Containers: Reopen in Container` with the
+  [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  extension installed.
+
+The Go and web dependencies are installed when the container is created, so you can run
+`make build`, `make test` and `make check` right away. Hugo is not included, so preview
+the docs site with the setup in [docs/README.md](./docs/README.md).
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
**What this PR does**:

Adds a Dev Container so contributors can get a working environment without
installing the toolchain by hand.

- `.devcontainer/devcontainer.json` — one file, based on
  `mcr.microsoft.com/devcontainers/go:1.26-trixie`, which ships the Go toolchain,
  the Go tools (gopls, dlv) and make/gcc that `go test -race` needs.
- Features: Node 24.10.0 (which also installs yarn) and Docker-in-Docker.
- `onCreateCommand` installs kind v0.32.0, kubectl and Helm 3.17.3, and pre-fetches
  dependencies (`go mod download`, `make setup-envtest`, `make update/web-deps`) in
  parallel, so `make build`, `make test` and `make check` work on first open.
- Forwards 8080 (Control Plane port-forward) and 9090 (web dev server).
- Recommends the Go, ESLint and Prettier extensions.
- `CONTRIBUTING.md`: replaces the "Online one-click setup for contributing"
  placeholder with usage instructions for Codespaces and VS Code.

Versions are pinned to CI (`build.yaml`, `lint.yaml`) and `web/package.json`, with
comments naming the source file so they get bumped together.

Notes:
- Docker-in-Docker rather than mounting the host socket, because `make lint/go` and
  `make gen/code` bind-mount `${PWD}`, which only resolves for a daemon running
  inside the container.
- `"moby": false` is required: Moby packages are not published for Debian trixie, so
  the feature installs Docker CE instead.
- The image tracks Go 1.26 (currently 1.26.5) rather than CI's exact 1.26.2. It
  satisfies go.mod's minimum, but it is not an exact pin.
- Hugo is not included, so previewing the docs site still follows `docs/README.md`.
- On arm64, `make gen/code` and `make run/pipecd` need
  `docker run --privileged --rm tonistiigi/binfmt --install amd64` first, since both
  are amd64-only in this repo today. Everything else runs natively.

**Why we need it**:

Setting up a local environment today means installing eight tools whose versions are
spread across five files (`go.mod`, `web/package.json`, `.github/workflows/build.yaml`,
`.github/workflows/lint.yaml`, `docs/README.md`), and several requirements are not
documented anywhere:

- `make test/go` passes `-race`, so it needs a C compiler; the failure does not say so.
- `make test/go` also needs `KUBEBUILDER_ASSETS`, i.e. `make setup-envtest` must run first.
- `make lint/go` and `make gen/code` need Docker, and break on setups where `${PWD}`
  is not visible to the daemon.
- The web app needs yarn 1.x to match `web/yarn.lock`.

It also helps Windows contributors, who currently need WSL — `docs/README.md` notes
that `make` and `grep` are not available in PowerShell. And running
`make up/local-cluster` inside Docker-in-Docker keeps the kind cluster, the
`kind-registry` container and the `pipecd-data` volume off the contributor's own Docker
and kubeconfig.

Finally, `CONTRIBUTING.md` has been advertising this as pending — "We are preparing
Gitpod and Codespace to facilitate the setup process for contributing." This implements
the Codespaces and VS Code half of that.

**Which issue(s) this PR fixes**:

Fixes #6581

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**: Not affected. This changes only the
  contributor environment; no PipeCD component, API, configuration or chart is touched.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A

