### PR TITLE
feat: Add address validation for gRPC connections and corresponding t…

### DIFF
--- a/pkg/app/pipectl/client/client.go
+++ b/pkg/app/pipectl/client/client.go
@@ -18,10 +18,16 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/resolver"
 
 	"github.com/pipe-cd/pipecd/pkg/app/server/service/apiservice"
 	"github.com/pipe-cd/pipecd/pkg/model"
@@ -45,9 +51,69 @@ func (o *Options) RegisterPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.CertFile, "cert-file", o.CertFile, "The path to the TLS certificate file.")
 }
 
+// validateAddress checks that addr is a target that gRPC is able to dial.
+//
+// It mirrors the way grpc-go itself parses a target: an address whose scheme is
+// backed by a registered resolver is a resolver URI, and its endpoint syntax is
+// resolver-specific (dns:///host defaults to port 443, unix:///path has no port
+// at all), so it is left to that resolver. Any other address is handed to the
+// default passthrough resolver and therefore has to be a dialable host:port.
+func validateAddress(addr string) error {
+	// Guarded here as well as in Validate so that the function is correct on its
+	// own, independently of the order its callers happen to run their checks in.
+	if addr == "" {
+		return errors.New("address must be set")
+	}
+
+	if u, err := url.Parse(addr); err == nil && u.Scheme != "" {
+		// Note that a scheme always wins over a host of the same name, so
+		// "dns:9000" is the dns resolver with endpoint "9000" rather than port
+		// 9000 of a host named "dns". That is grpc-go's own reading of it.
+		if resolver.Get(u.Scheme) != nil {
+			return nil
+		}
+		// An address written as a URL whose scheme is backed by no resolver,
+		// such as http:// or tcp://, is never a valid target. Report the scheme
+		// rather than letting it fall through and be blamed on the port.
+		if strings.Contains(addr, "://") {
+			return fmt.Errorf("invalid address %q: scheme %q is not a supported gRPC resolver", addr, u.Scheme)
+		}
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid address %q: must be in host:port form (e.g. localhost:9000) or use a gRPC scheme such as dns:///", addr)
+	}
+	if host == "" {
+		return fmt.Errorf("invalid address %q: host must not be empty", addr)
+	}
+	// Only the host of a host:port address is checked, so that socket paths
+	// behind a resolver scheme stay free to contain whitespace.
+	if strings.IndexFunc(host, unicode.IsSpace) >= 0 {
+		return fmt.Errorf("invalid address %q: host must not contain whitespace", addr)
+	}
+	// LookupPort rather than strconv.Atoi because net.Dial accepts named ports
+	// such as "localhost:http"; it reads the local services database, and does
+	// no network I/O.
+	//
+	// SplitHostPort accepts an empty port ("localhost:") and LookupPort maps it
+	// to 0, so both need rejecting here: a client can never dial port 0.
+	p, err := net.LookupPort("tcp", port)
+	if err != nil {
+		return fmt.Errorf("invalid address %q: %q is not a valid port", addr, port)
+	}
+	if p == 0 {
+		return fmt.Errorf("invalid address %q: port must be between 1 and 65535", addr)
+	}
+	return nil
+}
+
 func (o *Options) Validate() error {
 	if o.Address == "" {
 		return errors.New("address must be set")
+	}
+	if err := validateAddress(o.Address); err != nil {
+		return err
 	}
 	if o.APIKey == "" && o.APIKeyFile == "" {
 		return errors.New("either api-key or api-key-file must be set")

--- a/pkg/app/pipectl/client/client_test.go
+++ b/pkg/app/pipectl/client/client_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		address string
+		wantErr string // empty means the address is expected to be valid
+	}{
+		// host:port
+		{
+			name:    "host and port",
+			address: "localhost:9000",
+		},
+		{
+			name:    "IPv4 and port",
+			address: "127.0.0.1:443",
+		},
+		{
+			name:    "IPv6 and port",
+			address: "[::1]:9000",
+		},
+		{
+			name:    "fully qualified domain and port",
+			address: "api.pipecd.dev:443",
+		},
+		{
+			name:    "named port",
+			address: "localhost:http",
+		},
+
+		// Resolver URIs. Their endpoint syntax is resolver-specific, so an
+		// address without a port is still valid here.
+		{
+			name:    "dns resolver with port",
+			address: "dns:///localhost:9000",
+		},
+		{
+			name:    "dns resolver without port",
+			address: "dns:///localhost",
+		},
+		{
+			name:    "dns resolver with authority",
+			address: "dns://8.8.8.8/localhost:9000",
+		},
+		{
+			name:    "unix resolver",
+			address: "unix:///var/run/pipecd.sock",
+		},
+		{
+			name:    "unix resolver with relative path",
+			address: "unix:pipecd.sock",
+		},
+		{
+			name:    "passthrough resolver",
+			address: "passthrough:///localhost:9000",
+		},
+
+		// Missing port: the default passthrough resolver hands the address
+		// straight to net.Dial, which requires one.
+		{
+			name:    "host without port",
+			address: "localhost",
+			wantErr: "must be in host:port form",
+		},
+
+		// A scheme that no registered resolver backs is not a gRPC target,
+		// even though it parses as a URL.
+		{
+			name:    "http URL",
+			address: "http://localhost:9000",
+			wantErr: `scheme "http" is not a supported gRPC resolver`,
+		},
+		{
+			name:    "https URL",
+			address: "https://api.pipecd.dev",
+			wantErr: `scheme "https" is not a supported gRPC resolver`,
+		},
+		{
+			name:    "tcp scheme",
+			address: "tcp://localhost:9000",
+			wantErr: `scheme "tcp" is not a supported gRPC resolver`,
+		},
+
+		// Malformed input.
+		{
+			name:    "no scheme before separator",
+			address: "://bad",
+			wantErr: "host must not be empty",
+		},
+		{
+			name:    "empty host",
+			address: ":9000",
+			wantErr: "host must not be empty",
+		},
+		{
+			name:    "trailing path after port",
+			address: "localhost:9000/path",
+			wantErr: "is not a valid port",
+		},
+		{
+			name:    "non numeric port",
+			address: "localhost:abc",
+			wantErr: "is not a valid port",
+		},
+		{
+			name:    "port out of range",
+			address: "localhost:99999",
+			wantErr: "is not a valid port",
+		},
+		{
+			name:    "negative port",
+			address: "localhost:-1",
+			wantErr: "is not a valid port",
+		},
+		{
+			name:    "too many colons",
+			address: "localhost:9000:extra",
+			wantErr: "must be in host:port form",
+		},
+		{
+			name:    "IPv6 without brackets",
+			address: "::1:9000",
+			wantErr: "must be in host:port form",
+		},
+		{
+			name:    "bracketed IPv6 without port",
+			address: "[::1]",
+			wantErr: "must be in host:port form",
+		},
+		// SplitHostPort accepts an empty port and LookupPort maps it to 0, so
+		// these would otherwise slip through and be dialed against port 0.
+		{
+			name:    "trailing colon without port",
+			address: "localhost:",
+			wantErr: "port must be between 1 and 65535",
+		},
+		{
+			name:    "port zero",
+			address: "localhost:0",
+			wantErr: "port must be between 1 and 65535",
+		},
+		// A copy-paste stray space makes the host unresolvable.
+		{
+			name:    "leading whitespace",
+			address: " localhost:9000",
+			wantErr: "host must not contain whitespace",
+		},
+		{
+			name:    "whitespace inside host",
+			address: "local host:9000",
+			wantErr: "host must not contain whitespace",
+		},
+		{
+			name:    "carriage return from a pasted value",
+			address: "localhost\r:9000",
+			wantErr: "host must not contain whitespace",
+		},
+		{
+			name:    "empty address",
+			address: "",
+			wantErr: "address must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAddress(tt.address)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+			// The offending value is echoed back so the user can see what was
+			// parsed. It is quoted with %q, which escapes control characters.
+			if tt.address != "" {
+				assert.ErrorContains(t, err, fmt.Sprintf("%q", tt.address))
+			}
+		})
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options Options
+		wantErr string // empty means the options are expected to be valid
+	}{
+		{
+			name:    "valid with api key",
+			options: Options{Address: "localhost:9000", APIKey: "key"},
+		},
+		{
+			name:    "valid with api key file",
+			options: Options{Address: "localhost:9000", APIKeyFile: "/path/to/key"},
+		},
+		{
+			name:    "valid with resolver URI",
+			options: Options{Address: "dns:///localhost:9000", APIKey: "key"},
+		},
+		{
+			name:    "missing address",
+			options: Options{APIKey: "key"},
+			wantErr: "address must be set",
+		},
+		{
+			name:    "malformed address",
+			options: Options{Address: "localhost", APIKey: "key"},
+			wantErr: "must be in host:port form",
+		},
+		{
+			name:    "address is validated before credentials",
+			options: Options{Address: "localhost"},
+			wantErr: "must be in host:port form",
+		},
+		{
+			name:    "missing credentials",
+			options: Options{Address: "localhost:9000"},
+			wantErr: "either api-key or api-key-file must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.options.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// NewClient must reject a malformed address up front rather than spending the
+// dial timeout on it and reporting a transport error, which is the whole point
+// of validating the flag.
+func TestNewClientRejectsMalformedAddressWithoutDialing(t *testing.T) {
+	t.Parallel()
+
+	opts := &Options{Address: "localhost", APIKey: "key"}
+
+	start := time.Now()
+	client, err := opts.NewClient(context.Background())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.ErrorContains(t, err, "must be in host:port form")
+	// NewClient dials with a 5s timeout, so returning promptly proves the
+	// address was rejected before any connection was attempted.
+	assert.Less(t, elapsed, time.Second)
+}


### PR DESCRIPTION
**What this PR does**:

Adds `--address` format validation to `Options.Validate()` in `pkg/app/pipectl/client/client.go`.

A new `validateAddress` helper mirrors grpc-go's own target parsing instead of inventing its own rules:

- If the scheme is backed by a **registered resolver** (`resolver.Get`), the address is accepted and left to that resolver — endpoint syntax is resolver-specific, so `dns:///localhost` (defaults to `:443`) and `unix:///var/run/pipecd.sock` (no port at all) stay valid.
- Otherwise the address goes to the default `passthrough` resolver and must be a dialable `host:port`: non-empty host, no whitespace, and a port resolving via `net.LookupPort` to 1–65535.

Using the resolver registry rather than a hardcoded scheme allowlist keeps this correct automatically — it rejects `xds://`, for example, which is a real gRPC scheme but is not linked into the pipectl binary.

Also adds `pkg/app/pipectl/client/client_test.go`. This package previously had **no tests**; the new file covers `validateAddress`, `Options.Validate()`, and a `NewClient` case asserting a bad address fails fast rather than burning the 5s dial timeout (37 subtests).

**Why we need it**:

`Options.Validate()` only checked that `--address` was non-empty. Any non-empty malformed value passed through to `grpc.DialContext()` and surfaced after the dial timeout as:

```
desc = "transport: Error while dialing: dial tcp: address localhost: missing port in address"
```

That is hard to act on, and `Options` is shared by every pipectl subcommand (application, deployment, encrypt, event, planpreview, transfer, plugin), so it affects all pipectl users.

Behaviour was verified empirically against grpc v1.79.3 rather than from the docs. Inputs now rejected up front:

| input | error |
|---|---|
| `localhost` | `must be in host:port form (e.g. localhost:9000) or use a gRPC scheme such as dns:///` |
| `http://localhost:9000` | `scheme "http" is not a supported gRPC resolver` |
| `tcp://localhost:9000` | `scheme "tcp" is not a supported gRPC resolver` |
| `localhost:9000/path` | `"9000/path" is not a valid port` |
| `localhost:abc` | `"abc" is not a valid port` |
| `localhost:` and `localhost:0` | `port must be between 1 and 65535` |
| `" localhost:9000"` | `host must not contain whitespace` |
| `:9000` | `host must not be empty` |

The last three matter because the stdlib fails silently on them: `net.SplitHostPort("localhost:")` returns an empty port with **no error**, and `net.LookupPort("tcp", "")` returns `0, nil` — so gRPC would happily dial port 0.

**Which issue(s) this PR fixes**:

Fixes #7089

This deviates from the approach proposed in the issue. That algorithm (`SplitHostPort`, falling back to `url.Parse`, then checking for a non-empty host or any scheme) scored 9/13 against real gRPC behaviour — it accepts `http://…`, `tcp://…`, `localhost:9000/path`, and `localhost:abc`, because `SplitHostPort` does not validate that the port is numeric and "has a scheme" is too weak a test. Its instinct to exempt resolver URIs from the port requirement was correct and is preserved here.

**Does this PR introduce a user-facing change?**:

Yes.

- **How are users affected by this change**: A malformed `--address` now fails immediately with a specific message naming the problem and echoing the offending value, instead of a multi-line gRPC transport error after the dial timeout. Every previously valid form still works — `host:port`, IPv4, bracketed IPv6, FQDN, named ports (`localhost:http`), and `dns:///`, `unix:///`, `unix:`, `passthrough:///` resolver URIs.
- **Is this breaking change**: No. Validation was designed for zero false-rejects, and every newly rejected input was already non-functional. Two notes for reviewers: anyone parsing the old error text will see different strings, and an exotic target outside the tested set would now be blocked at validation rather than failing at dial.
- **How to migrate (if breaking change)**: N/A
