### PR TITLE
fix(web): prevent active stage selection from being overridden on pol…

### DIFF
--- a/web/src/components/deployments-detail-page/index.tsx
+++ b/web/src/components/deployments-detail-page/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { FC, memo, useEffect, useMemo, useState } from "react";
+import { FC, memo, useEffect, useMemo, useState, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { DeploymentDetail } from "./deployment-detail";
 import { LogViewer } from "./log-viewer";
@@ -21,6 +21,7 @@ export type ActiveStageInfo = {
 
 export const DeploymentDetailPage: FC = memo(function DeploymentDetailPage() {
   const [activeStageInfo, setActiveStageInfo] = useState<ActiveStageInfo>(null);
+  const prevDefaultStageIdRef = useRef<string | null>(null);
   const { deploymentId } = useParams<{ deploymentId: string }>();
 
   const { data: deployment } = useGetDeploymentById(
@@ -58,15 +59,31 @@ export const DeploymentDetailPage: FC = memo(function DeploymentDetailPage() {
   );
 
   useEffect(() => {
+    if (!deployment) return;
+
     const defaultActiveStage = findDefaultActiveStageInDeployment(deployment);
-    if (defaultActiveStage && deployment) {
+    const defaultStageId = defaultActiveStage?.id ?? null;
+
+    const isFirstLoad =
+      !activeStageInfo || activeStageInfo.deploymentId !== deployment.id;
+    const isTrackingDefault =
+      activeStageInfo &&
+      activeStageInfo.stageId === prevDefaultStageIdRef.current;
+
+    if (
+      defaultActiveStage &&
+      (isFirstLoad ||
+        (isTrackingDefault && defaultStageId !== prevDefaultStageIdRef.current))
+    ) {
       setActiveStageInfo({
         deploymentId: deployment.id ?? "",
         stageId: defaultActiveStage.id,
         name: defaultActiveStage.name,
       });
     }
-  }, [deployment]);
+
+    prevDefaultStageIdRef.current = defaultStageId;
+  }, [deployment, activeStageInfo]);
 
   // NOTE: Clear active stage when leave detail page
   useEffect(


### PR DESCRIPTION
## What this PR does

This PR fixes an issue in the **Deployment Details** page where the selected stage was reset during live polling.

The implementation introduces intelligent default stage tracking using a React `useRef` to distinguish between users who are following the default active stage and users who have manually selected a different stage. This preserves manual stage selections while still allowing the UI to automatically advance when the user is following the deployment's default progression.

## Why we need it

The deployment details page polls for updates every 4 seconds while a deployment is running. Each polling update refreshes the deployment object, causing the initialization effect to run repeatedly and reset the selected stage to the default active stage.

As a result, users are unable to inspect logs or details of another stage because their selection is overwritten on every polling cycle.

With this change:

* Users who manually select a stage keep their selection across polling updates.
* Users who are following the default active stage continue to automatically advance as the deployment progresses.
* Navigating to a different deployment still initializes the appropriate default active stage.

## Which issue(s) this PR fixes

Fixes #7119

## Does this PR introduce a user-facing change?

**Yes**

**How are users affected by this change?**

Users can inspect logs and details for any stage on the Deployment Details page without their selection being reset during live polling.

**Is this a breaking change?**

No.

**How to migrate (if breaking change)**

N/A.
