### PR TITLE
fix(pipedv1): clean up cloned repo after skip stage check

### DIFF
--- a/pkg/app/pipedv1/controller/skipstage.go
+++ b/pkg/app/pipedv1/controller/skipstage.go
@@ -36,6 +36,7 @@ func (s *scheduler) determineSkipStage(ctx context.Context, skipOpts config.Skip
 	if err != nil {
 		return false, err
 	}
+	defer repo.Clean()
 
 	// Check by path pattern
 	skip, err = skipByPathPattern(ctx, skipOpts, repo, s.runningDSP.Revision(), s.targetDSP.Revision())


### PR DESCRIPTION
**What this PR does**:

Same leak as #7021, on the pipedv1 side. `determineSkipStage` in `pkg/app/pipedv1/controller/skipstage.go` clones the application repo on every skip check and never removes it, so each check with skipOn conditions leaks one temp directory until the piped restarts. `Clean()` is not called anywhere in that file. This adds the deferred `repo.Clean()`, one line, mirroring what merged in #7021.

Follows up on @khanhtc1202's request in https://github.com/pipe-cd/pipecd/pull/7021#issuecomment-5379348990

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**: none
- **Is this breaking change**: no
- **How to migrate (if breaking change)**: n/a
