### PR TITLE
feat(kubernetes): validate helm/kustomize, traffic routing, and varia…

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/config/application.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application.go
@@ -16,6 +16,8 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/creasty/defaults"
 )
@@ -72,7 +74,35 @@ func (s *KubernetesApplicationSpec) UnmarshalJSON(data []byte) error {
 }
 
 func (s *KubernetesApplicationSpec) Validate() error {
-	// TODO: Validate KubernetesApplicationSpec fields.
+	if s.Input.HelmChart != nil && len(s.Input.KustomizeOptions) > 0 {
+		return errors.New("helmChart and kustomizeOptions are mutually exclusive")
+	}
+
+	if s.TrafficRouting != nil {
+		switch s.TrafficRouting.Method {
+		case "", KubernetesTrafficRoutingMethodPodSelector, KubernetesTrafficRoutingMethodIstio:
+		default:
+			return fmt.Errorf("unsupported trafficRouting.method %q", s.TrafficRouting.Method)
+		}
+	}
+
+	if s.VariantLabel.Key == "" {
+		return errors.New("variantLabel.key must not be empty")
+	}
+	if s.VariantLabel.PrimaryValue == "" {
+		return errors.New("variantLabel.primaryValue must not be empty")
+	}
+	if s.VariantLabel.CanaryValue == "" {
+		return errors.New("variantLabel.canaryValue must not be empty")
+	}
+	if s.VariantLabel.BaselineValue == "" {
+		return errors.New("variantLabel.baselineValue must not be empty")
+	}
+	if s.VariantLabel.PrimaryValue == s.VariantLabel.CanaryValue ||
+		s.VariantLabel.PrimaryValue == s.VariantLabel.BaselineValue ||
+		s.VariantLabel.CanaryValue == s.VariantLabel.BaselineValue {
+		return errors.New("variantLabel primaryValue, canaryValue, and baselineValue must be unique")
+	}
 	return nil
 }
 

--- a/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/config/application_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubernetesApplicationSpecValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		spec    KubernetesApplicationSpec
+		wantErr string
+	}{
+		{
+			name: "valid spec",
+			spec: validKubernetesApplicationSpec(),
+		},
+		{
+			name: "helmChart and kustomizeOptions are mutually exclusive",
+			spec: KubernetesApplicationSpec{
+				Input: KubernetesDeploymentInput{
+					HelmChart:        &InputHelmChart{Path: "./chart"},
+					KustomizeOptions: map[string]string{"load-restrictor": "LoadRestrictionsNone"},
+				},
+				VariantLabel: validKubernetesVariantLabel(),
+			},
+			wantErr: "helmChart and kustomizeOptions are mutually exclusive",
+		},
+		{
+			name: "unsupported traffic routing method",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: validKubernetesVariantLabel(),
+				TrafficRouting: &KubernetesTrafficRouting{
+					Method: "unknown",
+				},
+			},
+			wantErr: `unsupported trafficRouting.method "unknown"`,
+		},
+		{
+			name: "empty variant label key",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: KubernetesVariantLabel{
+					PrimaryValue:  "primary",
+					CanaryValue:   "canary",
+					BaselineValue: "baseline",
+				},
+			},
+			wantErr: "variantLabel.key must not be empty",
+		},
+		{
+			name: "empty primary variant label value",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: KubernetesVariantLabel{
+					Key:           "pipecd.dev/variant",
+					CanaryValue:   "canary",
+					BaselineValue: "baseline",
+				},
+			},
+			wantErr: "variantLabel.primaryValue must not be empty",
+		},
+		{
+			name: "empty canary variant label value",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: KubernetesVariantLabel{
+					Key:           "pipecd.dev/variant",
+					PrimaryValue:  "primary",
+					BaselineValue: "baseline",
+				},
+			},
+			wantErr: "variantLabel.canaryValue must not be empty",
+		},
+		{
+			name: "empty baseline variant label value",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: KubernetesVariantLabel{
+					Key:          "pipecd.dev/variant",
+					PrimaryValue: "primary",
+					CanaryValue:  "canary",
+				},
+			},
+			wantErr: "variantLabel.baselineValue must not be empty",
+		},
+		{
+			name: "duplicate variant label values",
+			spec: KubernetesApplicationSpec{
+				VariantLabel: KubernetesVariantLabel{
+					Key:           "pipecd.dev/variant",
+					PrimaryValue:  "stable",
+					CanaryValue:   "stable",
+					BaselineValue: "baseline",
+				},
+			},
+			wantErr: "variantLabel primaryValue, canaryValue, and baselineValue must be unique",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.spec.Validate()
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestKubernetesApplicationSpecUnmarshalJSONSetsDefaults(t *testing.T) {
+	t.Parallel()
+
+	var spec KubernetesApplicationSpec
+	err := json.Unmarshal([]byte(`{}`), &spec)
+
+	assert.NoError(t, err)
+	assert.NoError(t, spec.Validate())
+	assert.Equal(t, validKubernetesVariantLabel(), spec.VariantLabel)
+}
+
+func validKubernetesApplicationSpec() KubernetesApplicationSpec {
+	return KubernetesApplicationSpec{
+		VariantLabel: validKubernetesVariantLabel(),
+		TrafficRouting: &KubernetesTrafficRouting{
+			Method: KubernetesTrafficRoutingMethodPodSelector,
+		},
+	}
+}
+
+func validKubernetesVariantLabel() KubernetesVariantLabel {
+	return KubernetesVariantLabel{
+		Key:           "pipecd.dev/variant",
+		PrimaryValue:  "primary",
+		CanaryValue:   "canary",
+		BaselineValue: "baseline",
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Implements `KubernetesApplicationSpec.Validate()` in the pipedv1 Kubernetes plugin, replacing the previous TODO stub. It validates:

- Mutual exclusivity of `input.helmChart` and `input.kustomizeOptions`
- Supported `trafficRouting.method` values (`""`, `podselector`, `istio`)
- Non-empty and unique `variantLabel` key/values (`primary`, `canary`, `baseline`)

Adds unit tests covering valid specs, each error case, and default values applied via JSON unmarshaling.

**Why we need it**:

Invalid Kubernetes application configs were accepted until plan/sync time, which delayed feedback and could cause confusing progressive-delivery failures. Early validation returns clear errors before deployment starts and aligns the single-cluster plugin with validation patterns used elsewhere.

**Which issue(s) this PR fixes**:

Fixes #7142

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Invalid application specs now fail earlier with explicit validation errors instead of failing later during plan/sync.
- **Is this breaking change**: No (only invalid configs that would already fail or misbehave at runtime are rejected earlier)
- **How to migrate (if breaking change)**: N/A