### PR TITLE
Fix out-of-range panic on malformed cookie metadata in extractCookie

### DIFF
--- a/pkg/rpc/rpcauth/auth.go
+++ b/pkg/rpc/rpcauth/auth.go
@@ -137,6 +137,9 @@ func extractCookie(ctx context.Context) (map[string]string, error) {
 	cookie := make(map[string]string, len(cs))
 	for _, c := range cs {
 		subs := strings.SplitN(strings.TrimSpace(c), "=", 2)
+		if len(subs) != 2 {
+			return nil, status.Error(codes.Unauthenticated, "cookie is malformed")
+		}
 		cookie[subs[0]] = subs[1]
 	}
 	return cookie, nil

--- a/pkg/rpc/rpcauth/auth_test.go
+++ b/pkg/rpc/rpcauth/auth_test.go
@@ -216,6 +216,14 @@ func TestExtractCookie(t *testing.T) {
 			failed:         true,
 		},
 		{
+			name: "malformed cookie: segment without equal sign",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{
+				"cookie": []string{"token=xxx;"},
+			}),
+			expectedCookie: nil,
+			failed:         true,
+		},
+		{
 			name: "allow cookie with equal sign",
 			ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{
 				"cookie": []string{"token=xxx; another=yyy=zzz"},


### PR DESCRIPTION
Based on that investigation, you can fill the PR template like this:

**What this PR does**:

Fixes a panic in `extractCookie` when malformed `Cookie` metadata contains a segment without `=`. The change restores the bounds check removed in #6933 and adds a regression test to ensure malformed cookie input is rejected safely instead of causing the control-plane process to panic.

**Why we need it**:

A malformed `Cookie` header can currently trigger an index-out-of-range panic before JWT authentication is completed. Since the WebAPI server runs in the same control-plane process as the PipedAPI and APIService, an unrecovered panic can terminate the entire control-plane process.

This is a regression introduced by #6933.

**Which issue(s) this PR fixes**:

Fixes #7216

**Does this PR introduce a user-facing change?**:

* **How are users affected by this change**: Malformed Cookie metadata is now rejected safely instead of potentially crashing the control-plane process.
* **Is this breaking change**: No.
* **How to migrate (if breaking change)**: Not applicable.
