### PR TITLE
Prevent nil pointer panic in deployment metadata updates

### DIFF
--- a/pkg/datastore/deploymentstore.go
+++ b/pkg/datastore/deploymentstore.go
@@ -249,6 +249,9 @@ func (s *deploymentStore) UpdateStageMetadata(ctx context.Context, deploymentID,
 
 func (s *deploymentStore) UpdateSharedMetadata(ctx context.Context, id string, metadata map[string]string) error {
 	return s.update(ctx, id, func(d *model.Deployment) error {
+		if d.MetadataV2 == nil {
+			d.MetadataV2 = &model.DeploymentMetadata{}
+		}
 		if d.MetadataV2.Shared == nil {
 			d.MetadataV2.Shared = &model.DeploymentMetadata_KeyValues{}
 		}
@@ -261,6 +264,9 @@ func (s *deploymentStore) UpdateSharedMetadata(ctx context.Context, id string, m
 
 func (s *deploymentStore) UpdatePluginMetadata(ctx context.Context, id string, pluginName string, metadata map[string]string) error {
 	return s.update(ctx, id, func(d *model.Deployment) error {
+		if d.MetadataV2 == nil {
+			d.MetadataV2 = &model.DeploymentMetadata{}
+		}
 		if d.MetadataV2.Plugins == nil {
 			d.MetadataV2.Plugins = make(map[string]*model.DeploymentMetadata_KeyValues)
 		}

--- a/pkg/datastore/deploymentstore_test.go
+++ b/pkg/datastore/deploymentstore_test.go
@@ -529,3 +529,109 @@ func TestMergeMetadata(t *testing.T) {
 		})
 	}
 }
+
+// validDeployment returns the minimum deployment that passes Validate, so the
+// metadata tests below exercise the updater rather than tripping validation.
+// MetadataV2 is deliberately left nil.
+func validDeployment() *model.Deployment {
+	return &model.Deployment{
+		Id:              "id",
+		ApplicationId:   "app-id",
+		ApplicationName: "app-name",
+		PipedId:         "piped-id",
+		ProjectId:       "project-id",
+		Kind:            model.ApplicationKind_KUBERNETES,
+		GitPath: &model.ApplicationGitPath{
+			Repo: &model.ApplicationGitRepository{Id: "id"},
+			Path: "path",
+		},
+		PlatformProvider: "platform-provider",
+		Trigger: &model.DeploymentTrigger{
+			Commit: &model.Commit{
+				Hash:      "hash",
+				Message:   "message",
+				Author:    "author",
+				Branch:    "branch",
+				CreatedAt: 1,
+			},
+			Timestamp: 1,
+		},
+		Status:      model.DeploymentStatus_DEPLOYMENT_PENDING,
+		CompletedAt: 1,
+		CreatedAt:   1,
+		UpdatedAt:   1,
+	}
+}
+
+// A deployment triggered by pipedv0 never sets MetadataV2, and the store's own
+// Factory decodes into &model.Deployment{}, so the field arrives nil. Both
+// update methods guarded the inner fields but not the pointer itself.
+func TestUpdateSharedMetadataWithNilMetadataV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d := validDeployment()
+
+	ds := NewMockDataStore(ctrl)
+	ds.EXPECT().
+		Update(gomock.Any(), gomock.Any(), "id", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ Collection, _ string, updater Updater) error {
+			return updater(d)
+		})
+
+	s := NewDeploymentStore(ds)
+	err := s.UpdateSharedMetadata(context.Background(), "id", map[string]string{"k": "v"})
+
+	require.NoError(t, err)
+	require.NotNil(t, d.MetadataV2)
+	require.NotNil(t, d.MetadataV2.Shared)
+	assert.Equal(t, "v", d.MetadataV2.Shared.KeyValues["k"])
+}
+
+func TestUpdatePluginMetadataWithNilMetadataV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d := validDeployment()
+
+	ds := NewMockDataStore(ctrl)
+	ds.EXPECT().
+		Update(gomock.Any(), gomock.Any(), "id", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ Collection, _ string, updater Updater) error {
+			return updater(d)
+		})
+
+	s := NewDeploymentStore(ds)
+	err := s.UpdatePluginMetadata(context.Background(), "id", "kubernetes", map[string]string{"k": "v"})
+
+	require.NoError(t, err)
+	require.NotNil(t, d.MetadataV2)
+	require.NotNil(t, d.MetadataV2.Plugins["kubernetes"])
+	assert.Equal(t, "v", d.MetadataV2.Plugins["kubernetes"].KeyValues["k"])
+}
+
+// Existing metadata must survive the merge rather than being replaced.
+func TestUpdateSharedMetadataMergesExisting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d := validDeployment()
+	d.MetadataV2 = &model.DeploymentMetadata{
+		Shared: &model.DeploymentMetadata_KeyValues{
+			KeyValues: map[string]string{"existing": "1"},
+		},
+	}
+
+	ds := NewMockDataStore(ctrl)
+	ds.EXPECT().
+		Update(gomock.Any(), gomock.Any(), "id", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ Collection, _ string, updater Updater) error {
+			return updater(d)
+		})
+
+	s := NewDeploymentStore(ds)
+	require.NoError(t, s.UpdateSharedMetadata(context.Background(), "id", map[string]string{"new": "2"}))
+
+	assert.Equal(t, "1", d.MetadataV2.Shared.KeyValues["existing"])
+	assert.Equal(t, "2", d.MetadataV2.Shared.KeyValues["new"])
+}


