### PR TITLE
Fix git worktree race condition issue

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 var (
@@ -75,6 +76,10 @@ type repo struct {
 	remote       string
 	clonedBranch string
 	gitEnvs      []string
+
+	// worktreeMu protects git worktree operations (add, prune, remove)
+	// from race conditions when multiple goroutines operate on the same repository.
+	worktreeMu sync.Mutex
 }
 
 // worktree is a git worktree.
@@ -92,6 +97,12 @@ func (r *worktree) runGitCommand(ctx context.Context, args ...string) ([]byte, e
 }
 
 func (r *worktree) Copy(dest string) (Worktree, error) {
+	// Serialize worktree operations to avoid race conditions.
+	// Multiple concurrent "git worktree add" commands on the same repository
+	// can cause "failed to read commondir" or "could not open gitdir" errors.
+	r.base.worktreeMu.Lock()
+	defer r.base.worktreeMu.Unlock()
+
 	// garbage collecting worktrees
 	_, _ = r.runGitCommand(context.Background(), "worktree", "prune") // ignore the error
 
@@ -110,6 +121,10 @@ func (r *worktree) GetPath() string {
 }
 
 func (r *worktree) Clean() error {
+	// Serialize worktree operations to avoid race conditions.
+	r.base.worktreeMu.Lock()
+	defer r.base.worktreeMu.Unlock()
+
 	if out, err := r.base.runGitCommand(context.Background(), "worktree", "remove", r.worktreePath); err != nil {
 		return formatCommandError(err, out)
 	}
@@ -147,9 +162,15 @@ func (r *repo) GetClonedBranch() string {
 
 // Copy does copying the repository to the given destination using git worktree.
 // The repository is cloned to the given destination with the detached HEAD.
-// NOTE: the given “dest” must be a path that doesn’t exist yet.
+// NOTE: the given "dest" must be a path that doesn't exist yet.
 // If you don't, you will get an error.
 func (r *repo) Copy(dest string) (Worktree, error) {
+	// Serialize worktree operations to avoid race conditions.
+	// Multiple concurrent "git worktree add" commands on the same repository
+	// can cause "failed to read commondir" or "could not open gitdir" errors.
+	r.worktreeMu.Lock()
+	defer r.worktreeMu.Unlock()
+
 	// garbage collecting worktrees
 	_, _ = r.runGitCommand(context.Background(), "worktree", "prune") // ignore the error
 
@@ -374,12 +395,12 @@ func (r *repo) CommitChanges(ctx context.Context, branch, message string, newBra
 }
 
 // Clean deletes all local git data.
-func (r repo) Clean() error {
+func (r *repo) Clean() error {
 	return os.RemoveAll(r.dir)
 }
 
 // CleanPath deletes data in the given relative path in the repo with git clean.
-func (r repo) CleanPath(ctx context.Context, relativePath string) error {
+func (r *repo) CleanPath(ctx context.Context, relativePath string) error {
 	out, err := r.runGitCommand(ctx, "clean", "-f", relativePath)
 	if err != nil {
 		return formatCommandError(err, out)
@@ -395,7 +416,7 @@ func (r *repo) checkoutNewBranch(ctx context.Context, branch string) error {
 	return nil
 }
 
-func (r repo) addCommit(ctx context.Context, message string, trailers map[string]string) error {
+func (r *repo) addCommit(ctx context.Context, message string, trailers map[string]string) error {
 	out, err := r.runGitCommand(ctx, "add", ".")
 	if err != nil {
 		return formatCommandError(err, out)


### PR DESCRIPTION
**What this PR does**:

- Add a mutex for worktree to the repo structure, call it in Copy, and places that work with git worktree command to avoid race condition when multiple worktree add command calls to the same repo
- Change some repo method from value receiver to pointer receiver to keep the repo type methods consistent

**Why we need it**:

There was a race condition reported by users, when the piped runs multiple workers (approximately 13) that execute git worktree add in parallel on the same repository. Running multiple add commands simultaneously causes the underlying git directories to vanish mid-process, resulting in `failed to read common dir` or `could not open gitdir` errors.

**Which issue(s) this PR fixes**:

Follow PR #5412 
Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
