### PR TITLE
fix: use min requested index for ecs rollback stage

### DIFF
--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
@@ -96,14 +96,12 @@ func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) ([]sdk.Pipelin
 	}
 
 	if input.Request.Rollback {
-		// Guard against a rollback request without any stage, which would
-		// panic on stages[0] below.
+		// Guard against a rollback request without any stage
 		if len(stages) == 0 {
 			return nil, ErrRollbackRequiresStages
 		}
 		// The rollback stage must reuse one of the requested indexes and
 		// piped runs rollback stages as a trail sorted by index.
-		// Use the smallest requested index so our rollback runs first among all plugins' rollbacks.
 		minIndex := stages[0].Index
 		for _, s := range stages[1:] {
 			if s.Index < minIndex {

--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
@@ -90,9 +90,18 @@ func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 	}
 
 	if input.Request.Rollback {
+		// The rollback stage must reuse one of the requested indexes and
+		// piped runs rollback stages as a trail sorted by index.
+		// Use the smallest requested index so our rollback runs first among all plugins' rollbacks.
+		minIndex := stages[0].Index
+		for _, s := range stages[1:] {
+			if s.Index < minIndex {
+				minIndex = s.Index
+			}
+		}
 		out = append(out, sdk.PipelineStage{
 			Name:     StageECSRollback,
-			Index:    len(stages) + 1,
+			Index:    minIndex,
 			Rollback: true,
 		})
 	}

--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline.go
@@ -15,8 +15,14 @@
 package deployment
 
 import (
+	"errors"
+
 	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
 )
+
+// ErrRollbackRequiresStages is returned when a rollback is requested but no
+// stage was provided in the request.
+var ErrRollbackRequiresStages = errors.New("rollback requires at least one stage")
 
 const (
 	// StageECSSync represents the ECS sync stage.
@@ -76,7 +82,7 @@ func buildQuickSyncPipeline(autoRollback bool) []sdk.QuickSyncStage {
 	return out
 }
 
-func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.PipelineStage {
+func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) ([]sdk.PipelineStage, error) {
 	stages := input.Request.Stages
 
 	out := make([]sdk.PipelineStage, 0, len(stages)+1)
@@ -90,6 +96,11 @@ func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 	}
 
 	if input.Request.Rollback {
+		// Guard against a rollback request without any stage, which would
+		// panic on stages[0] below.
+		if len(stages) == 0 {
+			return nil, ErrRollbackRequiresStages
+		}
 		// The rollback stage must reuse one of the requested indexes and
 		// piped runs rollback stages as a trail sorted by index.
 		// Use the smallest requested index so our rollback runs first among all plugins' rollbacks.
@@ -106,5 +117,5 @@ func buildPipelineStages(input *sdk.BuildPipelineSyncStagesInput) []sdk.Pipeline
 		})
 	}
 
-	return out
+	return out, nil
 }

--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
@@ -109,7 +109,8 @@ func TestBuildPipelineStagesRollbackWithoutStages(t *testing.T) {
 	assert.ErrorIs(t, err, ErrRollbackRequiresStages)
 }
 
