### PR TITLE
Examples: Add v1 kubernetes kustomize-local-base example

### DIFF
--- a/examples/v1/kubernetes/kustomize-local-base/app.pipecd.yaml
+++ b/examples/v1/kubernetes/kustomize-local-base/app.pipecd.yaml
@@ -1,0 +1,18 @@
+apiVersion: pipecd.dev/v1beta1
+kind: Application
+spec:
+  name: kustomize-local-base
+  labels:
+    env: example
+    team: product
+  trigger:
+    onCommit:
+      paths:
+        - local-modules/kustomize-bases/helloworld/*
+  plugins:
+    kubernetes:
+      input:
+        kustomizeVersion: 5.4.3
+  description: |
+    This app demonstrates how to deploy a Kubernetes app that uses a Kustomize package sourced from the same Git repository.
+    References: [adding a new app](https://pipecd.dev/docs-v1.0.x/user-guide/managing-application/adding-an-application/), [app configuration](https://pipecd.dev/docs-v1.0.x/user-guide/managing-application/configuration-reference/)

--- a/examples/v1/kubernetes/kustomize-local-base/kustomization.yaml
+++ b/examples/v1/kubernetes/kustomize-local-base/kustomization.yaml
@@ -1,0 +1,11 @@
+bases:
+- ../../local-modules/kustomize-bases/helloworld
+
+nameSuffix: -local-base
+
+commonLabels:
+  app: kustomize-local-base
+
+images:
+- name: gcr.io/pipecd/helloworld
+  newTag: v0.6.0

--- a/examples/v1/kubernetes/kustomize-local-base/kustomization.yaml
+++ b/examples/v1/kubernetes/kustomize-local-base/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../../local-modules/kustomize-bases/helloworld
 
 nameSuffix: -local-base

--- a/examples/v1/local-modules/kustomize-bases/helloworld/deployment.yaml
+++ b/examples/v1/local-modules/kustomize-bases/helloworld/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize
+  labels:
+    app: kustomize
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kustomize
+  template:
+    metadata:
+      labels:
+        app: kustomize
+    spec:
+      containers:
+      - name: helloworld
+        image: gcr.io/pipecd/helloworld
+        args:
+          - server
+        ports:
+        - containerPort: 9085

--- a/examples/v1/local-modules/kustomize-bases/helloworld/kustomization.yaml
+++ b/examples/v1/local-modules/kustomize-bases/helloworld/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- service.yaml

--- a/examples/v1/local-modules/kustomize-bases/helloworld/service.yaml
+++ b/examples/v1/local-modules/kustomize-bases/helloworld/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kustomize
+spec:
+  selector:
+    app: kustomize
+  ports:
+    - protocol: TCP
+      port: 9085
+      targetPort: 9085


### PR DESCRIPTION
**What this PR does**:
Adds the v1 Kubernetes kustomize-local-base example under examples/v1/

**Why we need it**:
Add v1 examples

**Which issue(s) this PR fixes**:

 Part of #6266 

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
