### PR TITLE
[Plugin-SDK] Add helper function for appending rollback stage

### DIFF
--- a/pkg/plugin/sdk/deployment.go
+++ b/pkg/plugin/sdk/deployment.go
@@ -17,6 +17,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/pipe-cd/piped-plugin-sdk-go/signalhandler"
@@ -497,6 +498,25 @@ func (p *PipelineStage) toModel(description string, now time.Time) *model.Pipeli
 		AvailableOperation:  p.AvailableOperation.toModelEnum(),
 		AuthorizedOperators: p.AuthorizedOperators,
 	}
+}
+
+// AppendRollbackStage appends a rollback stage with the given name to stages.
+//
+// The rollback stage reuses the minimum index of the request stages
+// so that it satisfies piped's stage index validation
+// and runs first among all plugins' rollback stages.
+func AppendRollbackStage(input *BuildPipelineSyncStagesInput, stages []PipelineStage, name string) []PipelineStage {
+	req := input.Request.Stages
+
+	minIndex := slices.MinFunc(req, func(a, b StageConfig) int {
+		return a.Index - b.Index
+	}).Index
+
+	return append(stages, PipelineStage{
+		Name:     name,
+		Index:    minIndex,
+		Rollback: true,
+	})
 }
 
 // QuickSyncStage represents a stage in the pipeline.

--- a/pkg/plugin/sdk/deployment_test.go
+++ b/pkg/plugin/sdk/deployment_test.go
@@ -800,3 +800,20 @@ func TestSyncStrategy_toModelEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendRollbackStage(t *testing.T) {
+	input := &BuildPipelineSyncStagesInput{
+		Request: BuildPipelineSyncStagesRequest{
+			Rollback: true,
+			Stages: []StageConfig{
+				{Index: 2, Name: "stage-a"},
+				{Index: 5, Name: "stage-b"},
+				{Index: 0, Name: "stage-c"},
+			},
+		},
+	}
+	base := []PipelineStage{{Index: 2, Name: "stage-a"}}
+	got := AppendRollbackStage(input, base, "rollback")
+	require.Len(t, got, len(base)+1)
+	assert.Equal(t, PipelineStage{Name: "rollback", Index: 0, Rollback: true}, got[len(got)-1])
+}


### PR DESCRIPTION
**What this PR does**: Implement helper function for appending rollback stage. This can be reused across various deployment plugins (ECS/GCP/Kubernetes, etc)

**Why we need it**: Most deployment plugins (kubernetes, ecs, cloudrun, terraform) duplicate the exact same boilerplate in `BuildPipelineSyncStages`: copy the forward stages through, compute the min index of the requested stages, and append their rollback stage reusing that index. This is also the pattern recommended by the SDK contract docs ("For a rollback stage, use one of the indexes given by the request" / using the minimum index is recommended).

**Which issue(s) this PR fixes**: 

Fixes #7272 

**Does this PR introduce a user-facing change?**: No

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
