### PR TITLE
fix: paginate ListNotCompletedDeployments in legacy piped

### DIFF
--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -103,23 +103,30 @@ func (s *store) Lister() Lister {
 }
 
 func (s *store) sync(ctx context.Context) error {
-	// TODO: Call ListNotCompletedDeployments itervally until all required deployments are fetched.
-	resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{})
-	if err != nil {
-		s.logger.Error("failed to list unhandled deployment", zap.Error(err))
-		return err
-	}
-
 	var pendings, planneds, runnings []*model.Deployment
-	for _, d := range resp.Deployments {
-		switch d.Status {
-		case model.DeploymentStatus_DEPLOYMENT_PENDING:
-			pendings = append(pendings, d)
-		case model.DeploymentStatus_DEPLOYMENT_PLANNED:
-			planneds = append(planneds, d)
-		case model.DeploymentStatus_DEPLOYMENT_RUNNING, model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK:
-			runnings = append(runnings, d)
+	cursor := ""
+	for {
+		resp, err := s.apiClient.ListNotCompletedDeployments(ctx, &pipedservice.ListNotCompletedDeploymentsRequest{
+			Cursor: cursor,
+		})
+		if err != nil {
+			s.logger.Error("failed to list unhandled deployment", zap.Error(err))
+			return err
 		}
+		for _, d := range resp.Deployments {
+			switch d.Status {
+			case model.DeploymentStatus_DEPLOYMENT_PENDING:
+				pendings = append(pendings, d)
+			case model.DeploymentStatus_DEPLOYMENT_PLANNED:
+				planneds = append(planneds, d)
+			case model.DeploymentStatus_DEPLOYMENT_RUNNING, model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK:
+				runnings = append(runnings, d)
+			}
+		}
+		if resp.Cursor == "" {
+			break
+		}
+		cursor = resp.Cursor
 	}
 
 	headDeployments := make(map[string]*model.Deployment)

--- a/pkg/app/piped/apistore/deploymentstore/store.go
+++ b/pkg/app/piped/apistore/deploymentstore/store.go
@@ -123,6 +123,12 @@ func (s *store) sync(ctx context.Context) error {
 				runnings = append(runnings, d)
 			}
 		}
+		// Safety guard against a misbehaving server: if a page carries no
+		// deployments, stop paging even when a non-empty cursor is returned.
+		// Without this, such a response would spin this loop forever.
+		if len(resp.Deployments) == 0 {
+			break
+		}
 		if resp.Cursor == "" {
 			break
 		}

--- a/pkg/app/piped/apistore/deploymentstore/store_test.go
+++ b/pkg/app/piped/apistore/deploymentstore/store_test.go
@@ -36,14 +36,20 @@ import (
 // If err is set, it is returned instead of a page on the call index
 // identified by errAt (0-based), letting a test simulate a failure that
 // happens partway through pagination rather than on the very first call.
+//
+// gotCursors records the Cursor field of every request received, in order,
+// so tests can assert that each response cursor is threaded into the next
+// request ("" -> "page2" -> "page3").
 type fakeAPIClient struct {
-	pages []*pipedservice.ListNotCompletedDeploymentsResponse
-	call  int
-	err   error
-	errAt int
+	pages      []*pipedservice.ListNotCompletedDeploymentsResponse
+	call       int
+	err        error
+	errAt      int
+	gotCursors []string
 }
 
-func (f *fakeAPIClient) ListNotCompletedDeployments(_ context.Context, _ *pipedservice.ListNotCompletedDeploymentsRequest, _ ...grpc.CallOption) (*pipedservice.ListNotCompletedDeploymentsResponse, error) {
+func (f *fakeAPIClient) ListNotCompletedDeployments(_ context.Context, req *pipedservice.ListNotCompletedDeploymentsRequest, _ ...grpc.CallOption) (*pipedservice.ListNotCompletedDeploymentsResponse, error) {
+	f.gotCursors = append(f.gotCursors, req.GetCursor())
 	if f.err != nil && f.call == f.errAt {
 		return nil, f.err
 	}
@@ -75,6 +81,9 @@ func TestSync(t *testing.T) {
 		wantPlanneds []*model.Deployment
 		wantRunnings []*model.Deployment
 		wantHeads    map[string]*model.Deployment
+		// wantCursors is the ordered sequence of Cursor values sync() is
+		// expected to send. The first request always carries "".
+		wantCursors []string
 	}{
 		{
 			name: "empty_response",
@@ -85,6 +94,7 @@ func TestSync(t *testing.T) {
 			wantPlanneds: nil,
 			wantRunnings: nil,
 			wantHeads:    map[string]*model.Deployment{},
+			wantCursors:  []string{""},
 		},
 		{
 			name: "single_page_classifies_each_status",
@@ -100,6 +110,7 @@ func TestSync(t *testing.T) {
 				"app-3": running,
 				"app-4": rollingBack,
 			},
+			wantCursors: []string{""},
 		},
 		{
 			name: "paginates_across_multiple_pages",
@@ -115,6 +126,7 @@ func TestSync(t *testing.T) {
 				"app-2": planned,
 				"app-3": running,
 			},
+			wantCursors: []string{"", "page2"},
 		},
 		{
 			name: "rolling_back_is_classified_as_running",
@@ -127,6 +139,7 @@ func TestSync(t *testing.T) {
 			wantHeads: map[string]*model.Deployment{
 				"app-4": rollingBack,
 			},
+			wantCursors: []string{""},
 		},
 		// Three pages forces at least two follow-up requests, which a
 		// "call once more if the first cursor is non-empty" shortcut
@@ -146,25 +159,30 @@ func TestSync(t *testing.T) {
 				"app-2": planned,
 				"app-3": running,
 			},
+			wantCursors: []string{"", "page2", "page3"},
 		},
 		// Page 1 succeeds and yields a cursor; page 2 fails. sync() must
 		// return the error and must not apply the partial results already
 		// accumulated from page 1 — Lister() should reflect nothing new.
+		// The cursor from page 1 must still have been threaded into the
+		// failing request.
 		{
 			name: "fails_on_mid_pagination_error",
 			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
 				{Deployments: []*model.Deployment{pending}, Cursor: "page2"},
 			},
-			apiErr:  errors.New("unavailable"),
-			errAt:   1,
-			wantErr: true,
+			apiErr:      errors.New("unavailable"),
+			errAt:       1,
+			wantErr:     true,
+			wantCursors: []string{"", "page2"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeAPIClient{pages: tc.pages, err: tc.apiErr, errAt: tc.errAt}
 			s := &store{
-				apiClient: &fakeAPIClient{pages: tc.pages, err: tc.apiErr, errAt: tc.errAt},
+				apiClient: fc,
 				logger:    zap.NewNop(),
 			}
 
@@ -179,6 +197,7 @@ func TestSync(t *testing.T) {
 			assert.Equal(t, tc.wantPlanneds, s.ListPlanneds())
 			assert.Equal(t, tc.wantRunnings, s.ListRunnings())
 			assert.Equal(t, tc.wantHeads, s.ListAppHeadDeployments())
+			assert.Equal(t, tc.wantCursors, fc.gotCursors)
 		})
 	}
 }

--- a/pkg/app/piped/apistore/deploymentstore/store_test.go
+++ b/pkg/app/piped/apistore/deploymentstore/store_test.go
@@ -161,6 +161,24 @@ func TestSync(t *testing.T) {
 			},
 			wantCursors: []string{"", "page2", "page3"},
 		},
+		// A misbehaving server returns a page with no deployments but still
+		// hands back a non-empty cursor. sync() must stop paging on the empty
+		// page instead of looping forever, so the bogus "page3" cursor is
+		// never threaded into a follow-up request.
+		{
+			name: "stops_on_empty_page_with_non_empty_cursor",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending}, Cursor: "page2"},
+				{Deployments: nil, Cursor: "page3"},
+			},
+			wantPendings: []*model.Deployment{pending},
+			wantPlanneds: nil,
+			wantRunnings: nil,
+			wantHeads: map[string]*model.Deployment{
+				"app-1": pending,
+			},
+			wantCursors: []string{"", "page2"},
+		},
 		// Page 1 succeeds and yields a cursor; page 2 fails. sync() must
 		// return the error and must not apply the partial results already
 		// accumulated from page 1 — Lister() should reflect nothing new.

