### PR TITLE
fix(pkg/app/eventwatcher): log temporary repository cleanup errors

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -329,13 +329,31 @@ func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eve
 		w.logger.Error("failed to create a new temporary directory", zap.Error(err))
 		return err
 	}
-	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
+
+	var tmpRepo git.Repo
+	defer func() {
+		if tmpRepo != nil {
+			if err := tmpRepo.Clean(); err != nil {
+				w.logger.Error("failed to clean temporary repository",
+					zap.String("path", tmpRepo.GetPath()),
+					zap.Error(err),
+				)
+			}
+		}
+
+		if err := os.RemoveAll(tmpDir); err != nil {
+			w.logger.Error("failed to clean temporary directory",
+				zap.String("path", tmpDir),
+				zap.Error(err),
+			)
+		}
+	}()
+
+	tmpRepo, err = repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		w.logger.Error("failed to copy the repository to the temporary directory", zap.Error(err))
 		return err
 	}
-	// nolint: errcheck
-	defer tmpRepo.Clean()
 
 	var milestone int64
 	firstRead := true

--- a/pkg/app/pipedv1/eventwatcher/eventwatcher.go
+++ b/pkg/app/pipedv1/eventwatcher/eventwatcher.go
@@ -320,12 +320,30 @@ func (w *watcher) execute(ctx context.Context, repo git.Repo, repoID string, eve
 	if err != nil {
 		return fmt.Errorf("failed to create a new temporary directory: %w", err)
 	}
-	tmpRepo, err := repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
+
+	var tmpRepo git.Repo
+	defer func() {
+		if tmpRepo != nil {
+			if err := tmpRepo.Clean(); err != nil {
+				w.logger.Error("failed to clean temporary repository",
+					zap.String("path", tmpRepo.GetPath()),
+					zap.Error(err),
+				)
+			}
+		}
+
+		if err := os.RemoveAll(tmpDir); err != nil {
+			w.logger.Error("failed to clean temporary directory",
+				zap.String("path", tmpDir),
+				zap.Error(err),
+			)
+		}
+	}()
+
+	tmpRepo, err = repo.CopyToModify(filepath.Join(tmpDir, "tmp-repo"))
 	if err != nil {
 		return fmt.Errorf("failed to copy the repository to the temporary directory: %w", err)
 	}
-	// nolint: errcheck
-	defer tmpRepo.Clean()
 
 	var milestone int64
 	firstRead := true


### PR DESCRIPTION
## Summary

- Handle errors returned by `tmpRepo.Clean()` instead of suppressing them with `nolint: errcheck`.
- Log cleanup failures with the temporary repository path for easier diagnosis.
- Remove the parent temporary directory (`tmpDir`) after successful repository cleanup to prevent empty temporary directories from accumulating during the watcher's lifetime.
- Log failures when removing the parent temporary directory.
- Apply the same cleanup handling to both eventwatcher implementations.

## Files Changed

- `pkg/app/piped/eventwatcher/eventwatcher.go`
- `pkg/app/pipedv1/eventwatcher/eventwatcher.go`

## Testing

- `go test ./pkg/app/piped/eventwatcher ./pkg/app/pipedv1/eventwatcher` — passed.
- `git diff --check` — passed.
- `gofmt` — applied with no unrelated formatting changes.

## Note

The eventwatcher tests initially failed on Windows because the testdata files had CRLF line endings while `TestModifyText` compares the generated content against LF-based expected content. The files were temporarily normalized locally for test execution and restored afterward; no test or testdata changes are included in this PR.