### PR TITLE
Docs V1: Reorganize the plugins section

### DIFF
--- a/docs/content/en/docs-v1.0.x/plugins/_index.md
+++ b/docs/content/en/docs-v1.0.x/plugins/_index.md
@@ -6,20 +6,6 @@ description: >
   This section describes the plugins available for PipeCD v1 and how to use them.
 ---
 
-> **Note:**
-> The Plugins section is a work in progress. More plugin docs are on the way. Happy PipeCDing!
-
-| Plugin | Description | Status |
-|--------|-------------|--------|
-| [Kubernetes multi-cluster](kubernetes-multicluster/) | Deploy a single application to multiple Kubernetes clusters with one pipeline. | Alpha |
-| [ECS](ecs/) | Deploy applications to Amazon ECS using the `EXTERNAL` deployment controller | Alpha |
-
-This section contains configuration guides for the official PipeCD plugins.
-
-- [Kubernetes](./kubernetes/)
-- [Terraform](./terraform/)
-- [Analysis](./analysis/)
-
 In PipeCD v1, plugins handle deployments. `piped` runs each configured plugin as a separate process and communicates with it over gRPC, so which platforms your `piped` can deploy to depends on which plugins you configure. See more about [plugins](../concepts/#plugins).
 
 There are two types of plugins:
@@ -29,25 +15,7 @@ There are two types of plugins:
 
 ## Official plugins
 
-The PipeCD maintainers develop and maintain the following plugins. Each plugin is versioned and released independently. You can download the plugin binaries from the [releases page](https://github.com/pipe-cd/pipecd/releases).
-
-### Deployment plugins
-
-| Plugin | Description |
-|--------|-------------|
-| Kubernetes | Deploys applications to a Kubernetes cluster. Supports quick sync and pipeline sync with canary, baseline, and blue-green strategies. |
-| Kubernetes multi-cluster | Deploys a single application to multiple Kubernetes clusters with one pipeline. |
-| Terraform | Applies infrastructure changes by running `terraform plan` and `terraform apply` in a pipeline. |
-| Amazon ECS | Deploys applications to Amazon ECS. |
-
-### Stage plugins
-
-| Plugin | Stage | Description |
-|--------|-------|-------------|
-| [Wait](wait/) | `WAIT` | Waits for a specified duration before continuing the pipeline. |
-| [Wait approval](wait-approval/) | `WAIT_APPROVAL` | Pauses the pipeline until a user approves the deployment. |
-| [Analysis](analysis/) | `ANALYSIS` | Evaluates the deployment by querying metrics, logs, or HTTP endpoints. |
-| [Script run](script-run/) | `SCRIPT_RUN` | Runs arbitrary commands as a pipeline stage. |
+The PipeCD maintainers develop and maintain a set of official plugins, each versioned and released independently. See [Official Plugins](official/) for the full list and configuration guides.
 
 ## Community plugins
 

--- a/docs/content/en/docs-v1.0.x/plugins/official/_index.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Official Plugins"
+linkTitle: "Official Plugins"
+weight: 10
+description: >
+  Configuration guides for the official PipeCD plugins.
+---
+
+The PipeCD maintainers develop and maintain the following plugins. Each plugin is versioned and released independently. You can download the plugin binaries from the [releases page](https://github.com/pipe-cd/pipecd/releases).
+
+## Deployment plugins
+
+| Plugin | Description |
+|--------|-------------|
+| [Kubernetes](kubernetes/) | Deploys applications to a Kubernetes cluster. Supports quick sync and pipeline sync with canary, baseline, and blue-green strategies. |
+| [Kubernetes multi-cluster](kubernetes-multicluster/) | Deploys a single application to multiple Kubernetes clusters with one pipeline. |
+| [Terraform](terraform/) | Applies infrastructure changes by running `terraform plan` and `terraform apply` in a pipeline. |
+| [Amazon ECS](ecs/) | Deploys applications to Amazon ECS. |
+
+## Stage plugins
+
+| Plugin | Stage | Description |
+|--------|-------|-------------|
+| [Wait](wait/) | `WAIT` | Waits for a specified duration before continuing the pipeline. |
+| [Wait approval](wait-approval/) | `WAIT_APPROVAL` | Pauses the pipeline until a user approves the deployment. |
+| [Analysis](analysis/) | `ANALYSIS` | Evaluates the deployment by querying metrics, logs, or HTTP endpoints. |
+| [Script run](script-run/) | `SCRIPT_RUN` | Runs arbitrary commands as a pipeline stage. |

--- a/docs/content/en/docs-v1.0.x/plugins/official/analysis.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/analysis.md
@@ -1,7 +1,7 @@
 ---
 title: "Analysis plugin"
 linkTitle: "Analysis"
-weight: 30
+weight: 70
 description: >
   Evaluate a deployment by analyzing metrics, logs, and HTTP responses.
 ---
@@ -74,7 +74,7 @@ analysisProviders:
 
 See [AnalysisProviderDatadogConfig](#analysisproviderdatadogconfig) for all fields.
 
-If you install `piped` with Helm, use `--set-file` to mount the key files during the [upgrade process](../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode):
+If you install `piped` with Helm, use `--set-file` to mount the key files during the [upgrade process](../../installation/install-piped/installing-on-kubernetes/#in-the-cluster-wide-mode):
 
 ```bash
 --set-file secret.data.datadog-api-key={PATH_TO_API_KEY_FILE} \
@@ -237,7 +237,7 @@ Configured under `config.analysisProviders[].config` in the **piped** configurat
 
 ### AnalysisApplicationSpec
 
-The `spec` of an application using analysis shares the [common application fields](../user-guide/managing-application/configuration-reference/) and adds the following under `plugins.analysis`:
+The `spec` of an application using analysis shares the [common application fields](../../user-guide/managing-application/configuration-reference/) and adds the following under `plugins.analysis`:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|

--- a/docs/content/en/docs-v1.0.x/plugins/official/ecs.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/ecs.md
@@ -1,7 +1,7 @@
 ---
 title: "ECS Plugin"
 linkTitle: "ECS"
-weight: 2
+weight: 40
 description: >
   Specific guide to configuring deployment for Amazon ECS application using the ECS plugin.
 ---
@@ -419,7 +419,7 @@ spec:
 
 ## Migrating from v0
 
-This section covers the steps specific to ECS applications. For the general migration process (updating `pipectl`, migrating the Control Plane database, installing pipedv1), follow the [Migrate to PipeCD v1](../../migrating-from-v0-to-v1/) guide first.
+This section covers the steps specific to ECS applications. For the general migration process (updating `pipectl`, migrating the Control Plane database, installing pipedv1), follow the [Migrate to PipeCD v1](../../../migrating-from-v0-to-v1/) guide first.
 
 ### 1. Update the piped configuration
 

--- a/docs/content/en/docs-v1.0.x/plugins/official/kubernetes-multicluster.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/kubernetes-multicluster.md
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes multi-cluster plugin"
 linkTitle: "Kubernetes multi-cluster"
-weight: 10
+weight: 20
 description: >
   Deploy a single Kubernetes application to multiple clusters with one pipeline.
 ---

--- a/docs/content/en/docs-v1.0.x/plugins/official/kubernetes.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/kubernetes.md
@@ -221,7 +221,7 @@ spec:
 
 ### KubernetesApplicationSpec
 
-The `spec` of a Kubernetes `Application` shares the [common application fields](../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.kubernetes`:
+The `spec` of a Kubernetes `Application` shares the [common application fields](../../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.kubernetes`:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|

--- a/docs/content/en/docs-v1.0.x/plugins/official/script-run.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/script-run.md
@@ -1,7 +1,7 @@
 ---
 title: "Script run plugin"
 linkTitle: "Script run"
-weight: 70
+weight: 80
 description: >
   Run arbitrary commands as a pipeline stage.
 ---

--- a/docs/content/en/docs-v1.0.x/plugins/official/terraform.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/terraform.md
@@ -1,7 +1,7 @@
 ---
 title: "Terraform plugin"
 linkTitle: "Terraform"
-weight: 20
+weight: 30
 description: >
   Apply infrastructure changes with Terraform.
 ---
@@ -105,7 +105,7 @@ Before a pipeline runs, plan preview runs `terraform plan` and shows the changes
 
 ### TerraformApplicationSpec
 
-The `spec` of a Terraform `Application` shares the [common application fields](../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.terraform`:
+The `spec` of a Terraform `Application` shares the [common application fields](../../user-guide/managing-application/configuration-reference/) (`name`, `labels`, `pipeline`, ...) and adds the following under `plugins.terraform`:
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|

--- a/docs/content/en/docs-v1.0.x/plugins/official/wait-approval.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/wait-approval.md
@@ -1,7 +1,7 @@
 ---
 title: "Wait approval plugin"
 linkTitle: "Wait approval"
-weight: 50
+weight: 60
 description: >
   Pause the pipeline until a user approves.
 ---

--- a/docs/content/en/docs-v1.0.x/plugins/official/wait.md
+++ b/docs/content/en/docs-v1.0.x/plugins/official/wait.md
@@ -1,7 +1,7 @@
 ---
 title: "Wait plugin"
 linkTitle: "Wait"
-weight: 40
+weight: 50
 description: >
   Pause the pipeline for a fixed duration.
 ---


### PR DESCRIPTION
**What this PR does**:
Reorganizes the v1 plugins section into a proper sidebar hierarchy. Adds an "Official Plugins" subsection holding the eight official plugin pages.

**Why we need it**:
The plugin pages were flat with inconsistent weights

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