--- a/pkg/app/piped/apistore/deploymentstore/store_test.go
+++ b/pkg/app/piped/apistore/deploymentstore/store_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploymentstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/pipe-cd/pipecd/pkg/app/server/service/pipedservice"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+// fakeAPIClient returns a pre-canned sequence of pages, one per call.
+// If the test code calls beyond len(pages), an empty terminal response is
+// returned so misconfigured tests fail with a clear assertion mismatch
+// instead of an index-out-of-range panic.
+//
+// If err is set, it is returned instead of a page on the call index
+// identified by errAt (0-based), letting a test simulate a failure that
+// happens partway through pagination rather than on the very first call.
+type fakeAPIClient struct {
+	pages []*pipedservice.ListNotCompletedDeploymentsResponse
+	call  int
+	err   error
+	errAt int
+}
+
+func (f *fakeAPIClient) ListNotCompletedDeployments(_ context.Context, _ *pipedservice.ListNotCompletedDeploymentsRequest, _ ...grpc.CallOption) (*pipedservice.ListNotCompletedDeploymentsResponse, error) {
+	if f.err != nil && f.call == f.errAt {
+		return nil, f.err
+	}
+	if f.call >= len(f.pages) {
+		return &pipedservice.ListNotCompletedDeploymentsResponse{}, nil
+	}
+	resp := f.pages[f.call]
+	f.call++
+	return resp, nil
+}
+
+func makeDeployment(id, appID string, status model.DeploymentStatus) *model.Deployment {
+	return &model.Deployment{Id: id, ApplicationId: appID, Status: status}
+}
+
+func TestSync(t *testing.T) {
+	pending := makeDeployment("d-pending", "app-1", model.DeploymentStatus_DEPLOYMENT_PENDING)
+	planned := makeDeployment("d-planned", "app-2", model.DeploymentStatus_DEPLOYMENT_PLANNED)
+	running := makeDeployment("d-running", "app-3", model.DeploymentStatus_DEPLOYMENT_RUNNING)
+	rollingBack := makeDeployment("d-rolling-back", "app-4", model.DeploymentStatus_DEPLOYMENT_ROLLING_BACK)
+
+	tests := []struct {
+		name         string
+		pages        []*pipedservice.ListNotCompletedDeploymentsResponse
+		apiErr       error
+		errAt        int
+		wantErr      bool
+		wantPendings []*model.Deployment
+		wantPlanneds []*model.Deployment
+		wantRunnings []*model.Deployment
+		wantHeads    map[string]*model.Deployment
+	}{
+		{
+			name: "empty_response",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: nil, Cursor: ""},
+			},
+			wantPendings: nil,
+			wantPlanneds: nil,
+			wantRunnings: nil,
+			wantHeads:    map[string]*model.Deployment{},
+		},
+		{
+			name: "single_page_classifies_each_status",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending, planned, running, rollingBack}, Cursor: ""},
+			},
+			wantPendings: []*model.Deployment{pending},
+			wantPlanneds: []*model.Deployment{planned},
+			wantRunnings: []*model.Deployment{running, rollingBack},
+			wantHeads: map[string]*model.Deployment{
+				"app-1": pending,
+				"app-2": planned,
+				"app-3": running,
+				"app-4": rollingBack,
+			},
+		},
+		{
+			name: "paginates_across_multiple_pages",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending}, Cursor: "page2"},
+				{Deployments: []*model.Deployment{planned, running}, Cursor: ""},
+			},
+			wantPendings: []*model.Deployment{pending},
+			wantPlanneds: []*model.Deployment{planned},
+			wantRunnings: []*model.Deployment{running},
+			wantHeads: map[string]*model.Deployment{
+				"app-1": pending,
+				"app-2": planned,
+				"app-3": running,
+			},
+		},
+		{
+			name: "rolling_back_is_classified_as_running",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{rollingBack}, Cursor: ""},
+			},
+			wantPendings: nil,
+			wantPlanneds: nil,
+			wantRunnings: []*model.Deployment{rollingBack},
+			wantHeads: map[string]*model.Deployment{
+				"app-4": rollingBack,
+			},
+		},
+		// Three pages forces at least two follow-up requests, which a
+		// "call once more if the first cursor is non-empty" shortcut
+		// would not satisfy — only a genuine loop passes this case.
+		{
+			name: "paginates_across_three_or_more_pages",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending}, Cursor: "page2"},
+				{Deployments: []*model.Deployment{planned}, Cursor: "page3"},
+				{Deployments: []*model.Deployment{running}, Cursor: ""},
+			},
+			wantPendings: []*model.Deployment{pending},
+			wantPlanneds: []*model.Deployment{planned},
+			wantRunnings: []*model.Deployment{running},
+			wantHeads: map[string]*model.Deployment{
+				"app-1": pending,
+				"app-2": planned,
+				"app-3": running,
+			},
+		},
+		// Page 1 succeeds and yields a cursor; page 2 fails. sync() must
+		// return the error and must not apply the partial results already
+		// accumulated from page 1 — Lister() should reflect nothing new.
+		{
+			name: "fails_on_mid_pagination_error",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending}, Cursor: "page2"},
+			},
+			apiErr:  errors.New("unavailable"),
+			errAt:   1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &store{
+				apiClient: &fakeAPIClient{pages: tc.pages, err: tc.apiErr, errAt: tc.errAt},
+				logger:    zap.NewNop(),
+			}
+
+			err := s.sync(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.wantPendings, s.ListPendings())
+			assert.Equal(t, tc.wantPlanneds, s.ListPlanneds())
+			assert.Equal(t, tc.wantRunnings, s.ListRunnings())
+			assert.Equal(t, tc.wantHeads, s.ListAppHeadDeployments())
+		})
+	}
+}

