### PR TITLE
Persist HTTP basic auth credentials for git operations after clone

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -33,6 +33,14 @@ const (
 	defaultEmail    = "pipecd.dev@gmail.com"
 )
 
+// basicAuthHeader builds the value of an HTTP "Authorization" header
+// for basic authentication with the given username and password.
+func basicAuthHeader(username, password string) string {
+	token := fmt.Sprintf("%s:%s", username, password)
+	encodedToken := base64.StdEncoding.EncodeToString([]byte(token))
+	return fmt.Sprintf("Authorization: Basic %s", encodedToken)
+}
+
 // Client is a git client for cloning/fetching git repo.
 // It keeps a local cache for faster future cloning.
 type Client interface {
@@ -148,9 +156,7 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 	_, err, _ := c.repoSingleFlights.Do(repoID, func() (interface{}, error) {
 		authArgs := []string{}
 		if c.username != "" && c.password != "" {
-			token := fmt.Sprintf("%s:%s", c.username, c.password)
-			encodedToken := base64.StdEncoding.EncodeToString([]byte(token))
-			header := fmt.Sprintf("Authorization: Basic %s", encodedToken)
+			header := basicAuthHeader(c.username, c.password)
 			authArgs = append(authArgs, "-c", fmt.Sprintf("http.extraHeader=%s", header))
 		}
 
@@ -239,6 +245,14 @@ func (c *client) Clone(ctx context.Context, repoID, remote, branch, destination 
 	if c.username != "" || c.email != "" {
 		if err := r.setUser(ctx, c.username, c.email); err != nil {
 			return nil, fmt.Errorf("failed to set user: %v", err)
+		}
+	}
+	// Persist the basic auth header into the checked-out repo's git config so that
+	// subsequent git operations (e.g. pull, fetch, push) run directly against the
+	// remote continue to be authenticated, not just this initial clone.
+	if c.username != "" && c.password != "" {
+		if err := r.setHTTPAuthHeader(ctx, basicAuthHeader(c.username, c.password)); err != nil {
+			return nil, fmt.Errorf("failed to set up http auth: %v", err)
 		}
 	}
 

--- a/pkg/git/client_test.go
+++ b/pkg/git/client_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +91,43 @@ func TestClone(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(commits12))
 	assert.Equal(t, "Added note.txt", commits12[0].Message)
+}
+
+func TestClonePersistsHTTPAuthHeader(t *testing.T) {
+	faker, err := newFaker()
+	require.NoError(t, err)
+	defer faker.clean()
+
+	c, err := NewClient(WithUserName("git-user"), WithPassword("git-pass"))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	defer c.Clean()
+
+	err = faker.makeRepo("test-clone-org", "repo-auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	destPath, err := os.MkdirTemp("", "repo-auth-dest")
+	require.NoError(t, err)
+
+	repo, err := c.Clone(ctx, "repo-auth", filepath.Join(faker.dir, "test-clone-org/repo-auth"), "", destPath)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	defer func() {
+		assert.NoError(t, repo.Clean())
+	}()
+
+	// Simulates what happens after the initial clone: a plain `git pull` run
+	// directly against the checked-out repo, as done by e.g. the event watcher.
+	// This must be able to find the credentials without any extra args, otherwise
+	// it fails with "could not read Username" for an HTTP(S) remote requiring auth.
+	cmd := exec.CommandContext(ctx, c.(*client).gitPath, "config", "--get", "http.extraHeader")
+	cmd.Dir = destPath
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	wantHeader := basicAuthHeader("git-user", "git-pass")
+	assert.Equal(t, wantHeader, strings.TrimSuffix(string(out), "\n"))
 }
 
 type faker struct {

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -71,6 +71,11 @@ type repo struct {
 	username string
 	email    string
 
+	// httpAuthHeader is the HTTP "Authorization" header value used to authenticate
+	// with the remote when it's accessed over HTTP(S). It's empty when username/password
+	// based authentication isn't configured. It's set in the `setHTTPAuthHeader` method.
+	httpAuthHeader string
+
 	dir          string
 	gitPath      string
 	remote       string
@@ -205,6 +210,14 @@ func (r *repo) CopyToModify(dest string) (Repo, error) {
 	if r.username != "" || r.email != "" {
 		if err := cloned.setUser(context.Background(), r.username, r.email); err != nil {
 			return nil, fmt.Errorf("failed to set user: %v", err)
+		}
+	}
+
+	// the cloned repo doesn't inherit custom config from the source one,
+	// so we need to set the http auth header again if it was configured.
+	if r.httpAuthHeader != "" {
+		if err := cloned.setHTTPAuthHeader(context.Background(), r.httpAuthHeader); err != nil {
+			return nil, fmt.Errorf("failed to set up http auth: %v", err)
 		}
 	}
 
@@ -459,6 +472,18 @@ func (r *repo) setUser(ctx context.Context, username, email string) error {
 	if out, err := r.runGitCommand(ctx, "config", "user.email", email); err != nil {
 		return formatCommandError(err, out)
 	}
+	return nil
+}
+
+// setHTTPAuthHeader persists the given HTTP "Authorization" header value into the
+// repo's git config, so that it's automatically included by git in every future
+// git command run against this repo directory, not just the command it was
+// originally issued with via a one-off `-c` flag.
+func (r *repo) setHTTPAuthHeader(ctx context.Context, header string) error {
+	if out, err := r.runGitCommand(ctx, "config", "http.extraHeader", header); err != nil {
+		return formatCommandError(err, out)
+	}
+	r.httpAuthHeader = header
 	return nil
 }
 

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -480,7 +480,7 @@ func (r *repo) setUser(ctx context.Context, username, email string) error {
 // git command run against this repo directory, not just the command it was
 // originally issued with via a one-off `-c` flag.
 func (r *repo) setHTTPAuthHeader(ctx context.Context, header string) error {
-	if out, err := r.runGitCommand(ctx, "config", "http.extraHeader", header); err != nil {
+	if out, err := r.runGitCommand(ctx, "config", "--local", "--replace-all", "http.extraHeader", header); err != nil {
 		return formatCommandError(err, out)
 	}
 	r.httpAuthHeader = header

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -243,6 +243,49 @@ func Test_setGCAutoDetach(t *testing.T) {
 	assert.Equal(t, false, got)
 }
 
+func Test_setHTTPAuthHeader(t *testing.T) {
+	getHTTPExtraHeader := func(ctx context.Context, repo *repo) (string, error) {
+		cmd := exec.CommandContext(ctx, repo.gitPath, "config", "--get", "http.extraHeader")
+		cmd.Dir = repo.dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSuffix(string(out), "\n"), nil
+	}
+
+	faker, err := newFaker()
+	require.NoError(t, err)
+	defer faker.clean()
+
+	var (
+		org      = "test-repo-org"
+		repoName = "repo-set-http-auth-header"
+		ctx      = context.Background()
+	)
+
+	err = faker.makeRepo(org, repoName)
+	require.NoError(t, err)
+
+	r := &repo{
+		dir:     faker.repoDir(org, repoName),
+		gitPath: faker.gitPath,
+	}
+
+	// Before being set, the repo has no http.extraHeader configured.
+	_, err = getHTTPExtraHeader(ctx, r)
+	require.Error(t, err)
+
+	header := "Authorization: Basic dXNlcjpwYXNz"
+	err = r.setHTTPAuthHeader(ctx, header)
+	require.NoError(t, err)
+	assert.Equal(t, header, r.httpAuthHeader)
+
+	got, err := getHTTPExtraHeader(ctx, r)
+	require.NoError(t, err)
+	assert.Equal(t, header, got)
+}
+
 func TestCopy(t *testing.T) {
 	faker, err := newFaker()
 	require.NoError(t, err)
@@ -293,6 +336,10 @@ func TestCopyToModify(t *testing.T) {
 		remote:  faker.repoDir(org, repoName), // use the same directory as remote, it's not a real remote. it's strange but it's ok for testing.
 	}
 
+	header := "Authorization: Basic dXNlcjpwYXNz"
+	err = r.setHTTPAuthHeader(ctx, header)
+	require.NoError(t, err)
+
 	commits, err := r.ListCommits(ctx, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(commits))
@@ -300,6 +347,15 @@ func TestCopyToModify(t *testing.T) {
 	tmpDir := filepath.Join(faker.dir, "tmp-repo")
 	newRepo, err := r.CopyToModify(tmpDir)
 	require.NoError(t, err)
+
+	// The http auth header must be propagated to the cloned repo too,
+	// since it's not carried over by a plain `git clone`.
+	assert.Equal(t, header, newRepo.(*repo).httpAuthHeader)
+	cmd := exec.CommandContext(ctx, r.gitPath, "config", "--get", "http.extraHeader")
+	cmd.Dir = tmpDir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	assert.Equal(t, header, strings.TrimSuffix(string(out), "\n"))
 
 	// we can copy the repo to another directory multiple times
 	tmpDir2 := filepath.Join(faker.dir, "tmp-repo2")


### PR DESCRIPTION
**What this PR does**:

Persists the HTTP Basic-Auth header (built from the piped git `username`/`password` config) into the checked-out repository's git config, so that git operations run after the initial clone (`pull`, `fetch`, `push`, etc.) keep using the configured credentials.

**Why we need it**:

When a piped git repository is configured with `username`/`password` (a PAT) for HTTPS auth, `pkg/git/client.go`'s `Client.Clone()` only passed the `Authorization` header as a one-off `-c http.extraHeader=...` flag to the `git clone --mirror` / `git fetch` commands used to populate its internal cache. That flag is never persisted, and the `Repo` object handed back to callers (a worktree checked out from the cache, with `origin` rewritten to the real HTTPS remote URL) carries no credentials at all. Components such as the event watcher (`pkg/app/piped/eventwatcher`) call `repo.Pull()` repeatedly on that same object over time; `Pull`/`Push`/`MergeRemoteBranch`/`CheckoutPullRequest` in `pkg/git/repo.go` issue git commands straight at the remote with no auth, so every one of them fails with `fatal: could not read Username for 'https://github.com': No such device or address` — reproducing exactly the error reported in the issue.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: Piped deployments configured with HTTPS `username`/`password` git auth (a common CI/CD PAT pattern) now keep working after the initial clone — previously, background git operations like the event watcher's periodic pull and re-clone would fail indefinitely with a credential error. Deployments using SSH auth are unaffected.
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A

---
AI assistance: this change was drafted with Claude Code.

Fixes #6453