### PR TITLE
Docs: Fix remaining stale examples links after v0/v1 restructure

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -517,7 +517,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) and [Restrictions](#restrictions-of-task-definition) for parameters. | No |
 | targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes (if you want to perform progressive delivery) |
 | runStandaloneTask | bool | Run standalone tasks during deployments. About standalone task, see [here](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs_run_task-v2.html). The default value is `true`. |
-| accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/ecs/servicediscovery/simple). The default value is `ELB`. |
+| accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/v0/ecs/servicediscovery/simple). The default value is `ELB`. |
 
 ### Restrictions of Service Definition
 

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
@@ -13,12 +13,12 @@ But while the canary strategy slowly routes the traffic to the new version, the 
 
 In this guide, we will show you how to configure the application configuration file to apply the blue-green strategy.
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-bluegreen) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/mesh-istio-bluegreen) repository.
 
 ## Before you begin
 
 - Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
-- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L12) in the workload template
+- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-bluegreen/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-bluegreen/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 
 ``` yaml

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
@@ -14,12 +14,12 @@ And with PipeCD, you can enable and automate the canary strategy for your Kubern
 
 In this guide, we will show you how to configure the application configuration file to send 10% of traffic to the new version and keep 90% to the primary variant. Then after waiting for manual approval, you will complete the migration by sending 100% of traffic to the new version.
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-canary) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/mesh-istio-canary) repository.
 
 ## Before you begin
 
 - Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
-- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L12) in the workload template
+- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-canary/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-canary/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 
 ``` yaml

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
@@ -92,7 +92,7 @@ That is all, now let try to send a PR to update the container image version in t
 Deployment Details Page
 </p>
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/canary) repository.
 
 ## Understanding what happened
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
@@ -233,7 +233,7 @@ spec:
 
 The full list of configurable `ANALYSIS` stage fields are [here](../../../configuration-reference/#analysisstageoptions).
 
-See more the [example](https://github.com/pipe-cd/examples/blob/master/kubernetes/analysis-by-metrics/app.pipecd.yaml).
+See more the [example](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/analysis-by-metrics/app.pipecd.yaml).
 
 ## Analysis by logs
 

--- a/docs/content/en/docs-dev/user-guide/managing-application/manifest-attachment.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/manifest-attachment.md
@@ -62,4 +62,4 @@ See examples for detail.
 
 ## Examples
 
-- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)
+- [examples/v0/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)

--- a/docs/content/en/docs-dev/user-guide/managing-application/manifest-attachment.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/manifest-attachment.md
@@ -62,4 +62,4 @@ See examples for detail.
 
 ## Examples
 
-- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/ecs/attachment)
+- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)

--- a/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
@@ -114,8 +114,8 @@ In all cases, `Piped` will decrypt the encrypted secrets and render the decrypti
 
 ## Examples
 
-- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
-- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
-- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
-- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
-- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)
+- [examples/v0/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
+- [examples/v0/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
+- [examples/v0/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
+- [examples/v0/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
+- [examples/v0/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)

--- a/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-dev/user-guide/managing-application/secret-management.md
@@ -114,8 +114,8 @@ In all cases, `Piped` will decrypt the encrypted secrets and render the decrypti
 
 ## Examples
 
-- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/kubernetes/secret-management)
-- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/cloudrun/secret-management)
-- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/lambda/secret-management)
-- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management)
-- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/ecs/secret-management)
+- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
+- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
+- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
+- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
+- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)

--- a/docs/content/en/docs-v0.58.x/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/configuration-reference.md
@@ -517,7 +517,7 @@ See [Configuring Lambda application](../managing-application/defining-app-config
 | taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) and [Restrictions](#restrictions-of-task-definition) for parameters. | No |
 | targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes (if you want to perform progressive delivery) |
 | runStandaloneTask | bool | Run standalone tasks during deployments. About standalone task, see [here](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs_run_task-v2.html). The default value is `true`. |
-| accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/ecs/servicediscovery/simple). The default value is `ELB`. |
+| accessType | string | How the ECS service is accessed. One of `ELB` or `SERVICE_DISCOVERY`. See examples [here](https://github.com/pipe-cd/examples/tree/master/v0/ecs/servicediscovery/simple). The default value is `ELB`. |
 
 ### Restrictions of Service Definition
 

--- a/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-bluegreen-with-istio.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-bluegreen-with-istio.md
@@ -13,12 +13,12 @@ But while the canary strategy slowly routes the traffic to the new version, the 
 
 In this guide, we will show you how to configure the application configuration file to apply the blue-green strategy.
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-bluegreen) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/mesh-istio-bluegreen) repository.
 
 ## Before you begin
 
 - Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
-- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-bluegreen/deployment.yaml#L12) in the workload template
+- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-bluegreen/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-bluegreen/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 
 ``` yaml

--- a/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-canary-with-istio.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-canary-with-istio.md
@@ -14,12 +14,12 @@ And with PipeCD, you can enable and automate the canary strategy for your Kubern
 
 In this guide, we will show you how to configure the application configuration file to send 10% of traffic to the new version and keep 90% to the primary variant. Then after waiting for manual approval, you will complete the migration by sending 100% of traffic to the new version.
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/mesh-istio-canary) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/mesh-istio-canary) repository.
 
 ## Before you begin
 
 - Add a new Kubernetes application by following the instructions in [this guide](../../managing-application/adding-an-application/)
-- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/kubernetes/mesh-istio-canary/deployment.yaml#L12) in the workload template
+- Ensure having `pipecd.dev/variant: primary` [label](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-canary/deployment.yaml#L17) and [selector](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/mesh-istio-canary/deployment.yaml#L12) in the workload template
 - Ensure having at least one Istio's `DestinationRule` and defining the needed subsets (`primary` and `canary`) with `pipecd.dev/variant` label
 
 ``` yaml

--- a/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-canary-with-pod-selector.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/examples/k8s-app-canary-with-pod-selector.md
@@ -92,7 +92,7 @@ That is all, now let try to send a PR to update the container image version in t
 Deployment Details Page
 </p>
 
-Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/kubernetes/canary) repository.
+Complete source code for this example is hosted in [pipe-cd/examples](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/canary) repository.
 
 ## Understanding what happened
 

--- a/docs/content/en/docs-v0.58.x/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/managing-application/customizing-deployment/automated-deployment-analysis.md
@@ -233,7 +233,7 @@ spec:
 
 The full list of configurable `ANALYSIS` stage fields are [here](../../../configuration-reference/#analysisstageoptions).
 
-See more the [example](https://github.com/pipe-cd/examples/blob/master/kubernetes/analysis-by-metrics/app.pipecd.yaml).
+See more the [example](https://github.com/pipe-cd/examples/blob/master/v0/kubernetes/analysis-by-metrics/app.pipecd.yaml).
 
 ## Analysis by logs
 

--- a/docs/content/en/docs-v0.58.x/user-guide/managing-application/manifest-attachment.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/managing-application/manifest-attachment.md
@@ -62,4 +62,4 @@ See examples for detail.
 
 ## Examples
 
-- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)
+- [examples/v0/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)

--- a/docs/content/en/docs-v0.58.x/user-guide/managing-application/manifest-attachment.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/managing-application/manifest-attachment.md
@@ -62,4 +62,4 @@ See examples for detail.
 
 ## Examples
 
-- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/ecs/attachment)
+- [examples/ecs/attachment](https://github.com/pipe-cd/examples/tree/master/v0/ecs/attachment)

--- a/docs/content/en/docs-v0.58.x/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/managing-application/secret-management.md
@@ -114,8 +114,8 @@ In all cases, `Piped` will decrypt the encrypted secrets and render the decrypti
 
 ## Examples
 
-- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
-- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
-- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
-- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
-- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)
+- [examples/v0/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
+- [examples/v0/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
+- [examples/v0/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
+- [examples/v0/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
+- [examples/v0/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)

--- a/docs/content/en/docs-v0.58.x/user-guide/managing-application/secret-management.md
+++ b/docs/content/en/docs-v0.58.x/user-guide/managing-application/secret-management.md
@@ -114,8 +114,8 @@ In all cases, `Piped` will decrypt the encrypted secrets and render the decrypti
 
 ## Examples
 
-- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/kubernetes/secret-management)
-- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/cloudrun/secret-management)
-- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/lambda/secret-management)
-- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/terraform/secret-management)
-- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/ecs/secret-management)
+- [examples/kubernetes/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/kubernetes/secret-management)
+- [examples/cloudrun/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/cloudrun/secret-management)
+- [examples/lambda/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/lambda/secret-management)
+- [examples/terraform/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/terraform/secret-management)
+- [examples/ecs/secret-management](https://github.com/pipe-cd/examples/tree/master/v0/ecs/secret-management)


### PR DESCRIPTION
**What this PR does**:

**Why we need it**:
After #7173 split examples into  v0/ and v1/ directories, several other docs pages still linked to the old paths, which now 404.

**Which issue(s) this PR fixes**:

Follow-up to #7233

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
