### PR TITLE
Update golangci-lint version to fix CI warning

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 #v2.8.0
+        uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 #v2.10.0
         with:
           workdir: ${{ matrix.module }}
           go_version: ${{ env.GO_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ lint: lint/go lint/web lint/helm
 
 .PHONY: lint/go
 lint/go: FIX ?= false
-lint/go: VERSION ?= sha256:91460846c43b3de53eb77e968b17363e8747e6f3fc190575b52be60c49446e23 # golangci/golangci-lint:v2.4.0
+lint/go: VERSION ?= sha256:67dfc9eeeb0eb13fc1a36329c2c378197dc561f1edf1a7792e3f771606bb0e15 # golangci/golangci-lint:v2.11.4
 lint/go: FLAGS ?= --rm -e GOCACHE=/repo/.cache/go-build -e GOLANGCI_LINT_CACHE=/repo/.cache/golangci-lint -v ${PWD}:/repo
 lint/go: MODULES ?= $(shell find . -name go.mod | while read -r dir; do dirname "$$dir"; done | paste -sd, -) # comma separated list of modules. eg: MODULES=.,pkg/plugin/sdk
 lint/go:


### PR DESCRIPTION
**What this PR does**:

This PR changes the CI golangci-lint version to fix this warning https://github.com/pipe-cd/pipecd/actions/runs/32196373630/job/95901183589?pr=7194

Also, update the default version of golangci/golangci-lint used in Makefile to keep it the same as the version used in CI

**Why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