### PR DESCRIPTION
Fixes #7228

## What was wrong

`UpdateSharedMetadata` and `UpdatePluginMetadata` in `pkg/datastore/deploymentstore.go` guard the inner fields but never the pointer that holds them:

```go
return s.update(ctx, id, func(d *model.Deployment) error {
    if d.MetadataV2.Shared == nil {   // panics here when MetadataV2 is nil
        d.MetadataV2.Shared = &model.DeploymentMetadata_KeyValues{}
    }
    ...
```

So `d.MetadataV2.Shared` and `d.MetadataV2.Plugins` dereference a nil pointer.

## Why a nil gets there

Two paths, both normal:

- pipedv0's trigger, `pkg/app/piped/trigger/deployment.go`, builds a `model.Deployment` without setting `MetadataV2`. Only the pipedv1 trigger sets it.
- The deployment collection's `Factory()` decodes into `&model.Deployment{}`, so any stored document without the field arrives with it nil.

Either one leaves a deployment in the datastore that panics the moment something updates its metadata.

## The change

Both methods initialise `MetadataV2` before touching its fields. Six lines. I did not touch the existing inner guards or `mergeMetadata`, since they are correct once the outer pointer exists.

## Tests

Three added to `pkg/datastore/deploymentstore_test.go`:

- `TestUpdateSharedMetadataWithNilMetadataV2`
- `TestUpdatePluginMetadataWithNilMetadataV2`
- `TestUpdateSharedMetadataMergesExisting`, so the fix cannot quietly start replacing metadata instead of merging it

They drive the real updater through a `MockDataStore` whose `Update` invokes the callback. There is also a small `validDeployment()` helper, because `s.update` runs `Validate()` after the updater and an empty deployment fails on `ApplicationId` before reaching the code under test.

I checked they fail without the change. Stashing just `deploymentstore.go` gives:

```
--- FAIL: TestUpdateSharedMetadataWithNilMetadataV2
panic: runtime error: invalid memory address or nil pointer dereference
```

`go build`, `go test ./pkg/datastore/` green. `go vet ./pkg/datastore/` reports only the pre-existing copylock warnings in `deploymenttracestore.go`, `eventstore.go`, `projectstore.go` and the older test cases at lines 198, 210, 297 and 309, none of which this PR touches.