### PR TITLE
fix(web): guard undefined hash in commit detail view

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
@@ -1,8 +1,9 @@
 import userEvent from "@testing-library/user-event";
 import { dummyDeployment } from "~/__fixtures__/dummy-deployment";
+import { dummyTrigger } from "~/__fixtures__/dummy-trigger";
 import { render, screen, MemoryRouter, waitFor, act } from "~~/test-utils";
 import { DeploymentDetail } from ".";
-import { DeploymentStatus } from "~~/model/deployment_pb";
+import { Deployment, DeploymentStatus } from "~~/model/deployment_pb";
 import * as deploymentsApi from "~/api/deployments";
 import { server } from "~/mocks/server";
 
@@ -36,6 +37,32 @@ describe("DeploymentDetail", () => {
       screen.getByText(dummyDeployment.applicationName)
     ).toBeInTheDocument();
     expect(screen.getByText(dummyDeployment.summary)).toBeInTheDocument();
+  });
+
+  it("renders gracefully when commit hash is undefined", async () => {
+    const deploymentWithoutHash: Deployment.AsObject = {
+      ...dummyDeployment,
+      trigger: {
+        ...dummyTrigger,
+        commit: {
+          ...dummyTrigger.commit!,
+          hash: (undefined as unknown) as string,
+        },
+      },
+    };
+
+    render(
+      <MemoryRouter>
+        <DeploymentDetail
+          deploymentId={dummyDeployment.id}
+          deployment={deploymentWithoutHash}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("SUCCESS")).toBeInTheDocument();
+    });
   });
 
   describe("status: RUNNING", () => {

--- a/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -275,10 +275,9 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                                 target="_blank"
                                 rel="noreferrer"
                               >
-                                {`${deployment.trigger.commit.hash.slice(
-                                  0,
-                                  7
-                                )}`}
+                                {`${(
+                                  deployment.trigger.commit.hash ?? ""
+                                ).slice(0, 7)}`}
                                 <OpenInNewIcon
                                   sx={{
                                     fontSize: 16,


### PR DESCRIPTION
**What this PR does**:

Guard against `undefined` hash in the deployment detail commit section by adding a null-coalescing fallback (`?? ""`) before calling `.slice(0, 7)`.

**Why we need it**:

When `deployment.trigger.commit.hash` is `undefined` (possible from older Piped v0 protobuf messages where the field was unpopulated), the current code calls `.slice(0, 7)` directly on `undefined`, causing a runtime crash:

```
TypeError: Cannot read properties of undefined (reading 'slice')
```

The outer guard at L254 (`deployment.trigger?.commit &&`) only checks that `commit` exists, not that `hash` is populated. This fix adds a safe fallback so the link renders with an empty string instead of crashing.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

No. This prevents a crash for an edge case. Users with valid commit hashes see no difference.

- **How are users affected by this change**: Deployments with missing commit hashes no longer crash the detail page.
- - **Is this breaking change**: No.
- - **How to migrate (if breaking change)**: N/A.