### PR TITLE
Add unit tests for isStageRunning

### DIFF
--- a/web/src/utils/is-stage-running.test.ts
+++ b/web/src/utils/is-stage-running.test.ts
@@ -1,0 +1,16 @@
+import { StageStatus } from "~~/model/deployment_pb";
+import { isStageRunning } from "./is-stage-running";
+
+describe("isStageRunning", () => {
+  it.each([
+    [StageStatus.STAGE_NOT_STARTED_YET, true],
+    [StageStatus.STAGE_RUNNING, true],
+    [StageStatus.STAGE_SUCCESS, false],
+    [StageStatus.STAGE_FAILURE, false],
+    [StageStatus.STAGE_CANCELLED, false],
+    [StageStatus.STAGE_SKIPPED, false],
+    [StageStatus.STAGE_EXITED, false],
+  ])("given status %p, returns %p", (status, expected) => {
+    expect(isStageRunning(status)).toBe(expected);
+  });
+});


### PR DESCRIPTION
**What this PR does:**

Adds comprehensive unit tests for the `isStageRunning` utility function (`web/src/utils/is-stage-running.test.ts`).

**Why we need it:**

`isStageRunning` is a core utility used by the deployment detail log-viewer (`web/src/components/deployments-detail-page/log-viewer/index.tsx`) to determine whether an active stage is currently in progress or waiting, controlling the log loading indicator. It lacked automated test coverage across its enum state transitions.

**Does this PR introduce a user-facing change?:**

No.

- **How are users affected by this change**: N/A (Internal test coverage improvement)
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A.
