### PR TITLE
fix(plugin/kubernetes): prevent data race on applications map in livestate store

### DIFF
--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store.go
@@ -223,9 +223,16 @@ func (s *deployTargetResources) initialize() {
 // getApplicationResources returns the application resources by the application ID.
 func (s *deployTargetResources) getApplicationResources(appID string) *applicationResources {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	app, ok := s.applications[appID]
+	s.mu.RUnlock()
+	if ok {
+		return app
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	app, ok = s.applications[appID]
 	if !ok {
 		app = newApplicationResources(s.deployTarget)
 		s.applications[appID] = app

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store_test.go
@@ -1,0 +1,65 @@
+﻿// Copyright 2026 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetApplicationResources(t *testing.T) {
+	dtr := newDeployTargetResources("target-1")
+
+	app1 := dtr.getApplicationResources("app-1")
+	require.NotNil(t, app1)
+	assert.Equal(t, "target-1", app1.deployTarget)
+
+	// Fetching the same appID returns the same instance
+	app1Again := dtr.getApplicationResources("app-1")
+	assert.Same(t, app1, app1Again)
+
+	// Fetching a different appID returns a distinct instance
+	app2 := dtr.getApplicationResources("app-2")
+	require.NotNil(t, app2)
+	assert.NotSame(t, app1, app2)
+}
+
+func TestGetApplicationResources_Concurrent(t *testing.T) {
+	dtr := newDeployTargetResources("target-concurrent")
+
+	var wg sync.WaitGroup
+	workers := 100
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			appID := fmt.Sprintf("app-%d", workerID%10)
+			app := dtr.getApplicationResources(appID)
+			assert.NotNil(t, app)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all 10 application entries exist in the map
+	dtr.mu.RLock()
+	defer dtr.mu.RUnlock()
+	assert.Len(t, dtr.applications, 10)
+}

--- a/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store_test.go
+++ b/pkg/app/pipedv1/plugin/kubernetes/livestate/store/store_test.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2026 The PipeCD Authors.
+// Copyright 2026 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What this PR does / Why we need it
This PR fixes a concurrency bug in deployTargetResources.getApplicationResources in the pipedv1 Kubernetes plugin live state store.

Previously, getApplicationResources attempted to initialize and insert missing entries into s.applications while only holding a read lock (s.mu.RLock()). In Go, mutating a map under a read lock creates a data race that can crash the piped process with atal error: concurrent map writes when multiple goroutines access application resources concurrently.

This change:
1. First looks up the application in s.applications under s.mu.RLock().
2. If absent, releases the read lock, acquires s.mu.Lock() (write lock), and double-checks existence before initializing and storing 
ewApplicationResources(s.deployTarget).

### Changes
- Updated pkg/app/pipedv1/plugin/kubernetes/livestate/store/store.go to acquire a write lock before modifying s.applications.
- Added pkg/app/pipedv1/plugin/kubernetes/livestate/store/store_test.go with a concurrent test (TestGetApplicationResources_Concurrent) spawning 100 parallel workers to ensure thread safety.
- Verified all tests pass.

Signed-off-by: Vishakha7-Kumari <singhdaisy669@gmail.com>