### PR TITLE
Change Dependabot schedule to monthly with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,76 +1,47 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/pkg/plugin/sdk"
+      - "/tool/actions-gh-release"
+      - "/tool/actions-plan-preview"
+      - "/tool/codegen/protoc-gen-auth"
+      - "/pkg/app/pipedv1/plugin/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/plugin/sdk"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/tool/actions-gh-release"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/tool/actions-plan-preview"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/tool/codegen/protoc-gen-auth"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/kubernetes"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/kubernetes_multicluster"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/terraform"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/cloudrun"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/scriptrun"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/analysis"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/wait"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/pkg/app/pipedv1/plugin/waitapproval"
-    schedule:
-      interval: "weekly"
+    groups:
+      google:
+        patterns:
+          - "google.golang.org/*"
+          - "cloud.google.com/*"
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/docs"
@@ -80,4 +51,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
**What this PR does**: Reduces Dependabot PR noise by consolidating the 13 gomod entries into one via the directories key (which also adds the previously missing ecs plugin module), grouping related bumps (google, AWS SDK, k8s, and a minor/patch catch-all) into single PRs, and switching all ecosystems from weekly to monthly. Security updates are unaffected since advisory-triggered PRs bypass this schedule.

Fixes #7361

**Does this PR introduce a user-facing change?**:

- **How are users affected by this change**:
- **Is this breaking change**:
- **How to migrate (if breaking change)**:
