### PR TITLE
Add CLAUDE.md importing copilot-instructions.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.github/copilot-instructions.md


### PR DESCRIPTION
**What this PR does**:

Adds a one-line `CLAUDE.md` that imports `.github/copilot-instructions.md` using Claude Code's `@` import syntax.

**Why we need it**:

Tools like Claude Code automatically read `CLAUDE.md`, but this repo only has `.github/copilot-instructions.md`, which those tools do not pick up. New contributors using Claude Code would not know to point it at that file manually.

With this import, `.github/copilot-instructions.md` stays the single source of truth — there are no duplicate instructions and nothing to keep in sync.


**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: No user-facing change; this only affects contributors using Claude Code.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A
