### PR TITLE
Report a malformed config instead of panicking in pipectl migrate

### DIFF
--- a/pkg/app/pipectl/cmd/migrate/application_config.go
+++ b/pkg/app/pipectl/cmd/migrate/application_config.go
@@ -295,8 +295,8 @@ func (c *applicationConfig) migrateApplicationConfig(_ context.Context, configFi
 		}
 		spec["plugins"] = pluginCfg
 	default:
-		logger.Error("unsupported application kind", zap.String("config-file", configFile), zap.String("kind", cfg["kind"].(string)))
-		return fmt.Errorf("unsupported application kind: %s", cfg["kind"])
+		logger.Error("unsupported application kind", zap.String("config-file", configFile), zap.String("kind", kind))
+		return fmt.Errorf("unsupported application kind: %s", kind)
 	}
 
 	migrated["spec"] = spec

--- a/pkg/app/pipectl/cmd/migrate/application_config.go
+++ b/pkg/app/pipectl/cmd/migrate/application_config.go
@@ -139,7 +139,12 @@ func (c *applicationConfig) migrateApplicationConfig(_ context.Context, configFi
 		"driftDetection",
 	}
 
-	oldSpec := cfg["spec"].(map[string]any)
+	oldSpec, ok := cfg["spec"].(map[string]any)
+	if !ok {
+		err := fmt.Errorf("spec must be a mapping, got %T", cfg["spec"])
+		logger.Error("invalid application config", zap.String("config-file", configFile), zap.Error(err))
+		return err
+	}
 	for _, key := range keys {
 		if _, ok := oldSpec[key]; ok {
 			spec[key] = oldSpec[key]
@@ -151,7 +156,19 @@ func (c *applicationConfig) migrateApplicationConfig(_ context.Context, configFi
 	if oldPipelineCfg, ok := oldSpec["pipeline"]; ok {
 		pipelineCfg := make(map[string][]any)
 
-		for _, oldStage := range oldPipelineCfg.(map[string]any)["stages"].([]any) {
+		oldPipeline, ok := oldPipelineCfg.(map[string]any)
+		if !ok {
+			err := fmt.Errorf("spec.pipeline must be a mapping, got %T", oldPipelineCfg)
+			logger.Error("invalid application config", zap.String("config-file", configFile), zap.Error(err))
+			return err
+		}
+		oldStages, ok := oldPipeline["stages"].([]any)
+		if !ok && oldPipeline["stages"] != nil {
+			err := fmt.Errorf("spec.pipeline.stages must be a list, got %T", oldPipeline["stages"])
+			logger.Error("invalid application config", zap.String("config-file", configFile), zap.Error(err))
+			return err
+		}
+		for _, oldStage := range oldStages {
 			if oldStageCfg, ok := oldStage.(map[string]any); ok {
 				// Check if the stage is the analysis stage to determine if we need to fill plugins.analysis config
 				if oldStageCfg["name"] == string(model.StageAnalysis) {
@@ -177,7 +194,13 @@ func (c *applicationConfig) migrateApplicationConfig(_ context.Context, configFi
 		spec["pipeline"] = pipelineCfg
 	}
 
-	switch config.Kind(cfg["kind"].(string)) {
+	kind, ok := cfg["kind"].(string)
+	if !ok {
+		err := fmt.Errorf("kind must be a string, got %T", cfg["kind"])
+		logger.Error("invalid application config", zap.String("config-file", configFile), zap.Error(err))
+		return err
+	}
+	switch config.Kind(kind) {
 	case config.KindKubernetesApp:
 		logger.Info("migrating kubernetes application config", zap.String("config-file", configFile))
 		keys := []string{

--- a/pkg/app/pipectl/cmd/migrate/malformed_config_test.go
+++ b/pkg/app/pipectl/cmd/migrate/malformed_config_test.go
@@ -1,0 +1,42 @@
+package migrate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// migrateApplicationConfig reads a user-supplied YAML file into map[string]any,
+// so every lookup out of it can hold something other than the expected shape.
+// A malformed file has to be reported, not panic the CLI.
+func TestMigrateApplicationConfigMalformed(t *testing.T) {
+	cases := map[string]string{
+		"spec is a string":   "apiVersion: pipecd.dev/v1beta1\nkind: KubernetesApp\nspec: oops\n",
+		"spec missing":       "apiVersion: pipecd.dev/v1beta1\nkind: KubernetesApp\n",
+		"kind missing":       "apiVersion: pipecd.dev/v1beta1\nspec:\n  name: x\n",
+		"kind is a number":   "apiVersion: pipecd.dev/v1beta1\nkind: 42\nspec:\n  name: x\n",
+		"pipeline is a list": "apiVersion: pipecd.dev/v1beta1\nkind: KubernetesApp\nspec:\n  pipeline:\n    - a\n",
+		"stages is a string": "apiVersion: pipecd.dev/v1beta1\nkind: KubernetesApp\nspec:\n  pipeline:\n    stages: nope\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			f := filepath.Join(dir, "app.pipecd.yaml")
+			if err := os.WriteFile(f, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			c := &applicationConfig{}
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked on a user-supplied config: %v", r)
+				}
+			}()
+			if err := c.migrateApplicationConfig(context.Background(), f, zap.NewNop()); err == nil {
+				t.Error("expected an error for a malformed config, got nil")
+			}
+		})
+	}
+}

--- a/pkg/app/pipectl/cmd/migrate/malformed_config_test.go
+++ b/pkg/app/pipectl/cmd/migrate/malformed_config_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrate
 
 import (


### PR DESCRIPTION
## What happens

`pipectl migrate application-config` reads a user's YAML into `map[string]any` and then asserts on three lookups out of it without the comma-ok, so a file with the wrong shape panics the CLI instead of being reported.

`application_config.go`, on `3321879`:

```go
oldSpec := cfg["spec"].(map[string]any)
for _, oldStage := range oldPipelineCfg.(map[string]any)["stages"].([]any) {
switch config.Kind(cfg["kind"].(string)) {
```

`cfg` comes straight from `os.ReadFile` then `yaml.Unmarshal(data, &cfg)` a few lines above, so every one of those lookups can hold something other than the expected type, or nothing at all.

## Reproduction

Six configs a user could plausibly write, each in a file passed to `migrateApplicationConfig`. All six panic before this change:

```
--- FAIL: TestMigrateApplicationConfigMalformed/kind_missing
    panicked on a user-supplied config: interface conversion: interface {} is nil, not string
--- FAIL: TestMigrateApplicationConfigMalformed/kind_is_a_number
    panicked on a user-supplied config: interface conversion: interface {} is float64, not string
--- FAIL: TestMigrateApplicationConfigMalformed/pipeline_is_a_list
    panicked on a user-supplied config: interface conversion: interface {} is []interface {}, not map[string]interface {}
--- FAIL: TestMigrateApplicationConfigMalformed/stages_is_a_string
    panicked on a user-supplied config: interface conversion: interface {} is string, not []interface {}
--- FAIL: TestMigrateApplicationConfigMalformed/spec_is_a_string
    panicked on a user-supplied config: interface conversion: interface {} is string, not map[string]interface {}
--- FAIL: TestMigrateApplicationConfigMalformed/spec_missing
    panicked on a user-supplied config: interface conversion: interface {} is nil, not map[string]interface {}
```

A config file with no `kind:` is enough.

## The change

Each of the three uses the checked form and returns an error naming the field and the type that was actually there, matching how the same function already handles `stages[]` and `stages[].with` two lines further down:

```go
if oldStageCfg, ok := oldStage.(map[string]any); ok {
if withCfg, ok := stageCfg["with"].(map[string]any); ok {
```

So this is an omission rather than a different convention.

`spec.pipeline.stages` being absent stays valid and is not an error, only a non-list value is.

All six cases pass after the change, and `go test ./pkg/app/pipectl/...` is green.
