### PR TITLE
Fix undefined commit hash in deployment detail view

### DIFF
--- a/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
+++ b/web/src/components/deployments-detail-page/deployment-detail/index.test.tsx
@@ -45,9 +45,9 @@ describe("DeploymentDetail", () => {
       trigger: {
         ...dummyTrigger,
         commit: {
-          ...dummyTrigger.commit!,
+          ...dummyTrigger.commit,
           hash: (undefined as unknown) as string,
-        },
+        } as NonNullable<typeof dummyTrigger.commit>,
       },
     };
 


### PR DESCRIPTION
**What this PR does:**

Guard against undefined or null `deployment.trigger.commit.hash` in the `DeploymentDetail` component (`web/src/components/deployments-detail-page/deployment-detail/index.tsx`). When `hash` is missing, use a safe fallback `""` instead of directly calling `.slice(0, 7)`.

**Why we need it:**

In `DeploymentDetail`, the commit hash was directly sliced (`deployment.trigger.commit.hash.slice(0, 7)`). If a deployment contains a trigger commit object without a `hash` field (e.g. from an incomplete gRPC response or synthetic test payload), it throws an unhandled `TypeError: Cannot read properties of undefined (reading 'slice')` and crashes the entire component rendering.

**Does this PR introduce a user-facing change?:**

Yes. Fixes a potential UI crash on the deployment detail page.

- **How are users affected by this change**: Users will no longer encounter a blank screen / runtime crash when viewing deployments that have missing commit hash values.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A.
