### PR TITLE
fix(crypto): validate ciphertext length before nonce extraction in AES Decrypt

### DIFF
--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -85,8 +85,13 @@ func (a *AESEncryptDecrypter) Decrypt(encryptedText string) (string, error) {
 		return "", err
 	}
 
-	nonce := encrypted[:gcm.NonceSize()]
-	text, err := gcm.Open(nil, nonce, encrypted[gcm.NonceSize():], nil)
+	nonceSize := gcm.NonceSize()
+	if len(encrypted) < nonceSize {
+		return "", fmt.Errorf("ciphertext is shorter than nonce size")
+	}
+
+	nonce := encrypted[:nonceSize]
+	text, err := gcm.Open(nil, nonce, encrypted[nonceSize:], nil)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -42,3 +42,19 @@ func TestAESEncryptDecrypt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, text, decrypted)
 }
+
+func TestAESDecryptShortCiphertext(t *testing.T) {
+	ed, err := NewAESEncryptDecrypter("testdata/key")
+	require.NoError(t, err)
+	require.NotNil(t, ed)
+
+	// Short base64 encoded string (less than 12 bytes nonce)
+	_, err = ed.Decrypt("c2hvcnQ=")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ciphertext is shorter than nonce size")
+
+	// Empty string
+	_, err = ed.Decrypt("")
+	assert.Error(t, err)
+}
+

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -48,11 +48,10 @@ func TestAESDecryptShortCiphertext(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ed)
 
-	// Short base64 encoded string (less than 12 bytes nonce)
+	// Short base64 encoded string (smaller than GCM nonce size)
 	_, err = ed.Decrypt("c2hvcnQ=")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ciphertext is shorter than nonce size")
-
 	// Empty string
 	_, err = ed.Decrypt("")
 	assert.Error(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Validates that base64-decoded ciphertext is at least `gcm.NonceSize()` bytes long before extracting the nonce slice in `Decrypt()` (`pkg/crypto/aes.go`).

If the decoded ciphertext is shorter than `gcm.NonceSize()`, `Decrypt()` now returns an error gracefully instead of causing an out-of-range slice panic.

**Which issue(s) this PR fixes**:

Fixes #7215

**How was this tested?**:

- Added `TestAESDecryptShortCiphertext` unit tests in `pkg/crypto/aes_test.go` covering short base64 ciphertext and empty input
- Verified all unit tests pass with `go test -v ./pkg/crypto`
