### PR TITLE
fix(regexpool): preserve regex compilation errors

### DIFF
--- a/pkg/regexpool/regexpool.go
+++ b/pkg/regexpool/regexpool.go
@@ -31,7 +31,7 @@ var (
 // Pool is the representation of a pool of regular expression.
 type Pool struct {
 	cache *memorycache.LRUCache
-	fails map[string]struct{}
+	fails map[string]error
 	mu    sync.RWMutex
 }
 
@@ -54,7 +54,7 @@ func NewPool(size int) (*Pool, error) {
 		return nil, err
 	}
 	return &Pool{
-		fails: make(map[string]struct{}),
+		fails: make(map[string]error),
 		cache: cache,
 	}, nil
 }
@@ -69,10 +69,10 @@ func (p *Pool) Get(expr string) (*regexp.Regexp, error) {
 	// Check if the given expression was unable to compile before
 	// then return the error fast.
 	p.mu.RLock()
-	_, ok := p.fails[expr]
+	failErr, ok := p.fails[expr]
 	p.mu.RUnlock()
 	if ok {
-		return nil, fmt.Errorf("unable to compile: %s", expr)
+		return nil, fmt.Errorf("unable to compile %q: %w", expr, failErr)
 	}
 	// Compile the expression string and cache its result.
 	reg, err := regexp.Compile(expr)
@@ -81,7 +81,7 @@ func (p *Pool) Get(expr string) (*regexp.Regexp, error) {
 		return reg, nil
 	}
 	p.mu.Lock()
-	p.fails[expr] = struct{}{}
+	p.fails[expr] = err
 	p.mu.Unlock()
-	return nil, fmt.Errorf("unable to compile: %s", expr)
+	return nil, fmt.Errorf("unable to compile %q: %w", expr, err)
 }

--- a/pkg/regexpool/regexpool_test.go
+++ b/pkg/regexpool/regexpool_test.go
@@ -15,7 +15,6 @@
 package regexpool
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +35,14 @@ func TestPool(t *testing.T) {
 	assert.NotNil(t, regex)
 
 	regex, err = pool.Get("(abc")
-	assert.Equal(t, fmt.Errorf("unable to compile: (abc"), err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `unable to compile "(abc":`)
+	assert.Contains(t, err.Error(), "error parsing regexp")
+	assert.Nil(t, regex)
+
+	regex, err = pool.Get("(abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `unable to compile "(abc":`)
+	assert.Contains(t, err.Error(), "error parsing regexp")
 	assert.Nil(t, regex)
 }


### PR DESCRIPTION
**What this PR does**:

This PR preserves and returns the underlying regular expression compilation error in `pkg/regexpool`.

Previously, when a regular expression failed to compile, `Pool.Get` returned only the expression:

`unable to compile: (abc`

The actual error returned by `regexp.Compile` was discarded.

This change stores the compilation error for failed expressions and wraps it when returning the error:

`unable to compile "(abc": error parsing regexp: missing closing )`

The cached failure path now also returns the original compilation error instead of losing that diagnostic information.

Tests were updated to verify the improved error message for both the initial failed compilation and subsequent requests for the same invalid expression.

**Why we need it**:

Discarding the underlying compilation error makes invalid regular expressions harder to diagnose.

Preserving the error from `regexp.Compile` provides useful information about why compilation failed while maintaining the existing behavior of caching failed expressions to avoid repeatedly compiling the same invalid expression.


**Does this PR introduce a user-facing change?**:

Yes, error diagnostics are improved.

- **How are users affected by this change**: Users receive the underlying regular expression compilation error, making invalid expressions easier to diagnose.
- **Is this breaking change**: No.
- **How to migrate (if breaking change)**: N/A.

**Screenshots/Videos (for documentation or website changes)**:

N/A. This PR does not modify documentation, website, or Markdown files.