--- a/pkg/app/pipedv1/apistore/deploymentstore/store_test.go
+++ b/pkg/app/pipedv1/apistore/deploymentstore/store_test.go
@@ -31,13 +31,19 @@ import (
 // If the test code calls beyond len(pages), an empty terminal response is
 // returned so misconfigured tests fail with a clear assertion mismatch
 // instead of an index-out-of-range panic.
+//
+// gotCursors records the Cursor field of every request received, in order,
+// so tests can assert that each response cursor is threaded into the next
+// request.
 type fakeAPIClient struct {
-	pages []*pipedservice.ListNotCompletedDeploymentsResponse
-	call  int
-	err   error
+	pages      []*pipedservice.ListNotCompletedDeploymentsResponse
+	call       int
+	err        error
+	gotCursors []string
 }
 
-func (f *fakeAPIClient) ListNotCompletedDeployments(_ context.Context, _ *pipedservice.ListNotCompletedDeploymentsRequest, _ ...grpc.CallOption) (*pipedservice.ListNotCompletedDeploymentsResponse, error) {
+func (f *fakeAPIClient) ListNotCompletedDeployments(_ context.Context, req *pipedservice.ListNotCompletedDeploymentsRequest, _ ...grpc.CallOption) (*pipedservice.ListNotCompletedDeploymentsResponse, error) {
+	f.gotCursors = append(f.gotCursors, req.GetCursor())
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -66,6 +72,9 @@ func TestSync(t *testing.T) {
 		wantPlanneds []*model.Deployment
 		wantRunnings []*model.Deployment
 		wantHeads    map[string]*model.Deployment
+		// wantCursors is the ordered sequence of Cursor values sync() is
+		// expected to send. The first request always carries "".
+		wantCursors []string
 	}{
 		{
 			name: "empty_response",
@@ -76,6 +85,7 @@ func TestSync(t *testing.T) {
 			wantPlanneds: nil,
 			wantRunnings: nil,
 			wantHeads:    map[string]*model.Deployment{},
+			wantCursors:  []string{""},
 		},
 		{
 			name: "single_page_classifies_each_status",
@@ -91,6 +101,7 @@ func TestSync(t *testing.T) {
 				"app-3": running,
 				"app-4": rollingBack,
 			},
+			wantCursors: []string{""},
 		},
 		{
 			name: "paginates_across_multiple_pages",
@@ -106,6 +117,7 @@ func TestSync(t *testing.T) {
 				"app-2": planned,
 				"app-3": running,
 			},
+			wantCursors: []string{"", "page2"},
 		},
 		{
 			name: "rolling_back_is_classified_as_running",
@@ -118,13 +130,38 @@ func TestSync(t *testing.T) {
 			wantHeads: map[string]*model.Deployment{
 				"app-4": rollingBack,
 			},
+			wantCursors: []string{""},
+		},
+		// Regression guard for the server-side pagination contract: the
+		// ListNotCompletedDeployments handler runs an unordered query, so
+		// deploymentStore.List returns the whole result set in one page
+		// with an empty cursor even when deployments exist. The sync loop
+		// must treat that as "done" after a single request rather than
+		// following a bogus non-empty cursor into a second request the
+		// datastore would reject with "opts.Cursor also requires Orders to
+		// be set".
+		{
+			name: "server_returns_all_deployments_in_a_single_page",
+			pages: []*pipedservice.ListNotCompletedDeploymentsResponse{
+				{Deployments: []*model.Deployment{pending, planned, running}, Cursor: ""},
+			},
+			wantPendings: []*model.Deployment{pending},
+			wantPlanneds: []*model.Deployment{planned},
+			wantRunnings: []*model.Deployment{running},
+			wantHeads: map[string]*model.Deployment{
+				"app-1": pending,
+				"app-2": planned,
+				"app-3": running,
+			},
+			wantCursors: []string{""},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeAPIClient{pages: tc.pages}
 			s := &store{
-				apiClient: &fakeAPIClient{pages: tc.pages},
+				apiClient: fc,
 				logger:    zap.NewNop(),
 			}
 
@@ -135,6 +172,7 @@ func TestSync(t *testing.T) {
 			assert.Equal(t, tc.wantPlanneds, s.ListPlanneds())
 			assert.Equal(t, tc.wantRunnings, s.ListRunnings())
 			assert.Equal(t, tc.wantHeads, s.ListAppHeadDeployments())
+			assert.Equal(t, tc.wantCursors, fc.gotCursors)
 		})
 	}
 }

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -189,6 +189,18 @@ func (s *deploymentStore) List(ctx context.Context, opts ListOptions) ([]*model.
 	if len(ds) == 0 {
 		return ds, "", nil
 	}
+
+	// A cursor is only usable on a follow-up request when the query is
+	// ordered: the datastore rejects a cursor when Orders is empty, and
+	// Iterator.Cursor() cannot build a meaningful paging key without any
+	// ordering fields (the empty key it builds still serializes to a
+	// non-empty string). Callers that page through results always set
+	// Orders; those that don't - e.g. ListNotCompletedDeployments - get the
+	// whole result set in a single call and need no cursor.
+	if len(opts.Orders) == 0 {
+		return ds, "", nil
+	}
+
 	cursor, err := it.Cursor()
 	if err != nil {
 		return nil, "", err

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -425,10 +425,11 @@ func TestListDeployments(t *testing.T) {
 	defer ctrl.Finish()
 
 	testcases := []struct {
-		name    string
-		opts    ListOptions
-		ds      DataStore
-		wantErr bool
+		name       string
+		opts       ListOptions
+		ds         DataStore
+		wantCursor string
+		wantErr    bool
 	}{
 		{
 			name: "iterator done",
@@ -464,13 +465,71 @@ func TestListDeployments(t *testing.T) {
 			}(),
 			wantErr: true,
 		},
+		{
+			// Queries with no Orders (e.g. ListNotCompletedDeployments)
+			// must not advertise a cursor: Iterator.Cursor() is never
+			// consulted and the returned cursor is empty, so a client that
+			// loops until the cursor is empty stops after a single call
+			// instead of issuing a follow-up request the datastore would
+			// reject with "opts.Cursor also requires Orders to be set".
+			name: "no orders returns empty cursor without calling Iterator.Cursor",
+			opts: ListOptions{},
+			ds: func() DataStore {
+				it := NewMockIterator(ctrl)
+				gomock.InOrder(
+					it.EXPECT().Next(gomock.Any()).Return(nil),
+					it.EXPECT().Next(gomock.Any()).Return(nil),
+					it.EXPECT().Next(gomock.Any()).Return(ErrIteratorDone),
+				)
+
+				ds := NewMockDataStore(ctrl)
+				ds.EXPECT().
+					Find(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(it, nil)
+				return ds
+			}(),
+			wantCursor: "",
+			wantErr:    false,
+		},
+		{
+			// When the query is ordered, pagination is meaningful and the
+			// cursor built from the last read row is passed through to the
+			// caller unchanged.
+			name: "ordered query returns cursor from iterator",
+			opts: ListOptions{
+				Orders: []Order{
+					{Field: "UpdatedAt", Direction: Desc},
+					{Field: "Id", Direction: Asc},
+				},
+			},
+			ds: func() DataStore {
+				it := NewMockIterator(ctrl)
+				gomock.InOrder(
+					it.EXPECT().Next(gomock.Any()).Return(nil),
+					it.EXPECT().Next(gomock.Any()).Return(nil),
+					it.EXPECT().Next(gomock.Any()).Return(ErrIteratorDone),
+				)
+				it.EXPECT().Cursor().Return("next-cursor", nil)
+
+				ds := NewMockDataStore(ctrl)
+				ds.EXPECT().
+					Find(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(it, nil)
+				return ds
+			}(),
+			wantCursor: "next-cursor",
+			wantErr:    false,
+		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewDeploymentStore(tc.ds)
-			_, _, err := s.List(context.Background(), tc.opts)
+			_, cursor, err := s.List(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
+			if !tc.wantErr {
+				assert.Equal(t, tc.wantCursor, cursor)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

Updates the legacy `piped` deployment store to follow the pagination cursor returned by `ListNotCompletedDeployments`.

Previously, `sync()` fetched only the first page and ignored the returned cursor. It now continues fetching until the cursor is empty, ensuring all pending/planned/running deployments are included.

## Changes

- Update `pkg/app/piped/apistore/deploymentstore/store.go` to paginate `ListNotCompletedDeployments` using `resp.Cursor`.
- Add `store_test.go` with coverage for:
  - empty responses
  - deployment status classification
  - multi-page pagination
  - 3+ page pagination
  - `ROLLING_BACK` classification
  - errors during pagination
- Fix the server-side pagination contract in `pkg/datastore/deploymentstore.go` (see the Update section below).

## Tests

- `go test ./pkg/app/piped/apistore/deploymentstore/...` — pass
- `go test ./pkg/datastore/... ./pkg/app/pipedv1/apistore/deploymentstore/... ./pkg/app/server/grpcapi/...` — pass (incl. `-race`)
- `go vet ./pkg/app/piped/apistore/deploymentstore/...` — pass
- `make check` — Go build and web build pass. The golangci-lint step is blocked by the pinned lint image using Go 1.25.0 while the repository requires Go 1.26.2.

## Update: fixing the server-side pagination contract

Review feedback correctly pointed out that following the cursor is unsafe against the current server. `PipedAPI.ListNotCompletedDeployments` builds its datastore query with no `Orders` set. In that case `deploymentStore.List` was still asking the iterator for a cursor, and `Iterator.Cursor()` base64-encodes an empty ordering-key map to a *non-empty* string (`"e30="`). So the first page always came back with a non-empty cursor, the new client loop issued a second request carrying it, and both the Firestore and MySQL backends reject that with `opts.Cursor also requires Orders to be set` — meaning every sync tick would fail for any piped with at least one active deployment.

Rather than introduce an ordering plus a new `PipedId` composite Firestore index (a much larger change that is hard to verify without a live datastore), this fixes the contract at the source: `deploymentStore.List` now returns an empty cursor whenever the query has no `Orders`. Ordered, paginated callers (`WebAPI` / `API` `ListDeployments`) always set `Orders`, so their behaviour is unchanged. Unordered callers — `ListNotCompletedDeployments`, the inner lookup in `ListDeploymentTraces`, and the deployment-chain updater — already discard the cursor and receive the full result set in a single call.

The same loop was added to the pipedv1 deployment store in #6727 against this same unchanged handler, so this fix also removes a latent break there. A regression test is included on the v1 store.

### Additional changes

- `pkg/datastore/deploymentstore.go`: return an empty cursor for unordered `List` queries.
- `pkg/datastore/deploymentstore_test.go`: cover the unordered case (no cursor, `Iterator.Cursor()` not called) and the ordered case (cursor passed through).
- `store_test.go` (v0 and v1): the fake API client now records each request's cursor, and the table tests assert the full `"" -> "page2" -> "page3"` threading.

Fixes #1937