-// replica of piped's controller.validateStageIndexes (unexported there), kept in sync manually.
+// validateStageIndexes is a minimal subset of piped's controller.validateStageIndexes (unexported there).
+// It only enforces the "range" rule: every response Index must exist in the request.
 func validateStageIndexes(req []sdk.StageConfig, res []sdk.PipelineStage) error {
 	reqIndexes := make(map[int]struct{})
 	for _, s := range req {

--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
@@ -81,7 +81,8 @@ func TestBuildPipelineStages(t *testing.T) {
 					Rollback: tc.rollback,
 				},
 			}
-			got := buildPipelineStages(input)
+			got, err := buildPipelineStages(input)
+			require.NoError(t, err)
 
 			require.Len(t, got, len(tc.wantNames))
 			for i, s := range got {
@@ -91,6 +92,21 @@ func TestBuildPipelineStages(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildPipelineStagesRollbackWithoutStages ensures a rollback request with
+// no stages returns an error instead of panicking on stages[0].
+func TestBuildPipelineStagesRollbackWithoutStages(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildPipelineStages(&sdk.BuildPipelineSyncStagesInput{
+		Request: sdk.BuildPipelineSyncStagesRequest{
+			Stages:   []sdk.StageConfig{},
+			Rollback: true,
+		},
+	})
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, ErrRollbackRequiresStages)
 }
 
 // replica of piped's controller.validateStageIndexes (unexported there), kept in sync manually.
@@ -117,14 +133,15 @@ func TestBuildPipelineStagesRollbackIndexContract(t *testing.T) {
 		{Name: StageECSPrimaryRollout, Index: 0},
 		{Name: StageECSCanaryRollout, Index: 1},
 	}
-	got := buildPipelineStages(&sdk.BuildPipelineSyncStagesInput{
+	got, err := buildPipelineStages(&sdk.BuildPipelineSyncStagesInput{
 		Request: sdk.BuildPipelineSyncStagesRequest{
 			Stages:   reqStages,
 			Rollback: true,
 		},
 	})
+	require.NoError(t, err)
 
-	err := validateStageIndexes(reqStages, got)
+	err = validateStageIndexes(reqStages, got)
 	assert.NoError(t, err, "rollback stage index must be one of the requested indexes")
 }
 

--- a/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/pipeline_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/pipe-cd/piped-plugin-sdk-go"
+)
+
+func TestBuildPipelineStages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		stages        []sdk.StageConfig
+		rollback      bool
+		wantNames     []string
+		wantIndexes   []int
+		wantRollbacks []bool
+	}{
+		{
+			name: "no rollback",
+			stages: []sdk.StageConfig{
+				{Name: StageECSPrimaryRollout, Index: 0},
+				{Name: StageECSCanaryRollout, Index: 1},
+				{Name: StageECSTrafficRouting, Index: 2},
+			},
+			rollback:      false,
+			wantNames:     []string{StageECSPrimaryRollout, StageECSCanaryRollout, StageECSTrafficRouting},
+			wantIndexes:   []int{0, 1, 2},
+			wantRollbacks: []bool{false, false, false},
+		},
+		{
+			name: "with rollback",
+			stages: []sdk.StageConfig{
+				{Name: StageECSPrimaryRollout, Index: 0},
+				{Name: StageECSCanaryRollout, Index: 1},
+			},
+			rollback: true,
+			// The rollback stage reuses the smallest requested index so it
+			// stays valid under piped's stage index validation and runs
+			// first among all plugins' rollback stages.
+			wantNames:     []string{StageECSPrimaryRollout, StageECSCanaryRollout, StageECSRollback},
+			wantIndexes:   []int{0, 1, 0},
+			wantRollbacks: []bool{false, false, true},
+		},
+		{
+			name: "with rollback and non-contiguous indexes",
+			stages: []sdk.StageConfig{
+				{Name: StageECSPrimaryRollout, Index: 2},
+				{Name: StageECSTrafficRouting, Index: 5},
+			},
+			rollback:      true,
+			wantNames:     []string{StageECSPrimaryRollout, StageECSTrafficRouting, StageECSRollback},
+			wantIndexes:   []int{2, 5, 2},
+			wantRollbacks: []bool{false, false, true},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := &sdk.BuildPipelineSyncStagesInput{
+				Request: sdk.BuildPipelineSyncStagesRequest{
+					Stages:   tc.stages,
+					Rollback: tc.rollback,
+				},
+			}
+			got := buildPipelineStages(input)
+
+			require.Len(t, got, len(tc.wantNames))
+			for i, s := range got {
+				assert.Equal(t, tc.wantNames[i], s.Name)
+				assert.Equal(t, tc.wantIndexes[i], s.Index)
+				assert.Equal(t, tc.wantRollbacks[i], s.Rollback)
+			}
+		})
+	}
+}
+
+// replica of piped's controller.validateStageIndexes (unexported there), kept in sync manually.
+func validateStageIndexes(req []sdk.StageConfig, res []sdk.PipelineStage) error {
+	reqIndexes := make(map[int]struct{})
+	for _, s := range req {
+		reqIndexes[s.Index] = struct{}{}
+	}
+	for _, s := range res {
+		if _, ok := reqIndexes[s.Index]; !ok {
+			return fmt.Errorf("stage index %d from plugin is not defined in the request", s.Index)
+		}
+	}
+	return nil
+}
+
+// TestBuildPipelineStagesRollbackIndexContract verifies the SDK contract that
+// every returned Index must be one of the requested indexes
+// (see sdk.PipelineStage.Index comment).
+func TestBuildPipelineStagesRollbackIndexContract(t *testing.T) {
+	t.Parallel()
+
+	reqStages := []sdk.StageConfig{
+		{Name: StageECSPrimaryRollout, Index: 0},
+		{Name: StageECSCanaryRollout, Index: 1},
+	}
+	got := buildPipelineStages(&sdk.BuildPipelineSyncStagesInput{
+		Request: sdk.BuildPipelineSyncStagesRequest{
+			Stages:   reqStages,
+			Rollback: true,
+		},
+	})
+
+	err := validateStageIndexes(reqStages, got)
+	assert.NoError(t, err, "rollback stage index must be one of the requested indexes")
+}
+
+func TestBuildQuickSyncPipeline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without rollback", func(t *testing.T) {
+		t.Parallel()
+		got := buildQuickSyncPipeline(false)
+		require.Len(t, got, 1)
+		assert.Equal(t, StageECSSync, got[0].Name)
+		assert.False(t, got[0].Rollback)
+	})
+
+	t.Run("with rollback", func(t *testing.T) {
+		t.Parallel()
+		got := buildQuickSyncPipeline(true)
+		require.Len(t, got, 2)
+		assert.Equal(t, StageECSSync, got[0].Name)
+		assert.Equal(t, StageECSRollback, got[1].Name)
+		assert.True(t, got[1].Rollback)
+	})
+}

--- a/pkg/app/pipedv1/plugin/ecs/deployment/plugin.go
+++ b/pkg/app/pipedv1/plugin/ecs/deployment/plugin.go
@@ -55,8 +55,12 @@ func (p *ECSPlugin) BuildPipelineSyncStages(
 	_ *ecsconfig.ECSPluginConfig,
 	input *sdk.BuildPipelineSyncStagesInput,
 ) (*sdk.BuildPipelineSyncStagesResponse, error) {
+	stages, err := buildPipelineStages(input)
+	if err != nil {
+		return nil, err
+	}
 	return &sdk.BuildPipelineSyncStagesResponse{
-		Stages: buildPipelineStages(input),
+		Stages: stages,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does**:  
- Fixes `buildPipelineStages` in ECS plugin to reuse the smallest requested index for the appended rollback stage
- Adds unit tests covering the pipeline/quick-sync stage builders

**Why we need it**: `sdk.PipelineStage.Index` requires each returned index to be one of the indexes from the request. The previous implementation returned an invented index for `ECS_ROLLBACK`, so piped's `validateStageIndexes` rejected the plugin response