### PR TITLE
test(web): add unit tests for debounce utility

### DIFF
--- a/web/src/utils/debounce.test.ts
+++ b/web/src/utils/debounce.test.ts
@@ -1,0 +1,101 @@
+import debounce from "./debounce";
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("debounce", () => {
+  it("does not call the function before the wait period elapses", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(299);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("calls the function after the wait period", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced();
+    jest.advanceTimersByTime(300);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the default wait of 300ms when no wait is specified", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn);
+
+    debounced();
+    jest.advanceTimersByTime(299);
+    expect(fn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the timer on repeated calls and fires only once", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced();
+    jest.advanceTimersByTime(200);
+    debounced();
+    jest.advanceTimersByTime(200);
+    debounced();
+    jest.advanceTimersByTime(300);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the most recent arguments to the underlying function", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced("first");
+    jest.advanceTimersByTime(100);
+    debounced("second");
+    jest.advanceTimersByTime(300);
+
+    expect(fn).toHaveBeenCalledWith("second");
+  });
+
+  it("can be called again after the wait period fires", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced();
+    jest.advanceTimersByTime(300);
+    debounced();
+    jest.advanceTimersByTime(300);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear() prevents the pending call from executing", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    debounced();
+    jest.advanceTimersByTime(100);
+    debounced.clear();
+    jest.advanceTimersByTime(300);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("clear() is a no-op when called with no pending invocation", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 300);
+
+    expect(() => debounced.clear()).not.toThrow();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What?

Add `web/src/utils/debounce.test.ts` — unit tests for the `debounce` utility.

## Why?

`debounce.ts` had no test coverage. The tests cover all observable behaviours of the function:

- Does not invoke the wrapped function before the wait period elapses
- Invokes the wrapped function after the wait period
- Uses the default 300 ms wait when none is specified
- Resets the timer on repeated calls and fires only once (debounce semantics)
- Passes the most recent arguments to the underlying function
- Can be invoked again after a previous firing
- `clear()` cancels a pending invocation
- `clear()` is safe to call with no pending invocation

The tests use `jest.useFakeTimers()` to control `setTimeout` without real delays, matching the pattern used in other utility test files (e.g. `is-stage-running.test.ts`, `common.test.ts`).

## Fixes

N/A — self-identified coverage gap.

## Does this change affect how the app works for end users?

No — test file only.

## Does this change require an update to the documentation?

No.