### PR TITLE
fix(pkg/yamlprocessor): guard GetValue, ReplaceString, and Bytes against nil processor

### DIFF
--- a/pkg/yamlprocessor/yamlprocessor.go
+++ b/pkg/yamlprocessor/yamlprocessor.go
@@ -50,6 +50,9 @@ func NewProcessor(data []byte) (*Processor, error) {
 //
 // e.g. "$.foo.bar[0].baz"
 func (p *Processor) GetValue(path string) (interface{}, error) {
+	if p == nil || p.file == nil {
+		return nil, errors.New("processor or file is uninitialized")
+	}
 	if path == "" {
 		return nil, fmt.Errorf("no path given")
 	}
@@ -75,6 +78,9 @@ func (p *Processor) GetValue(path string) (interface{}, error) {
 // ReplaceString replaces the value placed at a given path with
 // a given string value.
 func (p *Processor) ReplaceString(path, value string) error {
+	if p == nil || p.file == nil {
+		return errors.New("processor or file is uninitialized")
+	}
 	if path == "" {
 		return errors.New("no path given")
 	}
@@ -104,5 +110,8 @@ func (p *Processor) ReplaceString(path, value string) error {
 }
 
 func (p *Processor) Bytes() []byte {
+	if p == nil || p.file == nil {
+		return nil
+	}
 	return []byte(p.file.String())
 }

--- a/pkg/yamlprocessor/yamlprocessor_test.go
+++ b/pkg/yamlprocessor/yamlprocessor_test.go
@@ -272,3 +272,27 @@ foo:
 		})
 	}
 }
+
+func TestNilProcessor(t *testing.T) {
+	var nilProc *Processor
+	val, err := nilProc.GetValue("$.foo")
+	assert.Error(t, err)
+	assert.Nil(t, val)
+
+	err = nilProc.ReplaceString("$.foo", "bar")
+	assert.Error(t, err)
+
+	bytes := nilProc.Bytes()
+	assert.Nil(t, bytes)
+
+	uninitProc := &Processor{}
+	val, err = uninitProc.GetValue("$.foo")
+	assert.Error(t, err)
+	assert.Nil(t, val)
+
+	err = uninitProc.ReplaceString("$.foo", "bar")
+	assert.Error(t, err)
+
+	bytes = uninitProc.Bytes()
+	assert.Nil(t, bytes)
+}


### PR DESCRIPTION
**What this PR does**:
Adds defensive nil-receiver and uninitialized AST file pointer guards (`p == nil || p.file == nil`) to `GetValue()`, `ReplaceString()`, and `Bytes()` in `pkg/yamlprocessor`.

**Why we need it**:
Calling `GetValue()`, `ReplaceString()`, or `Bytes()` on an uninitialized or nil `*Processor` previously caused an unhandled `runtime error: invalid memory address or nil pointer dereference` panic. Adding these checks prevents panics and safely returns clean error messages or nil byte slices.

**Which issue(s) this PR fixes**:
Fixes # NONE

**Does this PR introduce a user-facing change?**:
- **How are users affected by this change**: None
- **Is this breaking change**: No
- **How to migrate (if breaking change)**: N/A

**Screenshots/Videos (for documentation or website changes)**:
N/A