### PR TITLE
fix(pkg/filematcher): escape regex special characters in pattern matcher

### DIFF
--- a/pkg/filematcher/filematcher.go
+++ b/pkg/filematcher/filematcher.go
@@ -181,11 +181,23 @@ func (p *Pattern) regexpString() string {
 		escSL += `\`
 	}
 
+	inClass := false
+
 	for scan.Peek() != scanner.EOF {
 		ch := scan.Next()
 
 		switch ch {
+		case '[':
+			inClass = true
+			regStr += string(ch)
+		case ']':
+			inClass = false
+			regStr += string(ch)
 		case '*':
+			if inClass {
+				regStr += string(ch)
+				continue
+			}
 			if scan.Peek() == '*' {
 				// Is some flavor of "**".
 				scan.Next()
@@ -209,12 +221,19 @@ func (p *Pattern) regexpString() string {
 				regStr += "[^" + escSL + "]*"
 			}
 		case '?':
+			if inClass {
+				regStr += string(ch)
+				continue
+			}
 			// "?" is any char except "/".
 			regStr += "[^" + escSL + "]"
-		case '.', '$':
-			// Escape some regexp special chars that have no meaning
-			// in golang's filepath.Match.
-			regStr += `\` + string(ch)
+		case '.', '$', '+', '(', ')', '{', '}', '|', '^':
+			if inClass {
+				regStr += string(ch)
+			} else {
+				// Escape regexp special chars that have no meaning in filepath.Match.
+				regStr += `\` + string(ch)
+			}
 		case '\\':
 			// Escape next char. Note that a trailing \ in the pattern
 			// will be left alone (but need to escape it).

--- a/pkg/filematcher/filematcher_test.go
+++ b/pkg/filematcher/filematcher_test.go
@@ -172,6 +172,11 @@ func TestMatches(t *testing.T) {
 		{"abc/**", "abc/def/ghi", true},
 		{"**/.foo", ".foo", true},
 		{"**/.foo", "bar.foo", false},
+		{"a+b.txt", "a+b.txt", true},
+		{"foo(1).txt", "foo(1).txt", true},
+		{"foo{1}.txt", "foo{1}.txt", true},
+		{"foo|bar.txt", "foo|bar.txt", true},
+		{"^foo.txt", "^foo.txt", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does**:
Fixes an issue in `pkg/filematcher` where regular expression metacharacters (`+`, `(`, `)`, `{`, `}`, `|`, `^`) outside character classes `[...]` were not escaped when building internal regular expressions. As a result, file paths containing these characters (such as `a+b.txt`, `foo(1).txt`, `foo{1}.txt`, `foo|bar.txt`, or `^foo.txt`) failed to match their corresponding patterns.

**Why we need it**:
Without escaping regex metacharacters outside `[...]`, pattern matching fails on standard file paths and names containing parentheses, plus signs, braces, pipes, or carets.

**Which issue(s) this PR fixes**:
Fixes # NONE

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A

**Screenshots/Videos (for documentation or website changes)**:
N/A