### PR TITLE
Close datastore iterators to release underlying rows and Firestore resources on decode errors

### DIFF
--- a/pkg/datastore/apikey.go
+++ b/pkg/datastore/apikey.go
@@ -85,6 +85,7 @@ func (s *apiKeyStore) List(ctx context.Context, opts ListOptions) ([]*model.APIK
 	if err != nil {
 		return nil, err
 	}
+	defer it.Close()
 	ks := make([]*model.APIKey, 0)
 	for {
 		var k model.APIKey

--- a/pkg/datastore/apikey_test.go
+++ b/pkg/datastore/apikey_test.go
@@ -86,6 +86,7 @@ func TestListAPIKeys(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.APIKey{}).
 					Return(ErrIteratorDone)
@@ -103,6 +104,7 @@ func TestListAPIKeys(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.APIKey{}).
 					Return(errors.New("test-error"))

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -94,6 +94,7 @@ func (s *applicationStore) List(ctx context.Context, opts ListOptions) ([]*model
 	if err != nil {
 		return nil, "", err
 	}
+	defer it.Close()
 	apps := make([]*model.Application, 0)
 	for {
 		var app model.Application

--- a/pkg/datastore/applicationstore_test.go
+++ b/pkg/datastore/applicationstore_test.go
@@ -136,6 +136,7 @@ func TestListApplications(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Application{}).
 					Return(ErrIteratorDone)
@@ -153,6 +154,7 @@ func TestListApplications(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Application{}).
 					Return(fmt.Errorf("err"))

--- a/pkg/datastore/commandstore.go
+++ b/pkg/datastore/commandstore.go
@@ -83,6 +83,7 @@ func (s *commandStore) List(ctx context.Context, opts ListOptions) ([]*model.Com
 	if err != nil {
 		return nil, err
 	}
+	defer it.Close()
 	cmds := make([]*model.Command, 0)
 	for {
 		var cmd model.Command

--- a/pkg/datastore/commandstore_test.go
+++ b/pkg/datastore/commandstore_test.go
@@ -128,6 +128,7 @@ func TestListCommands(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Command{}).
 					Return(ErrIteratorDone)
@@ -145,6 +146,7 @@ func TestListCommands(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Command{}).
 					Return(fmt.Errorf("err"))

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -90,6 +90,12 @@ type DataStore interface {
 type Iterator interface {
 	Next(dst interface{}) error
 	Cursor() (string, error)
+	// Close releases the resources held by the iterator, such as the
+	// underlying database rows or Firestore iterator. It is safe to call
+	// Close multiple times, and callers should always close an iterator
+	// once they are done with it, regardless of whether iteration
+	// completed successfully or ended early because of an error.
+	Close() error
 }
 
 type ListFilter struct {

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -149,6 +149,7 @@ func (s *deploymentChainStore) List(ctx context.Context, opts ListOptions) ([]*m
 	if err != nil {
 		return nil, "", err
 	}
+	defer it.Close()
 	dcs := make([]*model.DeploymentChain, 0)
 	for {
 		var dc model.DeploymentChain

--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -172,6 +172,7 @@ func (s *deploymentStore) List(ctx context.Context, opts ListOptions) ([]*model.
 	if err != nil {
 		return nil, "", err
 	}
+	defer it.Close()
 	ds := make([]*model.Deployment, 0)
 	for {
 		var d model.Deployment

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -435,6 +435,7 @@ func TestListDeployments(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Deployment{}).
 					Return(ErrIteratorDone)
@@ -452,6 +453,7 @@ func TestListDeployments(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Deployment{}).
 					Return(fmt.Errorf("err"))

--- a/pkg/datastore/deploymenttracestore.go
+++ b/pkg/datastore/deploymenttracestore.go
@@ -74,6 +74,7 @@ func (s *deploymentTraceStore) List(ctx context.Context, opts ListOptions) ([]*m
 	if err != nil {
 		return nil, "", err
 	}
+	defer it.Close()
 	dts := make([]*model.DeploymentTrace, 0)
 	for {
 		var dt model.DeploymentTrace

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -75,6 +75,7 @@ func (s *eventStore) List(ctx context.Context, opts ListOptions) ([]*model.Event
 	if err != nil {
 		return nil, "", err
 	}
+	defer it.Close()
 	es := make([]*model.Event, 0)
 	for {
 		var e model.Event

--- a/pkg/datastore/firestore/iterator.go
+++ b/pkg/datastore/firestore/iterator.go
@@ -49,6 +49,13 @@ func (it *Iterator) Next(dst interface{}) error {
 	return doc.DataTo(dst)
 }
 
+// Close stops the underlying Firestore DocumentIterator, releasing its
+// resources. It is safe to call Close multiple times.
+func (it *Iterator) Close() error {
+	it.it.Stop()
+	return nil
+}
+
 // Cursor builds a base 64 string (encode from string in map[string]interface{} format).
 // The cursor contains only values attached with the fields used
 // as ordering fields.

--- a/pkg/datastore/mock.go
+++ b/pkg/datastore/mock.go
@@ -178,6 +178,20 @@ func (m *MockIterator) EXPECT() *MockIteratorMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockIterator) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockIteratorMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockIterator)(nil).Close))
+}
+
 // Cursor mocks base method.
 func (m *MockIterator) Cursor() (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/datastore/mysql/iterator.go
+++ b/pkg/datastore/mysql/iterator.go
@@ -51,6 +51,12 @@ func (it *Iterator) Next(dst interface{}) error {
 	return decodeJSONValue(val, dst)
 }
 
+// Close closes the underlying sql.Rows, releasing the connection back to
+// the pool. It is safe to call Close multiple times.
+func (it *Iterator) Close() error {
+	return it.rows.Close()
+}
+
 // Cursor builds a base64 string (encode from string in map[string]interface{} format).
 // The cursor contains only values attached with the fields used
 // as ordering fields.

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -89,6 +89,7 @@ func (s *pipedStore) List(ctx context.Context, opts ListOptions) ([]*model.Piped
 	if err != nil {
 		return nil, err
 	}
+	defer it.Close()
 	ps := make([]*model.Piped, 0)
 	for {
 		var p model.Piped

--- a/pkg/datastore/pipedstore_test.go
+++ b/pkg/datastore/pipedstore_test.go
@@ -128,6 +128,7 @@ func TestListPipeds(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Piped{}).
 					Return(ErrIteratorDone)
@@ -145,6 +146,7 @@ func TestListPipeds(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Piped{}).
 					Return(fmt.Errorf("err"))

--- a/pkg/datastore/projectstore.go
+++ b/pkg/datastore/projectstore.go
@@ -94,6 +94,7 @@ func (s *projectStore) List(ctx context.Context, opts ListOptions) ([]model.Proj
 	if err != nil {
 		return nil, err
 	}
+	defer it.Close()
 	ps := make([]model.Project, 0)
 	for {
 		var p model.Project

--- a/pkg/datastore/projectstore_test.go
+++ b/pkg/datastore/projectstore_test.go
@@ -130,6 +130,7 @@ func TestListProjects(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Project{}).
 					Return(ErrIteratorDone)
@@ -147,6 +148,7 @@ func TestListProjects(t *testing.T) {
 			opts: ListOptions{},
 			ds: func() DataStore {
 				it := NewMockIterator(ctrl)
+				it.EXPECT().Close().Return(nil)
 				it.EXPECT().
 					Next(&model.Project{}).
 					Return(fmt.Errorf("err"))

--- a/test/integration/datastore/firestore/firestore_test.go
+++ b/test/integration/datastore/firestore/firestore_test.go
@@ -154,6 +154,7 @@ func listEntities(it datastore.Iterator) ([]*Entity, error) {
 	if it == nil {
 		return entity, nil
 	}
+	defer it.Close()
 	for {
 		var e Entity
 		err := it.Next(&e)

--- a/test/integration/datastore/mysql/apikey_test.go
+++ b/test/integration/datastore/mysql/apikey_test.go
@@ -152,6 +152,7 @@ func listAPIKeys(it datastore.Iterator) ([]*model.APIKey, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.APIKey
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/application_test.go
+++ b/test/integration/datastore/mysql/application_test.go
@@ -169,6 +169,7 @@ func listApplications(it datastore.Iterator) ([]*model.Application, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Application
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/command_test.go
+++ b/test/integration/datastore/mysql/command_test.go
@@ -149,6 +149,7 @@ func listCommands(it datastore.Iterator) ([]*model.Command, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Command
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/deployment_test.go
+++ b/test/integration/datastore/mysql/deployment_test.go
@@ -218,6 +218,7 @@ func listDeployments(it datastore.Iterator) ([]*model.Deployment, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Deployment
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/deploymentchain_test.go
+++ b/test/integration/datastore/mysql/deploymentchain_test.go
@@ -185,6 +185,7 @@ func listDeploymentChains(it datastore.Iterator) ([]*model.DeploymentChain, erro
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.DeploymentChain
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/event_test.go
+++ b/test/integration/datastore/mysql/event_test.go
@@ -152,6 +152,7 @@ func listEvents(it datastore.Iterator) ([]*model.Event, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Event
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/piped_test.go
+++ b/test/integration/datastore/mysql/piped_test.go
@@ -146,6 +146,7 @@ func listPipeds(it datastore.Iterator) ([]*model.Piped, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Piped
 		err := it.Next(&v)

--- a/test/integration/datastore/mysql/project_test.go
+++ b/test/integration/datastore/mysql/project_test.go
@@ -149,6 +149,7 @@ func listProjects(it datastore.Iterator) ([]*model.Project, error) {
 	if it == nil {
 		return ret, nil
 	}
+	defer it.Close()
 	for {
 		var v model.Project
 		err := it.Next(&v)


### PR DESCRIPTION
**What this PR does**:

Adds explicit resource cleanup to `datastore.Iterator` so underlying MySQL and Firestore iterators are closed when datastore iteration completes or exits early due to an error. All `List()` callers now defer iterator cleanup, and tests verify that `Close()` is called on both successful and error paths.

**Why we need it**:

Previously, `datastore.Iterator` had no `Close()` method, so an early return caused by a decode/scan error could leave the underlying `sql.Rows` or Firestore `DocumentIterator` open. Repeated failures could accumulate unreleased database resources and potentially exhaust available connections.

**Which issue(s) this PR fixes**:

Fixes #7219

**Does this PR introduce a user-facing change?**:

* **How are users affected by this change**: No direct user-facing behavior change. This fixes datastore resource cleanup and prevents database/Firestore resources from remaining open after iterator errors.
* **Is this breaking change**: No.
* **How to migrate (if breaking change)**: Not applicable.
