### PR TITLE
fix(pkg/oci): standardize error messages in pull.go

### DIFF
--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -45,12 +45,12 @@ func PullFileFromRegistry(ctx context.Context, workdir string, dst io.Writer, so
 
 	repo, ref, err := parseOCIURL(sourceURL)
 	if err != nil {
-		return fmt.Errorf("could not parse OCI URL %s (%w)", sourceURL, err)
+		return fmt.Errorf("could not parse OCI URL %s: %w", sourceURL, err)
 	}
 
 	r, err := remote.NewRepository(repo)
 	if err != nil {
-		return fmt.Errorf("could not create repository (%w)", err)
+		return fmt.Errorf("could not create repository %s: %w", repo, err)
 	}
 
 	r.PlainHTTP = options.insecure
@@ -72,13 +72,13 @@ func PullFileFromRegistry(ctx context.Context, workdir string, dst io.Writer, so
 
 	d, err := os.MkdirTemp(workdir, "oci-pull")
 	if err != nil {
-		return fmt.Errorf("could not create temporary directory (%w)", err)
+		return fmt.Errorf("could not create temporary directory: %w", err)
 	}
 	defer os.RemoveAll(d)
 
 	store, err := file.New(d)
 	if err != nil {
-		return fmt.Errorf("could not create file system (%w)", err)
+		return fmt.Errorf("could not create file system: %w", err)
 	}
 	defer store.Close()
 
@@ -87,7 +87,7 @@ func PullFileFromRegistry(ctx context.Context, workdir string, dst io.Writer, so
 
 	desc, err := oras.Copy(ctx, r, ref, store, "", oras.DefaultCopyOptions)
 	if err != nil {
-		return fmt.Errorf("could not copy OCI image (%w)", err)
+		return fmt.Errorf("could not copy OCI image: %w", err)
 	}
 
 	return copyOCIArtifact(ctx, dst, desc, store, options.targetOS, options.targetArch, options.mediaType, options.artifactType)
@@ -97,7 +97,7 @@ func PullFileFromRegistry(ctx context.Context, workdir string, dst io.Writer, so
 func parseOCIURL(sourceURL string) (repo string, ref string, _ error) {
 	u, err := url.Parse(sourceURL)
 	if err != nil {
-		return "", "", fmt.Errorf("could not parse URL %s (%w)", sourceURL, err)
+		return "", "", fmt.Errorf("could not parse URL %s: %w", sourceURL, err)
 	}
 
 	if u.Scheme != "oci" {
@@ -137,13 +137,13 @@ func copyOCIArtifact(ctx context.Context, dst io.Writer, desc ocispec.Descriptor
 	case ocispec.MediaTypeImageIndex:
 		r, err := fetcher.Fetch(ctx, desc)
 		if err != nil {
-			return fmt.Errorf("could not fetch OCI image index (%w)", err)
+			return fmt.Errorf("could not fetch OCI image index: %w", err)
 		}
 		defer r.Close()
 
 		var idx ocispec.Index
 		if err := json.NewDecoder(r).Decode(&idx); err != nil {
-			return fmt.Errorf("could not decode OCI image index (%w)", err)
+			return fmt.Errorf("could not decode OCI image index: %w", err)
 		}
 
 		for _, m := range idx.Manifests {
@@ -161,13 +161,13 @@ func copyOCIArtifact(ctx context.Context, dst io.Writer, desc ocispec.Descriptor
 	case ocispec.MediaTypeImageManifest:
 		r, err := fetcher.Fetch(ctx, desc)
 		if err != nil {
-			return fmt.Errorf("could not fetch OCI image manifest (%w)", err)
+			return fmt.Errorf("could not fetch OCI image manifest: %w", err)
 		}
 		defer r.Close()
 
 		var manifest ocispec.Manifest
 		if err := json.NewDecoder(r).Decode(&manifest); err != nil {
-			return fmt.Errorf("could not decode OCI image manifest (%w)", err)
+			return fmt.Errorf("could not decode OCI image manifest: %w", err)
 		}
 
 		if artifactType != "" && artifactType != manifest.ArtifactType {
@@ -181,12 +181,12 @@ func copyOCIArtifact(ctx context.Context, dst io.Writer, desc ocispec.Descriptor
 
 			r, err = fetcher.Fetch(ctx, layer)
 			if err != nil {
-				return fmt.Errorf("could not fetch OCI layer (%w)", err)
+				return fmt.Errorf("could not fetch OCI layer: %w", err)
 			}
 			defer r.Close()
 
 			if _, err := io.Copy(dst, r); err != nil {
-				return fmt.Errorf("could not copy OCI layer (%w)", err)
+				return fmt.Errorf("could not copy OCI layer: %w", err)
 			}
 		}
 


### PR DESCRIPTION
**What this PR does**:

This PR standardizes error message formatting in `pkg/oci/pull.go`.

It replaces the parenthesized error wrapping style:

```text
operation (%w)
```

with the colon-separated format:

```text
operation: %w
```

This aligns the error messages in `pull.go` with the formatting style already used in `pkg/oci/push.go`.

**Why we need it**:

The OCI package currently uses inconsistent error message formatting between pull and push operations. Standardizing the format improves consistency and readability across the package.

This change is limited to error message formatting and does not modify any functional behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

No functional user-facing change.

- **How are users affected by this change**: Error messages returned during OCI pull operations now use a consistent formatting style.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A.

**Screenshots/Videos (for documentation or website changes)**:

N/A. This PR does not modify documentation, website, or Markdown files.