### PR TITLE
Prevent commandstore cache poisoning when backend Get fails after UpdateStatus

### DIFF
--- a/pkg/app/server/commandstore/cache.go
+++ b/pkg/app/server/commandstore/cache.go
@@ -52,12 +52,19 @@ func (c *commandCache) Put(commandID string, command *model.Command) error {
 	if command == nil {
 		return fmt.Errorf("command must not be nil")
 	}
+	if err := command.Validate(); err != nil {
+		return fmt.Errorf("command is invalid: %w", err)
+	}
 	key := cacheKey(commandID)
 	data, err := json.Marshal(command)
 	if err != nil {
 		return err
 	}
 	return c.backend.Put(key, data)
+}
+
+func (c *commandCache) Delete(commandID string) error {
+	return c.backend.Delete(cacheKey(commandID))
 }
 
 func cacheKey(commandID string) string {

--- a/pkg/app/server/commandstore/cache.go
+++ b/pkg/app/server/commandstore/cache.go
@@ -40,6 +40,9 @@ func (c *commandCache) Get(commandID string) (*model.Command, error) {
 }
 
 func (c *commandCache) Put(commandID string, command *model.Command) error {
+	if command == nil {
+		return fmt.Errorf("command must not be nil")
+	}
 	key := cacheKey(commandID)
 	data, err := json.Marshal(command)
 	if err != nil {

--- a/pkg/app/server/commandstore/cache.go
+++ b/pkg/app/server/commandstore/cache.go
@@ -36,6 +36,15 @@ func (c *commandCache) Get(commandID string) (*model.Command, error) {
 	if err := json.Unmarshal(item.([]byte), &s); err != nil {
 		return nil, err
 	}
+	// A cached entry that doesn't satisfy the same validation required to
+	// store a command (e.g. a zero-value Command decoded from a JSON null
+	// written before Put started rejecting nil commands) must not be
+	// treated as a valid cache hit. Evict it on a best-effort basis and
+	// report a miss so the caller falls back to the datastore.
+	if err := s.Validate(); err != nil {
+		_ = c.backend.Delete(key)
+		return nil, cache.ErrNotFound
+	}
 	return &s, nil
 }
 

--- a/pkg/app/server/commandstore/cache_test.go
+++ b/pkg/app/server/commandstore/cache_test.go
@@ -45,10 +45,25 @@ func TestCommandCachePut(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "command failing Validate() is rejected before reaching the cache backend",
+			command: &model.Command{
+				Id: "command-id",
+				// PipedId, CreatedAt and UpdatedAt are left unset, so
+				// Validate() fails.
+			},
+			prepare: func(c *cachetest.MockCache) {
+				// No EXPECT() set: the mock fails the test if an invalid
+				// command ever reaches the backend.
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid command is stored as before",
 			command: &model.Command{
-				Id:      "command-id",
-				PipedId: "piped-id",
+				Id:        "command-id",
+				PipedId:   "piped-id",
+				CreatedAt: 1700000000,
+				UpdatedAt: 1700000000,
 			},
 			prepare: func(c *cachetest.MockCache) {
 				c.EXPECT().Put(cacheKey("command-id"), gomock.Any()).Return(nil)

--- a/pkg/app/server/commandstore/cache_test.go
+++ b/pkg/app/server/commandstore/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/pipe-cd/pipecd/pkg/cache"
 	"github.com/pipe-cd/pipecd/pkg/cache/cachetest"
 	"github.com/pipe-cd/pipecd/pkg/model"
 )
@@ -66,4 +67,70 @@ func TestCommandCachePut(t *testing.T) {
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
+}
+
+// TestCommandCacheGet_InvalidEntry covers cache entries that were already
+// poisoned before commandCache.Put started rejecting nil commands: a raw
+// JSON "null" (unmarshals to a zero-value Command with an empty Id and
+// PipedId) and any other entry that fails model.Command.Validate() (the same
+// validation datastore.commandStore.Add already enforces before a command is
+// ever persisted, so no legitimately-stored command can fail it). Both must
+// be treated as a cache miss, not returned as if they were real commands,
+// and the poisoned key should be evicted on a best-effort basis.
+func TestCommandCacheGet_InvalidEntry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "previously poisoned null entry",
+			data: "null",
+		},
+		{
+			name: "cached command missing required PipedId",
+			data: `{"id":"command-id"}`,
+		},
+		{
+			name: "cached command missing required Id",
+			data: `{"piped_id":"piped-id"}`,
+		},
+		{
+			name: "cached command missing required CreatedAt/UpdatedAt",
+			data: `{"id":"command-id","piped_id":"piped-id"}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := cachetest.NewMockCache(ctrl)
+			key := cacheKey("command-id")
+			c.EXPECT().Get(key).Return([]byte(tc.data), nil)
+			// The invalid entry must be evicted on a best-effort basis.
+			c.EXPECT().Delete(key).Return(nil)
+
+			cc := &commandCache{backend: c}
+			got, err := cc.Get("command-id")
+			assert.Nil(t, got)
+			assert.ErrorIs(t, err, cache.ErrNotFound)
+		})
+	}
+}
+
+// TestCommandCacheGet_ValidEntry ensures a genuinely valid cached command is
+// still returned directly, without being mistaken for a poisoned entry.
+func TestCommandCacheGet_ValidEntry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := cachetest.NewMockCache(ctrl)
+	key := cacheKey("command-id")
+	c.EXPECT().Get(key).Return([]byte(`{"id":"command-id","piped_id":"piped-id","created_at":1700000000,"updated_at":1700000000}`), nil)
+
+	cc := &commandCache{backend: c}
+	got, err := cc.Get("command-id")
+	assert.NoError(t, err)
+	assert.Equal(t, &model.Command{Id: "command-id", PipedId: "piped-id", CreatedAt: 1700000000, UpdatedAt: 1700000000}, got)
 }

--- a/pkg/app/server/commandstore/cache_test.go
+++ b/pkg/app/server/commandstore/cache_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/pipe-cd/pipecd/pkg/cache/cachetest"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+func TestCommandCachePut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := []struct {
+		name    string
+		command *model.Command
+		prepare func(c *cachetest.MockCache)
+		wantErr bool
+	}{
+		{
+			name:    "nil command is rejected before reaching the cache backend",
+			command: nil,
+			prepare: func(c *cachetest.MockCache) {
+				// No EXPECT() set: the mock fails the test if the
+				// backend is ever called with a nil-derived payload.
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid command is stored as before",
+			command: &model.Command{
+				Id:      "command-id",
+				PipedId: "piped-id",
+			},
+			prepare: func(c *cachetest.MockCache) {
+				c.EXPECT().Put(cacheKey("command-id"), gomock.Any()).Return(nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := cachetest.NewMockCache(ctrl)
+			tc.prepare(c)
+
+			cc := &commandCache{backend: c}
+			err := cc.Put("command-id", tc.command)
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}

--- a/pkg/app/server/commandstore/store.go
+++ b/pkg/app/server/commandstore/store.go
@@ -111,6 +111,7 @@ func (s *store) UpdateCommandHandled(ctx context.Context, id string, status mode
 	cmd, err := s.backend.Get(ctx, id)
 	if err != nil {
 		s.logger.Error("failed to get command from datastore", zap.Error(err))
+		return nil
 	}
 
 	if err := s.cache.Put(id, cmd); err != nil {

--- a/pkg/app/server/commandstore/store.go
+++ b/pkg/app/server/commandstore/store.go
@@ -111,6 +111,13 @@ func (s *store) UpdateCommandHandled(ctx context.Context, id string, status mode
 	cmd, err := s.backend.Get(ctx, id)
 	if err != nil {
 		s.logger.Error("failed to get command from datastore", zap.Error(err))
+		// The datastore was already updated by UpdateStatus above, so any
+		// cache entry for this command (e.g. cached prior to the update) is
+		// now stale. Evict it so callers don't keep observing the old status
+		// until the TTL expires.
+		if delErr := s.cache.Delete(id); delErr != nil {
+			s.logger.Error("failed to delete command from cache", zap.Error(delErr))
+		}
 		return nil
 	}
 

--- a/pkg/app/server/commandstore/store_test.go
+++ b/pkg/app/server/commandstore/store_test.go
@@ -140,3 +140,73 @@ func TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure(t *testing.T) {
 	assert.Equal(t, realCommand, got)
 	assert.NotEmpty(t, got.PipedId, "cached/returned command must not be a poisoned zero-value with an empty PipedId")
 }
+
+// TestGetCommand_FallsBackToDatastoreWhenCacheEntryIsPoisoned covers a cache
+// entry that was already poisoned before this fix (e.g. by the JSON "null"
+// bug), independent of how it got there. It proves GetCommand never returns
+// the poisoned zero-value Command and instead falls back to the datastore
+// for the real one, which is exactly what ReportCommandHandled's
+// pipedID != cmd.PipedId check depends on to avoid a spurious PermissionDenied.
+func TestGetCommand_FallsBackToDatastoreWhenCacheEntryIsPoisoned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	realCommand := &model.Command{
+		Id:      "command-id",
+		PipedId: "legit-piped-id",
+		Status:  model.CommandStatus_COMMAND_SUCCEEDED,
+	}
+
+	backend := &fakeCommandStore{
+		getFunc: func(ctx context.Context, id string) (*model.Command, error) {
+			return realCommand, nil
+		},
+	}
+
+	c := cachetest.NewMockCache(ctrl)
+	key := cacheKey("command-id")
+	// Simulate a previously poisoned entry: raw JSON null in the cache.
+	c.EXPECT().Get(key).Return([]byte("null"), nil)
+	c.EXPECT().Delete(key).Return(nil)
+	c.EXPECT().Put(key, gomock.Any()).Return(nil)
+
+	s := &store{
+		backend: backend,
+		cache:   &commandCache{backend: c},
+		logger:  zap.NewNop(),
+	}
+
+	got, err := s.GetCommand(context.Background(), "command-id")
+	assert.NoError(t, err)
+	assert.Equal(t, realCommand, got)
+	assert.NotEmpty(t, got.PipedId, "must not return the poisoned zero-value command with an empty PipedId")
+}
+
+// TestGetCommand_ReturnsValidCachedCommandWithoutQueryingDatastore ensures the
+// fix doesn't overreach: a genuinely valid cache entry is still served
+// directly from the cache, without hitting the datastore.
+func TestGetCommand_ReturnsValidCachedCommandWithoutQueryingDatastore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend := &fakeCommandStore{
+		getFunc: func(ctx context.Context, id string) (*model.Command, error) {
+			t.Fatal("datastore must not be queried when the cache holds a valid command")
+			return nil, nil
+		},
+	}
+
+	c := cachetest.NewMockCache(ctrl)
+	key := cacheKey("command-id")
+	c.EXPECT().Get(key).Return([]byte(`{"id":"command-id","piped_id":"legit-piped-id","created_at":1700000000,"updated_at":1700000000}`), nil)
+
+	s := &store{
+		backend: backend,
+		cache:   &commandCache{backend: c},
+		logger:  zap.NewNop(),
+	}
+
+	got, err := s.GetCommand(context.Background(), "command-id")
+	assert.NoError(t, err)
+	assert.Equal(t, &model.Command{Id: "command-id", PipedId: "legit-piped-id", CreatedAt: 1700000000, UpdatedAt: 1700000000}, got)
+}

--- a/pkg/app/server/commandstore/store_test.go
+++ b/pkg/app/server/commandstore/store_test.go
@@ -16,6 +16,7 @@ package commandstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -55,9 +56,10 @@ func (f *fakeCommandStore) UpdateStatus(ctx context.Context, id string, status m
 // TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus reproduces
 // the reported cache poisoning scenario: UpdateStatus succeeds, but the
 // subsequent backend.Get fails transiently. It verifies that the failed Get
-// never results in a command being written to the cache, and that the
-// original UpdateCommandHandled behavior (returning nil once the status
-// update itself succeeded) is preserved.
+// never results in a command being written to the cache, that the now-stale
+// cache entry is deleted instead, and that the original UpdateCommandHandled
+// behavior (returning nil once the status update itself succeeded) is
+// preserved.
 func TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -65,6 +67,7 @@ func TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus(t *te
 	// No EXPECT() is set on Put: if the fix regresses and a nil/zero-value
 	// command reaches the cache, this mock call will fail the test.
 	c := cachetest.NewMockCache(ctrl)
+	c.EXPECT().Delete(cacheKey("command-id")).Return(nil)
 
 	backend := &fakeCommandStore{
 		updateStatusFunc: func(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error {
@@ -85,21 +88,35 @@ func TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus(t *te
 	assert.NoError(t, err)
 }
 
-// TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure exercises the full
-// UpdateCommandHandled -> GetCommand flow that ReportCommandHandled relies on
-// (it calls GetCommand and rejects the request with PermissionDenied when
-// cmd.PipedId doesn't match the requesting piped). It proves that after a
-// transient backend.Get failure during UpdateCommandHandled, a later
-// GetCommand call still returns the real, non-zero-value command instead of
-// a cached zero-value Command{} with an empty PipedId.
-func TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure(t *testing.T) {
+// TestGetCommand_StaleCacheDeletedAfterUpdateHandledGetFailure exercises the
+// full regression scenario reported against the earlier fix: an old command
+// is already cached (as GetCommand would leave it, e.g. from
+// ReportCommandHandled's lookup), UpdateStatus then succeeds against the
+// datastore, but the subsequent backend.Get fails transiently. It proves the
+// now-stale cache entry is deleted (rather than left in place until its TTL
+// expires), so a later GetCommand call misses the cache, falls back to the
+// datastore, and observes the updated command/status instead of the stale
+// one.
+func TestGetCommand_StaleCacheDeletedAfterUpdateHandledGetFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	realCommand := &model.Command{
-		Id:      "command-id",
-		PipedId: "legit-piped-id",
-		Status:  model.CommandStatus_COMMAND_SUCCEEDED,
+	oldCommand := &model.Command{
+		Id:        "command-id",
+		PipedId:   "legit-piped-id",
+		Status:    model.CommandStatus_COMMAND_NOT_HANDLED_YET,
+		CreatedAt: 1700000000,
+		UpdatedAt: 1700000000,
+	}
+	oldCommandData, err := json.Marshal(oldCommand)
+	assert.NoError(t, err)
+
+	updatedCommand := &model.Command{
+		Id:        "command-id",
+		PipedId:   "legit-piped-id",
+		Status:    model.CommandStatus_COMMAND_SUCCEEDED,
+		CreatedAt: 1700000000,
+		UpdatedAt: 1700000100,
 	}
 
 	getCalls := 0
@@ -110,21 +127,29 @@ func TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure(t *testing.T) {
 		getFunc: func(ctx context.Context, id string) (*model.Command, error) {
 			getCalls++
 			if getCalls == 1 {
-				// First Get (triggered by UpdateCommandHandled) fails transiently.
+				// The Get triggered by UpdateCommandHandled fails transiently,
+				// even though UpdateStatus above it already succeeded.
 				return nil, errors.New("transient datastore error")
 			}
-			// Second Get (triggered by GetCommand's cache-miss fallback)
-			// succeeds and returns the real command.
-			return realCommand, nil
+			// The later Get, triggered by GetCommand's cache-miss fallback,
+			// succeeds and returns the now-updated command.
+			return updatedCommand, nil
 		},
 	}
 
 	c := cachetest.NewMockCache(ctrl)
 	key := cacheKey("command-id")
-	// The cache must have never been populated by UpdateCommandHandled, so
-	// GetCommand's cache lookup misses and falls back to the backend.
-	c.EXPECT().Get(key).Return(nil, cache.ErrNotFound)
-	c.EXPECT().Put(key, gomock.Any()).Return(nil)
+	gomock.InOrder(
+		// Old command is cached, e.g. by an earlier GetCommand call.
+		c.EXPECT().Get(key).Return(oldCommandData, nil),
+		// UpdateStatus succeeds but backend.Get fails: the stale entry must
+		// be deleted instead of being left in place.
+		c.EXPECT().Delete(key).Return(nil),
+		// Subsequent GetCommand call misses the now-deleted cache entry.
+		c.EXPECT().Get(key).Return(nil, cache.ErrNotFound),
+		// ...and falls back to the datastore, re-caching the fresh result.
+		c.EXPECT().Put(key, gomock.Any()).Return(nil),
+	)
 
 	s := &store{
 		backend: backend,
@@ -132,13 +157,16 @@ func TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure(t *testing.T) {
 		logger:  zap.NewNop(),
 	}
 
-	err := s.UpdateCommandHandled(context.Background(), "command-id", model.CommandStatus_COMMAND_SUCCEEDED, nil, 12345)
-	assert.NoError(t, err)
-
 	got, err := s.GetCommand(context.Background(), "command-id")
 	assert.NoError(t, err)
-	assert.Equal(t, realCommand, got)
-	assert.NotEmpty(t, got.PipedId, "cached/returned command must not be a poisoned zero-value with an empty PipedId")
+	assert.Equal(t, oldCommand, got)
+
+	err = s.UpdateCommandHandled(context.Background(), "command-id", model.CommandStatus_COMMAND_SUCCEEDED, nil, 12345)
+	assert.NoError(t, err)
+
+	got, err = s.GetCommand(context.Background(), "command-id")
+	assert.NoError(t, err)
+	assert.Equal(t, updatedCommand, got)
 }
 
 // TestGetCommand_FallsBackToDatastoreWhenCacheEntryIsPoisoned covers a cache
@@ -152,9 +180,11 @@ func TestGetCommand_FallsBackToDatastoreWhenCacheEntryIsPoisoned(t *testing.T) {
 	defer ctrl.Finish()
 
 	realCommand := &model.Command{
-		Id:      "command-id",
-		PipedId: "legit-piped-id",
-		Status:  model.CommandStatus_COMMAND_SUCCEEDED,
+		Id:        "command-id",
+		PipedId:   "legit-piped-id",
+		Status:    model.CommandStatus_COMMAND_SUCCEEDED,
+		CreatedAt: 1700000000,
+		UpdatedAt: 1700000000,
 	}
 
 	backend := &fakeCommandStore{

--- a/pkg/app/server/commandstore/store_test.go
+++ b/pkg/app/server/commandstore/store_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commandstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipecd/pkg/cache"
+	"github.com/pipe-cd/pipecd/pkg/cache/cachetest"
+	"github.com/pipe-cd/pipecd/pkg/datastore"
+	"github.com/pipe-cd/pipecd/pkg/model"
+)
+
+// fakeCommandStore is a minimal hand-rolled datastore.CommandStore used to
+// control exactly what the backend returns for Get/UpdateStatus in each test.
+type fakeCommandStore struct {
+	getFunc          func(ctx context.Context, id string) (*model.Command, error)
+	updateStatusFunc func(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error
+}
+
+func (f *fakeCommandStore) Add(ctx context.Context, cmd *model.Command) error {
+	return nil
+}
+
+func (f *fakeCommandStore) Get(ctx context.Context, id string) (*model.Command, error) {
+	return f.getFunc(ctx, id)
+}
+
+func (f *fakeCommandStore) List(ctx context.Context, opts datastore.ListOptions) ([]*model.Command, error) {
+	return nil, nil
+}
+
+func (f *fakeCommandStore) UpdateStatus(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error {
+	return f.updateStatusFunc(ctx, id, status, metadata, handledAt)
+}
+
+// TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus reproduces
+// the reported cache poisoning scenario: UpdateStatus succeeds, but the
+// subsequent backend.Get fails transiently. It verifies that the failed Get
+// never results in a command being written to the cache, and that the
+// original UpdateCommandHandled behavior (returning nil once the status
+// update itself succeeded) is preserved.
+func TestUpdateCommandHandled_BackendGetFailureAfterSuccessfulUpdateStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// No EXPECT() is set on Put: if the fix regresses and a nil/zero-value
+	// command reaches the cache, this mock call will fail the test.
+	c := cachetest.NewMockCache(ctrl)
+
+	backend := &fakeCommandStore{
+		updateStatusFunc: func(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error {
+			return nil
+		},
+		getFunc: func(ctx context.Context, id string) (*model.Command, error) {
+			return nil, errors.New("transient datastore error")
+		},
+	}
+
+	s := &store{
+		backend: backend,
+		cache:   &commandCache{backend: c},
+		logger:  zap.NewNop(),
+	}
+
+	err := s.UpdateCommandHandled(context.Background(), "command-id", model.CommandStatus_COMMAND_SUCCEEDED, nil, 12345)
+	assert.NoError(t, err)
+}
+
+// TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure exercises the full
+// UpdateCommandHandled -> GetCommand flow that ReportCommandHandled relies on
+// (it calls GetCommand and rejects the request with PermissionDenied when
+// cmd.PipedId doesn't match the requesting piped). It proves that after a
+// transient backend.Get failure during UpdateCommandHandled, a later
+// GetCommand call still returns the real, non-zero-value command instead of
+// a cached zero-value Command{} with an empty PipedId.
+func TestGetCommand_NotPoisonedAfterUpdateHandledGetFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	realCommand := &model.Command{
+		Id:      "command-id",
+		PipedId: "legit-piped-id",
+		Status:  model.CommandStatus_COMMAND_SUCCEEDED,
+	}
+
+	getCalls := 0
+	backend := &fakeCommandStore{
+		updateStatusFunc: func(ctx context.Context, id string, status model.CommandStatus, metadata map[string]string, handledAt int64) error {
+			return nil
+		},
+		getFunc: func(ctx context.Context, id string) (*model.Command, error) {
+			getCalls++
+			if getCalls == 1 {
+				// First Get (triggered by UpdateCommandHandled) fails transiently.
+				return nil, errors.New("transient datastore error")
+			}
+			// Second Get (triggered by GetCommand's cache-miss fallback)
+			// succeeds and returns the real command.
+			return realCommand, nil
+		},
+	}
+
+	c := cachetest.NewMockCache(ctrl)
+	key := cacheKey("command-id")
+	// The cache must have never been populated by UpdateCommandHandled, so
+	// GetCommand's cache lookup misses and falls back to the backend.
+	c.EXPECT().Get(key).Return(nil, cache.ErrNotFound)
+	c.EXPECT().Put(key, gomock.Any()).Return(nil)
+
+	s := &store{
+		backend: backend,
+		cache:   &commandCache{backend: c},
+		logger:  zap.NewNop(),
+	}
+
+	err := s.UpdateCommandHandled(context.Background(), "command-id", model.CommandStatus_COMMAND_SUCCEEDED, nil, 12345)
+	assert.NoError(t, err)
+
+	got, err := s.GetCommand(context.Background(), "command-id")
+	assert.NoError(t, err)
+	assert.Equal(t, realCommand, got)
+	assert.NotEmpty(t, got.PipedId, "cached/returned command must not be a poisoned zero-value with an empty PipedId")
+}


### PR DESCRIPTION

**What this PR does**:

Prevents `commandstore` from caching a nil command when the datastore `Get` fails after a successful command status update. It also adds a defensive nil check in the cache and regression tests covering the failure path.

**Why we need it**:

A transient `Get` failure could previously result in `nil` being cached as JSON `null`. On a later cache read, this could become a zero-value `Command` with an empty `PipedId`, causing `ReportCommandHandled` to return `PermissionDenied` for the legitimate piped.

**Which issue(s) this PR fixes**:

Fixes #7230 

**Does this PR introduce a user-facing change**:

* **How are users affected by this change**: No direct user-facing behavior change. This prevents a transient datastore error from poisoning the command cache and incorrectly rejecting subsequent command-handling requests.
* **Is this breaking change**: No.
* **How to migrate (if breaking change)**: Not applicable.
